### PR TITLE
rsx: Misc optimizations and fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -467,7 +467,7 @@ void GLGSRender::emit_geometry(u32 sub_index)
 		for (auto& info : m_vertex_layout.interleaved_blocks)
 		{
 			const auto vertex_base_offset = rsx::method_registers.vertex_data_base_offset();
-			info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info.base_offset), info.memory_location);
+			info->real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info->base_offset), info->memory_location);
 		}
 	}
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -308,7 +308,7 @@ void GLGSRender::on_init_thread()
 	}
 
 	//Occlusion query
-	for (u32 i = 0; i < occlusion_query_count; ++i)
+	for (u32 i = 0; i < rsx::reports::occlusion_query_count; ++i)
 	{
 		GLuint handle = 0;
 		auto &query = m_occlusion_query_data[i];
@@ -484,7 +484,7 @@ void GLGSRender::on_exit()
 
 	m_shader_interpreter.destroy();
 
-	for (u32 i = 0; i < occlusion_query_count; ++i)
+	for (u32 i = 0; i < rsx::reports::occlusion_query_count; ++i)
 	{
 		auto &query = m_occlusion_query_data[i];
 		query.active = false;

--- a/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexBuffers.cpp
@@ -127,7 +127,7 @@ namespace
 		vertex_input_state operator()(const rsx::draw_inlined_array& /*command*/)
 		{
 			const auto stream_length = rsx::method_registers.current_draw_clause.inline_vertex_array.size();
-			const u32 vertex_count = u32(stream_length * sizeof(u32)) / m_vertex_layout.interleaved_blocks[0].attribute_stride;
+			const u32 vertex_count = u32(stream_length * sizeof(u32)) / m_vertex_layout.interleaved_blocks[0]->attribute_stride;
 
 			if (!gl::is_primitive_native(rsx::method_registers.current_draw_clause.primitive))
 			{
@@ -192,8 +192,8 @@ gl::vertex_upload_info GLGSRender::set_vertex_buffer()
 		if (m_vertex_layout.interleaved_blocks.size() == 1 &&
 			rsx::method_registers.current_draw_clause.command != rsx::draw_command::inlined_array)
 		{
-			const auto data_offset = (vertex_base * m_vertex_layout.interleaved_blocks[0].attribute_stride);
-			storage_address = m_vertex_layout.interleaved_blocks[0].real_offset_address + data_offset;
+			const auto data_offset = (vertex_base * m_vertex_layout.interleaved_blocks[0]->attribute_stride);
+			storage_address = m_vertex_layout.interleaved_blocks[0]->real_offset_address + data_offset;
 
 			if (auto cached = m_vertex_cache->find_vertex_range(storage_address, GL_R8UI, required.first))
 			{

--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -113,6 +113,7 @@ namespace rsx
 		class FIFO_control
 		{
 		private:
+			mutable rsx::thread* m_thread;
 			RsxDmaControl* m_ctrl = nullptr;
 			const rsx::rsx_iomap_table* m_iotable;
 			u32 m_internal_get = 0;
@@ -129,6 +130,7 @@ namespace rsx
 			u32 m_cache_addr = 0;
 			u32 m_cache_size = 0;
 			alignas(64) std::byte m_cache[8][128];
+
 		public:
 			FIFO_control(rsx::thread* pctrl);
 			~FIFO_control() = default;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -287,18 +287,36 @@ namespace rsx
 		transient = 2
 	};
 
-	struct vertex_input_layout
+	class vertex_input_layout
 	{
-		std::vector<interleaved_range_info> interleaved_blocks{};  // Interleaved blocks to be uploaded as-is
-		std::vector<std::pair<u8, u32>> volatile_blocks{};         // Volatile data blocks (immediate draw vertex data for example)
-		rsx::simple_array<u8> referenced_registers{};              // Volatile register data
+		int m_num_used_blocks = 0;
+		std::array<interleaved_range_info, 16> m_blocks_data{};
+
+	public:
+		rsx::simple_array<interleaved_range_info*> interleaved_blocks{};  // Interleaved blocks to be uploaded as-is
+		std::vector<std::pair<u8, u32>> volatile_blocks{};                // Volatile data blocks (immediate draw vertex data for example)
+		rsx::simple_array<u8> referenced_registers{};                     // Volatile register data
 
 		std::array<attribute_buffer_placement, 16> attribute_placement = fill_array(attribute_buffer_placement::none);
 
 		vertex_input_layout() = default;
 
+		interleaved_range_info* alloc_interleaved_block()
+		{
+			auto result = &m_blocks_data[m_num_used_blocks++];
+			result->attribute_stride = 0;
+			result->base_offset = 0;
+			result->memory_location = 0;
+			result->real_offset_address = 0;
+			result->single_vertex = false;
+			result->locations.clear();
+			result->interleaved = true;
+			return result;
+		}
+
 		void clear()
 		{
+			m_num_used_blocks = 0;
 			interleaved_blocks.clear();
 			volatile_blocks.clear();
 			referenced_registers.clear();
@@ -309,7 +327,7 @@ namespace rsx
 			// Criteria: At least one array stream has to be defined to feed vertex positions
 			// This stream cannot be a const register as the vertices cannot create a zero-area primitive
 
-			if (!interleaved_blocks.empty() && interleaved_blocks.front().attribute_stride != 0)
+			if (!interleaved_blocks.empty() && interleaved_blocks[0]->attribute_stride != 0)
 				return true;
 
 			if (!volatile_blocks.empty())
@@ -351,8 +369,8 @@ namespace rsx
 			u32 mem = 0;
 			for (auto &block : interleaved_blocks)
 			{
-				const auto range = block.calculate_required_range(first_vertex, vertex_count);
-				mem += range.second * block.attribute_stride;
+				const auto range = block->calculate_required_range(first_vertex, vertex_count);
+				mem += range.second * block->attribute_stride;
 			}
 
 			return mem;

--- a/rpcs3/Emu/RSX/RSXZCULL.cpp
+++ b/rpcs3/Emu/RSX/RSXZCULL.cpp
@@ -11,6 +11,11 @@ namespace rsx
 			{
 				m_free_occlusion_pool.push(&query);
 			}
+
+			for (auto& stat : m_statistics_map)
+			{
+				stat.flags = stat.result = 0;
+			}
 		}
 
 		ZCULL_control::~ZCULL_control()
@@ -157,6 +162,8 @@ namespace rsx
 			}
 
 			auto forwarder = &m_pending_writes.back();
+			m_statistics_map[m_statistics_tag_id].flags |= 1;
+
 			for (auto It = m_pending_writes.rbegin(); It != m_pending_writes.rend(); It++)
 			{
 				if (!It->sink)
@@ -272,8 +279,26 @@ namespace rsx
 				m_pending_writes.resize(valid_size);
 			}
 
-			m_statistics_tag_id++;
-			m_statistics_map[m_statistics_tag_id] = {};
+			if (m_pending_writes.empty())
+			{
+				// Clear can be invoked from flip as a workaround to prevent query leakage.
+				m_statistics_map[m_statistics_tag_id].flags = 0;
+			}
+
+			if (m_statistics_map[m_statistics_tag_id].flags)
+			{
+				m_statistics_tag_id = (m_statistics_tag_id + 1) % max_stat_registers;
+				auto data = m_statistics_map.data() + m_statistics_tag_id;
+
+				if (data->flags != 0)
+				{
+					// This shouldn't happen
+					rsx_log.error("Allocating a new ZCULL statistics slot %u overwrites previous data.", m_statistics_tag_id);
+				}
+
+				// Clear value before use
+				data->result = 0;
+			}
 		}
 
 		void ZCULL_control::on_draw()
@@ -462,13 +487,17 @@ namespace rsx
 				}
 			}
 
-			//Delete all statistics caches but leave the current one
-			for (auto It = m_statistics_map.begin(); It != m_statistics_map.end(); )
+			// Delete all statistics caches but leave the current one
+			const u32 current_index = m_statistics_tag_id;
+			for (u32 index = current_index - 1; index != current_index;)
 			{
-				if (It->first == m_statistics_tag_id)
-					++It;
-				else
-					It = m_statistics_map.erase(It);
+				if (m_statistics_map[index].flags == 0)
+				{
+					break;
+				}
+
+				m_statistics_map[index].flags = 0;
+				index = (index + max_stat_registers - 1) % max_stat_registers;
 			}
 
 			//Decrement jobs counter
@@ -534,21 +563,11 @@ namespace rsx
 				}
 			}
 
-			u32 stat_tag_to_remove = m_statistics_tag_id;
 			u32 processed = 0;
 			for (auto& writer : m_pending_writes)
 			{
 				if (!writer.sink)
 					break;
-
-				if (writer.counter_tag != stat_tag_to_remove &&
-					stat_tag_to_remove != m_statistics_tag_id)
-				{
-					//If the stat id is different from this stat id and the queue is advancing,
-					//its guaranteed that the previous tag has no remaining writes as the queue is ordered
-					m_statistics_map.erase(stat_tag_to_remove);
-					stat_tag_to_remove = m_statistics_tag_id;
-				}
 
 				auto query = writer.query;
 				auto& counter = m_statistics_map[writer.counter_tag];
@@ -586,14 +605,12 @@ namespace rsx
 					free_query(query);
 				}
 
-				stat_tag_to_remove = writer.counter_tag;
+				// Release the stat tag for this object. Slots are all or nothing.
+				m_statistics_map[writer.counter_tag].flags = 0;
 
 				retire(ptimer, &writer, counter.result);
 				processed++;
 			}
