### PR TITLE
SPU/LV2: Fix tiny race conditions

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -695,7 +695,6 @@ bool cpu_thread::check_state() noexcept
 			{
 				// Sticky flag, indicates check_state() is not allowed to return true
 				flags -= cpu_flag::temp;
-				flags -= cpu_flag::wait;
 				cpu_can_stop = false;
 				store = true;
 			}
@@ -766,9 +765,9 @@ bool cpu_thread::check_state() noexcept
 			}
 			else
 			{
-				if (cpu_can_stop && !(flags & cpu_flag::wait))
+				if (flags & cpu_flag::wait)
 				{
-					flags += cpu_flag::wait;
+					flags -= cpu_flag::wait;
 					store = true;
 				}
 

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -99,6 +99,7 @@ error_code sys_cond_create(ppu_thread& ppu, vm::ptr<u32> cond_id, u32 mutex_id, 
 		return error;
 	}
 
+	ppu.check_state();
 	*cond_id = idm::last_id();
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -77,6 +77,7 @@ error_code sys_event_flag_create(ppu_thread& ppu, vm::ptr<u32> id, vm::ptr<sys_e
 		return error;
 	}
 
+	ppu.check_state();
 	*id = idm::last_id();
 	return CELL_OK;
 }
@@ -253,6 +254,7 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 		}
 	}
 
+	ppu.check_state();
 	store.val = ppu.gpr[6];
 	return not_an_error(ppu.gpr[3]);
 }
@@ -290,6 +292,8 @@ error_code sys_event_flag_trywait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode,
 	{
 		return not_an_error(CELL_EBUSY);
 	}
+
+	ppu.check_state();
 
 	if (result) *result = pattern;
 	return CELL_OK;
@@ -502,6 +506,8 @@ error_code sys_event_flag_get(ppu_thread& ppu, u32 id, vm::ptr<u64> flags)
 	{
 		return +flag.pattern;
 	});
+
+	ppu.check_state();
 
 	if (!flag)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -190,6 +190,7 @@ error_code _sys_interrupt_thread_establish(ppu_thread& ppu, vm::ptr<u32> ih, u32
 
 	if (id)
 	{
+		ppu.check_state();
 		*ih = id;
 		return CELL_OK;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -50,6 +50,7 @@ error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmut
 
 	if (const u32 id = idm::make<lv2_obj, lv2_lwcond>(name, lwmutex_id, protocol, control))
 	{
+		ppu.check_state();
 		*lwcond_id = id;
 		return CELL_OK;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -42,6 +42,7 @@ error_code _sys_lwmutex_create(ppu_thread& ppu, vm::ptr<u32> lwmutex_id, u32 pro
 
 	if (const u32 id = idm::make<lv2_obj, lv2_lwmutex>(protocol, control, name))
 	{
+		ppu.check_state();
 		*lwmutex_id = id;
 		return CELL_OK;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -174,6 +174,7 @@ error_code sys_mmapper_allocate_address(ppu_thread& ppu, u64 size, u64 flags, u6
 	{
 		if (const auto area = vm::find_map(static_cast<u32>(size), static_cast<u32>(alignment), flags & SYS_MEMORY_PAGE_SIZE_MASK))
 		{
+			ppu.check_state();
 			*alloc_addr = area->addr;
 			return CELL_OK;
 		}
@@ -246,6 +247,7 @@ error_code sys_mmapper_allocate_shared_memory(ppu_thread& ppu, u64 ipc_key, u64 
 		return error;
 	}
 
+	ppu.check_state();
 	*mem_id = idm::last_id();
 	return CELL_OK;
 }
@@ -301,6 +303,7 @@ error_code sys_mmapper_allocate_shared_memory_from_container(ppu_thread& ppu, u6
 		return error;
 	}
 
+	ppu.check_state();
 	*mem_id = idm::last_id();
 	return CELL_OK;
 }
@@ -399,6 +402,7 @@ error_code sys_mmapper_allocate_shared_memory_ext(ppu_thread& ppu, u64 ipc_key, 
 		return error;
 	}
 
+	ppu.check_state();
 	*mem_id = idm::last_id();
 	return CELL_OK;
 }
@@ -496,6 +500,7 @@ error_code sys_mmapper_allocate_shared_memory_from_container_ext(ppu_thread& ppu
 		return error;
 	}
 
+	ppu.check_state();
 	*mem_id = idm::last_id();
 	return CELL_OK;
 }
@@ -718,6 +723,8 @@ error_code sys_mmapper_search_and_map(ppu_thread& ppu, u32 start_addr, u32 mem_i
 	}
 
 	vm::lock_sudo(addr, mem->size);
+
+	ppu.check_state();
 	*alloc_addr = addr;
 	return CELL_OK;
 }
@@ -763,6 +770,7 @@ error_code sys_mmapper_unmap_shared_memory(ppu_thread& ppu, u32 addr, vm::ptr<u3
 	}
 
 	// Write out the ID
+	ppu.check_state();
 	*mem_id = mem.ret;
 
 	// Acknowledge

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -92,6 +92,7 @@ error_code sys_mutex_create(ppu_thread& ppu, vm::ptr<u32> mutex_id, vm::ptr<sys_
 		return error;
 	}
 
+	ppu.check_state();
 	*mutex_id = idm::last_id();
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -488,8 +488,10 @@ error_code _sys_ppu_thread_create(ppu_thread& ppu, vm::ptr<u64> thread_id, vm::p
 		return CELL_EAGAIN;
 	}
 
-	*thread_id = tid;
 	sys_ppu_thread.warning(u8"_sys_ppu_thread_create(): Thread “%s” created (id=0x%x, func=*0x%x, rtoc=0x%x, user-tls=0x%x)", ppu_name, tid, entry.addr, entry.rtoc, tls);
+
+	ppu.check_state();
+	*thread_id = tid;
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -542,6 +542,7 @@ error_code _sys_prx_start_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sys
 		return CELL_PRX_ERROR_ERROR;
 	}
 
+	ppu.check_state();
 	pOpt->entry.set(prx->start ? prx->start.addr() : ~0ull);
 
 	// This check is probably for older fw
@@ -594,6 +595,7 @@ error_code _sys_prx_stop_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sys_
 			fmt::throw_exception("Invalid prx state (%d)", old);
 		}
 
