### PR TITLE
cellPhotoDecode: optimize get_scaled_image

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPhotoDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoDecode.cpp
@@ -162,7 +162,7 @@ error_code cellPhotoDecodeFromFile(vm::cptr<char> srcHddDir, vm::cptr<char> srcH
 	s32 width{};
 	s32 height{};
 
-	if (!Emu.GetCallbacks().get_scaled_image(path, set_param->width, set_param->height, width, height, static_cast<u8*>(set_param->dstBuffer.get_ptr())))
+	if (!Emu.GetCallbacks().get_scaled_image(path, set_param->width, set_param->height, width, height, static_cast<u8*>(set_param->dstBuffer.get_ptr()), false))
 	{
 		cellPhotoDecode.error("Failed to decode '%s'", path);
 		return CELL_PHOTO_DECODE_ERROR_DECODE;

--- a/rpcs3/Emu/Cell/Modules/cellPhotoImport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoImport.cpp
@@ -157,7 +157,7 @@ error_code select_photo(std::string dst_dir)
 
 					if (!fs::stat(info.path, f_info) || f_info.is_directory)
 					{
-						cellPhotoImportUtil.error("Path is not a directory: '%s'", info.path);
+						cellPhotoImportUtil.error("Path does not belong to a valid file: '%s'", info.path);
 						result = CELL_PHOTO_IMPORT_ERROR_ACCESS_ERROR; // TODO: is this correct ?
 						pi_manager.is_busy = false;
 						pi_manager.func_finish(ppu, result, g_filedata, pi_manager.userdata);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -97,7 +97,7 @@ struct EmuCallbacks
 	std::function<std::u32string(localized_string_id, const char*)> get_localized_u32string;
 	std::function<void(const std::string&)> play_sound;
 	std::function<bool(const std::string&, std::string&, s32&, s32&, s32&)> get_image_info; // (filename, sub_type, width, height, CellSearchOrientation)
-	std::function<bool(const std::string&, s32, s32, s32&, s32&, u8*)> get_scaled_image; // (filename, target_width, target_height, width, height, dst)
+	std::function<bool(const std::string&, s32, s32, s32&, s32&, u8*, bool)> get_scaled_image; // (filename, target_width, target_height, width, height, dst, force_fit)
 	std::string(*resolve_path)(std::string_view) = [](std::string_view arg){ return std::string{arg}; }; // Resolve path using Qt
 };
 


### PR DESCRIPTION
This decreases the loading times of images in media dialogs by ~20%
(It's not used in media Dialogs though. That's just how I tested it.)