### PR TITLE
[macOS] [Needs Testing] Update hid_pad_handler.cpp to prevent DS4 from disconnecting

### DIFF
--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -67,9 +67,9 @@ bool hid_pad_handler<Device>::Init()
 	if (res != 0)
 		fmt::throw_exception("%s hidapi-init error.threadproc", m_type);
 
-	#if defined(__APPLE__)
+#if defined(__APPLE__)
 	hid_darwin_set_open_exclusive(0);
-	#endif
+#endif
 	
 	for (usz i = 1; i <= MAX_GAMEPADS; i++) // Controllers 1-n in GUI
 	{

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -7,6 +7,10 @@
 #include "Emu/System.h"
 #include "pad_thread.h"
 
+#if defined(__APPLE__)
+#include "3rdparty/hidapi/hidapi/mac/hidapi_darwin.h"
+#endif
+
 #include <algorithm>
 #include <memory>
 
@@ -63,6 +67,10 @@ bool hid_pad_handler<Device>::Init()
 	if (res != 0)
 		fmt::throw_exception("%s hidapi-init error.threadproc", m_type);
 
+	#if defined(__APPLE__)
+	hid_darwin_set_open_exclusive(0);
+	#endif
+	
 	for (usz i = 1; i <= MAX_GAMEPADS; i++) // Controllers 1-n in GUI
 	{
 		m_controllers.emplace(m_name_string + std::to_string(i), std::make_shared<Device>());


### PR DESCRIPTION
Prevents DS4 (and possibly DS3 and DualSense) from disconnecting from bluetooth after 15 minutes by using hidapi's non-exclusive mode. 

The most recent version of hidapi, 0.12 from two months ago, added "macOS-specific function(s) to open device(s) in non-exclusive mode".

Fixes #12290

Testing: Try using DualShock 3, DualShock 4 and Dualsense with bluetooth for more than 15 minutes.

This PR should not affect Windows or Linux.

Note that this PR just prevents the controller from disconnecting. RPCS3 will probably still crash if the controller is disconnected for any other reason. 

Credit to Behodar