### PR TITLE
Savestates: QoL improvements

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -304,7 +304,7 @@ lv2_file::lv2_file(utils::serial& ar)
 void lv2_file::save(utils::serial& ar)
 {
 	USING_SERIALIZATION_VERSION(lv2_fs);
-	ar(name, mode, flags, type, lock, vfs::retrieve(real_path));
+	ar(name, mode, flags, type, lock, ensure(vfs::retrieve(real_path), FN(!x.empty())));
 
 	if (!(mp->flags & lv2_mp_flag::read_only) && flags & CELL_FS_O_ACCMODE)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -274,6 +274,12 @@ error_code sys_mutex_unlock(ppu_thread& ppu, u32 mutex_id)
 
 		if (auto cpu = mutex->reown<ppu_thread>())
 		{
+			if (cpu->state & cpu_flag::again)
+			{
+				ppu.state += cpu_flag::again;
+				return {};
+			}
+
 			mutex->awake(cpu);
 		}
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -134,6 +134,11 @@ struct lv2_mutex final : lv2_obj
 	{
 		if (auto cpu = schedule<T>(sq, protocol))
 		{
+			if (cpu->state & cpu_flag::again)
+			{
+				return static_cast<T*>(cpu);
+			}
+
 			owner = cpu->id << 1 | !sq.empty();
 			return static_cast<T*>(cpu);
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -461,7 +461,6 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 		if (res != game_boot_result::no_errors)
 		{
 			sys_process.fatal("Failed to boot from exitspawn! (path=\"%s\", error=%s)", path, res);
-			Emu.Kill();
 		}
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -347,9 +347,6 @@ std::pair<named_thread<spu_thread>*, std::shared_ptr<lv2_spu_group>> lv2_spu_gro
 	return res;
 }
 
-namespace
-{
-
 struct limits_data
 {
 	u32 physical = 0;
@@ -364,6 +361,23 @@ struct spu_limits_t
 	u32 max_raw = 0;
 	u32 max_spu = 6;
 	shared_mutex mutex;
+
+	spu_limits_t() = default;
+
+	spu_limits_t(utils::serial& ar) noexcept
+	{
+		if (GET_SERIALIZATION_VERSION(spu) >= 2)
+		{
+			ar(max_raw, max_spu);
+		}
+	}
+
+	void save(utils::serial& ar)
+	{
+		ar(max_raw, max_spu);
+	}
+
+	SAVESTATE_INIT_POS(47);
 
 	bool check(const limits_data& init) const
 	{
@@ -395,8 +409,6 @@ struct spu_limits_t
 		return true;
 	}
 };
-
-} // annonymous namespace
 
 error_code sys_spu_initialize(ppu_thread& ppu, u32 max_usable_spu, u32 max_raw_spu)
 {

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -79,7 +79,7 @@ extern void ppu_unload_prx(const lv2_prx&);
 extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, const std::string&, s64 = 0, utils::serial* = nullptr);
 extern std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object&, const std::string& path, s64 = 0, utils::serial* = nullptr);
 extern bool ppu_load_rel_exec(const ppu_rel_object&);
-extern bool is_savestate_version_compatible(const std::vector<std::pair<u16, u16>>& data, bool log);
+extern bool is_savestate_version_compatible(const std::vector<std::pair<u16, u16>>& data, bool is_boot_check);
 extern std::vector<std::pair<u16, u16>> read_used_savestate_versions();
 
 fs::file g_tty;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -672,11 +672,6 @@ game_boot_result Emulator::BootGame(const std::string& path, const std::string& 
 
 		auto error = Load(title_id, add_only);
 
-		if (is_error(error))
-		{
-			m_ar.reset();
-		}
-
 		if (g_cfg.savestate.suspend_emu && m_ar)
 		{
 			fs::remove_file(path);
@@ -764,6 +759,20 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 
 	sys_log.notice("Selected config: mode=%s, path=\"%s\"", m_config_mode, m_config_path);
 	sys_log.notice("Path: %s", m_path);
+
+	struct cleanup_t
+	{
+		Emulator* _this;
+		bool cleanup = true;
+
+		~cleanup_t()
+		{
+			if (cleanup && _this->IsStopped())
+			{
+				_this->Kill(false);
+			}
+		}
+	} cleanup{this};
 
 	{
 		Init(add_only);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -301,8 +301,8 @@ public:
 	bool Pause(bool freeze_emulation = false);
 	void Resume();
 	void GracefulShutdown(bool allow_autoexit = true, bool async_op = false, bool savestate = false);
-	void Kill(bool allow_autoexit = true, bool savestate = false);
-	game_boot_result Restart(bool savestate = false);
+	std::shared_ptr<utils::serial> Kill(bool allow_autoexit = true, bool savestate = false);
+	game_boot_result Restart();
 	bool Quit(bool force_quit);
 	static void CleanUp();
 

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -388,19 +388,34 @@ std::string vfs::retrieve(std::string_view path, const vfs_directory* node, std:
 	// Try to extract host root mount point name (if exists)
 	std::string_view host_root_name;
 
+	std::string result;
+	std::string result_dir;
+
 	for (const auto& [name, dir] : node->dirs)
 	{
 		mount_path->back() = name;
 
 		if (std::string res = vfs::retrieve(path, &dir, mount_path); !res.empty())
 		{
-			return res;
+			// Avoid app_home
+			// Prefer dev_bdvd over dev_hdd0
+			if (result.empty() || (name == "app_home") < (result_dir == "app_home") ||
+				(name == "dev_bdvd") > (result_dir == "dev_bdvd"))
+			{
+				result = std::move(res);
+				result_dir = name;
+			}
 		}
 
 		if (dir.path == "/"sv)
 		{
 			host_root_name = name;
 		}
+	}
+
+	if (!result.empty())
+	{
+		return result;
 	}
 
 	mount_path->pop_back();
@@ -434,7 +449,7 @@ std::string vfs::retrieve(std::string_view path, const vfs_directory* node, std:
 	{
 		// If failed to find mount point for path and /host_root is mounted
 		// Prepend "/host_root" to path and return the constructed string
-		std::string result{"/"};
+		result = "/";
 
 		for (const auto& name : *mount_path)
 		{
@@ -449,7 +464,7 @@ std::string vfs::retrieve(std::string_view path, const vfs_directory* node, std:
 		return result;
 	}
 
-	return {};
+	return result;
 }
 
 std::string vfs::escape(std::string_view name, bool escape_slash)

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -364,14 +364,7 @@ std::string vfs::retrieve(std::string_view path, const vfs_directory* node, std:
 
 	if (!node)
 	{
-		if (path.starts_with("."))
-		{
-			return {};
-		}
-
-		const std::string rpath = Emu.GetCallbacks().resolve_path(path);
-
-		if (rpath.empty())
+		if (path.starts_with(".") || path.empty())
 		{
 			return {};
 		}
@@ -379,6 +372,20 @@ std::string vfs::retrieve(std::string_view path, const vfs_directory* node, std:
 		reader_lock lock(table.mutex);
 
 		std::vector<std::string_view> mount_path_empty;
+
+		if (std::string res = vfs::retrieve(path, &table.root, &mount_path_empty); !res.empty())
+		{
+			return res;
+		}
+
+		mount_path_empty.clear();
+
+		const std::string rpath = Emu.GetCallbacks().resolve_path(path);
+
+		if (rpath.empty())
+		{
+			return {};
+		}
 
 		return vfs::retrieve(rpath, &table.root, &mount_path_empty);
 	}

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -37,7 +37,7 @@ static std::array<serial_ver_t, 23> s_serial_versions;
 
 SERIALIZATION_VER(global_version, 0,                            12) // For stuff not listed here
 SERIALIZATION_VER(ppu, 1,                                       1)
-SERIALIZATION_VER(spu, 2,                                       1)
+SERIALIZATION_VER(spu, 2,                                       1, 2 /*spu_limits_t ctor*/)
 SERIALIZATION_VER(lv2_sync, 3,                                  1)
 SERIALIZATION_VER(lv2_vm, 4,                                    1)
 SERIALIZATION_VER(lv2_net, 5,                                   1)

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -272,7 +272,7 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 	case Qt::Key_S:
 		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
 		{
-			Emu.Restart(true);
+			Emu.Kill(false, true);
 			return;
 		}
 		break;

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -637,7 +637,6 @@ void log_frame::UpdateUI()
 			m_log_text += font_end_tag;
 
 			m_log->appendHtml(m_log_text);
-			m_log_counter = 0;
 		}
 		else
 		{


### PR DESCRIPTION
* Fix RAW SPU creation after loading the savestate.
* Fix Ctrl+R reload savestate shortcut bug.
* Fix bugs of vfs::retrieve.
* Do not restart after Ctrl+S for now.
* sys_mutex_unlock saving bugfix.