### PR TITLE
Qt: fix image ratio in screenshot_manager_dialog

### DIFF
--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -195,6 +195,34 @@ namespace gui
 			return l.sizeHint().width();
 		}
 
+		QImage get_centered_image(const QString& path, const QSize& icon_size, int offset_x, int offset_y, qreal device_pixel_ratio)
+		{
+			// Create empty canvas for expanded image
+			QImage exp_img(icon_size, QImage::Format_ARGB32);
+			exp_img.setDevicePixelRatio(device_pixel_ratio);
+			exp_img.fill(Qt::transparent);
+
+			// Load scaled pixmap
+			const QPixmap pixmap = QPixmap(path).scaled(icon_size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+			// Define offset for raw image placement
+			QPoint offset(offset_x + icon_size.width() / 2 - pixmap.width() / 2,
+			              offset_y + icon_size.height() / 2 - pixmap.height() / 2);
+
+			// Place raw image inside expanded image
+			QPainter painter(&exp_img);
+			painter.setRenderHint(QPainter::SmoothPixmapTransform);
+			painter.drawPixmap(offset, pixmap);
+			painter.end();
+
+			return exp_img;
+		}
+
+		QPixmap get_centered_pixmap(const QString& path, const QSize& icon_size, int offset_x, int offset_y, qreal device_pixel_ratio)
+		{
+			return QPixmap::fromImage(get_centered_image(path, icon_size, offset_x, offset_y, device_pixel_ratio));
+		}
+
 		QImage get_opaque_image_area(const QString& path)
 		{
 			QImage image = QImage(path);

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -80,6 +80,12 @@ namespace gui
 			qobj.setFont(font);
 		}
 
+		// Returns a scaled, centered QImage
+		QImage get_centered_image(const QString& path, const QSize& icon_size, int offset_x, int offset_y, qreal device_pixel_ratio);
+
+		// Returns a scaled, centered QPixmap
+		QPixmap get_centered_pixmap(const QString& path, const QSize& icon_size, int offset_x, int offset_y, qreal device_pixel_ratio);
+
 		// Returns the part of the image loaded from path that is inside the bounding box of its opaque areas
 		QImage get_opaque_image_area(const QString& path);
 

--- a/rpcs3/rpcs3qt/screenshot_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/screenshot_manager_dialog.cpp
@@ -152,8 +152,7 @@ void screenshot_manager_dialog::update_icons(int value)
 
 	const std::function<thumbnail(thumbnail)> load = [icon_size = m_icon_size](thumbnail tn) -> thumbnail
 	{
-		const QPixmap pixmap(tn.path);
-		tn.icon = QIcon(pixmap.scaled(icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+		tn.icon = QIcon(gui::utils::get_centered_pixmap(tn.path, icon_size, 0, 0, 1.0));
 		return tn;
 	};
 


### PR DESCRIPTION
### **Old:**
![image](https://user-images.githubusercontent.com/23019877/181658463-932d8cd2-eb92-42c7-91cc-934d64dfa4e9.png)

### **New:**
![image](https://user-images.githubusercontent.com/23019877/181658875-ddc509b6-4989-482e-999c-96c27327dfad.png)
