### PR TITLE
SPU: Power consumption reduction when using SPU inaccurate reservations

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2642,11 +2642,9 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 	}())
 	{
 		// Test a common pattern in lwmutex
-		constexpr u64 mutex_free = u64{static_cast<u32>(0 - 1)} << 32;
-		const bool may_be_lwmutex_related = sizeof(T) == 8 ?
-			(new_data == mutex_free && old_data == u64{ppu.id} << 32) : (old_data == mutex_free && new_data == u64{ppu.id} << 32);
+		extern atomic_t<u32> liblv2_begin, liblv2_end;
 
-		if (!may_be_lwmutex_related)
+		if (ppu.cia < liblv2_begin || ppu.cia >= liblv2_end)
 		{
 			res.notify_all(-128);
 		}


### PR DESCRIPTION
Lower CPU usage and power consumption significantly when SPUs are waiting for SPURS tasks. This is because when Acuurate SPU Resevations are disabled all reservation writes notify the SPU, so it's possible to drop the timeout on sleep condition, making the SPUs able to be fully relaxed. This requires "Accurate SPU Reservations: false" in config.