### PR TITLE
IdManager.cpp: Fix cellFs IDs

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -230,18 +230,13 @@ disc_change_manager::~disc_change_manager()
 
 error_code disc_change_manager::register_callbacks(vm::ptr<CellGameDiscEjectCallback> func_eject, vm::ptr<CellGameDiscInsertCallback> func_insert)
 {
-	if (!func_eject || !func_insert)
-	{
-		return CELL_GAME_ERROR_PARAM;
-	}
-
 	std::lock_guard lock(mtx);
 
 	eject_callback = func_eject;
 	insert_callback = func_insert;
 
-	Emu.GetCallbacks().enable_disc_eject(true);
-	Emu.GetCallbacks().enable_disc_insert(false);
+	Emu.GetCallbacks().enable_disc_eject(!!func_eject);
+	Emu.GetCallbacks().enable_disc_insert(!!func_insert);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -160,9 +160,10 @@ extern lv2_fs_mount_point g_mp_sys_dev_hdd1;
 
 struct lv2_fs_object
 {
-	static const u32 id_base = 3;
-	static const u32 id_step = 1;
-	static const u32 id_count = 255 - id_base;
+	static constexpr u32 id_base = 3;
+	static constexpr u32 id_step = 1;
+	static constexpr u32 id_count = 255 - id_base;
+	static constexpr bool id_lowest = true;
 	SAVESTATE_INIT_POS(40);
 
 	// File Name (max 1055)

--- a/rpcs3/Emu/IdManager.cpp
+++ b/rpcs3/Emu/IdManager.cpp
@@ -29,7 +29,7 @@ std::vector<std::pair<u128, id_manager::typeinfo>>& id_manager::get_typeinfo_map
 	return s_map; 
 }
 
-idm::map_data* idm::allocate_id(std::vector<map_data>& vec, u32 type_id, u32 dst_id, u32 base, u32 step, u32 count, std::pair<u32, u32> invl_range)
+idm::map_data* idm::allocate_id(std::vector<map_data>& vec, u32 type_id, u32 dst_id, u32 base, u32 step, u32 count, bool uses_lowest_id, std::pair<u32, u32> invl_range)
 {
 	if (const u32 index = id_manager::get_index(dst_id, base, step, count, invl_range); index < count)
 	{
@@ -46,7 +46,12 @@ idm::map_data* idm::allocate_id(std::vector<map_data>& vec, u32 type_id, u32 dst
 		return &vec[index];
 	}
 
-	if (vec.size() < count)
+	if (uses_lowest_id)
+	{
+		// Disable the optimization below (hurts accuracy for known cases)
+		vec.resize(count);
+	}
+	else if (vec.size() < count)
 	{
 		// Try to emplace back
 		const u32 _next = base + step * ::size32(vec);


### PR DESCRIPTION
* Fix cellFs IDs to always take the lowest ID value possible, this fixes this game's installation: tries to access the ID of a closed installation file after opening different ones after. It works on PS3 because the old ID should be equal to one of the newer ones.
I've limited this fix very specifically to cellFs because I really do not want regressions.. Testcase which now matches RPCS3: https://github.com/elad335/myps3tests/commit/51b12574b71d52b48f35647ab1e6c248d25e7702

* Fix custom PS3 disc insertions, due to some typo it wasn't actually working. Also, remove wrong error checking - this allows for games to register only the eject callback as seen in this game.

Fixes [Spider-Man: Web of Shadows](https://forums.rpcs3.net/thread-179539.html), Intro -> Ingame. (if you already ran this game on RPCS3 you need to delete its installation data for it to work)
![image](https://user-images.githubusercontent.com/18193363/188313956-945c1c8d-fd57-4ad4-882d-8102fdfc32db.png)
