### PR TITLE
vm: Avoid unnecessary preallocations

### DIFF
--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -122,12 +122,13 @@ namespace vm
 	{
 		auto_typemap<block_t> m;
 
-		// Common mapped region for special cases
-		std::shared_ptr<utils::shm> m_common;
+		// Common mapped regions for special cases (32MB each, 16 max)
+		static constexpr u32 common_size = 0x200'0000;
+		std::array<std::shared_ptr<utils::shm>, 0x2000'0000 / common_size> m_common;
 
 		atomic_t<u64> m_id = 0;
 
-		bool try_alloc(u32 addr, u64 bflags, u32 size, std::shared_ptr<utils::shm>&&) const;
+		bool try_alloc(u32 addr, u64 bflags, u32 size, std::shared_ptr<utils::shm>&&);
 
 		// Unmap block
 		bool unmap();


### PR DESCRIPTION
It's no secret RPCS3 is a bit of a memory hog, with 16GB of RAM while in-game and a few Chrome tabs open (not even including background 3rd party processes) you can run out of RAM and use the system pagefile (extremely slow memory compared to RAM located on disk). Luckily there is a simple change to reduce more than 0.5GB already: by avoiding preallocating the whole VM regions at once, using blocks of 32MB and allocating them as needed instead.