### PR TITLE
Implement PPU usleep control setting hack

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -447,6 +447,18 @@ error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 
 	if (sleep_time)
 	{
+		const s64 add_time = g_cfg.core.usleep_addend;
+
+		// Over/underflow checks
+		if (add_time >= 0)
+		{
+			sleep_time = utils::add_saturate<u64>(sleep_time, add_time);
+		}
+		else
+		{
+			sleep_time = std::max<u64>(1, utils::sub_saturate<u64>(sleep_time, -add_time));
+		}
+
 		lv2_obj::sleep(ppu, g_cfg.core.sleep_timers_accuracy < sleep_timers_accuracy_level::_usleep ? sleep_time : 0);
 
 		if (!lv2_obj::wait_timeout(sleep_time, &ppu, true, true))

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -99,6 +99,7 @@ struct cfg_root : cfg::node
 #else
 		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy", sleep_timers_accuracy_level::_usleep, true };
 #endif
+		cfg::_int<-1000, 1500> usleep_addend{ this, "Usleep Time Addend", 0, true };
 
 		cfg::uint64 perf_report_threshold{this, "Performance Report Threshold", 500, true}; // In µs, 0.5ms = default, 0 = everything
 		cfg::_bool perf_report{this, "Enable Performance Report", false, true}; // Show certain perf-related logs


### PR DESCRIPTION
This setting ("Usleep Time Addend" in game config file) affects the sleeping time passed to the sys_timer_usleep PPU syscall by adding the specified value to it. Significant performance improvements have been noted when using this setting with some games (see https://github.com/RPCS3/rpcs3/pull/12598#issuecomment-1236063568). This setting allows negative values for up to -1000 and positive values for up to 1500. (default is 0 - no adjustments to sleeping time)