-
-			if (stat_tag_to_remove != m_statistics_tag_id)
-				m_statistics_map.erase(stat_tag_to_remove);
 
 			if (processed)
 			{

--- a/rpcs3/Emu/RSX/RSXZCULL.h
+++ b/rpcs3/Emu/RSX/RSXZCULL.h
@@ -62,7 +62,7 @@ namespace rsx
 		struct query_stat_counter
 		{
 			u32 result;
-			u32 reserved;
+			u32 flags;
 		};
 
 		struct sync_hint_payload_t
@@ -84,6 +84,15 @@ namespace rsx
 			sync_no_notify = 2   // If set, backend hint notifications will not be made
 		};
 
+		enum constants
+		{
+			max_zcull_delay_us    = 300,   // Delay before a report update operation is forced to retire
+			min_zcull_tick_us     = 100,   // Default tick duration. To avoid hardware spam, we schedule peeks in multiples of this.
+			occlusion_query_count = 2048,  // Number of occlusion query slots available. Real hardware actually has far fewer units before choking
+			max_safe_queue_depth  = 1792,  // Number of in-flight queries before we start forcefully flushing data from the GPU device.
+			max_stat_registers    = 8192   // Size of the statistics cache
+		};
+
 		class ZCULL_control
 		{
 		private:
@@ -97,13 +106,6 @@ namespace rsx
 			void disable_optimizations(class ::rsx::thread* ptimer, u32 location);
 
 		protected:
-			// Delay before a report update operation is forced to retire
-			const u32 max_zcull_delay_us = 300;
-			const u32 min_zcull_tick_us = 100;
-
-			// Number of occlusion query slots available. Real hardware actually has far fewer units before choking
-			const u32 occlusion_query_count = 2048;
-			const u32 max_safe_queue_depth = 1792;
 
 			bool unit_enabled = false;           // The ZCULL unit is on
 			bool write_enabled = false;          // A surface in the ZCULL-monitored tile region has been loaded for rasterization
@@ -126,7 +128,7 @@ namespace rsx
 			u64 m_timer = 0;
 
 			std::vector<queued_report_write> m_pending_writes{};
-			std::unordered_map<u32, query_stat_counter> m_statistics_map{};
+			std::array<query_stat_counter, max_stat_registers> m_statistics_map{};
 
 			// Enables/disables the ZCULL unit
 			void set_active(class ::rsx::thread* ptimer, bool state, bool flush_queue);

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -677,7 +677,7 @@ void VKGSRender::emit_geometry(u32 sub_index)
 		for (auto& info : m_vertex_layout.interleaved_blocks)
 		{
 			const auto vertex_base_offset = rsx::method_registers.vertex_data_base_offset();
-			info.real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info.base_offset), info.memory_location);
+			info->real_offset_address = rsx::get_address(rsx::get_vertex_offset_from_base(vertex_base_offset, info->base_offset), info->memory_location);
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -420,9 +420,9 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 
 	//Occlusion
 	m_occlusion_query_manager = std::make_unique<vk::query_pool_manager>(*m_device, VK_QUERY_TYPE_OCCLUSION, OCCLUSION_MAX_POOL_SIZE);
