### PR TITLE
sys_game_board_storage_read(): Fix regression after #12637

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
+#include "Emu/system_config.h"
 
 #include "sys_game.h"
 
@@ -15,11 +16,19 @@ error_code _sys_game_board_storage_read(vm::ptr<u8> buffer, u8 code)
 		return CELL_EFAULT;
 	}
 
+	be_t<u64> psid[2] = { +g_cfg.sys.console_psid_high, +g_cfg.sys.console_psid_low };
+	u8 psid_bytes[16];
+	memcpy(psid_bytes, psid, 16);
+
 	switch (code)
 	{
 	case 0xF0:
 	{
-		constexpr u8 response[16] = { 0x01, 0xFC, 0x43, 0x50, 0xA7, 0x9B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+		u8 response[16] = { 0x01, 0xFC, 0x43, 0x50, 0xA7, 0x9B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+		for (int i = 0; i < 16; i++)
+		{
+			response[i] ^= psid_bytes[i];
+		}
 		memcpy(buffer.get_ptr(), response, 16);
 		break;
 	}


### PR DESCRIPTION
The data that sys_game_board_storage_read() generates should be corresponding to the PSID by XOR.
Before #12637, the PSID was always set to 0 so it was fine to use the fixed data without XOR directly.
This PR fixed the regression that sys_game_board_storage_read() generated incorrect data when PSID was not set to 0;