### PR TITLE
rsx: Partial handling of surface pitch change

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -469,6 +469,12 @@ namespace rsx
 					free_rsx_memory(Traits::get(surface));
 					Traits::notify_surface_invalidated(surface);
 
+					if (old_surface_storage)
+					{
+						// Pitch-converted data. Send to invalidated pool immediately.
+						invalidated_resources.push_back(std::move(old_surface_storage));
+					}
+
 					old_surface_storage = std::move(surface);
 					primary_storage->erase(It);
 				}

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -427,11 +427,17 @@ namespace rsx
 
 				if (Traits::surface_matches_properties(surface, format, width, height, antialias))
 				{
-					if (pitch_compatible)
-						Traits::notify_surface_persist(surface);
-					else
-						Traits::invalidate_surface_contents(command_list, Traits::get(surface), address, pitch);
+					if (!pitch_compatible)
+					{
+						// This object should be pitch-converted and re-intersected with
+						if (old_surface_storage = Traits::convert_pitch(command_list, surface, pitch))
+						{
+							old_surface = Traits::get(old_surface_storage);
+							Traits::invalidate_surface_contents(command_list, Traits::get(surface), address, pitch);
+						}
+					}
 
+					Traits::notify_surface_persist(surface);
 					Traits::prepare_surface_for_drawing(command_list, Traits::get(surface));
 					new_surface = Traits::get(surface);
 					store = false;

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -242,6 +242,7 @@ struct gl_render_target_traits
 	{
 		// TODO
 		src->set_rsx_pitch(static_cast<u32>(out_pitch));
+		src->state_flags = rsx::surface_state_flags::erase_bkgnd;
 		return {};
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -235,6 +235,17 @@ struct gl_render_target_traits
 	}
 
 	static
+	std::unique_ptr<gl::render_target> convert_pitch(
+		gl::command_context& /*cmd*/,
+		std::unique_ptr<gl::render_target>& src,
+		usz out_pitch)
+	{
+		// TODO
+		src->set_rsx_pitch(static_cast<u32>(out_pitch));
+		return {};
+	}
+
+	static
 	bool is_compatible_surface(const gl::render_target* surface, const gl::render_target* ref, u16 width, u16 height, u8 sample_count)
 	{
 		return (surface->get_internal_format() == ref->get_internal_format() &&

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -336,6 +336,7 @@ namespace vk
 		{
 			// TODO
 			src->rsx_pitch = static_cast<u32>(out_pitch);
+			src->state_flags = rsx::surface_state_flags::erase_bkgnd;
 			return {};
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -329,6 +329,16 @@ namespace vk
 			sink->raster_type = ref->raster_type;     // Can't actually cut up swizzled data
 		}
 
+		static std::unique_ptr<vk::render_target> convert_pitch(
+			vk::command_buffer& /*cmd*/,
+			std::unique_ptr<vk::render_target>& src,
+			usz out_pitch)
+		{
+			// TODO
+			src->rsx_pitch = static_cast<u32>(out_pitch);
+			return {};
+		}
+
 		static bool is_compatible_surface(const vk::render_target* surface, const vk::render_target* ref, u16 width, u16 height, u8 sample_count)
 		{
 			return (surface->format() == ref->format() &&

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -574,6 +574,7 @@ namespace vk
 			view_swizzle = source->native_component_map;
 		}
 
+		image->set_debug_name("Temp view");
 		image->set_native_component_layout(view_swizzle);
 		auto view = image->get_view(rsx::get_remap_encoding(remap_vector), remap_vector);
 

--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
@@ -146,6 +146,7 @@ namespace vk
 			}
 
 			ptr.reset(create_texture());
+			ptr->set_debug_name(fmt::format("Scratch: Format=0x%x", static_cast<u32>(format)));
 		}
 
 		return ptr.get();


### PR DESCRIPTION
If pitch of a surface is changed, the only way to preserve data is to do a cache flush and rebuild from raw memory. While this is a huge task in and of itself, we do not need to implement all of that. For now, just set erase background flag but keep the old memory access tag. This forces a memory reload.
Of course this setup falls on its face if certain combinations of options are enabled, so I'd like to get some testing going.
I will still implement the full version of this, but it will take a long while to get ready (some re-architecting is required).
The only game I found affected by this issue is R&C ACiT, but I'm sure there are others.

Fixes https://github.com/RPCS3/rpcs3/issues/11205