### PR TITLE
PPU Interpreter: Fix STVLX

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -5311,7 +5311,7 @@ auto STVLX()
 	{
 		const u64 addr = op.ra ? a + b : b;
 		const u32 tail = u32(addr & 15);
-		u8* ptr = vm::_ptr<u8>(addr & -16);
+		u8* ptr = vm::_ptr<u8>(addr);
 		for (u32 j = 0; j < 16 - tail; j++)
 			ptr[j] = s.u8r[j];
 	};


### PR DESCRIPTION
Fixes Sly 2 and Sly 3 crash on boot (RSX desync).

Regression happened on #11412 (https://github.com/RPCS3/rpcs3/pull/11412/commits/17b1a34ebf124f4f2bab09fc6125290599a87059).

Not 100% sure the fix is correct, didn't bother to fully read the code / instruction semantics, but the values produced by the instruction for these particular games are identical to before the regression.

Reviewer: @Nekotekina 