### PR TITLE
LV2 Optimizations

### DIFF
--- a/Utilities/bit_set.h
+++ b/Utilities/bit_set.h
@@ -371,12 +371,12 @@ public:
 	bool bit_test_reset(uint bit) = delete;
 	bool bit_test_invert(uint bit) = delete;
 
-	bool all_of(bs_t arg)
+	bool all_of(bs_t arg) const
 	{
 		return base::load().all_of(arg);
 	}
 
-	bool none_of(bs_t arg)
+	bool none_of(bs_t arg) const
 	{
 		return base::load().none_of(arg);
 	}

--- a/Utilities/mutex.h
+++ b/Utilities/mutex.h
@@ -171,6 +171,11 @@ public:
 	{
 		return m_value.load() < c_one - 1;
 	}
+
+	bool has_waiters() const
+	{
+		return m_value.load() > c_one;
+	}
 };
 
 // Simplified shared (reader) lock implementation.

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -946,6 +946,24 @@ u32* cpu_thread::get_pc2()
 	return nullptr;
 }
 
+cpu_thread* cpu_thread::get_next_cpu()
+{
+	switch (id_type())
+	{
+	case 1:
+	{
+		return static_cast<ppu_thread*>(this)->next_cpu;
+	}
+	case 2:
+	{
+		return static_cast<spu_thread*>(this)->next_cpu;
+	}
+	default: break;
+	}
+
+	return nullptr;
+}
+
 std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu);
 
 void cpu_thread::dump_all(std::string& ret) const

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -140,6 +140,7 @@ public:
 
 	u32 get_pc() const;
 	u32* get_pc2(); // Last PC before stepping for the debugger (may be null)
+	cpu_thread* get_next_cpu(); // Access next_cpu member if the is one
 
 	void notify();
 	cpu_thread& operator=(thread_state);

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -606,6 +606,7 @@ void cell_audio_thread::advance(u64 timestamp)
 
 	for (u32 i = 0; i < queue_count; i++)
 	{
+		lv2_obj::notify_all_t notify;
 		queues[i]->send(event_sources[i], 0, 0, 0);
 	}
 }

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -2413,8 +2413,8 @@ s32 _spurs::add_workload(ppu_thread& ppu, vm::ptr<CellSpurs> spurs, vm::ptr<u32>
 
 	vm::atomic_op(spurs->wklMaxContention[index], [&](u8& v)
 	{
-		v &= (wnum <= 15 ? ~0xf : ~0xf0);
-		v |= (maxContention > 8 ? 8 : maxContention) << 4;
+		v &= (wnum <= 15 ? 0xf0 : 0x0f);
+		v |= (maxContention > 8 ? 8 : maxContention) << (wnum < CELL_SPURS_MAX_WORKLOAD ? 0 : 4);
 	});
 
 	vm::atomic_op<true>((wnum <= 15 ? spurs->wklSignal1 : spurs->wklSignal2), [&](be_t<u16>& data)

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -323,6 +323,10 @@ public:
 	std::shared_ptr<utils::serial> optional_savestate_state;
 	bool interrupt_thread_executing = false;
 
+	atomic_t<ppu_thread*> next_cpu{}; // LV2 sleep queues' node link
+	atomic_t<ppu_thread*> next_ppu{}; // LV2 PPU running queue's node link
+	bool ack_suspend = false;
+
 	be_t<u64>* get_stack_arg(s32 i, u64 align = alignof(u64));
 	void exec_task();
 	void fast_call(u32 addr, u64 rtoc);

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -323,8 +323,8 @@ public:
 	std::shared_ptr<utils::serial> optional_savestate_state;
 	bool interrupt_thread_executing = false;
 
-	atomic_t<ppu_thread*> next_cpu{}; // LV2 sleep queues' node link
-	atomic_t<ppu_thread*> next_ppu{}; // LV2 PPU running queue's node link
+	ppu_thread* next_cpu{}; // LV2 sleep queues' node link
+	ppu_thread* next_ppu{}; // LV2 PPU running queue's node link
 	bool ack_suspend = false;
 
 	be_t<u64>* get_stack_arg(s32 i, u64 align = alignof(u64));

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4860,9 +4860,9 @@ bool spu_thread::stop_and_signal(u32 code)
 			}
 		}
 
