### PR TITLE
[TESTERS ONLY][Experimental] rsx: Experimental "Fast" RSX mode

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -27,6 +27,10 @@ namespace rsx
 
 		void FIFO_control::sync_get() const
 		{
+			if (m_ctrl->get == m_ctrl->put && m_ctrl->get > m_internal_get)
+			{
+				return;
+			}
 			m_ctrl->get.release(m_internal_get);
 		}
 
@@ -175,6 +179,11 @@ namespace rsx
 					{
 						i = (i - 1) % 8;
 					}
+				}
+
+				if (addr < put && put == m_cache_addr + m_cache_size)
+				{
+					m_ctrl->get = put;
 				}
 			}
 


### PR DESCRIPTION
Make the CELL think RSX already finished its work so it can already prepare the next drawing state, meanwhile, RSX executes the previous draws submitted by CELL and therefore no side is stalling the other (at least that's the goal). This only applies when using Atomic FIFO accuracy atm. In theory, this may help to utilize more threads for high-threaded CPUs.
Test performance and CPU usage before and after with different games.