### PR TITLE
SPU: Lock-line reservation optimizations + Savestates bugfix

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -996,6 +996,11 @@ bool jit_compiler::check(const std::string& path)
 	return false;
 }
 
+void jit_compiler::update_global_mapping(const std::string& name, u64 addr)
+{
+	m_engine->updateGlobalMapping(name, addr);
+}
+
 void jit_compiler::fin()
 {
 	m_engine->finalizeObject();

--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -267,14 +267,14 @@ namespace asmjit
 
 // Build runtime function with asmjit::X86Assembler
 template <typename FT, typename Asm = native_asm, typename F>
-inline FT build_function_asm(std::string_view name, F&& builder)
+inline FT build_function_asm(std::string_view name, F&& builder, ::jit_runtime* custom_runtime = nullptr)
 {
 #ifdef __APPLE__
 	pthread_jit_write_protect_np(false);
 #endif
 	using namespace asmjit;
 
-	auto& rt = get_global_runtime();
+	auto& rt = custom_runtime ? *custom_runtime : get_global_runtime();
 
 	CodeHolder code;
 	code.init(rt.environment());
@@ -361,6 +361,9 @@ public:
 
 	// Add object (path to obj file)
 	void add(const std::string& path);
+
+	// Update global mapping for a single value
+	void update_global_mapping(const std::string& name, u64 addr);
 
 	// Check object file
 	static bool check(const std::string& path);

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1242,14 +1242,16 @@ bool handle_access_violation(u32 addr, bool is_writing, ucontext_t* context) noe
 
 	if (rsx::g_access_violation_handler)
 	{
+		bool state_changed = false;
+
 		if (cpu)
 		{
-			vm::temporary_unlock(*cpu);
+			state_changed = vm::temporary_unlock(*cpu);
 		}
 
 		bool handled = rsx::g_access_violation_handler(addr, is_writing);
 
-		if (cpu && (cpu->state += cpu_flag::temp, cpu->test_stopped()))
+		if (state_changed && (cpu->state += cpu_flag::temp, cpu->test_stopped()))
 		{
 			//
 		}

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -38,8 +38,6 @@ void fmt_class_string<bs_t<ppu_attr>>::format(std::string& out, u64 arg)
 	format_bitset(out, arg, "[", ",", "]", &fmt_class_string<ppu_attr>::format);
 }
 
-u32 ppu_get_far_jump(u32 pc);
-
 void ppu_module::validate(u32 reloc)
 {
 	// Load custom PRX configuration if available
@@ -1202,12 +1200,6 @@ void ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 				const ppu_opcode_t op{*_ptr++};
 				const ppu_itype::type type = s_ppu_itype.decode(op.opcode);
 
-				if (ppu_get_far_jump(iaddr))
-				{
-					block.second = _ptr.addr() - block.first - 4;
-					break;
-				}
-
 				if (type == ppu_itype::UNK)
 				{
 					// Invalid blocks will remain empty
@@ -1397,11 +1389,6 @@ void ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 				const ppu_opcode_t op{*_ptr++};
 				const ppu_itype::type type = s_ppu_itype.decode(op.opcode);
 
-				if (ppu_get_far_jump(iaddr))
-				{
-					break;
-				}
-
 				if (type == ppu_itype::B || type == ppu_itype::BC)
 				{
 					const u32 target = (op.aa ? 0 : iaddr) + (type == ppu_itype::B ? +op.bt24 : +op.bt14);
@@ -1476,11 +1463,7 @@ void ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 			const ppu_opcode_t op{*_ptr++};
 			const ppu_itype::type type = s_ppu_itype.decode(op.opcode);
 
-			if (ppu_get_far_jump(addr))
-			{
-				_ptr.set(next);
-			}
-			else if (type == ppu_itype::UNK)
+			if (type == ppu_itype::UNK)
 			{
 				break;
 			}
@@ -1692,11 +1675,6 @@ void ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 
 			for (; i_pos < lim; i_pos += 4)
 			{
-				if (ppu_get_far_jump(i_pos))
-				{
-					continue;
-				}
-
 				const u32 opc = vm::_ref<u32>(i_pos);
 
 				switch (auto type = s_ppu_itype.decode(opc))

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1135,6 +1135,12 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 				// Initialize executable code if necessary
 				if (prog.p_flags & 0x1)
 				{
+					if (ar)
+					{
+						// Disable analysis optimization for savestates (it's not compatible with savestate with patches applied)
+						end = std::max(end, utils::align<u32>(addr + mem_size, 0x10000));
+					}
+
 					ppu_register_range(addr, mem_size);
 				}
 
@@ -1589,6 +1595,12 @@ bool ppu_load_exec(const ppu_exec_object& elf, utils::serial* ar)
 			// Initialize executable code if necessary
 			if (prog.p_flags & 0x1)
 			{
+				if (already_loaded && ar)
+				{
+					// Disable analysis optimization for savestates (it's not compatible with savestate with patches applied)
+					end = std::max(end, utils::align<u32>(addr + size, 0x10000));
+				}
+
 				ppu_register_range(addr, size);
 			}
 
@@ -2197,6 +2209,12 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 			// Initialize executable code if necessary
 			if (prog.p_flags & 0x1)
 			{
+				if (ar)
+				{
+					// Disable analysis optimization for savestates (it's not compatible with savestate with patches applied)
+					end = std::max(end, utils::align<u32>(addr + size, 0x10000));
+				}
+
 				ppu_register_range(addr, size);
 			}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -616,9 +616,13 @@ struct ppu_far_jumps_t
 		bool link;
 		bool with_toc;
 		std::string module_name;
+		ppu_intrp_func_t func;
 	};
 
+	ppu_far_jumps_t(int) noexcept {}
+
 	std::unordered_map<u32, all_info_t> vals;
+	::jit_runtime rt;
 
 	mutable shared_mutex mutex;
 
@@ -679,17 +683,64 @@ struct ppu_far_jumps_t
 
 		return {};
 	}
+
+	template <bool Locked = true>
+	ppu_intrp_func_t gen_jump(u32 pc)
+	{
+		[[maybe_unused]] std::conditional_t<Locked, std::lock_guard<shared_mutex>, const shared_mutex&> lock(mutex);
+
+		auto it = vals.find(pc);
+
+		if (it == vals.end())
+		{
+			return nullptr;
+		}
+
+		if (!it->second.func)
+		{
+			it->second.func = build_function_asm<ppu_intrp_func_t>("", [&](native_asm& c, auto& args)
+			{
+				using namespace asmjit;
+
+#ifdef ARCH_X64
+				c.mov(args[0], x86::rbp);
+				c.mov(x86::dword_ptr(args[0], ::offset32(&ppu_thread::cia)), pc);
+				c.jmp(ppu_far_jump);
+#else
+				Label jmp_address = c.newLabel();
+				Label imm_address = c.newLabel();
+
+				c.ldr(args[1].r32(), arm::ptr(imm_address));
+				c.str(args[1].r32(), arm::Mem(args[0], ::offset32(&ppu_thread::cia)));
+				c.ldr(args[1], arm::ptr(jmp_address));
+				c.br(args[1]);
+
+				c.align(AlignMode::kCode, 16);
+				c.bind(jmp_address);
+				c.embedUInt64(reinterpret_cast<u64>(ppu_far_jump));
+				c.bind(imm_address);
+				c.embedUInt32(pc);
+#endif
+			}, &rt); 
+		}
+
+		return it->second.func;
+	}
 };
 
 u32 ppu_get_far_jump(u32 pc)
 {
-	g_fxo->init<ppu_far_jumps_t>();
+	if (!g_fxo->is_init<ppu_far_jumps_t>())
+	{
+		return 0;
+	}
+
 	return g_fxo->get<ppu_far_jumps_t>().get_target(pc);
 }
 
-static void ppu_far_jump(ppu_thread& ppu, ppu_opcode_t, be_t<u32>* this_op, ppu_intrp_func*)
+static void ppu_far_jump(ppu_thread& ppu, ppu_opcode_t, be_t<u32>*, ppu_intrp_func*)
 {
-	const u32 cia = g_fxo->get<ppu_far_jumps_t>().get_target(vm::get_addr(this_op), &ppu);
+	const u32 cia = g_fxo->get<ppu_far_jumps_t>().get_target(ppu.cia, &ppu);
 
 	if (!vm::check_addr(cia, vm::page_executable))
 	{
@@ -740,7 +791,7 @@ bool ppu_form_branch_to_code(u32 entry, u32 target, bool link, bool with_toc, st
 		return false;
 	}
 
-	g_fxo->init<ppu_far_jumps_t>();
+	g_fxo->init<ppu_far_jumps_t>(0);
 
 	if (!module_name.empty())
 	{
@@ -759,7 +810,7 @@ bool ppu_form_branch_to_code(u32 entry, u32 target, bool link, bool with_toc, st
 
 	std::lock_guard lock(jumps.mutex);
 	jumps.vals.insert_or_assign(entry, ppu_far_jumps_t::all_info_t{target, link, with_toc, std::move(module_name)});
-	ppu_register_function_at(entry, 4, &ppu_far_jump);
+	ppu_register_function_at(entry, 4, g_cfg.core.ppu_decoder == ppu_decoder_type::_static ? &ppu_far_jump : ensure(g_fxo->get<ppu_far_jumps_t>().gen_jump<false>(entry)));
 
 	return true;
 }
@@ -781,7 +832,10 @@ bool ppu_form_branch_to_code(u32 entry, u32 target)
 
 void ppu_remove_hle_instructions(u32 addr, u32 size)
 {
-	g_fxo->init<ppu_far_jumps_t>();
+	if (Emu.IsStopped() || !g_fxo->is_init<ppu_far_jumps_t>())
+	{
+		return;
+	}
 
 	auto& jumps = g_fxo->get<ppu_far_jumps_t>();
 
@@ -3392,6 +3446,19 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 				}
 			}
 
+			if (jit)
+			{
+				const auto far_jump = ppu_get_far_jump(func.addr) ? g_fxo->get<ppu_far_jumps_t>().gen_jump(func.addr) : nullptr;
+
+				if (far_jump)
+				{
+					// Replace the function with ppu_far_jump
+					jit->update_global_mapping(fmt::format("__0x%x", func.addr - reloc), reinterpret_cast<u64>(far_jump));
+					fpos++;
+					continue;
+				}
+			}
+
 			// Copy block or function entry
 			ppu_function& entry = part.funcs.emplace_back(func);
 
@@ -3713,8 +3780,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 			const auto addr = ensure(reinterpret_cast<ppu_intrp_func_t>(jit->get(name)));
 			jit_mod.funcs.emplace_back(addr);
 
-			if (ppu_ref(func.addr) != ppu_far_jump)
-				ppu_register_function_at(func.addr, 4, addr);
+			ppu_register_function_at(func.addr, 4, addr);
 
 			if (g_cfg.core.ppu_debug)
 				ppu_log.notice("Installing function %s at 0x%x: %p (reloc = 0x%x)", name, func.addr, ppu_ref(func.addr), reloc);
@@ -3733,8 +3799,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 
 			const u64 addr = reinterpret_cast<uptr>(ensure(jit_mod.funcs[index++]));
 
-			if (ppu_ref(func.addr) != ppu_far_jump)
-				ppu_register_function_at(func.addr, 4, addr);
+			ppu_register_function_at(func.addr, 4, addr);
 
 			if (g_cfg.core.ppu_debug)
 				ppu_log.notice("Reinstalling function at 0x%x: %p (reloc=0x%x)", func.addr, ppu_ref(func.addr), reloc);

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -236,14 +236,6 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 				m_rel = nullptr;
 			}
 
-			if (ppu_get_far_jump(m_addr + base))
-			{
-				// Branch into an HLEd instruction using the jump table
-				FlushRegisters();
-				CallFunction(0, m_reloc ? m_ir->CreateAdd(m_ir->getInt64(m_addr), m_seg0) : m_ir->getInt64(m_addr));
-				continue;
-			}
-
 			const u32 op = vm::read32(vm::cast(m_addr + base));
 
 			(this->*(s_ppu_decoder.decode(op)))({op});

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -836,6 +836,8 @@ public:
 	u32 last_faddr = 0;
 	u64 last_fail = 0;
 	u64 last_succ = 0;
+	u64 last_gtsc = 0;
+	u32 last_getllar = umax; // LS address of last GETLLAR (if matches current GETLLAR we can let the thread rest) 
 
 	std::vector<mfc_cmd_dump> mfc_history;
 	u64 mfc_dump_idx = 0;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -814,6 +814,7 @@ public:
 	const std::add_pointer_t<u8> ls; // SPU LS pointer
 	const u32 option; // sys_spu_thread_initialize option
 	const u32 lv2_id; // The actual id that is used by syscalls
+	u32 spurs_addr = 0;
 
 	spu_thread* next_cpu{}; // LV2 thread queues' node link
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -839,7 +839,8 @@ public:
 	u64 last_fail = 0;
 	u64 last_succ = 0;
 	u64 last_gtsc = 0;
-	u32 last_getllar = umax; // LS address of last GETLLAR (if matches current GETLLAR we can let the thread rest) 
+	u32 last_getllar = umax; // LS address of last GETLLAR (if matches current GETLLAR we can let the thread rest)
+	u32 getllar_busy_waiting_switch = umax; // umax means the test needs evaluation, otherwise it's a boolean
 
 	std::vector<mfc_cmd_dump> mfc_history;
 	u64 mfc_dump_idx = 0;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -751,6 +751,7 @@ public:
 	u64 rtime = 0;
 	alignas(64) std::byte rdata[128]{};
 	u32 raddr = 0;
+	const decltype(rdata)* resrv_mem{};
 
 	// Range Lock pointer
 	atomic_t<u64, 64>* range_lock{};

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -63,7 +63,7 @@ enum ppu_thread_status : u32;
 
 namespace vm
 {
-	void temporary_unlock(cpu_thread& cpu) noexcept;
+	bool temporary_unlock(cpu_thread& cpu) noexcept;
 }
 
 namespace cpu_counter

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -380,7 +380,7 @@ namespace vm
 		}
 	}
 
-	void temporary_unlock(cpu_thread& cpu) noexcept
+	bool temporary_unlock(cpu_thread& cpu) noexcept
 	{
 		bs_t<cpu_flag> add_state = cpu_flag::wait;
 
@@ -392,7 +392,10 @@ namespace vm
 		if (add_state - cpu.state)
 		{
 			cpu.state += add_state;
+			return true;
 		}
+
+		return false;
 	}
 
 	void temporary_unlock() noexcept

--- a/rpcs3/Emu/Memory/vm_locking.h
+++ b/rpcs3/Emu/Memory/vm_locking.h
@@ -105,7 +105,7 @@ namespace vm
 	void passive_unlock(cpu_thread& cpu);
 
 	// Optimization (set cpu_flag::memory)
-	void temporary_unlock(cpu_thread& cpu) noexcept;
+	bool temporary_unlock(cpu_thread& cpu) noexcept;
 	void temporary_unlock() noexcept;
 
 	struct writer_lock final

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -41,6 +41,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<spu_block_size_type> spu_block_size{ this, "SPU Block Size", spu_block_size_type::safe };
 		cfg::_bool spu_accurate_getllar{ this, "Accurate GETLLAR", false, true };
 		cfg::_bool spu_accurate_dma{ this, "Accurate SPU DMA", false };
+		cfg::_bool spu_accurate_reservations{ this, "Accurate SPU Reservations", true };
 		cfg::_bool accurate_cache_line_stores{ this, "Accurate Cache Line Stores", false };
 		cfg::_bool rsx_accurate_res_access{this, "Accurate RSX reservation access", false, true};
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -31,7 +31,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<thread_scheduler_mode> thread_scheduler{this, "Thread Scheduler Mode", thread_scheduler_mode::os};
 		cfg::_bool set_daz_and_ftz{ this, "Set DAZ and FTZ", false };
 		cfg::_enum<spu_decoder_type> spu_decoder{ this, "SPU Decoder", spu_decoder_type::llvm };
-		cfg::_bool spu_reservation_busy_waiting{ this, "SPU Reservation Busy Waiting", false, true };
+		cfg::uint<0, 100> spu_reservation_busy_waiting_percentage{ this, "SPU Reservation Busy Waiting Percentage", 0, true };
 		cfg::_bool spu_debug{ this, "SPU Debug" };
 		cfg::_bool mfc_debug{ this, "MFC Debug" };
 		cfg::_int<0, 6> preferred_spu_threads{ this, "Preferred SPU Threads", 0, true }; // Number of hardware threads dedicated to heavy simultaneous spu tasks

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -31,7 +31,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<thread_scheduler_mode> thread_scheduler{this, "Thread Scheduler Mode", thread_scheduler_mode::os};
 		cfg::_bool set_daz_and_ftz{ this, "Set DAZ and FTZ", false };
 		cfg::_enum<spu_decoder_type> spu_decoder{ this, "SPU Decoder", spu_decoder_type::llvm };
-		cfg::_bool spu_getllar_polling_detection{ this, "SPU GETLLAR polling detection", false, true };
+		cfg::_bool spu_reservation_busy_waiting{ this, "SPU Reservation Busy Waiting", false, true };
 		cfg::_bool spu_debug{ this, "SPU Debug" };
 		cfg::_bool mfc_debug{ this, "MFC Debug" };
 		cfg::_int<0, 6> preferred_spu_threads{ this, "Preferred SPU Threads", 0, true }; // Number of hardware threads dedicated to heavy simultaneous spu tasks

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -322,6 +322,7 @@ public:
 
 	static void set_wait_callback(bool(*cb)(const void* data, u64 attempts, u64 stamp0));
 	static void set_notify_callback(void(*cb)(const void* data, u64 progress));
+	static void set_one_time_use_wait_callback(bool(*cb)(u64 progress));
 
 	static void notify_all(const void* data)
 	{


### PR DESCRIPTION
* "SPU GETLLAR polling detection" setting (which was yielding resources when it's set to true) has been transformed to "SPU Reservation Busy Waiting Percentage" and is off ("0") by default. (0 is yielding resources, 100 is always busy-waiting)
* It's now responsible for SPU events waiting as well, so the yielding can be replaced with busy-waiting there. You can test if you get perf gains with it set to on if your CPU has many threads. 
* It's not allowed to be changed for TSX users because TSX is very sensitive to memory touching. It's always as if this setting is set to "0" for it.
* Fix the detection of GETLLAR spin and optimize the actual yielding.
* Add some more minor optimizations.
* Fix PPU HLE injection.
* Fix PPU function analysis for savestates.
* Added an experimental SPU setting called "SPU Accurate Reservations" which may benefit CPUs, especially without TSX when set to "false" ("true" is the default and was the default before this pull request). Game config file only atm.
* Detect PPU lwmutex updates, do not notify SPU threads when it's detected.
* Implement specialized atomic waiting for SPU reservations - emphasizing on cheap thread sleep entering and exiting cost.
* Disable notifications when no data was changed in PUTLLC.

This pull request is known to fix audio stutters and heavy framerate drops in Demon Souls for low threaded CPUs.
Fixes #12513 