-		while (auto old = state.fetch_sub(cpu_flag::signal))
+		while (auto old = +state)
 		{
-			if (old & cpu_flag::signal)
+			if (old & cpu_flag::signal && state.test_and_reset(cpu_flag::signal))
 			{
 				break;
 			}

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4832,7 +4832,7 @@ bool spu_thread::stop_and_signal(u32 code)
 
 			if (queue->events.empty())
 			{
-				queue->sq.emplace_back(this);
+				lv2_obj::emplace(queue->sq, this);
 				group->run_state = SPU_THREAD_GROUP_STATUS_WAITING;
 				group->waiter_spu_index = index;
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1362,6 +1362,7 @@ void spu_thread::cpu_return()
 		if (ensure(group->running)-- == 1)
 		{
 			{
+				lv2_obj::notify_all_t notify;
 				std::lock_guard lock(group->mutex);
 				group->run_state = SPU_THREAD_GROUP_STATUS_INITIALIZED;
 
@@ -4268,6 +4269,8 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 		}
 
 		state += cpu_flag::wait;
+
+		lv2_obj::notify_all_t notify;
 
 		const u32 code = value >> 24;
 		{

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -815,6 +815,8 @@ public:
 	const u32 option; // sys_spu_thread_initialize option
 	const u32 lv2_id; // The actual id that is used by syscalls
 
+	atomic_t<spu_thread*> next_cpu{}; // LV2 thread queues' node link
+
 	// Thread name
 	atomic_ptr<std::string> spu_tname;
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -815,7 +815,7 @@ public:
 	const u32 option; // sys_spu_thread_initialize option
 	const u32 lv2_id; // The actual id that is used by syscalls
 
-	atomic_t<spu_thread*> next_cpu{}; // LV2 thread queues' node link
+	spu_thread* next_cpu{}; // LV2 thread queues' node link
 
 	// Thread name
 	atomic_ptr<std::string> spu_tname;

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -49,6 +49,7 @@
 #include "sys_crypto_engine.h"
 
 #include <optional>
+#include <deque>
 
 extern std::string ppu_get_syscall_name(u64 code);
 
@@ -1187,13 +1188,17 @@ std::string ppu_get_syscall_name(u64 code)
 }
 
 DECLARE(lv2_obj::g_mutex);
-DECLARE(lv2_obj::g_ppu);
-DECLARE(lv2_obj::g_pending);
-DECLARE(lv2_obj::g_waiting);
-DECLARE(lv2_obj::g_to_sleep);
+DECLARE(lv2_obj::g_ppu){};
+DECLARE(lv2_obj::g_pending){};
 
 thread_local DECLARE(lv2_obj::g_to_notify){};
 thread_local DECLARE(lv2_obj::g_to_awake);
+
+// Scheduler queue for timeouts (wait until -> thread)
+static std::deque<std::pair<u64, class cpu_thread*>> g_waiting;
+
+// Threads which must call lv2_obj::sleep before the scheduler starts
+static std::deque<class cpu_thread*> g_to_sleep;
 
 namespace cpu_counter
 {
@@ -1260,7 +1265,7 @@ void lv2_obj::sleep_unlocked(cpu_thread& thread, u64 timeout, bool notify_later)
 
 	if (auto ppu = thread.try_get<ppu_thread>())
 	{
-		ppu_log.trace("sleep() - waiting (%zu)", g_pending.size());
+		ppu_log.trace("sleep() - waiting (%zu)", g_pending);
 
 		const auto [_, ok] = ppu->state.fetch_op([&](bs_t<cpu_flag>& val)
 		{
@@ -1280,10 +1285,11 @@ void lv2_obj::sleep_unlocked(cpu_thread& thread, u64 timeout, bool notify_later)
 		}
 
 		// Find and remove the thread
-		if (!unqueue(g_ppu, ppu))
+		if (!unqueue(g_ppu, ppu, &ppu_thread::next_ppu))
 		{
-			if (unqueue(g_to_sleep, ppu))
+			if (auto it = std::find(g_to_sleep.begin(), g_to_sleep.end(), ppu); it != g_to_sleep.end())
 			{
+				g_to_sleep.erase(it);
 				ppu->start_time = start_time;
 				on_to_sleep_update();
 			}
@@ -1293,15 +1299,19 @@ void lv2_obj::sleep_unlocked(cpu_thread& thread, u64 timeout, bool notify_later)
 			return;
 		}
 
-		unqueue(g_pending, ppu);
+		if (std::exchange(ppu->ack_suspend, false))
+		{
+			g_pending--;
+		}
 
 		ppu->raddr = 0; // Clear reservation
 		ppu->start_time = start_time;
 	}
 	else if (auto spu = thread.try_get<spu_thread>())
 	{
-		if (unqueue(g_to_sleep, spu))
+		if (auto it = std::find(g_to_sleep.begin(), g_to_sleep.end(), spu); it != g_to_sleep.end())
 		{
+			g_to_sleep.erase(it);
 			on_to_sleep_update();
 		}
 
@@ -1344,7 +1354,7 @@ bool lv2_obj::awake_unlocked(cpu_thread* cpu, bool notify_later, s32 prio)
 	default:
 	{
 		// Priority set
-		if (static_cast<ppu_thread*>(cpu)->prio.exchange(prio) == prio || !unqueue(g_ppu, cpu))
+		if (static_cast<ppu_thread*>(cpu)->prio.exchange(prio) == prio || !unqueue(g_ppu, static_cast<ppu_thread*>(cpu), &ppu_thread::next_ppu))
 		{
 			return true;
 		}
@@ -1353,36 +1363,66 @@ bool lv2_obj::awake_unlocked(cpu_thread* cpu, bool notify_later, s32 prio)
 	}
 	case yield_cmd:
 	{
+		usz i = 0;
+
 		// Yield command
-		for (usz i = 0;; i++)
+		for (auto ppu_next = &g_ppu;; i++)
 		{
-			if (i + 1 >= g_ppu.size())
+			const auto ppu = +*ppu_next;
+
+			if (!ppu)
 			{
 				return false;
 			}
 
-			if (const auto ppu = g_ppu[i]; ppu == cpu)
+			if (ppu == cpu)
 			{
-				usz j = i + 1;
+				auto ppu2_next = &ppu->next_ppu;
 
-				for (; j < g_ppu.size(); j++)
+				if (auto next = +*ppu2_next; !next || next->prio != ppu->prio)
 				{
-					if (g_ppu[j]->prio != ppu->prio)
+					return false;
+				}
+
+				for (;; i++)
+				{
+					const auto next = +*ppu2_next;
+
+					if (auto next2 = +next->next_ppu; !next2 || next2->prio != ppu->prio)
 					{
 						break;
 					}
+
+					ppu2_next = &next->next_ppu;
 				}
 
-				if (j == i + 1)
+				if (ppu2_next == &ppu->next_ppu)
 				{
 					// Empty 'same prio' threads list
 					return false;
 				}
 
-				// Rotate current thread to the last position of the 'same prio' threads list
-				std::rotate(g_ppu.begin() + i, g_ppu.begin() + i + 1, g_ppu.begin() + j);
+				auto ppu2 = +*ppu2_next;
 
-				if (j <= g_cfg.core.ppu_threads + 0u)
+				// Rotate current thread to the last position of the 'same prio' threads list
+				ppu_next->release(ppu2);
+
+				// Exchange forward pointers
+				if (ppu->next_ppu != ppu2)
+				{
+					auto ppu2_val = +ppu2->next_ppu;
+					ppu2->next_ppu.release(+ppu->next_ppu);
+					ppu->next_ppu.release(ppu2_val);
+					ppu2_next->release(ppu);
+				}
+				else
+				{
+					auto ppu2_val = +ppu2->next_ppu;
+					ppu2->next_ppu.release(ppu);
+					ppu->next_ppu.release(ppu2_val);
+				}
+
+				if (i <= g_cfg.core.ppu_threads + 0u)
 				{
 					// Threads were rotated, but no context switch was made
 					return false;
@@ -1392,7 +1432,10 @@ bool lv2_obj::awake_unlocked(cpu_thread* cpu, bool notify_later, s32 prio)
 				cpu = nullptr; // Disable current thread enqueing, also enable threads list enqueing
 				break;
 			}
+
+			ppu_next = &ppu->next_ppu;
 		}
+
 		break;
 	}
 	case enqueue_cmd:
@@ -1403,20 +1446,25 @@ bool lv2_obj::awake_unlocked(cpu_thread* cpu, bool notify_later, s32 prio)
 
 	const auto emplace_thread = [](cpu_thread* const cpu)
 	{
-		for (auto it = g_ppu.cbegin(), end = g_ppu.cend();; it++)
+		for (auto it = &g_ppu;;)
 		{
-			if (it != end && *it == cpu)
+			const auto next = +*it;
+
+			if (next == cpu)
 			{
-				ppu_log.trace("sleep() - suspended (p=%zu)", g_pending.size());
+				ppu_log.trace("sleep() - suspended (p=%zu)", g_pending);
 				return false;
 			}
 
 			// Use priority, also preserve FIFO order
-			if (it == end || (*it)->prio > static_cast<ppu_thread*>(cpu)->prio)
+			if (!next || next->prio > static_cast<ppu_thread*>(cpu)->prio)
 			{
-				g_ppu.insert(it, static_cast<ppu_thread*>(cpu));
+				it->release(static_cast<ppu_thread*>(cpu));
+				static_cast<ppu_thread*>(cpu)->next_ppu.release(next);
 				break;
 			}
+
+			it = &next->next_ppu;
 		}
 
 		// Unregister timeout if necessary
@@ -1448,20 +1496,28 @@ bool lv2_obj::awake_unlocked(cpu_thread* cpu, bool notify_later, s32 prio)
 	}
 
 	// Remove pending if necessary
-	if (!g_pending.empty() && ((cpu && cpu == get_current_cpu_thread()) || prio == yield_cmd))
+	if (g_pending && ((cpu && cpu == get_current_cpu_thread()) || prio == yield_cmd))
 	{
-		unqueue(g_pending, get_current_cpu_thread());
+		if (auto cur = cpu_thread::get_current<ppu_thread>())
+		{
+			if (std::exchange(cur->ack_suspend, false))
+			{
+				g_pending--;
+			}
+		}
 	}
 
-	// Suspend threads if necessary
-	for (usz i = g_cfg.core.ppu_threads; changed_queue && i < g_ppu.size(); i++)
-	{
-		const auto target = g_ppu[i];
+	auto target = +g_ppu;
 
-		if (!target->state.test_and_set(cpu_flag::suspend))
+	// Suspend threads if necessary
+	for (usz i = 0, thread_count = g_cfg.core.ppu_threads; changed_queue && target; target = target->next_ppu, i++)
+	{
+		if (i >= thread_count && cpu_flag::suspend - target->state)
 		{
 			ppu_log.trace("suspend(): %s", target->id);
-			g_pending.emplace_back(target);
+			target->ack_suspend = true;
+			g_pending++;
+			ensure(!target->state.test_and_set(cpu_flag::suspend));
 
 			if (is_paused(target->state - cpu_flag::suspend))
 			{
@@ -1476,23 +1532,23 @@ bool lv2_obj::awake_unlocked(cpu_thread* cpu, bool notify_later, s32 prio)
 
 void lv2_obj::cleanup()
 {
-	g_ppu.clear();
-	g_pending.clear();
-	g_waiting.clear();
+	g_ppu = nullptr;
 	g_to_sleep.clear();
+	g_waiting.clear();
+	g_pending = 0;
 }
 
 void lv2_obj::schedule_all(bool notify_later)
 {
-	if (g_pending.empty() && g_to_sleep.empty())
+	if (!g_pending && g_to_sleep.empty())
 	{
 		usz notify_later_idx = notify_later ? 0 : std::size(g_to_notify) - 1;
 
-		// Wake up threads
-		for (usz i = 0, x = std::min<usz>(g_cfg.core.ppu_threads, g_ppu.size()); i < x; i++)
-		{
-			const auto target = g_ppu[i];
+		auto target = +g_ppu;
 
+		// Wake up threads
+		for (usz x = g_cfg.core.ppu_threads; target && x; target = target->next_ppu, x--)
+		{
 			if (target->state & cpu_flag::suspend)
 			{
 				ppu_log.trace("schedule(): %s", target->id);
@@ -1557,9 +1613,19 @@ ppu_thread_status lv2_obj::ppu_state(ppu_thread* ppu, bool lock_idm, bool lock_l
 		opt_lock[1].emplace(lv2_obj::g_mutex);
 	}
 
-	const auto it = std::find(g_ppu.begin(), g_ppu.end(), ppu);
+	usz pos = umax;
+	usz i = 0;
 
-	if (it == g_ppu.end())
+	for (auto target = +g_ppu; target; target = target->next_ppu, i++)
+	{
+		if (target == ppu)
+		{
+			pos = i;
+			break;
+		}
+	}
+
+	if (pos == umax)
 	{
 		if (!ppu->interrupt_thread_executing)
 		{
@@ -1569,7 +1635,7 @@ ppu_thread_status lv2_obj::ppu_state(ppu_thread* ppu, bool lock_idm, bool lock_l
 		return PPU_THREAD_STATUS_SLEEP;
 	}
 
-	if (it - g_ppu.begin() >= g_cfg.core.ppu_threads)
+	if (pos >= g_cfg.core.ppu_threads + 0u)
 	{
 		return PPU_THREAD_STATUS_RUNNABLE;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -348,9 +348,9 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 		return CELL_EPERM;
 	}
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -9,6 +9,8 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 
+#include "util/asm.hpp"
+
 LOG_CHANNEL(sys_cond);
 
 lv2_cond::lv2_cond(utils::serial& ar)
@@ -372,6 +374,16 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 
 			ppu.state += cpu_flag::again;
 			return {};
+		}
+
+		for (usz i = 0; cpu_flag::signal - ppu.state && i < 50; i++)
+		{
+			busy_wait(500);
+		}
+
+		if (ppu.state & cpu_flag::signal)
+ 		{
+			continue;
 		}
 
 		if (timeout)

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -300,7 +300,7 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 			return -1;
 		}
 
-		lv2_obj::notify_all_t notify;
+		lv2_obj::notify_all_t notify(ppu);
 
 		std::lock_guard lock(cond.mutex->mutex);
 

--- a/rpcs3/Emu/Cell/lv2/sys_cond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.h
@@ -27,7 +27,7 @@ struct lv2_cond final : lv2_obj
 	const u32 mtx_id;
 
 	std::shared_ptr<lv2_mutex> mutex; // Associated Mutex
-	atomic_t<ppu_thread*> sq{};
+	ppu_thread* sq{};
 
 	lv2_cond(u64 key, u64 name, u32 mtx_id, std::shared_ptr<lv2_mutex> mutex)
 		: key(key)

--- a/rpcs3/Emu/Cell/lv2/sys_cond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.h
@@ -27,8 +27,7 @@ struct lv2_cond final : lv2_obj
 	const u32 mtx_id;
 
 	std::shared_ptr<lv2_mutex> mutex; // Associated Mutex
-	atomic_t<u32> waiters{0};
-	std::deque<cpu_thread*> sq;
+	atomic_t<ppu_thread*> sq{};
 
 	lv2_cond(u64 key, u64 name, u32 mtx_id, std::shared_ptr<lv2_mutex> mutex)
 		: key(key)

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -451,9 +451,9 @@ error_code sys_event_queue_receive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sys_e
 	}
 
 	// If cancelled, gpr[3] will be non-zero. Other registers must contain event data.
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -10,6 +10,8 @@
 #include "Emu/Cell/SPUThread.h"
 #include "sys_process.h"
 
+#include "util/asm.hpp"
+
 LOG_CHANNEL(sys_event);
 
 lv2_event_queue::lv2_event_queue(u32 protocol, s32 type, s32 size, u64 name, u64 ipc_key) noexcept
@@ -469,6 +471,16 @@ error_code sys_event_queue_receive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sys_e
 
 			ppu.state += cpu_flag::again;
 			return {};
+		}
+
+		for (usz i = 0; cpu_flag::signal - ppu.state && i < 50; i++)
+		{
+			busy_wait(500);
+		}
+
+		if (ppu.state & cpu_flag::signal)
+ 		{
+			continue;
 		}
 
 		if (timeout)

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -421,7 +421,7 @@ error_code sys_event_queue_receive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sys_e
 			return CELL_EINVAL;
 		}
 
-		lv2_obj::notify_all_t notify;
+		lv2_obj::notify_all_t notify(ppu);
 
 		std::lock_guard lock(queue.mutex);
 

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -103,11 +103,11 @@ struct lv2_event_queue final : public lv2_obj
 	static void save_ptr(utils::serial&, lv2_event_queue*);
 	static std::shared_ptr<lv2_event_queue> load_ptr(utils::serial& ar, std::shared_ptr<lv2_event_queue>& queue);
 
-	CellError send(lv2_event event, bool notify_later = false);
+	CellError send(lv2_event event);
 
-	CellError send(u64 source, u64 d1, u64 d2, u64 d3, bool notify_later = false)
+	CellError send(u64 source, u64 d1, u64 d2, u64 d3)
 	{
-		return send(std::make_tuple(source, d1, d2, d3), notify_later);
+		return send(std::make_tuple(source, d1, d2, d3));
 	}
 
 	// Get event queue by its global key

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -92,8 +92,8 @@ struct lv2_event_queue final : public lv2_obj
 
 	shared_mutex mutex;
 	std::deque<lv2_event> events;
-	atomic_t<spu_thread*> sq{};
-	atomic_t<ppu_thread*> pq{};
+	spu_thread* sq{};
+	ppu_thread* pq{};
 
 	lv2_event_queue(u32 protocol, s32 type, s32 size, u64 name, u64 ipc_key) noexcept;
 

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -4,7 +4,10 @@
 
 #include "Emu/Memory/vm_ptr.h"
 
+#include <deque>
+
 class cpu_thread;
+class spu_thrread;
 
 // Event Queue Type
 enum : u32
@@ -89,7 +92,8 @@ struct lv2_event_queue final : public lv2_obj
 
 	shared_mutex mutex;
 	std::deque<lv2_event> events;
-	std::deque<cpu_thread*> sq;
+	atomic_t<spu_thread*> sq{};
+	atomic_t<ppu_thread*> pq{};
 
 	lv2_event_queue(u32 protocol, s32 type, s32 size, u64 name, u64 ipc_key) noexcept;
 

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -99,11 +99,11 @@ struct lv2_event_queue final : public lv2_obj
 	static void save_ptr(utils::serial&, lv2_event_queue*);
 	static std::shared_ptr<lv2_event_queue> load_ptr(utils::serial& ar, std::shared_ptr<lv2_event_queue>& queue);
 
-	CellError send(lv2_event);
+	CellError send(lv2_event event, bool notify_later = false);
 
-	CellError send(u64 source, u64 d1, u64 d2, u64 d3)
+	CellError send(u64 source, u64 d1, u64 d2, u64 d3, bool notify_later = false)
 	{
-		return send(std::make_tuple(source, d1, d2, d3));
+		return send(std::make_tuple(source, d1, d2, d3), notify_later);
 	}
 
 	// Get event queue by its global key

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -152,7 +152,7 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 			return {};
 		}
 
-		lv2_obj::notify_all_t notify;
+		lv2_obj::notify_all_t notify(ppu);
 
 		std::lock_guard lock(flag.mutex);
 

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -150,6 +150,8 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 			return {};
 		}
 
+		lv2_obj::notify_all_t notify;
+
 		std::lock_guard lock(flag.mutex);
 
 		if (flag.pattern.fetch_op([&](u64& pat)
@@ -167,7 +169,7 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 
 		flag.waiters++;
 		flag.sq.emplace_back(&ppu);
-		flag.sleep(ppu, timeout);
+		flag.sleep(ppu, timeout, true);
 		return CELL_EBUSY;
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -191,9 +191,9 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 		return CELL_OK;
 	}
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -9,6 +9,8 @@
 
 #include <algorithm>
 
+#include "util/asm.hpp"
+
 LOG_CHANNEL(sys_event_flag);
 
 lv2_event_flag::lv2_event_flag(utils::serial& ar)
@@ -209,6 +211,16 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 
 			ppu.state += cpu_flag::again;
 			return {};
+		}
+
+		for (usz i = 0; cpu_flag::signal - ppu.state && i < 50; i++)
+		{
+			busy_wait(500);
+		}
+
+		if (ppu.state & cpu_flag::signal)
+ 		{
+			continue;
 		}
 
 		if (timeout)

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.h
@@ -41,9 +41,8 @@ struct lv2_event_flag final : lv2_obj
 	const u64 name;
 
 	shared_mutex mutex;
-	atomic_t<u32> waiters{0};
 	atomic_t<u64> pattern;
-	std::deque<cpu_thread*> sq;
+	atomic_t<ppu_thread*> sq{};
 
 	lv2_event_flag(u32 protocol, u64 key, s32 type, u64 name, u64 pattern) noexcept
 		: protocol{static_cast<u8>(protocol)}

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.h
@@ -42,7 +42,7 @@ struct lv2_event_flag final : lv2_obj
 
 	shared_mutex mutex;
 	atomic_t<u64> pattern;
-	atomic_t<ppu_thread*> sq{};
+	ppu_thread* sq{};
 
 	lv2_event_flag(u32 protocol, u64 key, s32 type, u64 name, u64 pattern) noexcept
 		: protocol{static_cast<u8>(protocol)}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -127,6 +127,8 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u6
 
 		if (cond.waiters)
 		{
+			lv2_obj::notify_all_t notify;
+
 			std::lock_guard lock(cond.mutex);
 
 			if (cpu)
@@ -188,7 +190,7 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u6
 
 				if (result)
 				{
-					cond.awake(result);
+					cond.awake(result, true);
 				}
 
 				return 1;
@@ -255,6 +257,8 @@ error_code _sys_lwcond_signal_all(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 
 		if (cond.waiters)
 		{
+			lv2_obj::notify_all_t notify;
+
 			std::lock_guard lock(cond.mutex);
 
 			u32 result = 0;
@@ -294,7 +298,7 @@ error_code _sys_lwcond_signal_all(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 
 			if (need_awake)
 			{
-				lv2_obj::awake_all();
+				lv2_obj::awake_all(true);
 			}
 
 			return result;
@@ -341,6 +345,8 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 		// Increment lwmutex's lwcond's waiters count
 		mutex->lwcond_waiters++;
 
+		lv2_obj::notify_all_t notify;
+
 		std::lock_guard lock(cond.mutex);
 
 		const bool mutex_sleep = sstate.try_read<bool>().second;
@@ -381,7 +387,7 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 		}
 
 		// Sleep current thread and schedule lwmutex waiter
-		cond.sleep(ppu, timeout);
+		cond.sleep(ppu, timeout, true);
 	});
 
 	if (!cond || !mutex)

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -400,9 +400,9 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 		return CELL_OK;
 	}
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "sys_lwcond.h"
 
 #include "Emu/IdManager.h"
@@ -343,7 +343,7 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 		// Increment lwmutex's lwcond's waiters count
 		mutex->lwcond_waiters++;
 
-		lv2_obj::notify_all_t notify;
+		lv2_obj::notify_all_t notify(ppu);
 
 		std::lock_guard lock(cond.mutex);
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+﻿#include "stdafx.h"
 #include "sys_lwcond.h"
 
 #include "Emu/IdManager.h"
@@ -6,6 +6,8 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 #include "sys_lwmutex.h"
+
+#include "util/asm.hpp"
 
 LOG_CHANNEL(sys_lwcond);
 
@@ -423,6 +425,16 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 			sstate(mutex_sleep);
 			ppu.state += cpu_flag::again;
 			break;
+		}
+
+		for (usz i = 0; cpu_flag::signal - ppu.state && i < 50; i++)
+		{
+			busy_wait(500);
+		}
+
+		if (ppu.state & cpu_flag::signal)
+ 		{
+			continue;
 		}
 
 		if (timeout)

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.h
@@ -31,8 +31,7 @@ struct lv2_lwcond final : lv2_obj
 	vm::ptr<sys_lwcond_t> control;
 
 	shared_mutex mutex;
-	atomic_t<u32> waiters{0};
-	std::deque<cpu_thread*> sq;
+	atomic_t<ppu_thread*> sq{};
 
 	lv2_lwcond(u64 name, u32 lwid, u32 protocol, vm::ptr<sys_lwcond_t> control) noexcept
 		: name(std::bit_cast<be_t<u64>>(name))

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.h
@@ -31,7 +31,7 @@ struct lv2_lwcond final : lv2_obj
 	vm::ptr<sys_lwcond_t> control;
 
 	shared_mutex mutex;
-	atomic_t<ppu_thread*> sq{};
+	ppu_thread* sq{};
 
 	lv2_lwcond(u64 name, u32 lwid, u32 protocol, vm::ptr<sys_lwcond_t> control) noexcept
 		: name(std::bit_cast<be_t<u64>>(name))

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -184,9 +184,9 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 		return not_an_error(ppu.gpr[3]);
 	}
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -6,6 +6,8 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 
+#include "util/asm.hpp"
+
 LOG_CHANNEL(sys_lwmutex);
 
 lv2_lwmutex::lv2_lwmutex(utils::serial& ar)
@@ -202,6 +204,16 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 
 			ppu.state += cpu_flag::again;
 			return {};
+		}
+
+		for (usz i = 0; cpu_flag::signal - ppu.state && i < 50; i++)
+		{
+			busy_wait(500);
+		}
+
+		if (ppu.state & cpu_flag::signal)
+ 		{
+			continue;
 		}
 
 		if (timeout)

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -146,7 +146,7 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 			return true;
 		}
 
-		lv2_obj::notify_all_t notify;
+		lv2_obj::notify_all_t notify(ppu);
 
 		std::lock_guard lock(mutex.mutex);
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -173,6 +173,7 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 		}
 
 		mutex.sleep(ppu, timeout);
+		notify.cleanup();
 		return false;
 	});
 
@@ -308,7 +309,7 @@ error_code _sys_lwmutex_unlock(ppu_thread& ppu, u32 lwmutex_id)
 			}
 
 			mutex.awake(cpu);
-			return;
+			notify.cleanup(); // lv2_lwmutex::mutex is not really active 99% of the time, can be ignored
 		}
 	});
 
