### PR TITLE
Savestates: Implement reload savestate shortcut and some bugfixes

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(rpcs3_emu
     cache_utils.cpp
     IdManager.cpp
     localized_string.cpp
+    savestate_utils.cpp
     System.cpp
     system_config.cpp
     system_config_types.cpp

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -187,7 +187,7 @@ audio_out_configuration::audio_out_configuration(utils::serial& ar)
 
 void audio_out_configuration::save(utils::serial& ar)
 {
-	USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellAudioOut);
+	GET_OR_USE_SERIALIZATION_VERSION(ar.is_writing(), cellAudioOut);
 
 	for (auto& state : out)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -145,7 +145,7 @@ void camera_context::save(utils::serial& ar)
 		return;
 	}
 
-	USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellCamera);
+	GET_OR_USE_SERIALIZATION_VERSION(ar.is_writing(), cellCamera);
 
 	ar(notify_data_map, start_timestamp, read_mode, is_streaming, is_attached, is_open, info, attr, frame_num);
 }

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -244,7 +244,7 @@ public:
 			return;
 		}
 
-		USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellGem);
+		GET_OR_USE_SERIALIZATION_VERSION(ar.is_writing(), cellGem);
 
 		ar(attribute, vc_attribute, status_flags, enable_pitch_correction, inertial_counter, controllers
 			, connected_controllers, update_started, camera_frame, memory_ptr, start_timestamp);

--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -96,7 +96,7 @@ struct music_state
 			return;
 		}
 
-		USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellMusic);
+		GET_OR_USE_SERIALIZATION_VERSION(ar.is_writing(), cellMusic);
 
 		ar(userData);
 	}

--- a/rpcs3/Emu/Cell/Modules/cellVoice.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVoice.cpp
@@ -48,7 +48,7 @@ void voice_manager::reset()
 
 void voice_manager::save(utils::serial& ar)
 {
-	USING_SERIALIZATION_VERSION_COND(ar.is_writing(), cellVoice);
+	GET_OR_USE_SERIALIZATION_VERSION(ar.is_writing(), cellVoice);
 	ar(id_ctr, port_source, ports, queue_keys, voice_service_started);
 }
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4790,6 +4790,12 @@ bool spu_thread::stop_and_signal(u32 code)
 				return false;
 			}
 
+			if (Emu.IsStarting())
+			{
+				// Deregister lv2_obj::g_to_sleep entry (savestates related) 
+				lv2_obj::sleep(*this);
+			}
+
 			if (group->run_state >= SPU_THREAD_GROUP_STATUS_WAITING && group->run_state <= SPU_THREAD_GROUP_STATUS_WAITING_AND_SUSPENDED)
 			{
 				// Try again

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -228,7 +228,7 @@ lv2_spu_group::lv2_spu_group(utils::serial& ar) noexcept
 		*ep = idm::get_unlocked<lv2_obj, lv2_event_queue>(ar.operator u32());
 	}
 
-	u32 waiter_spu_index = -1;
+	waiter_spu_index = -1;
 
 	switch (run_state)
 	{
@@ -256,15 +256,20 @@ lv2_spu_group::lv2_spu_group(utils::serial& ar) noexcept
 		// Suspend all SPU threads except a thread that waits on sys_spu_thread_receive_event  
 		for (const auto& thread : threads)
 		{
-			if (thread && thread->index != waiter_spu_index)
+			if (thread)
 			{
+				if (thread->index == waiter_spu_index)
+				{
+					lv2_obj::set_future_sleep(thread.get());
+					continue;
+				}
+
 				thread->state += cpu_flag::suspend;
 			}
 		}
 
 		break;
 	}
-	//case SPU_THREAD_GROUP_STATUS_WAITING_AND_SUSPENDED:
 	//case SPU_THREAD_GROUP_STATUS_RUNNING:
 	//case SPU_THREAD_GROUP_STATUS_STOPPED:
 	//case SPU_THREAD_GROUP_STATUS_UNKNOWN:

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -200,7 +200,7 @@ public:
 	}
 
 	// Serialization related
