### PR TITLE
sys_lwcond: Fix rare race on mode 3 signal

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -165,12 +165,18 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u6
 					{
 						// Respect ordering of the sleep queue
 						mutex->sq.emplace_back(result);
-						result = mutex->schedule<ppu_thread>(mutex->sq, mutex->protocol);
+						auto result2 = mutex->schedule<ppu_thread>(mutex->sq, mutex->protocol);
 
 						if (static_cast<ppu_thread*>(result)->state & cpu_flag::again)
 						{
 							ppu.state += cpu_flag::again;
 							return 0;
+						}
+
+						if (result2 != result)
+						{
+							cond.awake(result2);
+							result = nullptr;
 						}
 					}
 					else if (mode == 1)

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -167,7 +167,7 @@ error_code _sys_lwcond_signal(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id, u6
 						mutex->sq.emplace_back(result);
 						auto result2 = mutex->schedule<ppu_thread>(mutex->sq, mutex->protocol);
 
-						if (static_cast<ppu_thread*>(result)->state & cpu_flag::again)
+						if (static_cast<ppu_thread*>(result2)->state & cpu_flag::again)
 						{
 							ppu.state += cpu_flag::again;
 							return 0;


### PR DESCRIPTION
Call awake under mutex lock if we attempt to wake an lwmutex waiter, in a case a call for _sys_lwmutex_lock with timeout attempted to abort waiting and awake could have been executed after it has aborted waiting. (so it's a loose awake call which can wake the thread from another syscall as a bug)