@@ -345,7 +346,7 @@ error_code _sys_lwmutex_unlock2(ppu_thread& ppu, u32 lwmutex_id)
 
 			static_cast<ppu_thread*>(cpu)->gpr[3] = CELL_EBUSY;
 			mutex.awake(cpu);
-			return;
+			notify.cleanup(); // lv2_lwmutex::mutex is not really active 99% of the time, can be ignored
 		}
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -60,9 +60,16 @@ struct lv2_lwmutex final : lv2_obj
 	const be_t<u64> name;
 
 	shared_mutex mutex;
-	atomic_t<s32> signaled{0};
-	atomic_t<ppu_thread*> sq{};
 	atomic_t<s32> lwcond_waiters{0};
+
+	struct alignas(16) control_data_t
+	{
+		s32 signaled{0};
+		u32 reserved{};
+		ppu_thread* sq{};
+	};
+
+	atomic_t<control_data_t> lv2_control{};
 
 	lv2_lwmutex(u32 protocol, vm::ptr<sys_lwmutex_t> control, u64 name) noexcept
 		: protocol{static_cast<u8>(protocol)}
@@ -74,10 +81,28 @@ struct lv2_lwmutex final : lv2_obj
 	lv2_lwmutex(utils::serial& ar);
 	void save(utils::serial& ar);
 
