### PR TITLE
SPU LLVM: Try to reduce float clamping by using round-to-zero

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -8425,6 +8425,24 @@ public:
 		{
 			return true;
 		}
+	}
+
+	bool is_input_float_result(value_t<f32[4]> v)
+	{		
+		static const auto MT = match<f32[4]>();
+
+		if (std::get<0>(match_expr(v, fm(MT, MT))) ||
+			std::get<0>(match_expr(v, fma(MT, MT, MT))) ||
+			std::get<0>(match_expr(v, fms(MT, MT, MT))) ||
+			std::get<0>(match_expr(v, fnms(MT, MT, MT)))
+			//std::get<0>(match_expr(v, fa(MT, MT))) ||
+			//std::get<0>(match_expr(v, fs(MT, MT))) ||
+			//std::get<0>(match_expr(v, spu_re(MT))) ||
+			//std::get<0>(match_expr(v, spu_rsqrte(MT)))
+			)
+		{
+			return true;
+		}
 
 		return false;
 	}
@@ -8447,6 +8465,14 @@ public:
 
 	value_t<f32[4]> clamp_smax(value_t<f32[4]> v)
 	{
+		if (g_cfg.core.spu_approx_xfloat)
+		{
+			if (is_input_float_result(v))
+			{
+				return v;
+			} 
+		}
+
 		if (m_use_avx512)
 		{
 			if (is_input_positive(v))
@@ -8775,7 +8801,10 @@ public:
 
 				const auto ma = sext<s32[4]>(fcmp_uno(a != fsplat<f32[4]>(0.)));
 				const auto mb = sext<s32[4]>(fcmp_uno(b != fsplat<f32[4]>(0.)));
-				return eval(bitcast<f32[4]>(bitcast<s32[4]>(a * b) & ma & mb));
+				const auto mul = eval(bitcast<s32[4]>(a * b));
+				const auto after_a = is_input_float_result(a) ? mul : eval(ma & mul);
+				const auto after_b = is_input_float_result(b) ? after_a : eval(mb & after_a);
+				return eval(bitcast<f32[4]>(after_b));
 			}
 			else
 			{
@@ -9093,7 +9122,7 @@ public:
 
 			if (g_cfg.core.spu_approx_xfloat || g_cfg.core.spu_relaxed_xfloat)
 			{
-				return fma32x4(eval(-clamp_smax(a)), clamp_smax(b), c);
+				return fma32x4(eval(-clamp_smax(a)), clamp_smax(b), clamp_smax(c));
 			}
 			else
 			{
@@ -9130,9 +9159,9 @@ public:
 			{
 				const auto ma = sext<s32[4]>(fcmp_uno(a != fsplat<f32[4]>(0.)));
 				const auto mb = sext<s32[4]>(fcmp_uno(b != fsplat<f32[4]>(0.)));
-				const auto ca = bitcast<f32[4]>(bitcast<s32[4]>(a) & mb);
-				const auto cb = bitcast<f32[4]>(bitcast<s32[4]>(b) & ma);
-				return fma32x4(eval(ca), eval(cb), c);
+				const auto ca = is_input_float_result(b) ? a : eval(bitcast<f32[4]>(bitcast<s32[4]>(a) & mb));
+				const auto cb = is_input_float_result(a) ? b : eval(bitcast<f32[4]>(bitcast<s32[4]>(b) & ma));
+				return fma32x4(eval(ca), eval(cb), clamp_smax(c));
 			}
 			else
 			{
@@ -9202,7 +9231,7 @@ public:
 
 			if (g_cfg.core.spu_approx_xfloat)
 			{
-				return fma32x4(clamp_smax(a), clamp_smax(b), eval(-c));
+				return fma32x4(clamp_smax(a), clamp_smax(b), eval(-clamp_smax(c)));
 			}
 			else
 			{


### PR DESCRIPTION
Round-to-zero doesn't produce infinites with normal calculations. Let's use this fact to try to reduce float clamp to normalized range.