### PR TITLE
rsx: Refactor surface cache storage

### DIFF
--- a/rpcs3/Emu/RSX/Common/ranged_map.hpp
+++ b/rpcs3/Emu/RSX/Common/ranged_map.hpp
@@ -10,6 +10,7 @@ namespace rsx
 	template<typename T, int BlockSize>
 	class ranged_map
 	{
+	protected:
 		struct block_metadata_t
 		{
 			u32 id = umax;             // ID of the matadata blob
@@ -28,6 +29,11 @@ namespace rsx
 		static inline u32 block_for(u32 address)
 		{
 			return address / BlockSize;
+		}
+
+		static inline u32 block_address(u32 block_id)
+		{
+			return block_id * BlockSize;
 		}
 
 		void broadcast_insert(const utils::address_range& range)

--- a/rpcs3/Emu/RSX/Common/surface_cache_storage.hpp
+++ b/rpcs3/Emu/RSX/Common/surface_cache_storage.hpp
@@ -1,0 +1,113 @@
+#pragma once
+#include "ranged_map.hpp"
+
+namespace rsx
+{
+	template <typename Traits, int BlockSize>
+	class surface_cache_data_map : public ranged_map<typename Traits::surface_storage_type, BlockSize>
+	{
+		using super = class ranged_map<typename Traits::surface_storage_type, BlockSize>;
+		using metadata_t = typename super::block_metadata_t;
+
+		const metadata_t& find_head_block(u32 address)
+		{
+			auto& meta = super::m_metadata[address];
+			if (meta.head_block != umax)
+			{
+				return find_head_block(meta.head_block * BlockSize);
+			}
+
+			return meta;
+		}
+
+	public:
+		using buffer_object_storage_type = typename Traits::buffer_object_storage_type;
+		using buffer_object_type = typename Traits::buffer_object_type;
+
+		struct buffer_object_t
+		{
+			buffer_object_storage_type bo;
+			u64 memory_tag = 0;
+
+			inline buffer_object_type get()
+			{
+				return Traits::get(bo);
+			}
+
+			inline void release()
+			{
+				bo.release();
+			}
+
+			inline void acquire(buffer_object_type obj)
+			{
+				ensure(!get());
+				bo = obj;
+			}
+		};
+
+	protected:
+		using buffer_block_array = typename std::array<buffer_object_t, 0x100000000ull / BlockSize>;
+		buffer_block_array m_buffer_list;
+
+	public:
+		surface_cache_data_map()
+			: super::ranged_map()
+		{}
+
+		surface_cache_data_map& with_range(const utils::address_range& range)
+		{
+			// Prepare underlying memory so that the range specified is provisioned and contiguous
+			const auto& head_block = find_head_block(range.start);
+			const auto start_address = block_address(head_block.id);
+
+			const auto& current = m_buffer_list[head_block.id];
+			if (auto bo = current.get())
+			{
+				if (::size32(*bo) >= (range.end - start_address))
+				{
+					return *this;
+				}
+			}
+
+			// Data does not exist or is not contiguous. Merge the layer
+			std::vector<buffer_object_type> bo_list;
+			for (u32 address = start_address; address <= range.end;)
+			{
+				auto& bo_storage = m_buffer_list[super::block_for(address)];
+				if (auto bo = bo_storage.get())
+				{
+					bo_list.push_back(bo);
+					bo_storage.release();
+					address += ::size32(*bo);
+					continue;
+				}
+
+				bo_list.push_back(nullptr);
+				address += BlockSize;
+			}
+
+			auto unified = Traits::merge_bo_list<BlockSize>(bo_list);
+			ensure(unified);
+
+			current.acquire(unified);
+			return *this;
+		}
+
+		void spill(const utils::address_range& range)
+		{
+			// Move VRAM to system RAM
+			const auto& meta = with_range(range).find_head_block(range.start);
+			auto& storage = m_buffer_list[meta.id];
+			Traits::spill_buffer(storage.bo);
+		}
+
+		void unspill(const utils::address_range& range)
+		{
+			// Move system RAM to VRAM
+			const auto& meta = with_range(range).find_head_block(range.start);
+			auto& storage = m_buffer_list[meta.id];
+			Traits::unspill_buffer(storage.bo);
+		}
+	};
+}

--- a/rpcs3/Emu/RSX/Common/surface_cache_storage.hpp
+++ b/rpcs3/Emu/RSX/Common/surface_cache_storage.hpp
@@ -6,7 +6,11 @@ namespace rsx
 	template <typename Traits, int BlockSize>
 	class surface_cache_data_map : public ranged_map<typename Traits::surface_storage_type, BlockSize>
 	{
+#ifdef _MSC_VER
+		using super = ranged_map<typename Traits::surface_storage_type, BlockSize>;
+#else
 		using super = class ranged_map<typename Traits::surface_storage_type, BlockSize>;
+#endif
 		using metadata_t = typename super::block_metadata_t;
 
 		const metadata_t& find_head_block(u32 address)

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -2,7 +2,7 @@
 
 #include "surface_utils.h"
 #include "simple_array.hpp"
-#include "ranged_map.hpp"
+#include "surface_cache_storage.hpp"
 #include "../gcm_enums.h"
 #include "../rsx_utils.h"
 #include <list>
@@ -20,7 +20,7 @@ namespace rsx
 		usz get_packed_pitch(surface_color_format format, u32 width);
 	}
 
-	template<typename Traits>
+	template <typename Traits>
 	struct surface_store
 	{
 		static constexpr u32 get_aa_factor_u(surface_antialiasing aa_mode)
@@ -45,7 +45,7 @@ namespace rsx
 		using surface_type = typename Traits::surface_type;
 		using command_list_type = typename Traits::command_list_type;
 		using surface_overlap_info = surface_overlap_info_t<surface_type>;
-		using surface_ranged_map = typename rsx::ranged_map<surface_storage_type, 0x400000>;
+		using surface_ranged_map = surface_cache_data_map<Traits, 0x400000>;
 
 	protected:
 		surface_ranged_map m_render_targets_storage = {};

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -124,6 +124,8 @@ struct gl_render_target_traits
 {
 	using surface_storage_type = std::unique_ptr<gl::render_target>;
 	using surface_type = gl::render_target*;
+	using buffer_object_storage_type = std::unique_ptr<gl::buffer>;
+	using buffer_object_type = gl::buffer*;
 	using command_list_type = gl::command_context&;
 	using download_buffer_object = std::vector<u8>;
 	using barrier_descriptor_t = rsx::deferred_clipped_region<gl::render_target*>;
@@ -346,7 +348,27 @@ struct gl_render_target_traits
 	}
 
 	static
-	gl::render_target* get(const std::unique_ptr<gl::render_target> &in)
+	void spill_buffer(std::unique_ptr<gl::buffer>& bo)
+	{
+		// TODO
+	}
+
+	static
+	void unspill_buffer(std::unique_ptr<gl::buffer>& bo)
+	{
+		// TODO
+	}
+
+	static
+	gl::buffer* merge_bo_list(const std::vector<gl::buffer*>& list)
+	{
+		// TODO
+		return nullptr;
+	}
+
+	template <typename T>
+	static
+	T* get(const std::unique_ptr<T> &in)
 	{
 		return in.get();
 	}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -85,6 +85,8 @@ namespace vk
 	{
 		using surface_storage_type = std::unique_ptr<vk::render_target>;
 		using surface_type = vk::render_target*;
+		using buffer_object_storage_type = std::unique_ptr<vk::buffer>;
+		using buffer_object_type = vk::buffer*;
 		using command_list_type = vk::command_buffer&;
 		using download_buffer_object = void*;
 		using barrier_descriptor_t = rsx::deferred_clipped_region<vk::render_target*>;
@@ -451,9 +453,26 @@ namespace vk
 			return int_surface_matches_properties(surface, vk_format, width, height, antialias, check_refs);
 		}
 
-		static vk::render_target* get(const std::unique_ptr<vk::render_target>& tex)
+		static void spill_buffer(std::unique_ptr<vk::buffer>& bo)
 		{
-			return tex.get();
+			// TODO
+		}
+
+		static void unspill_buffer(std::unique_ptr<vk::buffer>& bo)
+		{
+			// TODO
+		}
+
+		static vk::buffer* merge_bo_list(const std::vector<vk::buffer*>& list)
+		{
+			// TODO
+			return nullptr;
+		}
+
+		template <typename T>
+		static T* get(const std::unique_ptr<T>& obj)
+		{
+			return obj.get();
 		}
 	};
 

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -514,6 +514,7 @@
     <ClInclude Include="Emu\RSX\Common\profiling_timer.hpp" />
     <ClInclude Include="Emu\RSX\Common\ranged_map.hpp" />
     <ClInclude Include="Emu\RSX\Common\simple_array.hpp" />
+    <ClInclude Include="Emu\RSX\Common\surface_cache_storage.hpp" />
     <ClInclude Include="Emu\RSX\Common\time.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_cursor.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_edit_text.hpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2140,6 +2140,9 @@
     <ClInclude Include="Emu\RSX\Common\ranged_map.hpp">
       <Filter>Emu\GPU\RSX\Common</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\Common\surface_cache_storage.hpp">
+      <Filter>Emu\GPU\RSX\Common</Filter>
+    </ClInclude>
     <ClInclude Include="Emu\CPU\sse2neon.h">
       <Filter>Emu\CPU</Filter>
     </ClInclude>


### PR DESCRIPTION
Refactor surface cache storage a bit to allow a persistent GPU memory cache to back all the surfaces. This layer can be used as a data source in case of unexpected corner cases, such as pitch mismatch reconstruction. This is only boilerplate code at this stage and no changes to functionality are expected at this time.
Part of https://github.com/RPCS3/rpcs3/issues/10208