-	// Add a waiter
-	template <typename T>
-	void add_waiter(T* cpu)
+	ppu_thread* load_sq() const
 	{
+		return atomic_storage<ppu_thread*>::load(lv2_control.raw().sq);
+	}
+
+	template <typename T>
+	s32 try_own(T* cpu, bool wait_only = false)
+	{
+		const s32 signal = lv2_control.fetch_op([&](control_data_t& data)
+		{
+			if (!data.signaled)
+			{
+				cpu->next_cpu = data.sq;
+				data.sq = cpu;
+			}
+			else
+			{
+				ensure(!wait_only);
+				data.signaled = 0;
+			}
+		}).signaled;
+
 		const bool notify = lwcond_waiters.fetch_op([](s32& val)
 		{
 			if (val + 0u <= 1u << 31)
@@ -92,13 +117,67 @@ struct lv2_lwmutex final : lv2_obj
 			return true;
 		}).second;
 
-		lv2_obj::emplace(sq, cpu);
-
 		if (notify)
 		{
 			// Notify lwmutex destroyer (may cause EBUSY to be returned for it)
 			lwcond_waiters.notify_all();
 		}
+	
+		return signal;
+	}
+
+	bool try_unlock(bool unlock2)
+	{
+		if (!load_sq())
+		{
+			control_data_t old{};
+			old.signaled = atomic_storage<s32>::load(lv2_control.raw().signaled);
+			control_data_t store = old;
+			store.signaled |= (unlock2 ? s32{smin} : 1);
+
+			if (lv2_control.compare_and_swap_test(old, store))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	template <typename T>
+	T* reown(bool unlock2 = false)
+	{
+		T* res{};
+		T* restore_next{};
+
+		lv2_control.fetch_op([&](control_data_t& data)
+		{
+			if (res)
+			{
+				res->next_cpu = restore_next;
+				res = nullptr;
+			}
+
+			if (auto sq = data.sq)
+			{
+				res = schedule<T>(data.sq, protocol);
+
+				if (sq == data.sq)
+				{
+					return false;
+				}
+
+				restore_next = res->next_cpu;
+				return true;
+			}
+			else
+			{
+				data.signaled |= (unlock2 ? s32{smin} : 1);
+				return true;
+			}
+		});
+
+		return res;
 	}
 };
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -141,7 +141,7 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 
 		if (result == CELL_EBUSY)
 		{
-			lv2_obj::notify_all_t notify;
+			lv2_obj::notify_all_t notify(ppu);
 
 			std::lock_guard lock(mutex.mutex);
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -7,6 +7,8 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 
+#include "util/asm.hpp"
+
 LOG_CHANNEL(sys_mutex);
 
 lv2_mutex::lv2_mutex(utils::serial& ar)
@@ -193,6 +195,16 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 
 			ppu.state += cpu_flag::again;
 			return {};
+		}
+
+		for (usz i = 0; cpu_flag::signal - ppu.state && i < 50; i++)
+		{
+			busy_wait(500);
+		}
+
+		if (ppu.state & cpu_flag::signal)
+ 		{
+			continue;
 		}
 
 		if (timeout)

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -169,6 +169,7 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 			else
 			{
 				mutex.sleep(ppu, timeout);
+				notify.cleanup();
 			}
 		}
 
