### PR TITLE
SPU: Implement "quintuple" Inbound MBOX storage

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -236,7 +236,7 @@ error_code disc_change_manager::register_callbacks(vm::ptr<CellGameDiscEjectCall
 	insert_callback = func_insert;
 
 	Emu.GetCallbacks().enable_disc_eject(!!func_eject);
-	Emu.GetCallbacks().enable_disc_insert(!!func_insert);
+	Emu.GetCallbacks().enable_disc_insert(false);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -244,7 +244,7 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 
 	case SPU_In_MBox_offs:
 	{
-		ch_in_mbox.push(*this, value);
+		ch_in_mbox.push(value);
 		return true;
 	}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4124,9 +4124,9 @@ s64 spu_thread::get_ch_value(u32 ch)
 				busy_wait();
 			}
 
-			u32 out = 0;
+			const auto [old_count, out] = ch_in_mbox.pop_wait(*this);
 
-			if (const uint old_count = ch_in_mbox.try_pop(out))
+			if (old_count)
 			{
 				if (old_count == 4 /* SPU_IN_MBOX_THRESHOLD */) // TODO: check this
 				{

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1696,7 +1696,7 @@ error_code sys_spu_thread_write_spu_mb(ppu_thread& ppu, u32 id, u32 value)
 
 	std::lock_guard lock(group->mutex);
 
-	thread->ch_in_mbox.push(*thread, value);
+	thread->ch_in_mbox.push(value);
 
 	return CELL_OK;
 }


### PR DESCRIPTION
Bring the changes of #12258 to the SPU inbound mailbox channel, improving performance and accuracy.
Also fix an always-executed notification in spu_channel. (optimization)