### PR TITLE
rsx: Do not require ZCULL buffer binding to enable ZPASS counting

### DIFF
--- a/rpcs3/Emu/RSX/RSXZCULL.cpp
+++ b/rpcs3/Emu/RSX/RSXZCULL.cpp
@@ -75,7 +75,7 @@ namespace rsx
 		{
 			// NOTE: Only enable host queries if pixel count is active to save on resources
 			// Can optionally be enabled for either stats enabled or zpass enabled for accuracy
-			const bool data_stream_available = write_enabled && (zpass_count_enabled /*|| stats_enabled*/);
+			const bool data_stream_available = zpass_count_enabled; // write_enabled && (zpass_count_enabled || stats_enabled);
 			if (host_queries_active && !data_stream_available)
 			{
 				// Stop
@@ -312,14 +312,14 @@ namespace rsx
 				}
 				break;
 			case CELL_GCM_ZCULL_STATS3:
-				value = value ? 0 : u16{ umax };
+				value = (value || !write_enabled || !stats_enabled) ? 0 : u16{ umax };
 				break;
 			case CELL_GCM_ZCULL_STATS2:
 			case CELL_GCM_ZCULL_STATS1:
 			case CELL_GCM_ZCULL_STATS:
 			default:
 				//Not implemented
-				value = -1;
+				value = (write_enabled && stats_enabled) ? -1 : 0;
 				break;
 			}
 


### PR DESCRIPTION
- ZPASS data is still accessible in unbuffered mode.
  The only thing that buffered ZCULL enables is something closer to early-Z where large blocks of pixels can be dicarded earlier.
  It is strictly a performance optimization and not required for ZPASS to work.
- Update ZCULL stat calculations to take into account unbuffered Z

Fixes https://github.com/RPCS3/rpcs3/issues/10869
Fixes https://github.com/RPCS3/rpcs3/issues/7741