### PR TITLE
CPU preemption control: bugfixes and performance improvements

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -654,7 +654,7 @@ bool cpu_thread::check_state() noexcept
 	{
 		// Process all flags in a single atomic op
 		bs_t<cpu_flag> state1;
-		const auto state0 = state.fetch_op([&](bs_t<cpu_flag>& flags)
+		auto state0 = state.fetch_op([&](bs_t<cpu_flag>& flags)
 		{
 			bool store = false;
 
@@ -784,7 +784,8 @@ bool cpu_thread::check_state() noexcept
 			if (cpu_flag::wait - state0)
 			{
 				// Yield itself
-				s_dummy_atomic.wait(0, 1u << 30, atomic_wait_timeout{80'000});
+				escape = false;
+				state0 += cpu_flag::yield;
 			}
 
 			if (const u128 bits = s_cpu_bits)

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -736,7 +736,7 @@ bool cpu_thread::check_state() noexcept
 			if (!is_stopped(flags) && flags.none_of(cpu_flag::ret))
 			{
 				// Check pause flags which hold thread inside check_state (ignore suspend/debug flags on cpu_flag::temp)
-				if (flags & (cpu_flag::pause + cpu_flag::memory + cpu_flag::yield + cpu_flag::preempt) || (cpu_can_stop && flags & (cpu_flag::dbg_global_pause + cpu_flag::dbg_pause + cpu_flag::suspend)))
+				if (flags & (cpu_flag::pause + cpu_flag::memory) || (cpu_can_stop && flags & (cpu_flag::dbg_global_pause + cpu_flag::dbg_pause + cpu_flag::suspend + cpu_flag::yield + cpu_flag::preempt)))
 				{
 					if (!(flags & cpu_flag::wait))
 					{
@@ -744,7 +744,7 @@ bool cpu_thread::check_state() noexcept
 						store = true;
 					}
 
-					if (flags & (cpu_flag::yield + cpu_flag::preempt))
+					if (flags & (cpu_flag::yield + cpu_flag::preempt) && cpu_can_stop)
 					{
 						flags -= (cpu_flag::yield + cpu_flag::preempt);
 						store = true;
@@ -779,7 +779,7 @@ bool cpu_thread::check_state() noexcept
 			return store;
 		}).first;
 
-		if (state0 & cpu_flag::preempt)
+		if (state0 & cpu_flag::preempt && cpu_can_stop)
 		{
 			if (cpu_flag::wait - state0)
 			{
@@ -899,7 +899,7 @@ bool cpu_thread::check_state() noexcept
 				continue;
 			}
 
-			if (state0 & cpu_flag::yield && cpu_flag::wait - state0)
+			if (state0 & cpu_flag::yield && cpu_flag::wait - state0 && cpu_can_stop)
 			{
 				if (auto spu = try_get<spu_thread>())
 				{

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -783,9 +783,12 @@ bool cpu_thread::check_state() noexcept
 		{
 			if (cpu_flag::wait - state0)
 			{
-				// Yield itself
-				escape = false;
-				state0 += cpu_flag::yield;
+				if (!escape || !retval)
+				{
+					// Yield itself
+					state0 += cpu_flag::yield;
+					escape = false;
+				}
 			}
 
 			if (const u128 bits = s_cpu_bits)

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -201,6 +201,11 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 		buffer_height = present_info.height;
 	}
 
+	if (info.emu_flip)
+	{
+		evaluate_cpu_usage_reduction_limits();
+	}
+
 	// Get window state
 	const int width = m_frame->client_width();
 	const int height = m_frame->client_height();

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -42,6 +42,7 @@ rsx::frame_capture_data frame_capture;
 
 extern CellGcmOffsetTable offsetTable;
 extern thread_local std::string(*g_tls_log_prefix)();
+extern atomic_t<u32> g_lv2_preempts_taken;
 
 LOG_CHANNEL(perf_log, "PERF");
 
@@ -3645,7 +3646,7 @@ namespace rsx
 				lower_preemption_count();
 			}
 
-			perf_log.trace("CPU preemption control: reeval=%d, preempt_count=%d, fails=%d, hard=%d, avg_frame_time=%d, highered=%d, lowered=%d", can_reevaluate, preempt_count, fails, hard_fails, avg_frame_time, highered_delay, lowered_delay);
+			perf_log.trace("CPU preemption control: reeval=%d, preempt_count=%d, fails=%d, hard=%d, avg_frame_time=%d, highered=%d, lowered=%d, taken=%u", can_reevaluate, preempt_count, fails, hard_fails, avg_frame_time, highered_delay, lowered_delay, ::g_lv2_preempts_taken.load());
 
 			if (hard_measures_taken)
 			{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3558,7 +3558,7 @@ namespace rsx
 				prev_preempt_count = frame_times[i].preempt_count;
 			}
 
-			preempt_count = frame_times.back().preempt_count;
+			preempt_count = std::min<u32>(frame_times.back().preempt_count, max_preempt_count);
 
 			u32 fails = 0;
 			u32 hard_fails = 0;
@@ -3630,9 +3630,9 @@ namespace rsx
 					{
 						prevent_preempt_increase_tickets--;
 					}
-					else if (preempt_count < max_preempt_count)
+					else
 					{
-						preempt_count += 4;
+						preempt_count = std::min<u32>(preempt_count + 4, max_preempt_count);
 					}
 				}
 				else
@@ -3650,7 +3650,7 @@ namespace rsx
 
 			if (hard_measures_taken)
 			{
-				preempt_fail_old_preempt_count = std::max<u32>(preempt_fail_old_preempt_count, frame_times.back().preempt_count);
+				preempt_fail_old_preempt_count = std::max<u32>(preempt_fail_old_preempt_count, std::min<u32>(frame_times.back().preempt_count, max_preempt_count));
 			}
 			else if (preempt_fail_old_preempt_count)
 			{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3493,8 +3493,6 @@ namespace rsx
 				intr_thread->cmd_notify.notify_one();
 			}
 		}
-
-		evaluate_cpu_usage_reduction_limits();
 	}
 
 	void thread::evaluate_cpu_usage_reduction_limits()
@@ -3574,9 +3572,9 @@ namespace rsx
 				const u64 cur_diff = (i == frame_times.size() ? current_time : frame_times[i].timestamp) - frame_times[i - 1].timestamp;
 
 				if (const u64 diff_of_diff = abs_dst(cur_diff, avg_frame_time);
-					diff_of_diff >= avg_frame_time / 4)
+					diff_of_diff >= avg_frame_time / 7)
 				{
-					if (diff_of_diff >= avg_frame_time / 2)
+					if (diff_of_diff >= avg_frame_time / 3)
 					{
 						highered_delay++;
 						hard_fails++;
@@ -3608,7 +3606,7 @@ namespace rsx
 					preempt_count = 0;
 				}
 
-				if (hard_fails > 2 && is_last_frame_a_fail)
+				if ((hard_fails > 2 || fails > 20) && is_last_frame_a_fail)
 				{
 					hard_measures_taken = preempt_count > 1;
 					preempt_count = preempt_count * 7 / 8;
@@ -3641,7 +3639,7 @@ namespace rsx
 				}
 			}
 			// Sudden FPS drop detection
-			else if ((fails > 10 || hard_fails > 2 || !(abs_dst(fps_10, 300) < 20 || abs_dst(fps_10, 600) < 30 || abs_dst(fps_10, g_cfg.video.vblank_rate * 10) < 20 || abs_dst(fps_10, g_cfg.video.vblank_rate * 10 / 2) < 30)) && lowered_delay < highered_delay && is_last_frame_a_fail)
+			else if ((fails > 13 || hard_fails > 2 || !(abs_dst(fps_10, 300) < 20 || abs_dst(fps_10, 600) < 30 || abs_dst(fps_10, g_cfg.video.vblank_rate * 10) < 20 || abs_dst(fps_10, g_cfg.video.vblank_rate * 10 / 2) < 30)) && lowered_delay < highered_delay && is_last_frame_a_fail)
 			{
 				lower_preemption_count();
 			}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -800,11 +800,12 @@ namespace rsx
 		 */
 		void write_vertex_data_to_memory(const vertex_input_layout& layout, u32 first_vertex, u32 vertex_count, void *persistent_data, void *volatile_data);
 
+		void evaluate_cpu_usage_reduction_limits();
+
 	private:
 		shared_mutex m_mtx_task;
 
 		void handle_emu_flip(u32 buffer);
-		void evaluate_cpu_usage_reduction_limits();
 		void handle_invalidated_memory_range();
 
 	public:

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -503,6 +503,11 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 		buffer_height = present_info.height;
 	}
 
+	if (info.emu_flip)
+	{
+		evaluate_cpu_usage_reduction_limits();
+	}
+
 	// Prepare surface for new frame. Set no timeout here so that we wait for the next image if need be
 	ensure(m_current_frame->present_image == umax);
 	ensure(m_current_frame->swap_command_buffer == nullptr);

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -91,7 +91,7 @@ struct cfg_root : cfg::node
 		cfg::_int<10, 3000> clocks_scale{ this, "Clocks scale", 100 }; // Changing this from 100 (percentage) may affect game speed in unexpected ways
 		cfg::uint<0, 3000> spu_wakeup_delay{ this, "SPU Wake-Up Delay", 0, true };
 		cfg::uint<0, (1 << 6) - 1> spu_wakeup_delay_mask{ this, "SPU Wake-Up Delay Thread Mask", (1 << 6) - 1, true };
-		cfg::uint<0, 300> max_cpu_preempt_count_per_frame{ this, "Max CPU Preempt Count", 0, true }; 
+		cfg::uint<0, 400> max_cpu_preempt_count_per_frame{ this, "Max CPU Preempt Count", 0, true }; 
 		cfg::_bool allow_rsx_cpu_preempt{ this, "Allow RSX CPU Preemptions", true, true }; 
 #if defined (__linux__) || defined (__APPLE__)
 		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy", sleep_timers_accuracy_level::_as_host, true };


### PR DESCRIPTION
* Make CPU preemption work in more cases.
* Make CPU preemption as sparse as possible allowing better performance and reduced side effects at higher values.
* Fix missed CPU preemptions.
* Add some debugging information.
* Avoid CPU preemptions in CELL reservations operations. (critical sections)