### PR TITLE
Add the ability to set the PSID from the configuration

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -2,7 +2,6 @@
 #include "sys_ss.h"
 
 #include "sys_process.h"
-#include "Utilities/StrUtil.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUThread.h"
 #include "Emu/Cell/timers.hpp"
@@ -137,20 +136,11 @@ s32 sys_ss_get_console_id(vm::ptr<u8> buf)
 
 s32 sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid)
 {
-        u64 phigh, plow;
 	sys_ss.warning("sys_ss_get_open_psid(psid=*0x%x)", psid);
 
-        if (try_to_uint64(&phigh, g_cfg.sys.console_psid_high.to_string(), 0, umax) &&
-            try_to_uint64(&plow, g_cfg.sys.console_psid_low.to_string(), 0, umax))
-        {
-            psid->high = phigh;
-            psid->low = plow;
-        }
-        else
-        {
-            psid->high = 0;
-            psid->low = 0;
-        }
+	psid->high = g_cfg.sys.console_psid_high;
+	psid->low = g_cfg.sys.console_psid_low;
+
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -2,9 +2,11 @@
 #include "sys_ss.h"
 
 #include "sys_process.h"
+#include "Utilities/StrUtil.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUThread.h"
 #include "Emu/Cell/timers.hpp"
+#include "Emu/system_config.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -135,11 +137,20 @@ s32 sys_ss_get_console_id(vm::ptr<u8> buf)
 
 s32 sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid)
 {
+        u64 phigh, plow;
 	sys_ss.warning("sys_ss_get_open_psid(psid=*0x%x)", psid);
 
-	psid->high = 0;
-	psid->low = 0;
-
+        if (try_to_uint64(&phigh, g_cfg.sys.console_psid_high.to_string(), 0, umax) &&
+            try_to_uint64(&plow, g_cfg.sys.console_psid_low.to_string(), 0, umax))
+        {
+            psid->high = phigh;
+            psid->low = plow;
+        }
+        else
+        {
+            psid->high = 0;
+            psid->low = 0;
+        }
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -295,8 +295,9 @@ struct cfg_root : cfg::node
 		cfg::_enum<CellKbMappingType> keyboard_type{ this, "Keyboard Type", CellKbMappingType{0} }; // CELL_KB_MAPPING_101 = US
 		cfg::_enum<enter_button_assign> enter_button_assignment{ this, "Enter button assignment", enter_button_assign::cross };
 		cfg::_int<-60*60*24*365*100LL, 60*60*24*365*100LL> console_time_offset{ this, "Console time offset (s)", 0 }; // console time offset, limited to +/-100years
-                cfg::string console_psid_high{ this, "PSID high", "0x0"};
-                cfg::string console_psid_low{ this, "PSID low", "0x0"};
+		cfg::uint<0,umax> console_psid_high{ this, "PSID high"};
+		cfg::uint<0,umax> console_psid_low{ this, "PSID low"};
+
 	} sys{ this };
 
 	struct node_net : cfg::node

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -295,7 +295,8 @@ struct cfg_root : cfg::node
 		cfg::_enum<CellKbMappingType> keyboard_type{ this, "Keyboard Type", CellKbMappingType{0} }; // CELL_KB_MAPPING_101 = US
 		cfg::_enum<enter_button_assign> enter_button_assignment{ this, "Enter button assignment", enter_button_assign::cross };
 		cfg::_int<-60*60*24*365*100LL, 60*60*24*365*100LL> console_time_offset{ this, "Console time offset (s)", 0 }; // console time offset, limited to +/-100years
-
+                cfg::string console_psid_high{ this, "PSID high", "0x0"};
+                cfg::string console_psid_low{ this, "PSID low", "0x0"};
 	} sys{ this };
 
 	struct node_net : cfg::node


### PR DESCRIPTION
The SingStar game has DLC songs which are encrypted to the PSID of the system. RPCS3 currently always returns a PSID of 0. This patch allows the PSID to be set in the config file allowing use of games which have content that is tied to a given PSID. 
(Ideally it would be settable in the GUI)