### PR TITLE
Debugger Improvements

### DIFF
--- a/rpcs3/Emu/RSX/Program/CgBinaryVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/Program/CgBinaryVertexProgram.cpp
@@ -55,6 +55,32 @@ std::string CgBinaryDisasm::GetDSTDisasm(bool is_sca)
 	std::string ret;
 	std::string mask = GetMaskDisasm(is_sca);
 
+	static constexpr std::array<std::string_view, 22> output_names =
+	{
+		"out_diffuse_color",
+		"out_specular_color",
+		"out_back_diffuse_color",
+		"out_back_specular_color",
+		"out_fog",
+		"out_point_size",
+		"out_clip_distance[0]",
+		"out_clip_distance[1]",
+		"out_clip_distance[2]",
+		"out_clip_distance[3]",
+		"out_clip_distance[4]",
+		"out_clip_distance[5]",
+		"out_tc8",
+		"out_tc9",
+		"out_tc0",
+		"out_tc1",
+		"out_tc2",
+		"out_tc3",
+		"out_tc4",
+		"out_tc5",
+		"out_tc6",
+		"out_tc7"
+	};
+
 	switch ((is_sca && d3.sca_dst_tmp != 0x3f) ? 0x1f : d3.dst)
 	{
 	case 0x1f:
@@ -62,13 +88,19 @@ std::string CgBinaryDisasm::GetDSTDisasm(bool is_sca)
 		break;
 
 	default:
-		if (d3.dst > 15)
+		if (d3.dst < output_names.size())
+		{
+			fmt::append(ret, "%s%s", output_names[d3.dst], mask);
+		}
+		else
+		{
 			rsx_log.error("dst index out of range: %u", d3.dst);
+			fmt::append(ret, "(bad out index) o[%d]", d3.dst);
+		}
 
-		ret += fmt::format("o[%d]", d3.dst) + mask;
 		// Vertex Program supports double destinations, notably in MOV
 		if (d0.dst_tmp != 0x3f)
-			ret += fmt::format(" R%d", d0.dst_tmp) + mask;
+			fmt::append(ret, " R%d%s", d0.dst_tmp, mask);
 		break;
 	}
 
@@ -79,20 +111,30 @@ std::string CgBinaryDisasm::GetSRCDisasm(const u32 n)
 {
 	std::string ret;
 
+	static constexpr std::array<std::string_view, 16> reg_table =
+	{
+		"in_pos", "in_weight", "in_normal",
+		"in_diff_color", "in_spec_color",
+		"in_fog",
+		"in_point_size", "in_7",
+		"in_tc0", "in_tc1", "in_tc2", "in_tc3",
+		"in_tc4", "in_tc5", "in_tc6", "in_tc7"
+	};
+
 	switch (src[n].reg_type)
 	{
 	case 1: //temp
 		ret += "R" + std::to_string(src[n].tmp_src);
 		break;
 	case 2: //input
-		if (d1.input_src < 16)
+		if (d1.input_src < reg_table.size())
 		{
-			ret += fmt::format("v[%d]", d1.input_src);
+			fmt::append(ret, "%s", reg_table[d1.input_src]);
 		}
 		else
 		{
 			rsx_log.error("Bad input src num: %d", u32{ d1.input_src });
-			ret += fmt::format("v[%d] # bad src", d1.input_src);
+			fmt::append(ret, "v[%d] # bad src", d1.input_src);
 		}
 		break;
 	case 3: //const

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -68,8 +68,6 @@ void breakpoint_list::RemoveBreakpoint(u32 addr)
 		}
 	}
 
-	Q_EMIT RequestShowAddress(addr);
-
 	if (!count())
 	{
 		hide();
@@ -93,8 +91,6 @@ bool breakpoint_list::AddBreakpoint(u32 pc)
 	breakpoint_item->setBackground(m_color_bp);
 	breakpoint_item->setData(Qt::UserRole, pc);
 	addItem(breakpoint_item);
-
-	Q_EMIT RequestShowAddress(pc);
 
 	show();
 

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -34,6 +34,26 @@ debugger_list::debugger_list(QWidget* parent, std::shared_ptr<gui_settings> gui_
 
 	setSizeAdjustPolicy(QListWidget::AdjustToContents);
 	setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+	connect(this, &QListWidget::currentRowChanged, this, [this](int row)
+	{
+		if (row < 0)
+		{
+			m_selected_instruction = -1;
+			m_showing_selected_instruction = false;
+			return;
+		}
+
+		u32 pc = m_start_addr;
+
+		for (; m_cpu && m_cpu->id_type() == 0x55 && row; row--)
+		{
+			// If scrolling forwards (downwards), we can skip entire commands
+			pc += std::max<u32>(m_disasm->disasm(pc), 4);
+		}
+
+		m_selected_instruction = pc + row * 4;
+	});
 }
 
 void debugger_list::UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm)
