### PR TITLE
Fixes warnings suppression in CMake build

### DIFF
--- a/3rdparty/SoundTouch/CMakeLists.txt
+++ b/3rdparty/SoundTouch/CMakeLists.txt
@@ -27,7 +27,7 @@ target_compile_definitions(soundtouch PUBLIC
 	SOUNDTOUCH_FLOAT_SAMPLES;
 )
 
-target_compile_options(soundtouch PUBLIC "-w")
+target_compile_options(soundtouch PRIVATE "-w")
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86|X86|amd64|AMD64|em64t|EM64T)")
 	target_compile_definitions(soundtouch PUBLIC

--- a/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
@@ -86,7 +86,7 @@ error_code cellGifDecExtCreate(vm::ptr<GifDecoder> mainHandle, vm::cptr<CellGifD
 		return CELL_GIFDEC_ERROR_ARG;
 	}
 
-	if (extThreadInParam->maxContention == 0 || extThreadInParam->maxContention >= 8)
+	if (extThreadInParam->maxContention == 0u || extThreadInParam->maxContention >= 8u)
 	{
 		return CELL_GIFDEC_ERROR_ARG;
 	}

--- a/rpcs3/Emu/Cell/Modules/cellPngEnc.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPngEnc.cpp
@@ -40,11 +40,11 @@ struct png_encoder
 bool check_config(vm::cptr<CellPngEncConfig> config)
 {
 	if (!config ||
-		config->maxWidth == 0 || config->maxWidth > 1000000 ||
-		config->maxHeight == 0 || config->maxHeight > 1000000 ||
-		config->maxBitDepth != 8 && config->maxBitDepth != 16 ||
+		config->maxWidth == 0u || config->maxWidth > 1000000u ||
+		config->maxHeight == 0u || config->maxHeight > 1000000u ||
+		config->maxBitDepth != 8u && config->maxBitDepth != 16u ||
 		static_cast<s32>(config->addMemSize) < 0 ||
-		config->exParamNum != 0)
+		config->exParamNum != 0u)
 	{
 		return false;
 	}

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -381,7 +381,7 @@ public:
 
 	void init_config(cfg_pad* cfg) override;
 	bool Init() override;
-	std::vector<pad_list_entry> list_devices();
+	std::vector<pad_list_entry> list_devices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, u8 player_id) override;
 	void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
 	void get_motion_sensors(const std::string& padId, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors) override;


### PR DESCRIPTION
Noticed today a [[deprecated]] wasn't generating any warning, turns out the warnings were being suppressed for the whole project from a leaking 3rdparty project.

EDIT:
Added some stuff for GCC to build again since the warnings being interpreted as errors are not being suppressed anymore.