-	static void set_future_sleep(ppu_thread* ppu);
+	static void set_future_sleep(cpu_thread* cpu);
 	static bool is_scheduler_ready();
 
 	static void cleanup();
@@ -450,7 +450,7 @@ private:
 	static std::deque<std::pair<u64, class cpu_thread*>> g_waiting;
 
 	// Threads which must call lv2_obj::sleep before the scheduler starts
-	static std::deque<class ppu_thread*> g_to_sleep;
+	static std::deque<class cpu_thread*> g_to_sleep;
 
 	static void schedule_all();
 };

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -30,6 +30,16 @@ namespace rsx
 			m_ctrl->get.release(m_internal_get);
 		}
 
+		void FIFO_control::restore_state(u32 cmd, u32 count)
+		{
+			m_cmd = cmd;
+			m_command_inc = ((m_cmd & RSX_METHOD_NON_INCREMENT_CMD_MASK) == RSX_METHOD_NON_INCREMENT_CMD) ? 0 : 4;
+			m_remaining_commands = count - 1;
+			m_internal_get = m_ctrl->get;
+			m_args_ptr = m_iotable->get_addr(m_internal_get);	
+			m_command_reg = (m_cmd & 0xffff) + m_command_inc * (((m_cmd >> 18) - count) & 0x7ff);
+		}
+
 		void FIFO_control::inc_get(bool wait)
 		{
 			m_internal_get += 4;
@@ -806,13 +816,16 @@ namespace rsx
 			if (auto method = methods[reg])
 			{
 				method(this, reg, value);
+
+				if (state & cpu_flag::again)
+				{
+					method_registers.decode(reg, method_registers.register_previous_value);
+					break;
+				}
 			}
 		}
 		while (fifo_ctrl->read_unsafe(command));
 
-		if (cpu_flag::again - state)
-		{
-			fifo_ctrl->sync_get();
-		}
+		fifo_ctrl->sync_get();
 	}
 }

--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -141,6 +141,7 @@ namespace rsx
 			void sync_get() const;
 			std::span<const u32> get_current_arg_ptr() const;
 			u32 get_remaining_args_count() const { return m_remaining_commands; }
+			void restore_state(u32 cmd, u32 count);
 			void inc_get(bool wait);
 
 			void set_get(u32 get, u32 spin_cmd = 0);

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -478,6 +478,8 @@ namespace rsx
 		FIFO::flattening_helper m_flattener;
 		u32 fifo_ret_addr = RSX_CALL_STACK_EMPTY;
 		u32 saved_fifo_ret = RSX_CALL_STACK_EMPTY;
+		u32 restore_fifo_cmd = 0;
+		u32 restore_fifo_count = 0;
 
 		// Occlusion query
 		bool zcull_surface_active = false;

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -115,6 +115,7 @@ namespace rsx
 			{
 				if (rsx->test_stopped())
 				{
+					rsx->state += cpu_flag::again;
 					return;
 				}
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2270,6 +2270,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate)
 	if (m_state.exchange(system_state::stopped) == system_state::stopped)
 	{
 		// Ensure clean state
+		m_ar.reset();
 		argv.clear();
 		envp.clear();
 		data.clear();
@@ -2563,7 +2564,6 @@ void Emulator::Kill(bool allow_autoexit, bool savestate)
 	}
 
 	// Boot arg cleanup (preserved in the case restarting)
-	m_ar.reset();
 	argv.clear();
 	envp.clear();
 	data.clear();