@@ -42,17 +62,40 @@ void debugger_list::UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm)
 	{
 		m_cpu = cpu;
 		m_selected_instruction = -1;
+		m_showing_selected_instruction = false;
 	}
 
 	m_disasm = disasm;
 }
 
-u32 debugger_list::GetCenteredAddress(u32 address) const
+u32 debugger_list::GetStartAddress(u32 address)
 {
-	return address - ((m_item_count / 2) * 4);
+	const u32 steps = m_item_count / 3;
+
+	u32 result = address;
+
+	if (m_cpu && m_cpu->id_type() == 0x55)
+	{
+		if (auto [count, res] = static_cast<rsx::thread*>(m_cpu)->try_get_pc_of_x_cmds_backwards(steps, address); count == steps)
+		{
+			result = res;
+		}
+	}
+	else
+	{
+		result = address - (steps * 4);
+	}
+
+	if (address > m_pc || m_start_addr > address)
+	{
+		m_pc = address;
+		m_start_addr = result;
+	}
+
+	return m_start_addr;
 }
 
-void debugger_list::ShowAddress(u32 addr, bool select_addr, bool force)
+void debugger_list::ShowAddress(u32 addr, bool select_addr, bool direct)
 {
 	const decltype(spu_thread::local_breakpoints)* spu_bps_list;
 
@@ -71,31 +114,23 @@ void debugger_list::ShowAddress(u32 addr, bool select_addr, bool force)
 		}
 	};
 
-	bool center_pc = m_gui_settings->GetValue(gui::d_centerPC).toBool();
-
-	// How many spaces addr can move down without us needing to move the entire view
-	const u32 addr_margin = (m_item_count / (center_pc ? 2 : 1) - 4); // 4 is just a buffer of 4 spaces at the bottom
-
-	if (select_addr || force)
+	if (select_addr || direct)
 	{
 		// The user wants to survey a specific memory location, do not interfere from this point forth 
 		m_follow_thread = false;
 	}
 
-	if (force || ((m_follow_thread || select_addr) && addr - m_pc > addr_margin * 4)) // 4 is the number of bytes in each instruction
+	u32 pc = m_start_addr;
+
+	if (!direct && (m_follow_thread || select_addr))
 	{
-		if (center_pc)
-		{
-			m_pc = GetCenteredAddress(addr);
-		}
-		else
-		{
-			m_pc = addr;
-		}
+		pc = GetStartAddress(addr);
 	}
 
 	const auto& default_foreground = palette().color(foregroundRole());
 	const auto& default_background = palette().color(backgroundRole());
