### PR TITLE
Input: fix pad initialization

### DIFF
--- a/rpcs3/Input/pad_thread.h
+++ b/rpcs3/Input/pad_thread.h
@@ -17,7 +17,7 @@ class PadHandlerBase;
 class pad_thread
 {
 public:
-	pad_thread(void* _curthread, void* _curwindow, std::string_view title_id); // void * instead of QThread * and QWindow * because of include in emucore
+	pad_thread(void* curthread, void* curwindow, std::string_view title_id); // void * instead of QThread * and QWindow * because of include in emucore
 	pad_thread(const pad_thread&) = delete;
 	pad_thread& operator=(const pad_thread&) = delete;
 	~pad_thread();
@@ -45,8 +45,8 @@ protected:
 	std::map<pad_handler, std::shared_ptr<PadHandlerBase>> handlers;
 
 	// Used for pad_handler::keyboard
-	void *curthread;
-	void *curwindow;
+	void* m_curthread = nullptr;
+	void* m_curwindow = nullptr;
 
 	PadInfo m_info{ 0, 0, false };
 	std::array<std::shared_ptr<Pad>, CELL_PAD_MAX_PORT_NUM> m_pads;
@@ -61,6 +61,7 @@ namespace pad
 	extern std::string g_title_id;
 	extern atomic_t<bool> g_enabled;
 	extern atomic_t<bool> g_reset;
+	extern atomic_t<bool> g_started;
 
 	static inline class pad_thread* get_current_handler(bool relaxed = false)
 	{

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -106,7 +106,7 @@ EmuCallbacks main_application::CreateCallbacks()
 	callbacks.init_pad_handler = [this](std::string_view title_id)
 	{
 		ensure(g_fxo->init<named_thread<pad_thread>>(get_thread(), m_game_window, title_id));
-		while (pad::g_reset) std::this_thread::yield();
+		while (!pad::g_started) std::this_thread::yield();
 	};
 
 	callbacks.get_audio = []() -> std::shared_ptr<AudioBackend>


### PR DESCRIPTION
Seems like someone changed the pad initialization and bastardised the reset flag for some thread yield loop.
This meant that the pads were never initialized in certain scenarios, because the reset flag was set to false right before they were supposed to be ... reset.

fixes #12331