### PR TITLE
Fix a deadlock with non-TSX and SPU creation

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -563,9 +563,10 @@ struct vdec_context final
 									break;
 								}
 							}
-							thread_ctrl::wait_for(1000);
 
-							if (elapsed++ >= 5000) // 5 seconds
+							thread_ctrl::wait_for(10000);
+
+							if (elapsed++ >= 500) // 5 seconds
 							{
 								cellVdec.error("Video au decode has been waiting for a consumer for 5 seconds. (handle=0x%x, seq_id=%d, cmd_id=%d, queue_size=%d)", handle, cmd->seq_id, cmd->id, out_queue.size());
 								elapsed = 0;
@@ -997,8 +998,10 @@ error_code cellVdecClose(ppu_thread& ppu, u32 handle)
 	return CELL_OK;
 }
 
-error_code cellVdecStartSeq(u32 handle)
+error_code cellVdecStartSeq(ppu_thread& ppu, u32 handle)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellVdec.warning("cellVdecStartSeq(handle=0x%x)", handle);
 
 	const auto vdec = idm::get<vdec_context>(handle);
@@ -1047,8 +1050,10 @@ error_code cellVdecStartSeq(u32 handle)
 	return CELL_OK;
 }
 
-error_code cellVdecEndSeq(u32 handle)
+error_code cellVdecEndSeq(ppu_thread& ppu, u32 handle)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellVdec.warning("cellVdecEndSeq(handle=0x%x)", handle);
 
 	const auto vdec = idm::get<vdec_context>(handle);
@@ -1078,8 +1083,10 @@ error_code cellVdecEndSeq(u32 handle)
 	return CELL_OK;
 }
 
-error_code cellVdecDecodeAu(u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVdecAuInfo> auInfo)
+error_code cellVdecDecodeAu(ppu_thread& ppu, u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVdecAuInfo> auInfo)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellVdec.trace("cellVdecDecodeAu(handle=0x%x, mode=%d, auInfo=*0x%x)", handle, +mode, auInfo);
 
 	const auto vdec = idm::get<vdec_context>(handle);
@@ -1124,8 +1131,10 @@ error_code cellVdecDecodeAu(u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVd
 	return CELL_OK;
 }
 
-error_code cellVdecDecodeAuEx2(u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVdecAuInfoEx2> auInfo)
+error_code cellVdecDecodeAuEx2(ppu_thread& ppu, u32 handle, CellVdecDecodeMode mode, vm::cptr<CellVdecAuInfoEx2> auInfo)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellVdec.todo("cellVdecDecodeAuEx2(handle=0x%x, mode=%d, auInfo=*0x%x)", handle, +mode, auInfo);
 
 	const auto vdec = idm::get<vdec_context>(handle);
@@ -1178,8 +1187,10 @@ error_code cellVdecDecodeAuEx2(u32 handle, CellVdecDecodeMode mode, vm::cptr<Cel
 	return CELL_OK;
 }
 
-error_code cellVdecGetPictureExt(u32 handle, vm::cptr<CellVdecPicFormat2> format, vm::ptr<u8> outBuff, u32 arg4)
+error_code cellVdecGetPictureExt(ppu_thread& ppu, u32 handle, vm::cptr<CellVdecPicFormat2> format, vm::ptr<u8> outBuff, u32 arg4)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellVdec.trace("cellVdecGetPictureExt(handle=0x%x, format=*0x%x, outBuff=*0x%x, arg4=*0x%x)", handle, format, outBuff, arg4);
 
 	const auto vdec = idm::get<vdec_context>(handle);
@@ -1323,8 +1334,10 @@ error_code cellVdecGetPictureExt(u32 handle, vm::cptr<CellVdecPicFormat2> format
 	return CELL_OK;
 }
 
-error_code cellVdecGetPicture(u32 handle, vm::cptr<CellVdecPicFormat> format, vm::ptr<u8> outBuff)
+error_code cellVdecGetPicture(ppu_thread& ppu, u32 handle, vm::cptr<CellVdecPicFormat> format, vm::ptr<u8> outBuff)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellVdec.trace("cellVdecGetPicture(handle=0x%x, format=*0x%x, outBuff=*0x%x)", handle, format, outBuff);
 
 	if (!format)
@@ -1339,11 +1352,13 @@ error_code cellVdecGetPicture(u32 handle, vm::cptr<CellVdecPicFormat> format, vm
 	format2->unk0 = 0;
 	format2->unk1 = 0;
 
-	return cellVdecGetPictureExt(handle, format2, outBuff, 0);
+	return cellVdecGetPictureExt(ppu, handle, format2, outBuff, 0);
 }
 
-error_code cellVdecGetPicItem(u32 handle, vm::pptr<CellVdecPicItem> picItem)
+error_code cellVdecGetPicItem(ppu_thread& ppu, u32 handle, vm::pptr<CellVdecPicItem> picItem)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellVdec.trace("cellVdecGetPicItem(handle=0x%x, picItem=**0x%x)", handle, picItem);
 
 	const auto vdec = idm::get<vdec_context>(handle);

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -323,6 +323,8 @@ void spu_load_exec(const spu_exec_object& elf)
 	spu_thread::g_raw_spu_ctr++;
 
 	auto spu = idm::make_ptr<named_thread<spu_thread>>(nullptr, 0, "test_spu", 0);
+	ensure(vm::get(vm::spu)->falloc(spu->vm_offset(), SPU_LS_SIZE, &spu->shm, vm::page_size_64k));
+	spu->map_ls(*spu->shm, spu->ls);
 
 	for (const auto& prog : elf.progs)
 	{
@@ -343,6 +345,8 @@ void spu_load_rel_exec(const spu_rel_object& elf)
 	spu_thread::g_raw_spu_ctr++;
 
 	auto spu = idm::make_ptr<named_thread<spu_thread>>(nullptr, 0, "test_spu", 0);
+	ensure(vm::get(vm::spu)->falloc(spu->vm_offset(), SPU_LS_SIZE, &spu->shm, vm::page_size_64k));
+	spu->map_ls(*spu->shm, spu->ls);
 
 	u64 total_memsize = 0;
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -918,7 +918,7 @@ public:
 		return group ? SPU_FAKE_BASE_ADDR + SPU_LS_SIZE * (id & 0xffffff) : RAW_SPU_BASE_ADDR + RAW_SPU_OFFSET * index;
 	}
 
-	static u8* map_ls(utils::shm& shm);
+	static u8* map_ls(utils::shm& shm, void* ptr = nullptr);
 
 	// Returns true if reservation existed but was just discovered to be lost
 	// It is safe to use on any address, even if not directly accessed by SPU (so it's slower)


### PR DESCRIPTION
vm::writer_lock inside SPU constructor can lead to a deadlock when the waiting PPU waits for SPU to finish a lock-line update, but the SPU waits for a different PPU which hasn't unlocked its memory mutex because it is waiting on IDM mutex to unlock. (owned by the PPU creating the SPU)
Also, improve cellVdec performance with reservations. That is also where I've seen the second PPU deadlocks initially.