### PR TITLE
Stability fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1592,7 +1592,7 @@ void lv2_obj::schedule_all(u64 current_time)
 			if (target->state & cpu_flag::suspend)
 			{
 				ppu_log.trace("schedule(): %s", target->id);
-				target->state ^= (cpu_flag::signal + cpu_flag::suspend);
+				target->state.atomic_op(FN(x += cpu_flag::signal, x -= cpu_flag::suspend));
 				target->start_time = 0;
 
 				if (notify_later_idx == std::size(g_to_notify))

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -368,11 +368,13 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 					return;
 				}
 
+				// Put the current thread to sleep and schedule lwmutex waiter atomically
 				cond.append(cpu);
+				cond.sleep(ppu, timeout);
+				return;
 			}
 		}
 
-		// Sleep current thread and schedule lwmutex waiter
 		cond.sleep(ppu, timeout);
 	});
 


### PR DESCRIPTION
Adds 2 new bug fixes.
* ### Fix an LV2 bug that over time can randomly kill the PPUs at once. Timeline of the race condition:
1. The PPU is in SLEEP state. state = suspend.
2. lv2_obj::awake is called on the traced thread and is now in ONPROC state, state = signal.
3. lv2_obj::awake is called by another thread externally with a priority higher than our traced thread and appends it to g_pending. state = suspend + signal.
4. lv2_obj::sleep/set_priority (highering priority) is called on any thread which is in ONPROC. Causing it to enter SLEEP or RUNNING state, while the traced thread is back in queue in ONPROC. state = suspend + signal.
5. The traced thread finally calls lv2_obj::awake on itself, g_pending decrements to 0 and we a have a rescheduling event, after XOR state = no flags (no signal)
6. In cpu_thread::check_state: cpu_sleep_called is now true and remains this way.
7. Another thread with a higher prioty kicks in and appends the traced thread into g_pending. state = suspend.
8. The traced thread is at cpu_thread::cpu_wait() waiting on state flags, awake is not called again because cpu_sleep_called is true. And that function is where it's gonna spend the rest of its life.
Fix this bug by not using XOR, instead properly add signal and substruct suspend flags.

* ### Fix a loose notification in lwcond wait: put awake under mutex lock so when an lwmutex waiter times out a notification won't be able to awake it from other syscalls.

For me it fixes freezes in Demon Souls after a while.