### PR TITLE
rsx: Do not tamper with surface variables in convert_pitch stub

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -445,9 +445,8 @@ namespace rsx
 
 				if (Traits::surface_matches_properties(surface, format, width, height, antialias))
 				{
-					if (old_surface)
+					if (!pitch_compatible)
 					{
-						ensure(!pitch_compatible);
 						Traits::invalidate_surface_contents(command_list, Traits::get(surface), address, pitch);
 					}
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -240,10 +240,9 @@ struct gl_render_target_traits
 	std::unique_ptr<gl::render_target> convert_pitch(
 		gl::command_context& /*cmd*/,
 		std::unique_ptr<gl::render_target>& src,
-		usz out_pitch)
+		usz /*out_pitch*/)
 	{
 		// TODO
-		src->set_rsx_pitch(static_cast<u32>(out_pitch));
 		src->state_flags = rsx::surface_state_flags::erase_bkgnd;
 		return {};
 	}
@@ -348,19 +347,19 @@ struct gl_render_target_traits
 	}
 
 	static
-	void spill_buffer(std::unique_ptr<gl::buffer>& bo)
+	void spill_buffer(std::unique_ptr<gl::buffer>& /*bo*/)
 	{
 		// TODO
 	}
 
 	static
-	void unspill_buffer(std::unique_ptr<gl::buffer>& bo)
+	void unspill_buffer(std::unique_ptr<gl::buffer>& /*bo*/)
 	{
 		// TODO
 	}
 
 	static
-	gl::buffer* merge_bo_list(const std::vector<gl::buffer*>& list)
+	gl::buffer* merge_bo_list(const std::vector<gl::buffer*>& /*list*/)
 	{
 		// TODO
 		return nullptr;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -335,10 +335,9 @@ namespace vk
 		static std::unique_ptr<vk::render_target> convert_pitch(
 			vk::command_buffer& /*cmd*/,
 			std::unique_ptr<vk::render_target>& src,
-			usz out_pitch)
+			usz /*out_pitch*/)
 		{
 			// TODO
-			src->rsx_pitch = static_cast<u32>(out_pitch);
 			src->state_flags = rsx::surface_state_flags::erase_bkgnd;
 			return {};
 		}
@@ -454,17 +453,17 @@ namespace vk
 			return int_surface_matches_properties(surface, vk_format, width, height, antialias, check_refs);
 		}
 
-		static void spill_buffer(std::unique_ptr<vk::buffer>& bo)
+		static void spill_buffer(std::unique_ptr<vk::buffer>& /*bo*/)
 		{
 			// TODO
 		}
 
-		static void unspill_buffer(std::unique_ptr<vk::buffer>& bo)
+		static void unspill_buffer(std::unique_ptr<vk::buffer>& /*bo*/)
 		{
 			// TODO
 		}
 
-		static vk::buffer* merge_bo_list(const std::vector<vk::buffer*>& list)
+		static vk::buffer* merge_bo_list(const std::vector<vk::buffer*>& /*list*/)
 		{
 			// TODO
 			return nullptr;


### PR DESCRIPTION
Overriding the pitch directly was a bad idea. Very rarely, a mismatch will occur when the surface has an external read reference pending. This causes access with the wrong pitch which triggers some asserts down the line and crashes the emulator.