@@ -314,6 +315,7 @@ error_code sys_mutex_unlock(ppu_thread& ppu, u32 mutex_id)
 			result = {};
 		}
 
+		notify.cleanup();
 		return result;
 	});
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -175,9 +175,9 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 
 	ppu.gpr[3] = CELL_OK;
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -4,6 +4,8 @@
 
 #include "Emu/Memory/vm_ptr.h"
 
+#include "Emu/Cell/PPUThread.h"
+
 struct sys_mutex_attribute_t
 {
 	be_t<u32> protocol; // SYS_SYNC_FIFO, SYS_SYNC_PRIORITY or SYS_SYNC_PRIORITY_INHERIT
@@ -21,6 +23,8 @@ struct sys_mutex_attribute_t
 	};
 };
 
+class ppu_thread;
+
 struct lv2_mutex final : lv2_obj
 {
 	static const u32 id_base = 0x85000000;
@@ -33,9 +37,16 @@ struct lv2_mutex final : lv2_obj
 
 	u32 cond_count = 0; // Condition Variables
 	shared_mutex mutex;
-	atomic_t<u32> owner{0};
 	atomic_t<u32> lock_count{0}; // Recursive Locks
-	atomic_t<ppu_thread*> sq{};
+
+	struct alignas(16) control_data_t
+	{
+		u32 owner{};
+		u32 reserved{};
+		ppu_thread* sq{};
+	};
+
+	atomic_t<control_data_t> control{};
 
 	lv2_mutex(u32 protocol, u32 recursive,u32 adaptive, u64 key, u64 name) noexcept
 		: protocol{static_cast<u8>(protocol)}
@@ -50,11 +61,24 @@ struct lv2_mutex final : lv2_obj
 	static std::shared_ptr<void> load(utils::serial& ar); 
 	void save(utils::serial& ar);
 
-	CellError try_lock(u32 id)
+	template <typename T>
+	CellError try_lock(T& cpu)
 	{
-		const u32 value = owner;
+		auto it = control.load();
 
-		if (value >> 1 == id)
+		if (!it.owner)
+		{
+			auto store = it;
+			store.owner = cpu.id;
+			if (!control.compare_and_swap_test(it, store))
+			{
+				return CELL_EBUSY;
+			}
+
+			return {};
+		}
+
+		if (it.owner == cpu.id)
 		{
 			// Recursive locking
 			if (recursive == SYS_SYNC_RECURSIVE)
@@ -71,44 +95,34 @@ struct lv2_mutex final : lv2_obj
 			return CELL_EDEADLK;
 		}
 
-		if (value == 0)
-		{
-			if (owner.compare_and_swap_test(0, id << 1))
-			{
-				return {};
-			}
-		}
-
 		return CELL_EBUSY;
 	}
 
 	template <typename T>
-	bool try_own(T& cpu, u32 id)
+	bool try_own(T& cpu)
 	{
-		if (owner.fetch_op([&](u32& val)
+		return control.atomic_op([&](control_data_t& data)
 		{
-			if (val == 0)
+			if (data.owner)
 			{
-				val = id << 1;
+				cpu.next_cpu = data.sq;
+				data.sq = &cpu;
+				return false;
 			}
 			else
 			{
-				val |= 1;
+				data.owner = cpu.id;
+				return true;
 			}
-		}))
-		{
-			lv2_obj::emplace(sq, &cpu);
-			return false;
-		}
-
-		return true;
+		});
 	}
 
