### PR TITLE
Overlays: Improve media list dialog

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -111,7 +111,7 @@ error_code cell_music_select_contents()
 
 	const std::string dir_path = "/dev_hdd0/music";
 	const std::string vfs_dir_path = vfs::get("/dev_hdd0/music");
-	const std::string title = get_localized_string(localized_string_id::RSX_OVERLAYS_MEDIA_DIALOG_EMPTY);
+	const std::string title = get_localized_string(localized_string_id::RSX_OVERLAYS_MEDIA_DIALOG_TITLE);
 
 	error_code error = rsx::overlays::show_media_list_dialog(rsx::overlays::media_list_dialog::media_type::audio, vfs_dir_path, title,
 		[&music, dir_path, vfs_dir_path](s32 status, utils::media_info info)

--- a/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
@@ -183,7 +183,7 @@ error_code cell_music_decode_select_contents()
 
 	const std::string dir_path = "/dev_hdd0/music";
 	const std::string vfs_dir_path = vfs::get("/dev_hdd0/music");
-	const std::string title = get_localized_string(localized_string_id::RSX_OVERLAYS_MEDIA_DIALOG_EMPTY);
+	const std::string title = get_localized_string(localized_string_id::RSX_OVERLAYS_MEDIA_DIALOG_TITLE);
 
 	error_code error = rsx::overlays::show_media_list_dialog(rsx::overlays::media_list_dialog::media_type::audio, vfs_dir_path, title,
 		[&dec, dir_path, vfs_dir_path](s32 status, utils::media_info info)

--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.h
@@ -27,6 +27,7 @@ namespace rsx
 				std::string name;
 				std::string path;
 				utils::media_info info;
+				u32 index = 0;
 
 				media_entry* parent = nullptr;
 				std::vector<media_entry> children;

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -65,7 +65,7 @@ save_data_list_dialog::save_data_list_dialog(const std::vector<SaveDataEntry>& e
 		QPushButton *saveNewEntry = new QPushButton(tr("Save New Entry"), this);
 		connect(saveNewEntry, &QAbstractButton::clicked, this, [&]()
 		{
-			m_entry = selection_code::new_save;
+			m_entry = rsx::overlays::user_interface::selection_code::new_save;
 			accept();
 		});
 		hbox_action->addWidget(saveNewEntry);
@@ -135,15 +135,15 @@ s32 save_data_list_dialog::GetSelection() const
 {
 	if (result() == QDialog::Accepted)
 	{
-		if (m_entry == selection_code::new_save)
+		if (m_entry == rsx::overlays::user_interface::selection_code::new_save)
 		{ // Save new entry
-			return selection_code::new_save;
+			return rsx::overlays::user_interface::selection_code::new_save;
 		}
 		return m_list->item(m_entry, 0)->data(Qt::UserRole).toInt();
 	}
 
 	// Cancel is pressed. May figure out proper cellsavedata code to use later.
-	return selection_code::canceled;
+	return rsx::overlays::user_interface::selection_code::canceled;
 }
 
 void save_data_list_dialog::OnSort(int logicalIndex)

--- a/rpcs3/rpcs3qt/save_data_list_dialog.h
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.h
@@ -3,6 +3,7 @@
 #include "util/types.hpp"
 #include "Emu/Memory/vm.h"
 #include "Emu/Cell/Modules/cellSaveData.h"
+#include "Emu/RSX/Overlays/overlays.h"
 
 #include <QTableWidget>
 #include <QDialog>
@@ -20,12 +21,6 @@ class save_data_list_dialog : public QDialog
 {
 	Q_OBJECT
 
-	enum selection_code
-	{
-		new_save = -1,
-		canceled = -2
-	};
-
 public:
 	explicit save_data_list_dialog(const std::vector<SaveDataEntry>& entries, s32 focusedEntry, u32 op, vm::ptr<CellSaveDataListSet>, QWidget* parent = nullptr);
 
@@ -37,7 +32,7 @@ private:
 	void UpdateSelectionLabel();
 	void UpdateList();
 
-	s32 m_entry = selection_code::new_save;
+	s32 m_entry = rsx::overlays::user_interface::selection_code::new_save;
 	QLabel* m_entry_label = nullptr;
 
 	QTableWidget* m_list = nullptr;


### PR DESCRIPTION
During my cellMusicDecode testing I found a couple of bugs in the media list dialog.

- Fixed the title. It defaulted to "No media found"
- Added ability to jump out of a directory and into the previous one using the "Back" button (circle)
- The list now focuses the current directory after going back
- The Qt savedata dialog now uses the rsx overlays selection codes