@@ -2608,6 +2608,7 @@ game_boot_result Emulator::Restart(bool savestate)
 
 		if (g_cfg.savestate.suspend_emu)
 		{
+			m_ar.reset();
 			return game_boot_result::no_errors;
 		}
 	}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -101,7 +101,7 @@ SERIALIZATION_VER(lv2_config, 9,                                1)
 
 namespace rsx
 {
-	SERIALIZATION_VER(rsx, 10,                                  1)
+	SERIALIZATION_VER(rsx, 10,                                  1, 2)
 }
 
 namespace np

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -1,0 +1,210 @@
+#include "stdafx.h"
+#include "util/types.hpp"
+#include "util/serialization.hpp"
+#include "util/logs.hpp"
+#include "Utilities/File.h"
+#include "system_config.h"
+
+#include "System.h"
+
+#include <set>
+
+LOG_CHANNEL(sys_log, "SYS");
+
+struct serial_ver_t
+{
+	bool used = false;
+	s32 current_version = 0;
+	std::set<s32> compatible_versions;
+};
+
+static std::array<serial_ver_t, 23> s_serial_versions;
+
+#define SERIALIZATION_VER(name, identifier, ...) \
+\
+	const bool s_##name##_serialization_fill = []() { if (::s_serial_versions[identifier].compatible_versions.empty()) ::s_serial_versions[identifier].compatible_versions = {__VA_ARGS__}; return true; }();\
+\
+	extern void using_##name##_serialization()\
+	{\
+		ensure(Emu.IsStopped());\
+		::s_serial_versions[identifier].used = true;\
+	}\
+\
+	extern s32 get_##name##_serialization_version()\
+	{\
+		return ::s_serial_versions[identifier].current_version;\
+	}
+
+SERIALIZATION_VER(global_version, 0,                            12) // For stuff not listed here
+SERIALIZATION_VER(ppu, 1,                                       1)
+SERIALIZATION_VER(spu, 2,                                       1)
+SERIALIZATION_VER(lv2_sync, 3,                                  1)
+SERIALIZATION_VER(lv2_vm, 4,                                    1)
+SERIALIZATION_VER(lv2_net, 5,                                   1)
+SERIALIZATION_VER(lv2_fs, 6,                                    1)
+SERIALIZATION_VER(lv2_prx_overlay, 7,                           1)
+SERIALIZATION_VER(lv2_memory, 8,                                1)
+SERIALIZATION_VER(lv2_config, 9,                                1)
+
+namespace rsx
+{
+	SERIALIZATION_VER(rsx, 10,                                  1, 2)
+}
+
+namespace np
+{
+	SERIALIZATION_VER(sceNp, 11,                                1)
+}
+
+#ifdef _MSC_VER
+// Compiler bug, lambda function body does seem to inherit used namespace atleast for function decleration 
+SERIALIZATION_VER(rsx, 10)
+SERIALIZATION_VER(sceNp, 11)
+#endif
+
+SERIALIZATION_VER(cellVdec, 12,                                 1)
+SERIALIZATION_VER(cellAudio, 13,                                1)
+SERIALIZATION_VER(cellCamera, 14,                               1)
+SERIALIZATION_VER(cellGem, 15,                                  1)
+SERIALIZATION_VER(sceNpTrophy, 16,                              1)
+SERIALIZATION_VER(cellMusic, 17,                                1)
+SERIALIZATION_VER(cellVoice, 18,                                1)
+SERIALIZATION_VER(cellGcm, 19,                                  1)
+SERIALIZATION_VER(sysPrxForUser, 20,                            1)
+SERIALIZATION_VER(cellSaveData, 21,                             1)
+SERIALIZATION_VER(cellAudioOut, 22,                             1)
+
+std::vector<std::pair<u16, u16>> get_savestate_versioning_data(const fs::file& file)
+{
+	if (!file)
+	{
+		return {};
+	}
+
+	file.seek(0);
+
+	if (u64 r = 0; !file.read(r) || r != "RPCS3SAV"_u64)
+	{
+		return {};
+	}
+
+	file.seek(10);
+
+	u64 offs = 0;
+	file.read(offs);
+
+    const usz fsize = file.size();
+
+	if (!offs || fsize <= offs)
+	{
+		return {};
+	}
+
+	file.seek(offs);
+
+	utils::serial ar;
+	ar.set_reading_state();
+    file.read(ar.data, fsize - offs);
+	return ar;
+}
+
+bool is_savestate_version_compatible(const std::vector<std::pair<u16, u16>>& data, bool log)
+{
+	if (data.empty())
+	{
+		return false;
+	}
+
+	bool ok = true;
+
+	for (auto [identifier, version] : data)
+	{
+		if (identifier >= s_serial_versions.size())
+		{
+			(log ? sys_log.error : sys_log.trace)("Savestate version identider is unknown! (category=%u, version=%u)", identifier, version);
+			ok = false; // Log all mismatches
+		}
+		else if (!s_serial_versions[identifier].compatible_versions.count(version))
+		{
+			(log ? sys_log.error : sys_log.trace)("Savestate version is not supported. (category=%u, version=%u)", identifier, version);
+			ok = false;
+		}
+		else
+		{
+			s_serial_versions[identifier].current_version = version;
+		}
+	}
+
+	return ok;
+}
+
+bool is_savestate_compatible(const fs::file& file)
+{
+	return is_savestate_version_compatible(get_savestate_versioning_data(file), false);
+}
+
+std::vector<std::pair<u16, u16>> read_used_savestate_versions()
+{
+	std::vector<std::pair<u16, u16>> used_serial;
+	used_serial.reserve(s_serial_versions.size());
+
+	for (serial_ver_t& ver : s_serial_versions)
+	{
+		if (std::exchange(ver.used, false))
+		{
+			used_serial.emplace_back(&ver - s_serial_versions.data(), *ver.compatible_versions.rbegin());
+		}
+	}
+
+	return used_serial;
+}
+
+bool boot_last_savestate()
+{
+	if (!g_cfg.savestate.suspend_emu && !Emu.GetTitleID().empty() && (Emu.IsRunning() || Emu.GetStatus() == system_state::paused))
+	{
+		extern bool is_savestate_compatible(const fs::file& file);
+
+		const std::string save_dir = fs::get_cache_dir() + "/savestates/";
+
+		std::string savestate_path;
+		u64 mtime = umax;
+
+		for (auto&& entry : fs::dir(save_dir))
+		{
+			if (entry.is_directory)
+			{
+				continue;
+			}
+
+			// Find the latest savestate file compatible with the game (TODO: Check app version and anything more)
+			if (entry.name.find(Emu.GetTitleID()) != umax && mtime < entry.mtime)
+			{
+				if (std::string path = save_dir + entry.name; is_savestate_compatible(fs::file(path)))
+				{
+					savestate_path = std::move(path);
+					mtime = entry.mtime;
+				}
+			}
+		}
+
+		if (fs::is_file(savestate_path))
+		{
+			sys_log.success("Booting the most recent savestate \'%s\' using the Reload shortcut.", savestate_path);
+			Emu.GracefulShutdown(false);
+
+			if (game_boot_result error = Emu.BootGame(savestate_path, "", true); error != game_boot_result::no_errors)
+			{
+				sys_log.error("Failed to booting savestate \'%s\' using the Reload shortcut. (error: %s)", savestate_path, error);
+			}
+			else
+			{
+				return true;
+			}
+		}
+
+		sys_log.error("No compatible savestate file found in \'%s\''", save_dir);
+	}
+
+	return false;
+}

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -313,7 +313,7 @@ struct cfg_root : cfg::node
 		node_savestate(cfg::node* _this) : cfg::node(_this, "Savestate") {}
 
 		cfg::_bool start_paused{ this, "Start Paused" }; // Pause on first frame