-	CellError try_unlock(u32 id)
+	template <typename T>
+	CellError try_unlock(T& cpu)
 	{
-		const u32 value = owner;
+		auto it = control.load();
 
-		if (value >> 1 != id)
+		if (it.owner != cpu.id)
 		{
 			return CELL_EPERM;
 		}
@@ -119,9 +133,12 @@ struct lv2_mutex final : lv2_obj
 			return {};
 		}
 
-		if (value == id << 1)
+		if (!it.sq)
 		{
-			if (owner.compare_and_swap_test(value, 0))
+			auto store = it;
+			store.owner = 0;
+
+			if (control.compare_and_swap_test(it, store))
 			{
 				return {};
 			}
@@ -133,25 +150,42 @@ struct lv2_mutex final : lv2_obj
 	template <typename T>
 	T* reown()
 	{
-		if (auto cpu = schedule<T>(sq, protocol))
+		T* res{};
+		T* restore_next{};
+
+		control.fetch_op([&](control_data_t& data)
 		{
-			if (cpu->state & cpu_flag::again)
+			if (res)
 			{
-				return static_cast<T*>(cpu);
+				res->next_cpu = restore_next;
+				res = nullptr;
 			}
 
-			owner = cpu->id << 1 | !!sq;
-			return static_cast<T*>(cpu);
-		}
-		else
-		{
-			owner = 0;
-			return nullptr;
-		}
+			if (auto sq = data.sq)
+			{
+				res = schedule<T>(data.sq, protocol);
+
+				if (sq == data.sq)
+				{
+					atomic_storage<u32>::release(control.raw().owner, res->id);
+					return false;
+				}
+
+				restore_next = res->next_cpu;
+				data.owner = res->id;
+				return true;
+			}
+			else
+			{
+				data.owner = 0;
+				return true;
+			}
+		});
+
+		return res;
 	}
 };
 
-class ppu_thread;
 
 // Syscalls
 

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -358,7 +358,7 @@ error_code sys_net_bnet_accept(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr>
 	sys_net_sockaddr sn_addr{};
 	std::shared_ptr<lv2_socket> new_socket{};
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock)
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock)
 		{
 			const auto [success, res, res_socket, res_addr] = sock.accept();
 
@@ -391,6 +391,7 @@ error_code sys_net_bnet_accept(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr>
 					return false;
 				});
 
+			lv2_obj::prepare_for_sleep(ppu);
 			lv2_obj::sleep(ppu);
 			return false;
 		});
@@ -482,7 +483,7 @@ error_code sys_net_bnet_bind(ppu_thread& ppu, s32 s, vm::cptr<sys_net_sockaddr> 
 		return -SYS_NET_EAFNOSUPPORT;
 	}
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock) -> s32
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock) -> s32
 		{
 			return sock.bind(sn_addr);
 		});
@@ -519,7 +520,7 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 	s32 result               = 0;
 	sys_net_sockaddr sn_addr = *addr;
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock)
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock)
 		{
 			const auto success = sock.connect(sn_addr);
 
@@ -544,8 +545,8 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 					return false;
 				});
 
