### PR TITLE
Allow USB passthrough for Densha de GO! controller

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -276,6 +276,9 @@ usb_handler_thread::usb_handler_thread()
 		{
 			found_usio = true;
 		}
+		
+		// Densha de GO! controller
+		check_device(0x0AE4, 0x0004, 0x0004, "Densha de GO! Type 2 Controller");
 	}
 
 	libusb_free_device_list(list, 1);


### PR DESCRIPTION
This adds the Densha de GO! Type 2 controller to the list of controllers supporting USB passthrough. The first Railfan game (BLJM60013) is compatible with this controller.

More info here: https://marcriera.github.io/ddgo-controller-docs/controllers/usb/tcpp20009/