### PR TITLE
cellPhotoExport/cellVideoExport: fix filenames

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -615,3 +615,13 @@ bool fmt::match(const std::string& source, const std::string& mask)
 
 	return true;
 }
+
+std::string get_file_extension(const std::string& file_path)
+{
+	if (usz dotpos = file_path.find_last_of('.'); dotpos != std::string::npos && dotpos + 1 < file_path.size())
+	{
+		return file_path.substr(dotpos + 1);
+	}
+
+	return {};
+}

--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -27,6 +27,9 @@ bool try_to_int64(s64* out, std::string_view value, s64 min, s64 max);
 // Convert string to unsigned integer
 bool try_to_uint64(u64* out, std::string_view value, u64 min, u64 max);
 
+// Get the file extension of a file path ("png", "jpg", etc.)
+std::string get_file_extension(const std::string& file_path);
+
 namespace fmt
 {
 	std::string replace_all(std::string_view src, std::string_view from, std::string_view to, usz count = -1);

--- a/rpcs3/Emu/Cell/Modules/cellPhotoExport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoExport.cpp
@@ -2,6 +2,7 @@
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/IdManager.h"
 #include "Emu/VFS.h"
+#include "Utilities/StrUtil.h"
 #include "cellSysutil.h"
 
 LOG_CHANNEL(cellPhotoExport);
@@ -115,7 +116,7 @@ std::string get_available_photo_path(const std::string& filename)
 	// Do not overwrite existing files. Add a suffix instead.
 	for (u32 i = 0; fs::exists(dst_path); i++)
 	{
-		const std::string suffix = std::to_string(i);
+		const std::string suffix = fmt::format("_%d", i);
 		std::string new_filename = filename;
 
 		if (const usz pos = new_filename.find_last_of('.'); pos != std::string::npos)
@@ -196,12 +197,23 @@ error_code cellPhotoRegistFromFile(vm::cptr<char> path, vm::cptr<char> photo_tit
 		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
+	std::string filename = photo_title.get_ptr();
+
+	if (filename.empty())
+	{
+		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "title empty" };
+	}
+
+	if (const std::string extension = get_file_extension(file_path); !extension.empty())
+	{
+		fmt::append(filename, ".%s", extension);
+	}
+
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32
 	{
 		auto& pexp = g_fxo->get<photo_export>();
 		pexp.progress = 0; // 0%
 
-		const std::string filename = file_path.substr(file_path.find_last_of('/') + 1);
 		const std::string src_path = vfs::get(file_path);
 		const std::string dst_path = get_available_photo_path(filename);
 
@@ -312,6 +324,10 @@ error_code cellPhotoExportFromFile(vm::cptr<char> srcHddDir, vm::cptr<char> srcH
 		return CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM;
 	}
 
+	// TODO: check param members ?
+
+	cellPhotoExport.notice("cellPhotoExportFromFile: param: photo_title=%s, game_title=%s, game_comment=%s", param->photo_title, param->game_title, param->game_comment);
+
 	const std::string file_path = fmt::format("%s/%s", srcHddDir.get_ptr(), srcHddFile.get_ptr());
 
 	if (!check_photo_path(file_path))
@@ -319,12 +335,23 @@ error_code cellPhotoExportFromFile(vm::cptr<char> srcHddDir, vm::cptr<char> srcH
 		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
+	std::string filename = param->photo_title.get_ptr();
+
+	if (filename.empty())
+	{
+		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "title empty" };
+	}
+
+	if (const std::string extension = get_file_extension(file_path); !extension.empty())
+	{
+		fmt::append(filename, ".%s", extension);
+	}
+
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32
 	{
 		auto& pexp = g_fxo->get<photo_export>();
 		pexp.progress = 0; // 0%
 
-		const std::string filename = file_path.substr(file_path.find_last_of('/') + 1);
 		const std::string src_path = vfs::get(file_path);
 		const std::string dst_path = get_available_photo_path(filename);
 
@@ -371,6 +398,10 @@ error_code cellPhotoExportFromFileWithCopy(vm::cptr<char> srcHddDir, vm::cptr<ch
 		return CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM;
 	}
 
+	// TODO: check param members ?
+
+	cellPhotoExport.notice("cellPhotoExportFromFileWithCopy: param: photo_title=%s, game_title=%s, game_comment=%s", param->photo_title, param->game_title, param->game_comment);
+
 	const std::string file_path = fmt::format("%s/%s", srcHddDir.get_ptr(), srcHddFile.get_ptr());
 
 	if (!check_photo_path(file_path))
@@ -378,12 +409,23 @@ error_code cellPhotoExportFromFileWithCopy(vm::cptr<char> srcHddDir, vm::cptr<ch
 		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
+	std::string filename = param->photo_title.get_ptr();
+
+	if (filename.empty())
+	{
+		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "title empty" };
+	}
+
+	if (const std::string extension = get_file_extension(file_path); !extension.empty())
+	{
+		fmt::append(filename, ".%s", extension);
+	}
+
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32
 	{
 		auto& pexp = g_fxo->get<photo_export>();
 		pexp.progress = 0; // 0%
 
-		const std::string filename = file_path.substr(file_path.find_last_of('/') + 1);
 		const std::string src_path = vfs::get(file_path);
 		const std::string dst_path = get_available_photo_path(filename);
 

--- a/rpcs3/Emu/Cell/Modules/cellPhotoImport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoImport.cpp
@@ -121,9 +121,9 @@ error_code select_photo(std::string dst_dir)
 		return CELL_PHOTO_IMPORT_ERROR_PARAM;
 	}
 
-	if (!dst_dir.starts_with("/dev_hdd0"))
+	if (!dst_dir.starts_with("/dev_hdd0"sv) && !dst_dir.starts_with("/dev_hdd1"sv))
 	{
-		cellPhotoImportUtil.error("Destination '%s' is not inside dev_hdd0", dst_dir);
+		cellPhotoImportUtil.error("Destination '%s' is not inside dev_hdd0 or dev_hdd1", dst_dir);
 		return CELL_PHOTO_IMPORT_ERROR_ACCESS_ERROR; // TODO: is this correct?
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellPhotoImport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoImport.cpp
@@ -175,8 +175,8 @@ error_code select_photo(std::string dst_dir)
 
 					const std::string filename = info.path.substr(info.path.find_last_of(fs::delim) + 1);
 					const std::string title = info.get_metadata("title", filename);
-					const std::string sub_type = fmt::to_lower(info.sub_type);
 					const std::string dst_path = dst_dir + "/" + filename;
+					std::string sub_type = info.sub_type;
 
 					strcpy_trunc(g_filedata->dstFileName, filename);
 					strcpy_trunc(g_filedata->photo_title, title);
@@ -186,6 +186,20 @@ error_code select_photo(std::string dst_dir)
 					g_filedata->data_sub = g_filedata_sub;
 					g_filedata->data_sub->width = info.width;
 					g_filedata->data_sub->height = info.height;
+
+					cellPhotoImportUtil.notice("Raw image data: filename='%s', title='%s', game='%s', sub_type='%s', width=%d, height=%d, orientation=%d ",
+						filename, title, Emu.GetTitle(), sub_type, info.width, info.height, info.orientation);
+
+					// Fallback to extension if necessary
+					if (sub_type.empty())
+					{
+						sub_type = get_file_extension(filename);
+					}
+
+					if (!sub_type.empty())
+					{
+						sub_type = fmt::to_lower(sub_type);
+					}
 
 					if (sub_type == "jpg" || sub_type == "jpeg")
 					{
@@ -234,16 +248,13 @@ error_code select_photo(std::string dst_dir)
 						break;
 					}
 
-					cellPhotoImportUtil.notice("Media list dialog: selected entry '%s'. Copying to '%s'...", info.path, dst_path);
+					cellPhotoImportUtil.notice("Media list dialog: Copying '%s' to '%s'...", info.path, dst_path);
 
 					if (!fs::copy_file(info.path, dst_path, false))
 					{
 						cellPhotoImportUtil.error("Failed to copy '%s' to '%s'. Error = '%s'", info.path, dst_path, fs::g_tls_error);
 						result = CELL_PHOTO_IMPORT_ERROR_COPY;
 					}
-
-					cellPhotoImportUtil.notice("Raw image data: filename='%s', title='%s', game='%s', sub_type='%s', width=%d, height=%d, orientation=%d ",
-						filename, title, Emu.GetTitle(), sub_type, info.width, info.height, info.orientation);
 
 					cellPhotoImportUtil.notice("Cell image data: dstFileName='%s', photo_title='%s', game_title='%s', format=%d, width=%d, height=%d, rotate=%d ",
 						g_filedata->dstFileName, g_filedata->photo_title, g_filedata->game_title, static_cast<s32>(g_filedata->data_sub->format), g_filedata->data_sub->width, g_filedata->data_sub->height, static_cast<s32>(g_filedata->data_sub->rotate));


### PR DESCRIPTION
- Use the title passed to param in cellPhotoExport as proper filename.
- Use the title passed to param in cellVideoExport as proper filename.
- Allow /dev_hdd1 as destination in cellPhotoImport.
- Fallback to file extension when determining the subtype of an image.