+
+	m_showing_selected_instruction = false;
 
 	if (select_addr)
 	{
@@ -124,14 +159,14 @@ void debugger_list::ShowAddress(u32 addr, bool select_addr, bool force)
 	{
 		const bool is_spu = m_cpu->id_type() == 2;
 		const u32 address_limits = (is_spu ? 0x3fffc : ~3);
-		m_pc &= address_limits;
-		u32 pc = m_pc;
+		m_start_addr &= address_limits;
+		u32 pc = m_start_addr;
 
 		for (uint i = 0, count = 4; i < m_item_count; ++i, pc = (pc + count) & address_limits)
 		{
 			QListWidgetItem* list_item = item(i);
 
-			if (m_cpu->is_paused() && pc == m_cpu->get_pc())
+			if (pc == m_cpu->get_pc())
 			{
 				list_item->setForeground(m_text_color_pc);
 				list_item->setBackground(m_color_pc);
@@ -143,6 +178,8 @@ void debugger_list::ShowAddress(u32 addr, bool select_addr, bool force)
 				{
 					list_item->setSelected(true);
 				}
+
+				m_showing_selected_instruction = true;
 			}
 			else if (IsBreakpoint(pc))
 			{
@@ -204,26 +241,25 @@ void debugger_list::EnableThreadFollowing(bool enable)
 
 void debugger_list::scroll(s32 steps)
 {
-	while (m_cpu && m_cpu->id_type() == 0x55 && steps > 0)
+	for (; m_cpu && m_cpu->id_type() == 0x55 && steps > 0; steps--)
 	{
 		// If scrolling forwards (downwards), we can skip entire commands
-		// Backwards is impossible though
-		m_pc += std::max<u32>(m_disasm->disasm(m_pc), 4);
-		steps--;
+		m_start_addr += std::max<u32>(m_disasm->disasm(m_start_addr), 4);
 	}
 
 	if (m_cpu && m_cpu->id_type() == 0x55 && steps < 0)
 	{
 		// If scrolling backwards (upwards), try to obtain the start of commands tail 
-		if (auto [count, res] = static_cast<rsx::thread*>(m_cpu)->try_get_pc_of_x_cmds_backwards(-steps, m_pc); count == 0u - steps)
+		if (auto [count, res] = static_cast<rsx::thread*>(m_cpu)->try_get_pc_of_x_cmds_backwards(-steps, m_start_addr); count == 0u - steps)
 		{
 			steps = 0;
-			m_pc = res;
+			m_start_addr = res;
 		}
 	}
 
 	EnableThreadFollowing(false);
-	ShowAddress(m_pc + (steps * 4), false, true);
+	m_start_addr += steps * 4;
+	ShowAddress(0, false, true);
 }
 
 void debugger_list::keyPressEvent(QKeyEvent* event)
@@ -247,7 +283,7 @@ void debugger_list::keyPressEvent(QKeyEvent* event)
 		}
 		if (m_cpu && m_cpu->id_type() == 0x55)
 		{
-			create_rsx_command_detail(m_pc, currentRow());
+			create_rsx_command_detail(m_showing_selected_instruction ? m_selected_instruction : m_pc);
 			return;
 		}
 		return;
@@ -269,19 +305,8 @@ void debugger_list::hideEvent(QHideEvent* event)
 	QListWidget::hideEvent(event);
 }
 
-void debugger_list::create_rsx_command_detail(u32 pc, int row)
+void debugger_list::create_rsx_command_detail(u32 pc)
 {
-	if (row < 0)
-	{
-		return;
-	}
-
-	for (; row > 0; row--)
-	{
-		// Skip methods
-		pc += std::max<u32>(m_disasm->disasm(pc), 4);
-	}
-
 	RSXDisAsm rsx_dis = *static_cast<RSXDisAsm*>(m_disasm);
 	rsx_dis.change_mode(cpu_disasm_mode::list);
 
@@ -321,10 +346,19 @@ void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
 {
 	if (event->button() == Qt::LeftButton)
 	{
-		const int i = currentRow();
+		int i = currentRow();
 		if (i < 0) return;
 
-		const u32 pc = m_pc + i * 4;
+		u32 pc = m_start_addr;
+
+		for (; m_cpu && m_cpu->id_type() == 0x55 && i; i--)
+		{
+			// If scrolling forwards (downwards), we can skip entire commands
+			pc += std::max<u32>(m_disasm->disasm(pc), 4);
+		}
+
+		pc += i * 4;
+		m_selected_instruction = pc;
 
 		// Let debugger_frame know about breakpoint.
 		// Other option is to add to breakpoint manager directly and have a signal there instead.

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -18,9 +18,11 @@ class debugger_list : public QListWidget
 
 public:
 	u32 m_pc = 0;
+	u32 m_start_addr = 0;
 	u32 m_item_count = 30;
-	bool m_follow_thread = true; // If true, follow the selected thread to wherever it goes in code
 	u32 m_selected_instruction = -1;
+	bool m_follow_thread = true; // If true, follow the selected thread to wherever it goes in code
+	bool m_showing_selected_instruction = false;
 	QColor m_color_bp;
 	QColor m_color_pc;
 	QColor m_text_color_bp;
@@ -33,7 +35,7 @@ public:
 	void UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm);
 	void EnableThreadFollowing(bool enable = true);
 public Q_SLOTS:
-	void ShowAddress(u32 addr, bool select_addr = true, bool force = false);
+	void ShowAddress(u32 addr, bool select_addr = true, bool direct = false);
 	void RefreshView();
 protected:
 	void keyPressEvent(QKeyEvent* event) override;
@@ -43,12 +45,12 @@ protected:
 	void showEvent(QShowEvent* event) override;
 	void hideEvent(QHideEvent* event) override;
 	void scroll(s32 steps);
-	void create_rsx_command_detail(u32 pc, int row);
+	void create_rsx_command_detail(u32 pc);
 private:
 	/**
 	* It really upsetted me I had to copy this code to make debugger_list/frame not circularly dependent.
 	*/
-	u32 GetCenteredAddress(u32 address) const;
+	u32 GetStartAddress(u32 address);
 
 	std::shared_ptr<gui_settings> m_gui_settings;
 

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -196,7 +196,6 @@ namespace gui
 	const gui_save l_limit_tty = gui_save(logger, "TTY_limit", 1000);
 
 	const gui_save d_splitterState = gui_save(debugger, "splitterState", QByteArray());
-	const gui_save d_centerPC      = gui_save(debugger, "centerPC",      false);
 
 	const gui_save rsx_geometry = gui_save(rsx, "geometry", QByteArray());
 	const gui_save rsx_states   = gui_save(rsx, "states",   QVariantMap());

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -39,6 +39,7 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 {
 	setWindowTitle(tr("RSX Debugger"));
 	setObjectName("rsx_debugger");
+	setAttribute(Qt::WA_DeleteOnClose);
 	setWindowFlags(Qt::Window);
 
 	// Fonts and Colors


### PR DESCRIPTION
* Fix the selection of instructions and all the connected functionality of it - it was hilariously broken.
* Use "third-centered" PC by default on the debugger instead of back PC - we want to view previous instructions, just not as many as future instructions.
* Fix memory leak in RSX debugger.
* Name VP vertex arrays. 
* Minor race fix in sys_spu_thread_receive_eventt.