### PR TITLE
Add some debugging information

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1527,6 +1527,14 @@ void ppu_thread::cpu_on_stop()
 
 		current_function = {};
 	}
+
+	// TODO: More conditions
+	if (Emu.IsStopped() && g_cfg.core.spu_debug)
+	{
+		std::string ret;
+		dump_all(ret);
+		ppu_log.notice("thread context: %s", ret);
+	}
 }
 
 void ppu_thread::exec_task()

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1284,6 +1284,31 @@ std::string spu_thread::dump_misc() const
 	return ret;
 }
 
+void spu_thread::cpu_on_stop()
+{
+	if (current_func)
+	{
+		if (start_time)
+		{
+			ppu_log.warning("'%s' aborted (%fs)", current_func, (get_guest_system_time() - start_time) / 1000000.);
+		}
+		else
+		{
+			ppu_log.warning("'%s' aborted", current_func);
+		}
+
+		current_func = {};
+	}
+
+	// TODO: More conditions
+	if (Emu.IsStopped() && g_cfg.core.spu_debug)
+	{
+		std::string ret;
+		dump_all(ret);
+		spu_log.notice("thread context: %s", ret);
+	}
+}
+
 void spu_thread::cpu_init()
 {
 	std::memset(gpr.data(), 0, gpr.size() * sizeof(gpr[0]));

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -682,6 +682,7 @@ public:
 	virtual std::vector<std::pair<u32, u32>> dump_callstack_list() const override;
 	virtual std::string dump_misc() const override;
 	virtual void cpu_task() override final;
+	virtual void cpu_on_stop() override;
 	virtual void cpu_return() override;
 	virtual void cpu_work() override;
 	virtual ~spu_thread() override;
@@ -965,6 +966,9 @@ public:
 
 	~spu_function_logger()
 	{
-		spu.start_time = 0;
+		if (!spu.is_stopped())
+		{
+			spu.start_time = 0;
+		}
 	}
 };

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2067,7 +2067,7 @@ void Emulator::Resume()
 	}
 
 	// Print and reset debug data collected
-	if (g_cfg.core.ppu_debug)
+	if (g_cfg.core.ppu_decoder == ppu_decoder_type::_static && g_cfg.core.ppu_debug)
 	{
 		PPUDisAsm dis_asm(cpu_disasm_mode::dump, vm::g_sudo_addr);
 
@@ -2092,7 +2092,10 @@ void Emulator::Resume()
 			}
 		}
 
-		ppu_log.notice("[RESUME] Dumping instruction stats:%s", dump);
+		if (!dump.empty())
+		{
+			ppu_log.notice("[RESUME] Dumping instruction stats:%s", dump);
+		}
 	}
 
 	// Try to resume

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -159,6 +159,7 @@ void debugger_list::ShowAddress(u32 addr, bool select_addr, bool direct)
 	{
 		const bool is_spu = m_cpu->id_type() == 2;
 		const u32 address_limits = (is_spu ? 0x3fffc : ~3);
+		const u32 current_pc = m_cpu->get_pc();
 		m_start_addr &= address_limits;
 		u32 pc = m_start_addr;
 
@@ -166,7 +167,7 @@ void debugger_list::ShowAddress(u32 addr, bool select_addr, bool direct)
 		{
 			QListWidgetItem* list_item = item(i);
 
-			if (pc == m_cpu->get_pc())
+			if (pc == current_pc)
 			{
 				list_item->setForeground(m_text_color_pc);
 				list_item->setBackground(m_color_pc);


### PR DESCRIPTION
Pulling the debugger's contents when PPU/SPU debug options are enabled on emulation stopping.
This is for remote debugging. (user sends log)