-	m_occlusion_map.resize(occlusion_query_count);
+	m_occlusion_map.resize(rsx::reports::occlusion_query_count);
 
-	for (u32 n = 0; n < occlusion_query_count; ++n)
+	for (u32 n = 0; n < rsx::reports::occlusion_query_count; ++n)
 		m_occlusion_query_data[n].driver_handle = n;
 
 	if (g_cfg.video.precise_zpass_count)

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -206,7 +206,7 @@ namespace
 			VkPrimitiveTopology prims = vk::get_appropriate_topology(draw_clause.primitive, primitives_emulated);
 
 			const auto stream_length = rsx::method_registers.current_draw_clause.inline_vertex_array.size();
-			const u32 vertex_count = u32(stream_length * sizeof(u32)) / m_vertex_layout.interleaved_blocks[0].attribute_stride;
+			const u32 vertex_count = u32(stream_length * sizeof(u32)) / m_vertex_layout.interleaved_blocks[0]->attribute_stride;
 
 			if (!primitives_emulated)
 			{
@@ -257,8 +257,8 @@ vk::vertex_upload_info VKGSRender::upload_vertex_data()
 		if (m_vertex_layout.interleaved_blocks.size() == 1 &&
 			rsx::method_registers.current_draw_clause.command != rsx::draw_command::inlined_array)
 		{
-			const auto data_offset = (vertex_base * m_vertex_layout.interleaved_blocks[0].attribute_stride);
-			storage_address = m_vertex_layout.interleaved_blocks[0].real_offset_address + data_offset;
+			const auto data_offset = (vertex_base * m_vertex_layout.interleaved_blocks[0]->attribute_stride);
+			storage_address = m_vertex_layout.interleaved_blocks[0]->real_offset_address + data_offset;
 
 			if (auto cached = m_vertex_cache->find_vertex_range(storage_address, VK_FORMAT_R8_UINT, required.first))
 			{

--- a/rpcs3/Emu/RSX/VK/vkutils/image.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.cpp
@@ -71,16 +71,16 @@ namespace vk
 		info.initialLayout = initial_layout;
 		info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
+		std::array<u32, 2> concurrency_queue_families = {
+			dev.get_graphics_queue_family(),
+			dev.get_transfer_queue_family()
+		};
+
 		if (image_flags & VK_IMAGE_CREATE_SHAREABLE_RPCS3)
 		{
-			u32 queue_families[] = {
-				dev.get_graphics_queue_family(),
-				dev.get_transfer_queue_family()
-			};
-
 			info.sharingMode = VK_SHARING_MODE_CONCURRENT;
-			info.queueFamilyIndexCount = 2;
-			info.pQueueFamilyIndices = queue_families;
+			info.queueFamilyIndexCount = ::size32(concurrency_queue_families);
+			info.pQueueFamilyIndices = concurrency_queue_families.data();
 		}
 
 		create_impl(dev, access_flags, memory_type, allocation_pool);

--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -358,9 +358,9 @@ namespace utils
 	// Synchronization helper (cache-friendly busy waiting)
 	inline void busy_wait(usz cycles = 3000)
 	{
-		const u64 start = get_tsc();
+		const u64 stop = get_tsc() + cycles;
 		do pause();
-		while (get_tsc() - start < cycles);
+		while (get_tsc() < stop);
 	}
 
 	// Align to power of 2


### PR DESCRIPTION
- Avoid unordered_map insert/erase in hot loop. Use a ring allocation instead. This was an issue in ZCULL code where frequent insert/erase cycles were wasting performance.
- Avoid malloc/realloc/free in the vertex analysis routine. This method is called several times for every draw call and the cost was adding up quite a bit.
- Elide contention by aborting FIFO puller cache load if we have at least 50% of the data already loaded. Since the usecase for this is a "chase" situation, it is a far better use of resources to let CELL run ahead further and reduces time wasted spinning. This speeds up the FIFO read routine by ~12% when using atomic FIFO.
- Fix image concurrency access when using async compute with vulkan.

Overall, this set of changes gives a ~10% uplift on average which is nice.