### PR TITLE
GUI: Log fixes and possible optimizations

### DIFF
--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -594,7 +594,7 @@ void log_frame::UpdateUI()
 	// Preserve capacity
 	m_log_text.resize(0);
 
-	// Handle a special case in which we may need to override the previous repetition count 
+	// Handle a special case in which we may need to override the previous repetition count
 	bool is_first_rep = true;
 
 	// Batch output of multiple lines if possible (optimization)
@@ -688,19 +688,18 @@ void log_frame::UpdateUI()
 
 			is_first_rep = false;
 
-			if (m_log_counter > 1)
+			// Add counter suffix if needed. Try not to hold too much data at a time so the frame content will be updated frequently.
+			if (m_log_counter > 1 || m_log_text.size() > 0x1000)
 			{
-				// Add counter suffix if needed
 				flush();
 			}
 
-			if (m_log_text.size() > 0x1000)
+			if (m_log_text.isEmpty())
 			{
-				// Try not to hold too much data at a time so the frame content will be updated frequently
-				flush();
+				m_old_log_level = packet->sev;
+				m_log_text += font_start_tag(m_color[static_cast<int>(m_old_log_level)]);
 			}
-
-			if (!m_log_text.isEmpty())
+			else
 			{
 				if (packet->sev != m_old_log_level)
 				{
@@ -712,11 +711,6 @@ void log_frame::UpdateUI()
 				{
 					m_log_text += QStringLiteral("<br/>");
 				}
-			}
-			else
-			{
-				m_old_log_level = packet->sev;
-				m_log_text += font_start_tag(m_color[static_cast<int>(m_old_log_level)]);
 			}
 
 			switch (packet->sev)

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -594,7 +594,7 @@ void log_frame::UpdateUI()
 	// Preserve capacity
 	m_log_text.resize(0);
 
-	// Handle a special case in which we may need to override the previous repetition count
+	// Handle a common case in which we may need to override the previous repetition count
 	bool is_first_rep = true;
 
 	// Batch output of multiple lines if possible (optimization)
@@ -622,10 +622,12 @@ void log_frame::UpdateUI()
 
 		if (is_first_rep)
 		{
-			// Override repetition count of previous UpdateUI() (special case)
+			// Overwrite existing repetition counter in our text document.
+			ensure(m_log_counter > 2); // Anything else is a bug
+			constexpr int size_of_x = 2; // " x"
 			text_cursor.movePosition(QTextCursor::End, QTextCursor::MoveAnchor);
-			text_cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, (m_log_counter != 2 ? 1 + QString::number(m_log_counter - 1).size() : 0));
-			text_cursor.insertHtml(font_start_tag_stack % QStringLiteral(" x") % QString::number(m_log_counter) % font_end_tag);
+			text_cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, size_of_x + QString::number(m_log_counter - 1).size());
+			text_cursor.insertHtml(font_start_tag_stack % QStringLiteral("&nbsp;x") % QString::number(m_log_counter) % font_end_tag);
 		}
 		else if (m_log_counter > 1)
 		{
@@ -666,6 +668,7 @@ void log_frame::UpdateUI()
 		// Confirm log level
 		if (packet->sev <= s_gui_listener.enabled)
 		{
+			// Check if we can stack this log message.
 			if (m_stack_log && m_old_log_level == packet->sev && packet->msg == m_old_log_text)
 			{
 				m_log_counter++;

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -52,8 +52,8 @@ private:
 	std::string m_old_log_text;
 	QString m_old_tty_text;
 	QString m_log_text;
-	ullong m_log_counter{};
-	ullong m_tty_counter{};
+	usz m_log_counter{};
+	usz m_tty_counter{};
 	bool m_stack_log{};
 	bool m_stack_tty{};
 	logs::level m_old_log_level{};


### PR DESCRIPTION
- Fixes missing space between log message and suffix in stacked log
- Only patch the old suffix once. There's no need to do it several times in 7ms.