### PR TITLE
LV2 Fixups

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -700,6 +700,12 @@ bool cpu_thread::check_state() noexcept
 				store = true;
 			}
 
+			if (flags & cpu_flag::notify)
+			{
+				flags -= cpu_flag::notify;
+				store = true;
+			}
+
 			// Can't process dbg_step if we only paused temporarily
 			if (cpu_can_stop && flags & cpu_flag::dbg_step)
 			{
@@ -779,6 +785,8 @@ bool cpu_thread::check_state() noexcept
 				if ((state1 ^ state) - pending_and_temp)
 				{
 					// Work could have changed flags
+					// Reset internal flags as if check_state() has just been called
+					cpu_sleep_called = false;
 					continue;
 				}
 			}

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -775,14 +775,12 @@ bool cpu_thread::check_state() noexcept
 				cpu_counter::add(this);
 			}
 
-			constexpr auto pending_and_temp = (cpu_flag::pending + cpu_flag::temp);
-
-			if ((state0 & pending_and_temp) == cpu_flag::pending)
+			if (cpu_can_stop && state0 & cpu_flag::pending)
 			{
 				// Execute pending work
 				cpu_work();
 
-				if ((state1 ^ state) - pending_and_temp)
+				if ((state1 ^ state) - cpu_flag::pending)
 				{
 					// Work could have changed flags
 					// Reset internal flags as if check_state() has just been called

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -24,6 +24,7 @@ enum class cpu_flag : u32
 	memory, // Thread must unlock memory mutex
 	pending, // Thread has postponed work
 	pending_recheck, // Thread needs to recheck if there is pending work before ::pending removal
+	notify, // Flag meant solely to allow atomic notification on state without changing other flags
 
 	dbg_global_pause, // Emulation paused
 	dbg_pause, // Thread paused
@@ -174,7 +175,7 @@ public:
 	virtual void cpu_sleep() {}
 
 	// Callback for cpu_flag::pending
-	virtual void cpu_work() {}
+	virtual void cpu_work() { state -= cpu_flag::pending + cpu_flag::pending_recheck; }
 
 	// Callback for cpu_flag::ret
 	virtual void cpu_return() {}

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -270,6 +270,8 @@ public:
 
 	alignas(64) const ppu_func_opd_t entry_func;
 	u64 start_time{0}; // Sleep start timepoint
+	u64 end_time{umax}; // Sleep end timepoint
+	s32 cancel_sleep{0}; // Flag to cancel the next lv2_obj::sleep call (when equals 2)
 	u64 syscall_args[8]{0}; // Last syscall arguments stored
 	const char* current_function{}; // Current function name for diagnosis, optimized for speed.
 	const char* last_function{}; // Sticky copy of current_function, is not cleared on function return

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -416,6 +416,8 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 		{
 			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
+				const u64 start_time = ppu.start_time;
+
 				// Wait for rescheduling
 				if (ppu.check_state())
 				{
@@ -442,6 +444,7 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 				}
 
 				cond->mutex->sleep(ppu);
+				ppu.start_time = start_time; // Restore start time because awake has been called
 				timeout = 0;
 				continue;
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -443,6 +443,8 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 		{
 			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
+				const u64 start_time = ppu.start_time;
+
 				// Wait for rescheduling
 				if (ppu.check_state())
 				{
@@ -476,6 +478,7 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 				}
 
 				mutex->sleep(ppu);
+				ppu.start_time = start_time; // Restore start time because awake has been called
 				timeout = 0;
 				continue;
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -395,8 +395,7 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 
 		if (is_stopped(state))
 		{
-			reader_lock lock(cond->mutex);
-			reader_lock lock2(mutex->mutex);
+			std::scoped_lock lock(cond->mutex, mutex->mutex);
 
 			bool mutex_sleep = false;
 			bool cond_sleep = false;

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -135,7 +135,7 @@ struct lv2_lwmutex final : lv2_obj
 			control_data_t store = old;
 			store.signaled |= (unlock2 ? s32{smin} : 1);
 
-			if (lv2_control.compare_and_swap_test(old, store))
+			if (lv2_control.compare_exchange(old, store))
 			{
 				return true;
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -123,6 +123,11 @@ struct lv2_lwmutex final : lv2_obj
 			lwcond_waiters.notify_all();
 		}
 	
+		if (signal)
+		{
+			cpu->next_cpu = nullptr;
+		}
+
 		return signal;
 	}
 
@@ -158,8 +163,9 @@ struct lv2_lwmutex final : lv2_obj
 				res = nullptr;
 			}
 
-			if (auto sq = data.sq)
+			if (auto sq = static_cast<T*>(data.sq))
 			{
+				restore_next = sq->next_cpu;
 				res = schedule<T>(data.sq, protocol);
 
 				if (sq == data.sq)
@@ -167,7 +173,6 @@ struct lv2_lwmutex final : lv2_obj
 					return false;
 				}
 
-				restore_next = res->next_cpu;
 				return true;
 			}
 			else

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -162,15 +162,19 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 		{
 			lv2_obj::prepare_for_sleep(ppu);
 
-			if (mutex.try_own(ppu))
+			ppu.cancel_sleep = 1;
+
+			if (mutex.try_own(ppu) || !mutex.sleep(ppu, timeout))
 			{
 				result = {};
 			}
-			else
+
+			if (ppu.cancel_sleep != 1)
 			{
-				mutex.sleep(ppu, timeout);
 				notify.cleanup();
 			}
+
+			ppu.cancel_sleep = 0;
 		}
 
 		return result;

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -225,7 +225,7 @@ public:
 
 private:
 	// Remove the current thread from the scheduling queue, register timeout
-	static void sleep_unlocked(cpu_thread&, u64 timeout);
+	static bool sleep_unlocked(cpu_thread&, u64 timeout, u64 current_time);
 
 	// Schedule the thread
 	static bool awake_unlocked(cpu_thread*, s32 prio = enqueue_cmd);
@@ -233,7 +233,7 @@ private:
 public:
 	static constexpr u64 max_timeout = u64{umax} / 1000;
 
-	static void sleep(cpu_thread& cpu, const u64 timeout = 0);
+	static bool sleep(cpu_thread& cpu, const u64 timeout = 0);
 
 	static bool awake(cpu_thread* thread, s32 prio = enqueue_cmd);
 
@@ -406,95 +406,7 @@ public:
 		return make;
 	}
 
-	template <bool IsUsleep = false, bool Scale = true>
-	static bool wait_timeout(u64 usec, cpu_thread* const cpu = {})
-	{
-		static_assert(u64{umax} / max_timeout >= 100, "max timeout is not valid for scaling");
-
-		if constexpr (Scale)
-		{
-			// Scale time
-			usec = std::min<u64>(usec, u64{umax} / 100) * 100 / g_cfg.core.clocks_scale;
-		}
-
-		// Clamp
-		usec = std::min<u64>(usec, max_timeout);
-
-		u64 passed = 0;
-
-		const u64 start_time = get_system_time();
-
-		auto wait_for = [cpu](u64 timeout)
-		{
-			atomic_bs_t<cpu_flag> dummy{};
-			auto& state = cpu ? cpu->state : dummy;
-			const auto old = +state;
-
-			if (old & cpu_flag::signal)
-			{
-				return true;
-			}
-
-			thread_ctrl::wait_on(state, old, timeout);
-			return false;
-		};
-
-		while (usec >= passed)
-		{
-			u64 remaining = usec - passed;
-#ifdef __linux__
-			// NOTE: Assumption that timer initialization has succeeded
-			u64 host_min_quantum = IsUsleep && remaining <= 1000 ? 10 : 50;
-#else
-			// Host scheduler quantum for windows (worst case)
-			// NOTE: On ps3 this function has very high accuracy
-			constexpr u64 host_min_quantum = 500;
-#endif
-			// TODO: Tune for other non windows operating sytems
-			bool escape = false;
-			if (g_cfg.core.sleep_timers_accuracy < (IsUsleep ? sleep_timers_accuracy_level::_usleep : sleep_timers_accuracy_level::_all_timers))
-			{
-				escape = wait_for(remaining);
-			}
-			else
-			{
-				if (remaining > host_min_quantum)
-				{
-#ifdef __linux__
-					// Do not wait for the last quantum to avoid loss of accuracy
-					escape = wait_for(remaining - ((remaining % host_min_quantum) + host_min_quantum));
-#else
-					// Wait on multiple of min quantum for large durations to avoid overloading low thread cpus
-					escape = wait_for(remaining - (remaining % host_min_quantum));
-#endif
-				}
-				else
-				{
-					// Try yielding. May cause long wake latency but helps weaker CPUs a lot by alleviating resource pressure
-					std::this_thread::yield();
-				}
-			}
-
-			if (auto cpu0 = get_current_cpu_thread(); cpu0 && cpu0->is_stopped())
-			{
-				return false;
-			}
-
-			if (thread_ctrl::state() == thread_state::aborting)
-			{
-				return false;
-			}
-
-			if (escape)
-			{
-				return false;
-			}
-
-			passed = get_system_time() - start_time;
-		}
-
-		return true;
-	}
+	static bool wait_timeout(u64 usec, ppu_thread* cpu = {}, bool scale = true, bool is_usleep = false);
 
 	static inline void notify_all()
 	{
@@ -502,9 +414,7 @@ public:
 		{
 			if (!cpu)
 			{
-				g_to_notify[0] = nullptr;
-				g_postpone_notify_barrier = false;
-				return;
+				break;
 			}
 
 			if (cpu != &g_to_notify)
@@ -514,6 +424,9 @@ public:
 				atomic_wait_engine::notify_one(cpu, 4, atomic_wait::default_mask<atomic_bs_t<cpu_flag>>);
 			}
 		}
+
+		g_to_notify[0] = nullptr;
+		g_postpone_notify_barrier = false;
 	}
 
 	// Can be called before the actual sleep call in order to move it out of mutex scope
