### PR TITLE
Fix GETLLAR spin detection and restore default configuration as before #12523

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -721,6 +721,7 @@ public:
 
 	// MFC command data
 	spu_mfc_cmd ch_mfc_cmd;
+	u32 mfc_cmd_id = 0;
 
 	// MFC command queue
 	spu_mfc_cmd mfc_queue[16]{};
@@ -840,6 +841,8 @@ public:
 	u64 last_succ = 0;
 	u64 last_gtsc = 0;
 	u32 last_getllar = umax; // LS address of last GETLLAR (if matches current GETLLAR we can let the thread rest)
+	u32 last_getllar_id = umax;
+	u32 getllar_spin_count = 0;
 	u32 getllar_busy_waiting_switch = umax; // umax means the test needs evaluation, otherwise it's a boolean
 
 	std::vector<mfc_cmd_dump> mfc_history;

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -32,6 +32,7 @@ struct cfg_root : cfg::node
 		cfg::_bool set_daz_and_ftz{ this, "Set DAZ and FTZ", false };
 		cfg::_enum<spu_decoder_type> spu_decoder{ this, "SPU Decoder", spu_decoder_type::llvm };
 		cfg::uint<0, 100> spu_reservation_busy_waiting_percentage{ this, "SPU Reservation Busy Waiting Percentage", 0, true };
+		cfg::uint<0, 100> spu_getllar_busy_waiting_percentage{ this, "SPU GETLLAR Busy Waiting Percentage", 100, true };
 		cfg::_bool spu_debug{ this, "SPU Debug" };
 		cfg::_bool mfc_debug{ this, "MFC Debug" };
 		cfg::_int<0, 6> preferred_spu_threads{ this, "Preferred SPU Threads", 0, true }; // Number of hardware threads dedicated to heavy simultaneous spu tasks


### PR DESCRIPTION
Revert GETLLAR polling detection to be off (100 by default now) and the setting has been remaned to "SPU GETLLAR Busy Waiting Percentage", added a new setting with the old one's name "SPU Reservation Busy Waiting Percentage" which controls busy-waiting in reading SPU_RdEventStat channel (0 by default). Demon Souls needs GETLLAR to be 0 to have the results of pr #12523.