### PR TITLE
rsx: Implement atomic vertex upload (with Strict Rendering Mode)

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -6563,7 +6563,7 @@ public:
 					break;
 				}
 
-				if (u64 cmdh = ci->getZExtValue() & ~(MFC_BARRIER_MASK | MFC_FENCE_MASK | MFC_RESULT_MASK); g_cfg.core.rsx_fifo_accuracy || !g_use_rtm)
+				if (u64 cmdh = ci->getZExtValue() & ~(MFC_BARRIER_MASK | MFC_FENCE_MASK | MFC_RESULT_MASK); g_cfg.core.rsx_fifo_accuracy || g_cfg.video.strict_rendering_mode || !g_use_rtm)
 				{
 					// TODO: don't require TSX (current implementation is TSX-only)
 					if (cmdh == MFC_PUT_CMD || cmdh == MFC_SNDSIG_CMD)

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2063,7 +2063,7 @@ void spu_thread::do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8*
 		src = zero_buf;
 	}
 
-	rsx::reservation_lock<false, 1> rsx_lock(eal, args.size, !is_get && g_cfg.core.rsx_fifo_accuracy && !g_cfg.core.spu_accurate_dma);
+	rsx::reservation_lock<false, 1> rsx_lock(eal, args.size, !is_get && (g_cfg.video.strict_rendering_mode || (g_cfg.core.rsx_fifo_accuracy && !g_cfg.core.spu_accurate_dma && eal < rsx::constants::local_mem_base)));
 
 	if ((!g_use_rtm && !is_get) || g_cfg.core.spu_accurate_dma)  [[unlikely]]
 	{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4458,7 +4458,9 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 
 				if (res == CELL_EAGAIN)
 				{
+					// Restore mailboxes state
 					ch_out_mbox.set_value(data);
+					ch_in_mbox.try_pop(data);
 					return false;
 				}
 
@@ -4529,7 +4531,9 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 
 				if (res == CELL_EAGAIN)
 				{
+					// Restore mailboxes state
 					ch_out_mbox.set_value(data);
+					ch_in_mbox.try_pop(data);
 					return false;
 				}
 

--- a/rpcs3/Emu/RSX/RSXOffload.cpp
+++ b/rpcs3/Emu/RSX/RSXOffload.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#include "Emu/Memory/vm.h"
 #include "Common/BufferUtils.h"
 #include "RSXOffload.h"
 #include "RSXThread.h"
@@ -44,6 +45,8 @@ namespace rsx
 					{
 					case raw_copy:
 					{
+						const u32 vm_addr = vm::try_get_addr(job.src).first;
+						rsx::reservation_lock<true, 1> rsx_lock(vm_addr, job.length, g_cfg.video.strict_rendering_mode && vm_addr);
 						std::memcpy(job.dst, job.src, job.length);
 						break;
 					}
@@ -108,6 +111,8 @@ namespace rsx
 	{
 		if (length <= max_immediate_transfer_size || !g_cfg.video.multithreaded_rsx)
 		{
+			const u32 vm_addr = vm::try_get_addr(src).first;
+			rsx::reservation_lock<true, 1> rsx_lock(vm_addr, length, g_cfg.video.strict_rendering_mode && vm_addr);
 			std::memcpy(dst, src, length);
 		}
 		else

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -814,7 +814,7 @@ namespace rsx
 			u64 local_vblank_count = 0;
 
 			// TODO: exit condition
-			while (!is_stopped() && !unsent_gcm_events)
+			while (!is_stopped() && !unsent_gcm_events && thread_ctrl::state() != thread_state::aborting)
 			{
 				// Get current time
 				const u64 current = get_system_time();

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -879,7 +879,7 @@ namespace rsx
 
 		reservation_lock(u32 addr, u32 length, bool setting)
 		{
-			if (setting && addr < constants::local_mem_base)
+			if (setting)
 			{
 				lock_range(addr, length);
 			}


### PR DESCRIPTION
Implement RSX 128-byte atomic vertex fetching when "Strict Rendering Mode" is used. May fix 3D model or color flickering in some cases. It makes sense performance-wise for games to be able to update vertex coordinates at run-time of RSX if the developer actually knew it would fetch it atomically and the scene on screen is changing.