+			lv2_obj::prepare_for_sleep(ppu);
 			lv2_obj::sleep(ppu);
-
 			return false;
 		});
 
@@ -612,7 +613,7 @@ error_code sys_net_bnet_getpeername(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sock
 		return -SYS_NET_EINVAL;
 	}
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock) -> s32
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock) -> s32
 		{
 			auto [res, sn_addr] = sock.getpeername();
 
@@ -650,7 +651,7 @@ error_code sys_net_bnet_getsockname(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sock
 		return -SYS_NET_EINVAL;
 	}
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock) -> s32
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock) -> s32
 		{
 			auto [res, sn_addr] = sock.getsockname();
 
@@ -708,7 +709,7 @@ error_code sys_net_bnet_getsockopt(ppu_thread& ppu, s32 s, s32 level, s32 optnam
 		return -SYS_NET_EINVAL;
 	}
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock) -> s32
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock) -> s32
 		{
 			if (len < sizeof(s32))
 			{
@@ -750,7 +751,7 @@ error_code sys_net_bnet_listen(ppu_thread& ppu, s32 s, s32 backlog)
 		return -SYS_NET_EINVAL;
 	}
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock) -> s32
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock) -> s32
 		{
 			return sock.listen(backlog);
 		});
@@ -788,7 +789,7 @@ error_code sys_net_bnet_recvfrom(ppu_thread& ppu, s32 s, vm::ptr<void> buf, u32 
 	s32 result = 0;
 	sys_net_sockaddr sn_addr{};
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock)
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock)
 		{
 			const auto success = sock.recvfrom(flags, len);
 
@@ -832,6 +833,7 @@ error_code sys_net_bnet_recvfrom(ppu_thread& ppu, s32 s, vm::ptr<void> buf, u32 
 					return false;
 				});
 
+			lv2_obj::prepare_for_sleep(ppu);
 			lv2_obj::sleep(ppu);
 			return false;
 		});
@@ -929,7 +931,7 @@ error_code sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 l
 	const std::vector<u8> buf_copy(vm::_ptr<const char>(buf.addr()), vm::_ptr<const char>(buf.addr()) + len);
 	s32 result{};
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock)
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock)
 		{
 			auto success = sock.sendto(flags, buf_copy, sn_addr);
 
@@ -958,6 +960,7 @@ error_code sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 l
 					return false;
 				});
 
+			lv2_obj::prepare_for_sleep(ppu);
 			lv2_obj::sleep(ppu);
 			return false;
 		});
@@ -1036,7 +1039,7 @@ error_code sys_net_bnet_setsockopt(ppu_thread& ppu, s32 s, s32 level, s32 optnam
 
 	std::vector<u8> optval_copy(vm::_ptr<u8>(optval.addr()), vm::_ptr<u8>(optval.addr() + optlen));
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock) -> s32
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock) -> s32
 		{
 			return sock.setsockopt(level, optname, optval_copy);
 		});
@@ -1065,7 +1068,7 @@ error_code sys_net_bnet_shutdown(ppu_thread& ppu, s32 s, s32 how)
 		return -SYS_NET_EINVAL;
 	}
 
-	const auto sock = idm::check<lv2_socket>(s, [&](lv2_socket& sock) -> s32
+	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock) -> s32
 		{
 			return sock.shutdown(how);
 		});
@@ -1180,6 +1183,8 @@ error_code sys_net_bnet_poll(ppu_thread& ppu, vm::ptr<sys_net_pollfd> fds, s32 n
 
 	{
 		fds_buf.assign(fds.get_ptr(), fds.get_ptr() + nfds);
+
+		lv2_obj::prepare_for_sleep(ppu);
 
 		std::unique_lock nw_lock(g_fxo->get<network_context>().s_nw_mutex);
 		std::shared_lock lock(id_manager::g_mutex);

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -114,7 +114,7 @@ error_code sys_rwlock_rlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 			}
 		}
 
-		lv2_obj::notify_all_t notify;
+		lv2_obj::notify_all_t notify(ppu);
 
 		std::lock_guard lock(rwlock.mutex);
 
@@ -346,7 +346,7 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 			return val;
 		}
 
-		lv2_obj::notify_all_t notify;
+		lv2_obj::notify_all_t notify(ppu);
 
 		std::lock_guard lock(rwlock.mutex);
 

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -112,6 +112,8 @@ error_code sys_rwlock_rlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 			}
 		}
 
+		lv2_obj::notify_all_t notify;
+
 		std::lock_guard lock(rwlock.mutex);
 
 		const s64 _old = rwlock.owner.fetch_op([&](s64& val)
@@ -129,7 +131,7 @@ error_code sys_rwlock_rlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 		if (_old > 0 || _old & 1)
 		{
 			rwlock.rq.emplace_back(&ppu);
-			rwlock.sleep(ppu, timeout);
+			rwlock.sleep(ppu, timeout, true);
 			return false;
 		}
 
@@ -334,6 +336,8 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 			return val;
 		}
 
+		lv2_obj::notify_all_t notify;
+
 		std::lock_guard lock(rwlock.mutex);
 
 		const s64 _old = rwlock.owner.fetch_op([&](s64& val)
@@ -351,7 +355,7 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 		if (_old != 0)
 		{
 			rwlock.wq.emplace_back(&ppu);
-			rwlock.sleep(ppu, timeout);
+			rwlock.sleep(ppu, timeout, true);
 		}
 
 		return _old;

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -150,9 +150,9 @@ error_code sys_rwlock_rlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 
 	ppu.gpr[3] = CELL_OK;
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}
@@ -378,9 +378,9 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 
 	ppu.gpr[3] = CELL_OK;
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.h
@@ -29,8 +29,8 @@ struct lv2_rwlock final : lv2_obj
 
 	shared_mutex mutex;
 	atomic_t<s64> owner{0};
-	std::deque<cpu_thread*> rq;
-	std::deque<cpu_thread*> wq;
+	atomic_t<ppu_thread*> rq{};
+	atomic_t<ppu_thread*> wq{};
 
 	lv2_rwlock(u32 protocol, u64 key, u64 name) noexcept
 		: protocol{static_cast<u8>(protocol)}

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.h
@@ -29,8 +29,8 @@ struct lv2_rwlock final : lv2_obj
 
 	shared_mutex mutex;
 	atomic_t<s64> owner{0};
-	atomic_t<ppu_thread*> rq{};
-	atomic_t<ppu_thread*> wq{};
+	ppu_thread* rq{};
+	ppu_thread* wq{};
 
 	lv2_rwlock(u32 protocol, u64 key, u64 name) noexcept
 		: protocol{static_cast<u8>(protocol)}

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -147,9 +147,9 @@ error_code sys_semaphore_wait(ppu_thread& ppu, u32 sem_id, u64 timeout)
 
 	ppu.gpr[3] = CELL_OK;
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -7,6 +7,8 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 
+#include "util/asm.hpp"
+
 LOG_CHANNEL(sys_semaphore);
 
 lv2_sema::lv2_sema(utils::serial& ar)
