### PR TITLE
rsx: Intel workarounds

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -1005,13 +1005,13 @@ namespace gl
 		if (rsx::is_compressed_host_format(gcm_format))
 		{
 			const auto& desc = subresources_layout[0];
-			const usz texture_data_sz = desc.width_in_block * desc.height_in_block * desc.depth * rsx::get_format_block_size_in_bytes(gcm_format);
+			const u32 texture_data_sz = desc.width_in_block * desc.height_in_block * desc.depth * rsx::get_format_block_size_in_bytes(gcm_format);
 			data_upload_buf.resize(texture_data_sz);
 		}
 		else
 		{
 			const auto aligned_pitch = utils::align<u32>(dst->pitch(), 4);
-			const usz texture_data_sz = dst->depth() * dst->height() * aligned_pitch;
+			const u32 texture_data_sz = dst->depth() * dst->height() * aligned_pitch;
 			data_upload_buf.resize(texture_data_sz);
 		}
 

--- a/rpcs3/Emu/RSX/GL/glutils/program.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/program.cpp
@@ -8,8 +8,109 @@ namespace gl
 {
 	namespace glsl
 	{
+		void patch_macros_INTEL(std::string& source)
+		{
+			auto read_token = [&source](size_t start) -> std::tuple<size_t, size_t>
+			{
+				size_t string_begin = std::string::npos, i = start;
+				for (size_t count = 0; i < source.length(); ++i)
+				{
+					const auto& c = source[i];
+					const auto is_space = std::isspace(c);
+
+					if (string_begin == std::string::npos)
+					{
+						if (c == '\n') break;
+						if (is_space) continue;
+
+						string_begin = i;
+					}
+
+					if (is_space)
+					{
+						if (!count) break;
+					}
+					else if (c == '(')
+					{
+						count++;
+					}
+					else if (c == ')')
+					{
+						count--;
+					}
+				}
+
+				return std::make_tuple(string_begin, i - 1);
+			};
+
+			auto is_exempt = [&source](const std::string_view& token) -> bool
+			{
+				const char* handled_keywords[] =
+				{
+					"SSBO_LOCATION(x)",
+					"UBO_LOCATION(x)",
+					"IMAGE_LOCATION(x)"
+				};
+
+				for (const auto& keyword : handled_keywords)
+				{
+					if (token.starts_with(keyword))
+					{
+						return false;
+					}
+				}
+
+				return true;
+			};
+
+			size_t prev_loc = 0;
+			while (true)
+			{
+				// Find macro define blocks and remove the outer-most brackets around the expression part
+				const auto next_loc = source.find("#define", prev_loc);
+				if (next_loc == std::string::npos)
+				{
+					break;
+				}
+
+				prev_loc = next_loc + 1;
+
+				const auto [name_start, name_end] = read_token(next_loc + ("#define"sv).length());
+				if (name_start == std::string::npos)
+				{
+					break;
+				}
+
+				const auto macro_name = std::string_view(source.data() + name_start, source.data() + name_end + 1);
+				if (is_exempt(macro_name))
+				{
+					continue;
+				}
+
+				const auto [expr_start, expr_end] = read_token(name_end + 1);
+				if (expr_start == std::string::npos)
+				{
+					continue;
+				}
+
+				if (source[expr_start] == '(' && source[expr_end] == ')')
+				{
+					rsx_log.notice("[Compiler warning] We'll remove brackets around the expression named '%s'. Add it to exclusion list if this is not desired.", macro_name);
+
+					source[expr_start] = ' ';
+					source[expr_end] = ' ';
+				}
+			}
+		}
+
 		void shader::precompile()
 		{
+			if (gl::get_driver_caps().vendor_INTEL)
+			{
+				// Workaround for broken macro expansion.
+				patch_macros_INTEL(source);
+			}
+
 			const char* str = source.c_str();
 			const GLint length = ::narrow<GLint>(source.length());
 

--- a/rpcs3/Emu/RSX/GL/glutils/program.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/program.cpp
@@ -81,7 +81,7 @@ namespace gl
 					break;
 				}
 
-				const auto macro_name = std::string_view(source.data() + name_start, source.data() + name_end + 1);
+				const auto macro_name = std::string_view(source.data() + name_start, (name_end - name_start) + 1);
 				if (is_exempt(macro_name))
 				{
 					continue;

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/GPUDeswizzle.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/GPUDeswizzle.glsl
@@ -1,13 +1,12 @@
 R"(
 #version 450
 
-#define SSBO_BASE_LOCATION %loc
-#define SSBO(x) (SSBO_BASE_LOCATION + x)
+#define SSBO_LOCATION(x) (x + %loc)
 
 layout(local_size_x = %ws, local_size_y = 1, local_size_z = 1) in;
 
-layout(%set, binding=SSBO(0), std430) buffer ssbo0{ uint data_in[]; };
-layout(%set, binding=SSBO(1), std430) buffer ssbo1{ uint data_out[]; };
+layout(%set, binding=SSBO_LOCATION(0), std430) buffer ssbo0{ uint data_in[]; };
+layout(%set, binding=SSBO_LOCATION(1), std430) buffer ssbo1{ uint data_out[]; };
 layout(%push_block) uniform parameters
 {
 	uint image_width;

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -554,6 +554,14 @@ namespace vk
 		}
 #endif
 
+		if (pgpu->get_driver_vendor() == driver_vendor::ANV &&
+			pgpu->descriptor_update_after_bind_mask & (1 << VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER))
+		{
+			// Just disable robust access for now. I'll revisit after ARC launches.
+			rsx_log.error("Robust buffer access is broken when enabled with EXT_descriptor_indexing on ANV");
+			enabled_features.robustBufferAccess = VK_FALSE;
+		}
+
 		VkDeviceCreateInfo device = {};
 		device.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 		device.pNext = nullptr;


### PR DESCRIPTION
- Disable robust buffer access on ANV if descriptor indexing is in use. This is a long-standing driver bug with no solutions expected any time soon, so we might as well add an official workaround.
- Temporary workaround for OpenGL shaders not compiling on intel. This workaround will be dropped soon and we shall switch to SPIRV shaders on that platform. INTEL will only be supported for OpenGL when the GL_ARB_gl_spirv extension is supported after that point. The OpenGL driver is too broken to be considered usable otherwise.

Fixes https://github.com/RPCS3/rpcs3/issues/12285
Fixes ANV incompatibility
Adds one task to https://github.com/RPCS3/rpcs3/issues/12166