+		ppu.check_state();
 		pOpt->entry.set(prx->stop ? prx->stop.addr() : ~0ull);
 		set_entry2(prx->epilogue ? prx->epilogue.addr() : ~0ull);
 		return CELL_OK;
@@ -633,6 +635,7 @@ error_code _sys_prx_stop_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sys_
 
 		if (pOpt->cmd == 4u)
 		{
+			ppu.check_state();
 			pOpt->entry.set(prx->stop ? prx->stop.addr() : ~0ull);
 			set_entry2(prx->epilogue ? prx->epilogue.addr() : ~0ull);
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -62,6 +62,7 @@ error_code sys_rwlock_create(ppu_thread& ppu, vm::ptr<u32> rw_lock_id, vm::ptr<s
 		return error;
 	}
 
+	ppu.check_state();
 	*rw_lock_id = idm::last_id();
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -163,6 +163,7 @@ error_code sys_timer_create(ppu_thread& ppu, vm::ptr<u32> timer_id)
 			}
 		}
 
+		ppu.check_state();
 		*timer_id = idm::last_id();
 		return CELL_OK;
 	}
@@ -226,6 +227,7 @@ error_code sys_timer_get_information(ppu_thread& ppu, u32 timer_id, vm::ptr<sys_
 		return CELL_ESRCH;
 	}
 
+	ppu.check_state();
 	std::memcpy(info.get_ptr(), &_info, info.size());
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -619,11 +619,14 @@ error_code sys_usbd_initialize(ppu_thread& ppu, vm::ptr<u32> handle)
 
 	auto& usbh = g_fxo->get<named_thread<usb_handler_thread>>();
 
-	std::lock_guard lock(usbh.mutex);
+	{
+		std::lock_guard lock(usbh.mutex);
 
-	// Must not occur (lv2 allows multiple handles, cellUsbd does not)
-	ensure(!usbh.is_init.exchange(true));
+		// Must not occur (lv2 allows multiple handles, cellUsbd does not)
+		ensure(!usbh.is_init.exchange(true));
+	}
 
+	ppu.check_state();
 	*handle = 0x115B;
 
 	// TODO
@@ -888,6 +891,7 @@ error_code sys_usbd_receive_event(ppu_thread& ppu, u32 handle, vm::ptr<u64> arg1
 		thread_ctrl::wait_on(ppu.state, state);
 	}
 
+	ppu.check_state();
 	*arg1 = ppu.gpr[4];
 	*arg2 = ppu.gpr[5];
 	*arg3 = ppu.gpr[6];

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -98,6 +98,7 @@ error_code sys_vm_memory_map(ppu_thread& ppu, u32 vsize, u32 psize, u32 cid, u64
 		idm::make<sys_vm_t>(area->addr, vsize, ct, psize);
 
 		// Write a pointer for the allocated memory
+		ppu.check_state();
 		*addr = area->addr;
 		return CELL_OK;
 	}
@@ -399,6 +400,7 @@ error_code sys_vm_test(ppu_thread& ppu, u32 addr, u32 size, vm::ptr<u64> result)
 		return CELL_EINVAL;
 	}
 
+	ppu.check_state();
 	*result = SYS_VM_STATE_ON_MEMORY;
 
 	return CELL_OK;
@@ -417,6 +419,7 @@ error_code sys_vm_get_statistics(ppu_thread& ppu, u32 addr, vm::ptr<sys_vm_stati
 		return CELL_EINVAL;
 	}
 
+	ppu.check_state();
 	stat->page_fault_ppu = 0;
 	stat->page_fault_spu = 0;
 	stat->page_in = 0;


### PR DESCRIPTION
Writing to VM memory while cpu wait flag is set is no laughing material, in this case SPU reservation operations may eliminatte these writes because they aren't tracked by the CPU in case they share a single byte or more of reservation data within the 128-byte cache line.