### PR TITLE
gl: Avoid UBO/SSBO binding index collisions

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -31,7 +31,7 @@ std::string GLVertexDecompilerThread::compareFunction(COMPARE f, const std::stri
 void GLVertexDecompilerThread::insertHeader(std::stringstream &OS)
 {
 	OS << "#version 430\n";
-	OS << "layout(std140, binding = 0) uniform VertexContextBuffer\n";
+	OS << "layout(std140, binding = " << GL_VERTEX_PARAMS_BIND_SLOT << ") uniform VertexContextBuffer\n";
 	OS << "{\n";
 	OS << "	mat4 scale_offset_mat;\n";
 	OS << "	ivec4 user_clip_enabled[2];\n";
@@ -42,7 +42,7 @@ void GLVertexDecompilerThread::insertHeader(std::stringstream &OS)
 	OS << "	float z_far;\n";
 	OS << "};\n\n";
 
-	OS << "layout(std140, binding = 1) uniform VertexLayoutBuffer\n";
+	OS << "layout(std140, binding = " << GL_VERTEX_LAYOUT_BIND_SLOT << ") uniform VertexLayoutBuffer\n";
 	OS << "{\n";
 	OS << "	uint  vertex_base_index;\n";
 	OS << "	uint  vertex_index_offset;\n";
@@ -66,7 +66,7 @@ void GLVertexDecompilerThread::insertConstants(std::stringstream& OS, const std:
 		{
 			if (PI.name.starts_with("vc["))
 			{
-				OS << "layout(std140, binding = 2) uniform VertexConstantsBuffer\n";
+				OS << "layout(std140, binding = " << GL_VERTEX_CONSTANT_BUFFERS_BIND_SLOT << ") uniform VertexConstantsBuffer\n";
 				OS << "{\n";
 				OS << "	vec4 " << PI.name << ";\n";
 				OS << "};\n\n";

--- a/rpcs3/Emu/RSX/GL/glutils/common.h
+++ b/rpcs3/Emu/RSX/GL/glutils/common.h
@@ -21,7 +21,7 @@
 #define GL_INTERPRETER_VERTEX_BLOCK            SSBO_SLOT(0)
 #define GL_INTERPRETER_FRAGMENT_BLOCK          SSBO_SLOT(1)
 #define GL_COMPUTE_BUFFER_SLOT(index)          SSBO_SLOT(2 + index)
-#define GL_COMPUTE_IMAGE_SLOT(index)           UBO_SLOT(index)
+#define GL_COMPUTE_IMAGE_SLOT(index)           SSBO_SLOT(index)
 
 //Function call wrapped in ARB_DSA vs EXT_DSA compat check
 #define DSA_CALL(func, object_name, target, ...)\

--- a/rpcs3/Emu/RSX/GL/glutils/common.h
+++ b/rpcs3/Emu/RSX/GL/glutils/common.h
@@ -8,7 +8,7 @@
 #define GL_STREAM_BUFFER_START     (GL_STENCIL_MIRRORS_START + 16)
 #define GL_TEMP_IMAGE_SLOT         31
 
-#define UBO_SLOT(x)  (x)
+#define UBO_SLOT(x)  (x + 8)
 #define SSBO_SLOT(x) (x)
 
 #define GL_VERTEX_PARAMS_BIND_SLOT             UBO_SLOT(0)

--- a/rpcs3/Emu/RSX/GL/glutils/state_tracker.hpp
+++ b/rpcs3/Emu/RSX/GL/glutils/state_tracker.hpp
@@ -287,6 +287,12 @@ namespace gl
 			glUseProgram(program);
 		}
 
+		GLuint get_bound_texture(GLuint layer, GLenum target)
+		{
+			ensure(layer < 48);
+			return bound_textures[layer][target];
+		}
+
 		void bind_texture(GLuint layer, GLenum target, GLuint name, GLboolean force = GL_FALSE)
 		{
 			ensure(layer < 48);

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/CopyBufferToColorImage.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/CopyBufferToColorImage.glsl
@@ -2,8 +2,8 @@ R"(
 #version 450
 layout(local_size_x = %ws, local_size_y = 1, local_size_z = 1) in;
 
-#define SSBO_LOCATION(x)  (x + %loc)
-#define IMAGE_LOCATION(x) (x)
+#define IMAGE_LOCATION(x) (x + %image_slot)
+#define SSBO_LOCATION(x)  (x + %ssbo_slot)
 
 layout(%set, binding=IMAGE_LOCATION(0)) uniform writeonly restrict image2D output2D;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/image.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image.cpp
@@ -250,7 +250,7 @@ namespace vk
 			VkImageSubresourceRange range = { aspect(), 0, mipmaps(), 0, layers() };
 			const u32 src_queue_family = info.sharingMode == VK_SHARING_MODE_EXCLUSIVE ? current_queue_family : VK_QUEUE_FAMILY_IGNORED;
 			const u32 dst_queue_family2 = info.sharingMode == VK_SHARING_MODE_EXCLUSIVE ? dst_queue_family : VK_QUEUE_FAMILY_IGNORED;
-			change_image_layout(src_queue_cmd, value, current_layout, new_layout, range, current_queue_family, dst_queue_family2, ~0u, 0u);
+			change_image_layout(src_queue_cmd, value, current_layout, new_layout, range, src_queue_family, dst_queue_family2, ~0u, 0u);
 		}
 
 		current_layout = new_layout;


### PR DESCRIPTION
- Some drivers don't like this. Actually only Radeonsi. For some reason their slots aren't duplicated across different targets, so writing slot 0 UBO erases slot 0 SSBO and vice-versa :man_facepalming: 
- Almost all GPUs going back 15 years have a large number of UBO slots but limited SSBO slots. Move UBO slots up as we have tons more headroom there. e.g The 6600M has like 75 UBO slots but only 8 SSBO slots.

Fixes https://github.com/RPCS3/rpcs3/issues/12476