### PR TITLE
rsx/vk/gl: Send PS3 flip event as soon possible

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -201,6 +201,8 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 		buffer_height = present_info.height;
 	}
 
+	rsx::thread::flip(info);
+
 	// Get window state
 	const int width = m_frame->client_width();
 	const int height = m_frame->client_height();
@@ -370,7 +372,6 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 	}
 
 	m_frame->flip(m_context);
-	rsx::thread::flip(info);
 
 	// Cleanup
 	m_gl_texture_cache.on_frame_end();

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -507,6 +507,8 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 	ensure(m_current_frame->present_image == umax);
 	ensure(m_current_frame->swap_command_buffer == nullptr);
 
+	rsx::thread::flip(info);
+
 	u64 timeout = m_swapchain->get_swap_image_count() <= VK_MAX_ASYNC_FRAMES? 0ull: 100000000ull;
 	while (VkResult status = m_swapchain->acquire_next_swapchain_image(m_current_frame->acquire_signal_semaphore, timeout, &m_current_frame->present_image))
 	{
@@ -798,5 +800,4 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 	m_frame_stats.flip_time = m_profiler.duration();
 
 	m_frame->flip(m_context);
-	rsx::thread::flip(info);
 }


### PR DESCRIPTION
Previously PS3 flip event was sent only after host frame preparations have been done, this pr makes the event being sent right away when the dependency on CELL (guest preparations) is over. 

Advantages:
* Improves RSX flip event timing accuracy.
* Improves performance by allowing CELL to prepare earlier the contents of the next frame.
* Improves analysis of the new CPU power saving preemptions.