### PR TITLE
rsx: Fix initialization of null cubemap resources

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -180,7 +180,7 @@ void GLGSRender::on_init_thread()
 
 	// Fallback null texture instead of relying on texture0
 	{
-		std::vector<u32> pixeldata = { 0, 0, 0, 0 };
+		std::array<u32, 8> pixeldata = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
 		// 1D
 		auto tex1D = std::make_unique<gl::texture>(GL_TEXTURE_1D, 1, 1, 1, 1, GL_RGBA8);

--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
@@ -110,7 +110,7 @@ namespace vk
 		tex->change_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
 		VkClearColorValue clear_color = {};
-		VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+		VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, tex->mipmaps(), 0, tex->layers() };
 		vkCmdClearColorImage(cmd, tex->value, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear_color, 1, &range);
 
 		// Prep for shader access


### PR DESCRIPTION
We need to set all the data to 0 to match RSX behaviour.
Fixes some random glitching in games such as God of War III when diving under water.