@@ -542,7 +455,8 @@ public:
 				}
 
 				// While IDM mutex is still locked (this function assumes so) check if the notification is still needed
-				if (cpu != &g_to_notify && !static_cast<const decltype(cpu_thread::state)*>(cpu)->all_of(cpu_flag::signal + cpu_flag::wait))
+				// Pending flag is meant for forced notification (if the CPU really has pending work it can restore the flag in theory)
+				if (cpu != &g_to_notify && static_cast<const decltype(cpu_thread::state)*>(cpu)->none_of(cpu_flag::signal + cpu_flag::pending))
 				{
 					// Omit it (this is a void pointer, it can hold anything)
 					cpu = &g_to_notify;
@@ -575,5 +489,5 @@ private:
 	// If a notify_all_t object exists locally, postpone notifications to the destructor of it (not recursive, notifies on the first destructor for safety)
 	static thread_local bool g_postpone_notify_barrier;
 
-	static void schedule_all();
+	static void schedule_all(u64 current_time = 0);
 };

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -409,7 +409,7 @@ error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 	{
 		lv2_obj::sleep(ppu, g_cfg.core.sleep_timers_accuracy < sleep_timers_accuracy_level::_usleep ? sleep_time : 0);
 
-		if (!lv2_obj::wait_timeout<true>(sleep_time))
+		if (!lv2_obj::wait_timeout(sleep_time, &ppu, true, true))
 		{
 			ppu.state += cpu_flag::again;
 		}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3404,7 +3404,7 @@ namespace rsx
 				if (target_rsx_flip_time > time + 1000)
 				{
 					const auto delay_us = target_rsx_flip_time - time;
-					lv2_obj::wait_timeout<false, false>(delay_us);
+					lv2_obj::wait_timeout(delay_us, nullptr, false);
 					performance_counters.idle_time += delay_us;
 				}
 			}

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -607,7 +607,7 @@ void kernel_explorer::update()
 		const ppu_thread_status status = lv2_obj::ppu_state(&ppu, false, false);
 
 		add_leaf(find_node(root, additional_nodes::ppu_threads), qstr(fmt::format(u8"PPU 0x%07x: “%s”, PRIO: %d, Joiner: %s, Status: %s, State: %s, %s func: “%s”", id, *ppu.ppu_tname.load(), +ppu.prio, ppu.joiner.load(), status, ppu.state.load()
-			, ppu.current_function ? "In" : "Last", func ? func : "")));
+			, ppu.ack_suspend ? "After" : (ppu.current_function ? "In" : "Last"), func ? func : "")));
 	}, idm::unlocked);
 
 	lock_idm_lv2.reset();

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -676,6 +676,13 @@ void log_frame::UpdateUI()
 				}
 
 				s_gui_listener.pop();
+
+				if (steady_clock::now() >= start + 7ms)
+				{
+					// Must break eventually
+					break;
+				}
+
 				continue;
 			}
 


### PR DESCRIPTION
* Optimize lv2_obj::yield, fix a bug that existed before the pr and some which were introduced by it.
* A hotfix in sys_lwmutex/mutex.
* Fix a race in savestates with sys_lwcond.
* Improve the accuracy of LV2 timers regardless of the setting used. (count time passed from the time of sleep, not of wait_timeout)
* ~~**_Fix a race condition which existed before the pr as well. For me it fixes a freeze in Demon Souls after a while but it improves overall PPU stability in nearly every game. description is in the commit: https://github.com/RPCS3/rpcs3/pull/12482/commits/bf4791f571c9ea7be59fbc9b958ae73731ab0672_**~~ Removed from this pr.

Fixes #12480 
Fixes #12485
Fixes #12486
Fixes #12489 