### PR TITLE
Savestates/MSVC: Replace bugged std::unique (compiler bug)

### DIFF
--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -2008,9 +2008,26 @@ namespace vm
 			if (loc) loc->get_shared_memory(shared);
 		}
 
-		shared.erase(std::unique(shared.begin(), shared.end(), [](auto& a, auto& b) { return a.first == b.first; }), shared.end());
-
 		std::map<utils::shm*, usz> shared_map;
+
+#ifndef _MSC_VER
+		shared.erase(std::unique(shared.begin(), shared.end(), [](auto& a, auto& b) { return a.first == b.first; }), shared.end());
+#else
+		// Workaround for bugged std::unique
+		for (auto it = shared.begin(); it != shared.end();)
+		{
+			if (shared_map.count(it->first))
+			{
+				it = shared.erase(it);
+				continue;
+			}
+
+			shared_map.emplace(it->first, 0);
+			it++;
+		}
+
+		shared_map.clear();
+#endif
 
 		for (auto& p : shared)
 		{

--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -34,10 +34,10 @@ namespace rsx
 		{
 			m_cmd = cmd;
 			m_command_inc = ((m_cmd & RSX_METHOD_NON_INCREMENT_CMD_MASK) == RSX_METHOD_NON_INCREMENT_CMD) ? 0 : 4;
-			m_remaining_commands = count - 1;
-			m_internal_get = m_ctrl->get;
+			m_remaining_commands = count;
+			m_internal_get = m_ctrl->get - 4;
 			m_args_ptr = m_iotable->get_addr(m_internal_get);	
-			m_command_reg = (m_cmd & 0xffff) + m_command_inc * (((m_cmd >> 18) - count) & 0x7ff);
+			m_command_reg = (m_cmd & 0xffff) + m_command_inc * (((m_cmd >> 18) - count) & 0x7ff) - m_command_inc;
 		}
 
 		void FIFO_control::inc_get(bool wait)


### PR DESCRIPTION
Seems like std::unique on MSVC always return an end iterator, I've encountered this bug in the past. For now push a hotfix to RPCS3.
Fixes Killzone 3 savestates, it uses PS3 memory mirrors that's why it happens to it.