-		cfg::_bool suspend_emu{ this, "Suspend Emulation Savestate Mode", false }; // Close emulation when saving, delete save after loading
+		cfg::_bool suspend_emu{ this, "Suspend Emulation Savestate Mode", true }; // Close emulation when saving, delete save after loading
 		cfg::_bool state_inspection_mode{ this, "Inspection Mode Savestates" }; // Save memory stored in executable files, thus allowing to view state without any files (for debugging)
 		cfg::_bool save_disc_game_data{ this, "Save Disc Game Data", false };
 	} savestate{this};

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile Include="Emu\RSX\RSXDisAsm.cpp" />
     <ClCompile Include="Emu\RSX\RSXZCULL.cpp" />
     <ClCompile Include="Emu\RSX\rsx_vertex_data.cpp" />
+    <ClCompile Include="Emu\savestate_utils.cpp" />
     <ClCompile Include="Emu\system_config_types.cpp" />
     <ClCompile Include="Emu\perf_meter.cpp" />
     <ClCompile Include="Emu\system_progress.cpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1084,6 +1084,9 @@
     <ClCompile Include="Emu\RSX\Overlays\overlay_cursor.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\savestate_utils.cpp">
+      <Filter>Emu</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -1176,7 +1176,6 @@ int main(int argc, char** argv)
 		return 0;
 	}
 
