### PR TITLE
Fixed SIG: Thread terminated due to fatal error: Failed to read hex string: invalid argument

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1948,7 +1948,7 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 
 		const cfg::device_info device = g_cfg_vfs.get_device(g_cfg_vfs.dev_usb, vpath);
 
-		if (device.path.empty())
+		if (device.path.empty() || device.vid.empty() || device.pid.empty())
 		{
 			arg->out_code = CELL_ENOTSUP;
 			break;
@@ -2023,7 +2023,7 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 
 		const cfg::device_info device = g_cfg_vfs.get_device(g_cfg_vfs.dev_usb, vpath);
 
-		if (device.path.empty())
+		if (device.path.empty() || device.vid.empty() || device.pid.empty())
 		{
 			arg->out_code = CELL_ENOTSUP;
 			break;


### PR DESCRIPTION
Fixed the error which occurred when a game attempted to read the VID/PID of an undefined VFS USB device:

SIG: Thread terminated due to fatal error: Failed to read hex string: invalid argument
(in file C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build\rpcs3\Emu\Cell\lv2\sys_fs.cpp:1942[:25], in function sys_fs_fcntl)