@@ -165,6 +167,16 @@ error_code sys_semaphore_wait(ppu_thread& ppu, u32 sem_id, u64 timeout)
 
 			ppu.state += cpu_flag::again;
 			return {};
+		}
+
+		for (usz i = 0; cpu_flag::signal - ppu.state && i < 50; i++)
+		{
+			busy_wait(500);
+		}
+
+		if (ppu.state & cpu_flag::signal)
+ 		{
+			continue;
 		}
 
 		if (timeout)

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -123,7 +123,7 @@ error_code sys_semaphore_wait(ppu_thread& ppu, u32 sem_id, u64 timeout)
 			}
 		}
 
-		lv2_obj::notify_all_t notify;
+		lv2_obj::notify_all_t notify(ppu);
 
 		std::lock_guard lock(sema.mutex);
 

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -121,12 +121,14 @@ error_code sys_semaphore_wait(ppu_thread& ppu, u32 sem_id, u64 timeout)
 			}
 		}
 
+		lv2_obj::notify_all_t notify;
+
 		std::lock_guard lock(sema.mutex);
 
 		if (sema.val-- <= 0)
 		{
 			sema.sq.emplace_back(&ppu);
-			sema.sleep(ppu, timeout);
+			sema.sleep(ppu, timeout, true);
 			return false;
 		}
 

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.h
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.h
@@ -30,7 +30,7 @@ struct lv2_sema final : lv2_obj
 
 	shared_mutex mutex;
 	atomic_t<s32> val;
-	atomic_t<ppu_thread*> sq{};
+	ppu_thread* sq{};
 
 	lv2_sema(u32 protocol, u64 key, u64 name, s32 max, s32 value) noexcept
 		: protocol{static_cast<u8>(protocol)}

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.h
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.h
@@ -30,7 +30,7 @@ struct lv2_sema final : lv2_obj
 
 	shared_mutex mutex;
 	atomic_t<s32> val;
-	std::deque<cpu_thread*> sq;
+	atomic_t<ppu_thread*> sq{};
 
 	lv2_sema(u32 protocol, u64 key, u64 name, s32 max, s32 value) noexcept
 		: protocol{static_cast<u8>(protocol)}

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1408,11 +1408,9 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 		lv2_obj::sleep(ppu);
 		lock.unlock();
 
-		while (true)
+		while (auto state = +ppu.state)
 		{
-			const auto state = ppu.state.fetch_sub(cpu_flag::signal);
-
-			if (state & cpu_flag::signal)
+			if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 			{
 				break;
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1399,6 +1399,8 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 
 	do
 	{
+		lv2_obj::prepare_for_sleep(ppu);
+
 		std::unique_lock lock(group->mutex);
 
 		const auto state = +group->run_state;
@@ -1433,8 +1435,11 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 			group->waiter = &ppu;
 		}
 
-		lv2_obj::sleep(ppu);
-		lock.unlock();
+		{
+			lv2_obj::notify_all_t notify;
+			lv2_obj::sleep(ppu);
+			lock.unlock();
+		}
 
 		while (auto state = +ppu.state)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -60,6 +60,8 @@ u64 lv2_timer::check()
 			// If aborting, perform the last accurate check for event
 			if (_now >= next)
 			{
+				lv2_obj::notify_all_t notify;
+
 				std::lock_guard lock(mutex);
 
 				if (next = expire; _now < next)

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -395,7 +395,7 @@ error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 
 	if (sleep_time)
 	{
-		lv2_obj::sleep(ppu, sleep_time);
+		lv2_obj::sleep(ppu, g_cfg.core.sleep_timers_accuracy < sleep_timers_accuracy_level::_usleep ? sleep_time : 0);
 
 		if (!lv2_obj::wait_timeout<true>(sleep_time))
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -860,9 +860,9 @@ error_code sys_usbd_receive_event(ppu_thread& ppu, u32 handle, vm::ptr<u64> arg1
 		usbh.sq.emplace_back(&ppu);
 	}
 
-	while (auto state = ppu.state.fetch_sub(cpu_flag::signal))
+	while (auto state = +ppu.state)
 	{
-		if (state & cpu_flag::signal)
+		if (state & cpu_flag::signal && ppu.state.test_and_reset(cpu_flag::signal))
 		{
 			sys_usbd.trace("Received event(queued): arg1=0x%x arg2=0x%x arg3=0x%x", ppu.gpr[4], ppu.gpr[5], ppu.gpr[6]);
 			break;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -382,11 +382,16 @@ namespace vm
 
 	void temporary_unlock(cpu_thread& cpu) noexcept
 	{
-		if (!(cpu.state & cpu_flag::wait)) cpu.state += cpu_flag::wait;
+		bs_t<cpu_flag> add_state = cpu_flag::wait;
 
 		if (g_tls_locked && g_tls_locked->compare_and_swap_test(&cpu, nullptr))
 		{
-			cpu.state += cpu_flag::memory;
+			add_state += cpu_flag::memory;
+		}
+
+		if (add_state - cpu.state)
+		{
+			cpu.state += add_state;
 		}
 	}
 

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -315,10 +315,11 @@ private:
 	friend class atomic_wait::list;
 
 	static void wait(const void* data, u32 size, u128 old_value, u64 timeout, u128 mask, atomic_wait::info* ext = nullptr);
+
+public:
 	static void notify_one(const void* data, u32 size, u128 mask128);
 	static void notify_all(const void* data, u32 size, u128 mask128);
 
-public:
 	static void set_wait_callback(bool(*cb)(const void* data, u64 attempts, u64 stamp0));
 	static void set_notify_callback(void(*cb)(const void* data, u64 progress));
 


### PR DESCRIPTION
* Reduce time spent while owning mutexes.
* Avoid situations in which the notified thread gets blocked again on the same mutex the notifier thread still holds.
* Add busy waiting before entering atomic wait.
* Make LV2 synchronization syscalls allocation-free using a node system. (nearly)
* Move memory unlocking outside of mutex ownership and make it conditional.
* Make sys_mutex lock-free, add some busy waiting in sys_mutex_lock.
* Make sys_lwmutex nearly lock-free.
* Do not lock IDM mutex if the preliminary ID check failed.
* Optimize shared_mutex for more than 2 concurrent threads.

In addition to improving performance for low theaded CPUs (8 threads or less), this pull request helps the performamce of more than 2 PPU threads (the most accurate value and the default yet may be slower than more threads).
This pr may improve loading times as well due to improved PPU performance.

Results of a test locking and unlocking 4 LV2 mutexes on 8 threads.
[ppumain.self.zip](https://github.com/RPCS3/rpcs3/files/9183412/ppumain.self.zip)

Master, 2 PPU threads: sample finished in **24.269772** seconds.
Master, 4 PPU threads: sample finished in **59.015042** seconds.
Pull request, 2 PPU threads: sample finished in **2.951544** seconds.
Pull request, 4 PPU threads: sample finished in **5.736856** seconds.