### PR TITLE
CI: upgrade FreeBSD to 13.1 to avoid future breakage

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -108,7 +108,7 @@ freebsd_task:
   matrix:
     - name: Cirrus FreeBSD
       freebsd_instance:
-        image_family: freebsd-13-0
+        image_family: freebsd-13-1
         cpu: 8
         memory: 8G
   env:


### PR DESCRIPTION
FreeBSD Project currently doesn't keep recent binary packages for EOL versions. `/release_0` packages (non-default) frozen at 13.0 release (2021-04-13) will remain after 13.0 EOL (2022-08-31) for 13.* branch lifetime (until 2026-01-31) but likely too old for RPCS3 CI.