### PR TITLE
cubeb: add some more logging and error checks

### DIFF
--- a/rpcs3/Emu/Audio/AudioBackend.h
+++ b/rpcs3/Emu/Audio/AudioBackend.h
@@ -229,7 +229,7 @@ protected:
 	shared_mutex m_cb_mutex{};
 	std::function<u32(u32, void *)> m_write_callback{};
 
-	shared_mutex m_state_cb_mutex{};
+	std::recursive_mutex m_state_cb_mutex{};
 	std::function<void(AudioStateEvent)> m_state_callback{};
 
 	bool m_playing = false;

--- a/rpcs3/Emu/Audio/Cubeb/CubebBackend.h
+++ b/rpcs3/Emu/Audio/Cubeb/CubebBackend.h
@@ -45,7 +45,7 @@ private:
 	atomic_t<bool> m_reset_req = false;
 
 	shared_mutex m_dev_sw_mutex{};
-	std::string m_current_device{};
+	std::string m_default_device{};
 	bool m_default_dev_changed = false;
 
 	bool m_dev_collection_cb_enabled = false;
@@ -57,6 +57,13 @@ private:
 
 	void CloseUnlocked();
 
-	std::tuple<cubeb_devid, std::string /* dev_ident */, u32 /* ch_cnt */> GetDevice(std::string_view dev_id = "");
-	std::tuple<cubeb_devid, std::string /* dev_ident */, u32 /* ch_cnt */> GetDefaultDeviceAlt(AudioFreq freq, AudioSampleSize sample_size, AudioChannelCnt ch_cnt);
+	struct device_handle
+	{
+		cubeb_devid handle{};
+		std::string id;
+		u32 ch_cnt{};
+	};
+
+	device_handle GetDevice(std::string_view dev_id = "");
+	device_handle GetDefaultDeviceAlt(AudioFreq freq, AudioSampleSize sample_size, AudioChannelCnt ch_cnt);
 };


### PR DESCRIPTION
- Added more debug log messages. Cubeb was practically mute and logs were not helpful at all. These messages should be rarely logged. So I don't expect any spam from them.
- Replaced tuple with a struct for semantics. Also replaced m_current_device for m_default_device, which seems more appropriate.
- Added a bunch of sanity checks. I don't trust any third party software.