-
 	// run event loop (maybe only needed for the gui application)
 	return app->exec();
 }

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -971,7 +971,9 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		});
 	}
 
-	if (const std::string sstate = fs::get_cache_dir() + "/savestates/" + current_game.serial + ".SAVESTAT"; fs::is_file(sstate))
+	extern bool is_savestate_compatible(const fs::file& file);
+
+	if (const std::string sstate = fs::get_cache_dir() + "/savestates/" + current_game.serial + ".SAVESTAT"; is_savestate_compatible(fs::file(sstate)))
 	{
 		QAction* boot_state = menu.addAction(is_current_running_game
 			? tr("&Reboot with savestate")

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -247,20 +247,6 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 		}
 		break;
 	case Qt::Key_P:
-		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys && Emu.IsRunning())
-		{
-			Emu.Pause();
-			return;
-		}
-		break;
-	case Qt::Key_S:
-		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
-		{
-			Emu.Restart(true);
-			return;
-		}
-		break;
-	case Qt::Key_R:
 		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
 		{
 			switch (Emu.GetStatus())
@@ -275,8 +261,26 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 				Emu.Resume();
 				return;
 			}
-			default: break;
+			default:
+			{
+				Emu.Pause();
+				return;
 			}
+			}
+		}
+		break;
+	case Qt::Key_S:
+		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
+		{
+			Emu.Restart(true);
+			return;
+		}
+		break;
+	case Qt::Key_R:
+		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
+		{
+			extern bool boot_last_savestate();
+			boot_last_savestate();
 		}
 		break;
 	case Qt::Key_C:

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -331,7 +331,7 @@ public:
 template <uint Max, typename... T>
 void atomic_wait::list<Max, T...>::wait(atomic_wait_timeout timeout)
 {
-	static_assert(Max, "Cannot initiate atomic wait with empty list.");
+	static_assert(!!Max, "Cannot initiate atomic wait with empty list.");
 
 	atomic_wait_engine::wait(m_info[0].data, m_info[0].size, m_info[0].old, static_cast<u64>(timeout), m_info[0].mask, m_info + 1);
 }

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1168,10 +1168,11 @@ extern bool serialize(utils::serial& ar, T& obj);
 	using_##name##_serialization();\
 }()
 
-#define USING_SERIALIZATION_VERSION_COND(cond, name) [&]()\
+#define GET_OR_USE_SERIALIZATION_VERSION(cond, name) [&]()\
 {\
 	extern void using_##name##_serialization();\
-	if (static_cast<bool>(cond)) using_##name##_serialization();\
+	extern s32 get_##name##_serialization_version();\
+	return (static_cast<bool>(cond) ? (using_##name##_serialization(), 0) : get_##name##_serialization_version());\
 }()
 
 #define GET_SERIALIZATION_VERSION(name) []()\


### PR DESCRIPTION
Ctrl+R to reload savestate during gameplay if it exists and is compatible with the current RPCS3 version.
You need the "Suspend Emulation Savestate Mode" setting on in the config file to use it.
The reason this setting is not on by default is that there is a risk HDD0 state has been changed by the game when playing after the savestate has been created in a way that is not compatible with the created savestate file. (because HDD0 state is not saved by default at the moment, so use with caution)

In addition save RSX semaphore waiting state, for synchronization should not be harmed when reloading.