### PR TITLE
Overlays: smash some bugs in message dialogs

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
@@ -398,7 +398,6 @@ namespace rsx
 						{
 						case '\r':
 						{
-							word_end = line_end = line_begin = ctr;
 							continue;
 						}
 						case '\n':
@@ -481,7 +480,7 @@ namespace rsx
 							const bool is_last_glyph = i_next >= end;
 
 							// The line may be wrapped, so we need to check if the next glyph's position is below the current position.
-							if (is_last_glyph || (std::fabs(result[i_next - 1].y() - result[i_begin + 3].y()) >= size_px))
+							if (is_last_glyph || (result[i_next - 1].y() - result[i_begin + 3].y() >= size_px))
 							{
 								// Whenever we reached the end of a visual line we need to move its glyphs accordingly.
 								const u32 i_end = i_next - (is_last_glyph ? 0 : 4);

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
@@ -327,15 +327,28 @@ namespace rsx
 					if (is_whitespace)
 					{
 						// Skip whitespace if we are at the start of a line.
-						if (x_advance > 0.f)
+						if (x_advance <= 0.f)
 						{
+							// Set the glyph to the current position.
+							// This is necessary for downstream linewidth calculations.
+							quad.x0 = quad.x1 = x_advance;
+							quad.y0 = quad.y1 = y_advance;
+						}
+						else
+						{
+							const f32 x_advance_old = x_advance;
+							const f32 y_advance_old = y_advance;
+
 							// Get the glyph size.
 							quad = get_char(c, x_advance, y_advance);
 
 							// Reset the result if the glyph would protrude out of the given space anyway.
 							if (x_advance > max_width)
 							{
-								quad = {};
+								// Set the glyph to the previous position.
+								// This is necessary for downstream linewidth calculations.
+								quad.x0 = quad.x1 = x_advance_old;
+								quad.y0 = quad.y1 = y_advance_old;
 							}
 						}
 					}


### PR DESCRIPTION
Old positioning was completely wrong in certain cases. How did I miss that?
I'll just show the good versions. On master these are all off-center or aligned to the left (apart from the first one, which works).

![image](https://user-images.githubusercontent.com/23019877/181108626-ed7319c1-7ac8-4c87-a233-caa858f9505f.png)
![image](https://user-images.githubusercontent.com/23019877/181108184-567c480e-8c8f-40bd-8f25-d914417138d1.png)
![image](https://user-images.githubusercontent.com/23019877/181108913-50ceea1e-e8aa-41f8-83e2-2f81d7f41882.png)
