### PR TITLE
rsx/vp: Fix Demon Souls missing graphics

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -267,7 +267,7 @@ namespace glsl
 		"vec4 fetch_attribute(const in attribute_desc desc, const in int vertex_id, usamplerBuffer input_stream)\n"
 		"{\n"
 		"	const int elem_size_table[] = { 2, 4, 2, 1, 2, 4, 1 };\n"
-		"	const float scaling_table[] = { 32768., 1., 1., 255., 1., 32767., 1. };\n"
+		"	const float scaling_table[] = { 65535., 1., 1., 255., 1., 32767., 1. };\n"
 		"	const int elem_size = elem_size_table[desc.type];\n"
 		"	const vec4 scale = scaling_table[desc.type].xxxx;\n\n"
 
@@ -298,6 +298,11 @@ namespace glsl
 		"	if (desc.type == VTX_FMT_SNORM16 || desc.type == VTX_FMT_SINT16)\n"
 		"	{\n"
 		"		ret = sext(ivec4(result));\n"
+
+		"		if (desc.type == VTX_FMT_SNORM16)\n"
+		"		{\n"
+		"			ret = ret * 2. + 1.;\n"
+		"		}\n"
 		"	}\n"
 		"	else if (desc.type == VTX_FMT_FLOAT32)\n"
 		"	{\n"


### PR DESCRIPTION
This is the correct decoding of the vertex value here, it affected Demon Souls because it passed an integer of 0 to the vertex shader and then raised it to the power of -1. RPCS3 previously believed that it results in a float of 0 but no it results in float(1)/65535. So when raising it to -1 instead of NaN being produced it now results in precisely 65535. If you want to benefit from this you need to clear the Shaders cache.

![image](https://user-images.githubusercontent.com/18193363/182464720-f174110f-cb03-4cc1-91d9-424964d3bca4.png)

Fixes #4302 