### PR TITLE
Replace .at() calls with custom method showing actual source location on failure

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -939,7 +939,7 @@ std::basic_string<u32> patch_engine::apply(const std::string& name, u8* dst, u32
 	}
 
 	std::basic_string<u32> applied_total;
-	const auto& container = m_map.at(name);
+	const auto& container = ::at32(m_map, name);
 	const auto& serial = Emu.GetTitleID();
 	const auto& app_version = Emu.GetAppVersion();
 
@@ -975,7 +975,7 @@ std::basic_string<u32> patch_engine::apply(const std::string& name, u8* dst, u32
 				continue;
 			}
 
-			const auto& app_versions = serials.at(found_serial);
+			const auto& app_versions = ::at32(serials, found_serial);
 			std::string found_app_version;
 
 			if (app_versions.find(app_version) != app_versions.end())
@@ -988,7 +988,7 @@ std::basic_string<u32> patch_engine::apply(const std::string& name, u8* dst, u32
 				is_all_versions = true;
 			}
 
-			if (!found_app_version.empty() && app_versions.at(found_app_version))
+			if (!found_app_version.empty() && ::at32(app_versions, found_app_version))
 			{
 				// This patch is enabled
 				if (is_all_serials)
@@ -1073,7 +1073,7 @@ void patch_engine::unload(const std::string& name)
 		return;
 	}
 
-	const auto& container = m_map.at(name);
+	const auto& container = ::at32(m_map, name);
 
 	for (const auto& [description, patch] : container.patch_info_map)
 	{

--- a/rpcs3/Emu/Audio/AudioBackend.cpp
+++ b/rpcs3/Emu/Audio/AudioBackend.cpp
@@ -111,7 +111,7 @@ std::pair<AudioChannelCnt, AudioChannelCnt> AudioBackend::get_channel_count_and_
 	audio_out_configuration& audio_out_cfg = g_fxo->get<audio_out_configuration>();
 	std::lock_guard lock(audio_out_cfg.mtx);
 	ensure(device_index < audio_out_cfg.out.size());
-	const audio_out_configuration::audio_out& out = audio_out_cfg.out.at(device_index);
+	const audio_out_configuration::audio_out& out = ::at32(audio_out_cfg.out, device_index);
 	return out.get_channel_count_and_downmixer();
 }
 
@@ -120,7 +120,7 @@ AudioChannelCnt AudioBackend::get_max_channel_count(u32 device_index)
 	audio_out_configuration& audio_out_cfg = g_fxo->get<audio_out_configuration>();
 	std::lock_guard lock(audio_out_cfg.mtx);
 	ensure(device_index < audio_out_cfg.out.size());
-	const audio_out_configuration::audio_out& out = audio_out_cfg.out.at(device_index);
+	const audio_out_configuration::audio_out& out = ::at32(audio_out_cfg.out, device_index);
 
 	AudioChannelCnt count = AudioChannelCnt::STEREO;
 

--- a/rpcs3/Emu/Cell/Modules/StaticHLE.cpp
+++ b/rpcs3/Emu/Cell/Modules/StaticHLE.cpp
@@ -162,7 +162,7 @@ bool statichle_handler::check_against_patterns(vm::cptr<u8>& data, u32 size, u32
 			return false;
 		}
 
-		const auto sfunc   = &smodule->functions.at(pat.fnid);
+		const auto sfunc   = &::at32(smodule->functions, pat.fnid);
 		const u32 target   = g_fxo->get<ppu_function_manager>().func_addr(sfunc->index) + 4;
 
 		// write stub

--- a/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudioOut.cpp
@@ -33,8 +33,8 @@ void fmt_class_string<CellAudioOutError>::format(std::string& out, u64 arg)
 
 audio_out_configuration::audio_out_configuration()
 {
-	audio_out& primary_output = out.at(CELL_AUDIO_OUT_PRIMARY);
-	audio_out& secondary_output = out.at(CELL_AUDIO_OUT_SECONDARY);
+	audio_out& primary_output = ::at32(out, CELL_AUDIO_OUT_PRIMARY);
+	audio_out& secondary_output = ::at32(out, CELL_AUDIO_OUT_SECONDARY);
 
 	std::vector<CellAudioOutSoundMode>& primary_modes = primary_output.sound_modes;
 	std::vector<CellAudioOutSoundMode>& secondary_modes = secondary_output.sound_modes;
@@ -58,8 +58,8 @@ audio_out_configuration::audio_out_configuration()
 
 	const auto add_sound_mode = [&](u32 index, u8 type, u8 channel, u8 fs, u32 layout, bool supported)
 	{
-		audio_out& output = out.at(index);
-		bool& selected = initial_mode_selected.at(index);
+		audio_out& output = ::at32(out, index);
+		bool& selected = ::at32(initial_mode_selected, index);
 
 		CellAudioOutSoundMode mode{};
 		mode.type = type;
@@ -103,7 +103,7 @@ audio_out_configuration::audio_out_configuration()
 	{
 		// Linear PCM 5.1 Ch. 48 kHz
 		add_sound_mode(CELL_AUDIO_OUT_PRIMARY, CELL_AUDIO_OUT_CODING_TYPE_LPCM, CELL_AUDIO_OUT_CHNUM_6, CELL_AUDIO_OUT_FS_48KHZ, CELL_AUDIO_OUT_SPEAKER_LAYOUT_6CH_LREClr, supports_lpcm_5_1);
-		
+
 		// Dolby Digital 5.1 Ch.
 		add_sound_mode(CELL_AUDIO_OUT_PRIMARY, CELL_AUDIO_OUT_CODING_TYPE_AC3, CELL_AUDIO_OUT_CHNUM_6, CELL_AUDIO_OUT_FS_48KHZ, CELL_AUDIO_OUT_SPEAKER_LAYOUT_6CH_LREClr, supports_ac3);
 
@@ -161,8 +161,8 @@ audio_out_configuration::audio_out_configuration()
 	// The secondary output only supports Linear PCM 2 Ch.
 	add_sound_mode(CELL_AUDIO_OUT_SECONDARY, CELL_AUDIO_OUT_CODING_TYPE_LPCM, CELL_AUDIO_OUT_CHNUM_2, CELL_AUDIO_OUT_FS_48KHZ, CELL_AUDIO_OUT_SPEAKER_LAYOUT_2CH, true);
 
-	ensure(!primary_modes.empty() && initial_mode_selected.at(CELL_AUDIO_OUT_PRIMARY));
-	ensure(!secondary_modes.empty() && initial_mode_selected.at(CELL_AUDIO_OUT_SECONDARY));
+	ensure(!primary_modes.empty() && ::at32(initial_mode_selected, CELL_AUDIO_OUT_PRIMARY));
+	ensure(!secondary_modes.empty() && ::at32(initial_mode_selected, CELL_AUDIO_OUT_SECONDARY));
 
 	for (const CellAudioOutSoundMode& mode : primary_modes)
 	{
@@ -238,7 +238,7 @@ error_code cellAudioOutGetSoundAvailability(u32 audioOut, u32 type, u32 fs, u32 
 	// Check if the requested audio parameters are available and find the max supported channel count
 	audio_out_configuration& cfg = g_fxo->get<audio_out_configuration>();
 	std::lock_guard lock(cfg.mtx);
-	const audio_out_configuration::audio_out& out = cfg.out.at(audioOut);
+	const audio_out_configuration::audio_out& out = ::at32(cfg.out, audioOut);
 
 	for (const CellAudioOutSoundMode& mode : out.sound_modes)
 	{
@@ -265,7 +265,7 @@ error_code cellAudioOutGetSoundAvailability2(u32 audioOut, u32 type, u32 fs, u32
 	// Check if the requested audio parameters are available
 	audio_out_configuration& cfg = g_fxo->get<audio_out_configuration>();
 	std::lock_guard lock(cfg.mtx);
-	const audio_out_configuration::audio_out& out = cfg.out.at(audioOut);
+	const audio_out_configuration::audio_out& out = ::at32(cfg.out, audioOut);
 
 	for (const CellAudioOutSoundMode& mode : out.sound_modes)
 	{
@@ -319,7 +319,7 @@ error_code cellAudioOutGetState(u32 audioOut, u32 deviceIndex, vm::ptr<CellAudio
 	{
 		audio_out_configuration& cfg = g_fxo->get<audio_out_configuration>();
 		std::lock_guard lock(cfg.mtx);
-		const audio_out_configuration::audio_out& out = cfg.out.at(audioOut);
+		const audio_out_configuration::audio_out& out = ::at32(cfg.out, audioOut);
 
 		_state.state = out.state;
 		_state.encoder = out.encoder;
@@ -360,7 +360,7 @@ error_code cellAudioOutConfigure(u32 audioOut, vm::ptr<CellAudioOutConfiguration
 	{
 		std::lock_guard lock(cfg.mtx);
 
-		audio_out_configuration::audio_out& out = cfg.out.at(audioOut);
+		audio_out_configuration::audio_out& out = ::at32(cfg.out, audioOut);
 
 		// Apparently the set config does not necessarily have to exist in the list of sound modes.
 
@@ -406,7 +406,7 @@ error_code cellAudioOutConfigure(u32 audioOut, vm::ptr<CellAudioOutConfiguration
 			audio_out_configuration& cfg = g_fxo->get<audio_out_configuration>();
 			{
 				std::lock_guard lock(cfg.mtx);
-				cfg.out.at(audioOut).state = CELL_AUDIO_OUT_OUTPUT_STATE_DISABLED;
+				::at32(cfg.out, audioOut).state = CELL_AUDIO_OUT_OUTPUT_STATE_DISABLED;
 			}
 
 			audio::configure_audio(true);
@@ -414,7 +414,7 @@ error_code cellAudioOutConfigure(u32 audioOut, vm::ptr<CellAudioOutConfiguration
 
 			{
 				std::lock_guard lock(cfg.mtx);
-				cfg.out.at(audioOut).state = CELL_AUDIO_OUT_OUTPUT_STATE_ENABLED;
+				::at32(cfg.out, audioOut).state = CELL_AUDIO_OUT_OUTPUT_STATE_ENABLED;
 			}
 		};
 
@@ -455,7 +455,7 @@ error_code cellAudioOutGetConfiguration(u32 audioOut, vm::ptr<CellAudioOutConfig
 	audio_out_configuration& cfg = g_fxo->get<audio_out_configuration>();
 	std::lock_guard lock(cfg.mtx);
 
-	const audio_out_configuration::audio_out& out = cfg.out.at(audioOut);
+	const audio_out_configuration::audio_out& out = ::at32(cfg.out, audioOut);
 
 	// Return the active config.
 	CellAudioOutConfiguration _config{};
@@ -516,7 +516,7 @@ error_code cellAudioOutGetDeviceInfo(u32 audioOut, u32 deviceIndex, vm::ptr<Cell
 	audio_out_configuration& cfg = g_fxo->get<audio_out_configuration>();
 	std::lock_guard lock(cfg.mtx);
 	ensure(audioOut < cfg.out.size());
-	const audio_out_configuration::audio_out& out = cfg.out.at(audioOut);
+	const audio_out_configuration::audio_out& out = ::at32(cfg.out, audioOut);
 	ensure(out.sound_modes.size() <= 16);
 
 	CellAudioOutDeviceInfo _info{};
@@ -528,7 +528,7 @@ error_code cellAudioOutGetDeviceInfo(u32 audioOut, u32 deviceIndex, vm::ptr<Cell
 
 	for (usz i = 0; i < out.sound_modes.size(); i++)
 	{
-		_info.availableModes[i] = out.sound_modes.at(i);
+		_info.availableModes[i] = ::at32(out.sound_modes, i);
 	}
 
 	*info = _info;
@@ -557,7 +557,7 @@ error_code cellAudioOutSetCopyControl(u32 audioOut, u32 control)
 	audio_out_configuration& cfg = g_fxo->get<audio_out_configuration>();
 	std::lock_guard lock(cfg.mtx);
 
-	cfg.out.at(audioOut).copy_control = control;
+	::at32(cfg.out, audioOut).copy_control = control;
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -418,13 +418,13 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 		const psf::registry psf = psf::load_object(fs::file(local_dir +"/PARAM.SFO"));
 
 		// Some following fields may be zero in old FW 1.00 version PARAM.SFO
-		if (psf.contains("PARENTAL_LEVEL")) get->getParam.parentalLevel = psf.at("PARENTAL_LEVEL").as_integer();
-		if (psf.contains("ATTRIBUTE")) get->getParam.attribute = psf.at("ATTRIBUTE").as_integer();
-		if (psf.contains("RESOLUTION")) get->getParam.resolution = psf.at("RESOLUTION").as_integer();
-		if (psf.contains("SOUND_FORMAT")) get->getParam.soundFormat = psf.at("SOUND_FORMAT").as_integer();
-		if (psf.contains("TITLE")) strcpy_trunc(get->getParam.title, psf.at("TITLE").as_string());
-		if (psf.contains("APP_VER")) strcpy_trunc(get->getParam.dataVersion, psf.at("APP_VER").as_string());
-		if (psf.contains("TITLE_ID")) strcpy_trunc(get->getParam.titleId, psf.at("TITLE_ID").as_string());
+		if (psf.contains("PARENTAL_LEVEL")) get->getParam.parentalLevel = ::at32(psf, "PARENTAL_LEVEL").as_integer();
+		if (psf.contains("ATTRIBUTE")) get->getParam.attribute = ::at32(psf, "ATTRIBUTE").as_integer();
+		if (psf.contains("RESOLUTION")) get->getParam.resolution = ::at32(psf, "RESOLUTION").as_integer();
+		if (psf.contains("SOUND_FORMAT")) get->getParam.soundFormat = ::at32(psf, "SOUND_FORMAT").as_integer();
+		if (psf.contains("TITLE")) strcpy_trunc(get->getParam.title, ::at32(psf, "TITLE").as_string());
+		if (psf.contains("APP_VER")) strcpy_trunc(get->getParam.dataVersion, ::at32(psf, "APP_VER").as_string());
+		if (psf.contains("TITLE_ID")) strcpy_trunc(get->getParam.titleId, ::at32(psf, "TITLE_ID").as_string());
 
 		for (u32 i = 0; i < CELL_HDDGAME_SYSP_LANGUAGE_NUM; i++)
 		{
@@ -1710,8 +1710,8 @@ error_code cellDiscGameGetBootDiscInfo(vm::ptr<CellDiscGameSystemFileParam> getP
 
 	const psf::registry psf = psf::load_object(fs::file(vfs::get(dir + "/PARAM.SFO")));
 
-	if (psf.contains("PARENTAL_LEVEL")) getParam->parentalLevel = psf.at("PARENTAL_LEVEL").as_integer();
-	if (psf.contains("TITLE_ID")) strcpy_trunc(getParam->titleId, psf.at("TITLE_ID").as_string());
+	if (psf.contains("PARENTAL_LEVEL")) getParam->parentalLevel = ::at32(psf, "PARENTAL_LEVEL").as_integer();
+	if (psf.contains("TITLE_ID")) strcpy_trunc(getParam->titleId, ::at32(psf, "TITLE_ID").as_string());
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -219,7 +219,7 @@ public:
 			break;
 		}
 
-		gem_controller& controller = controllers.at(gem_num);
+		gem_controller& controller = ::at32(controllers, gem_num);
 		controller = {};
 		controller.sphere_rgb = gem_color::get_default_color(gem_num);
 
@@ -563,7 +563,7 @@ static void ds3_input_to_pad(const u32 port_no, be_t<u16>& digital_buttons, be_t
 	std::lock_guard lock(pad::g_pad_mutex);
 
 	const auto handler = pad::get_current_handler();
-	const auto& pad = handler->GetPads().at(port_no);
+	const auto& pad = ::at32(handler->GetPads(), port_no);
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
 	{
@@ -656,7 +656,7 @@ static void ds3_pos_to_gem_image_state(const u32 port_no, const gem_config::gem_
 	std::lock_guard lock(pad::g_pad_mutex);
 
 	const auto handler = pad::get_current_handler();
-	const auto& pad = handler->GetPads().at(port_no);
+	const auto& pad = ::at32(handler->GetPads(), port_no);
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
 	{
@@ -679,7 +679,7 @@ static void ds3_pos_to_gem_state(const u32 port_no, const gem_config::gem_contro
 	std::lock_guard lock(pad::g_pad_mutex);
 
 	const auto handler = pad::get_current_handler();
-	const auto& pad = handler->GetPads().at(port_no);
+	const auto& pad = ::at32(handler->GetPads(), port_no);
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
 	{
@@ -712,7 +712,7 @@ static void ds3_input_to_ext(const u32 port_no, const gem_config::gem_controller
 	std::lock_guard lock(pad::g_pad_mutex);
 
 	const auto handler = pad::get_current_handler();
-	const auto& pad = handler->GetPads().at(port_no);
+	const auto& pad = ::at32(handler->GetPads(), port_no);
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
 	{
@@ -769,7 +769,7 @@ static bool mouse_input_to_pad(const u32 mouse_no, be_t<u16>& digital_buttons, b
 		return false;
 	}
 
-	const auto& mouse_data = handler.GetMice().at(mouse_no);
+	const auto& mouse_data = ::at32(handler.GetMice(), mouse_no);
 	const auto is_pressed = [&mouse_data](MouseButtonCodes button) -> bool { return !!(mouse_data.buttons & button); };
 
 	digital_buttons = 0;
@@ -822,7 +822,7 @@ static void mouse_pos_to_gem_image_state(const u32 mouse_no, const gem_config::g
 		return;
 	}
 
-	const auto& mouse = handler.GetMice().at(mouse_no);
+	const auto& mouse = ::at32(handler.GetMice(), mouse_no);
 
 	pos_to_gem_image_state(mouse_no, controller, gem_image_state, mouse.x_pos, mouse.y_pos, mouse.x_max, mouse.y_max);
 }
@@ -846,7 +846,7 @@ static void mouse_pos_to_gem_state(const u32 mouse_no, const gem_config::gem_con
 		return;
 	}
 
-	const auto& mouse = handler.GetMice().at(mouse_no);
+	const auto& mouse = ::at32(handler.GetMice(), mouse_no);
 
 	pos_to_gem_state(mouse_no, controller, gem_state, mouse.x_pos, mouse.y_pos, mouse.x_max, mouse.y_max);
 }

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -151,23 +151,23 @@ void mic_context::load_config_and_init()
 			for (s32 index = 0; index < static_cast<s32>(device_list.size()); index++)
 			{
 				mic_list.emplace(std::piecewise_construct, std::forward_as_tuple(index), std::forward_as_tuple(microphone_handler::standard));
-				mic_list.at(index).add_device(device_list[index]);
+				::at32(mic_list, index).add_device(device_list[index]);
 			}
 			break;
 		}
 		case microphone_handler::singstar:
 		{
 			mic_list.emplace(std::piecewise_construct, std::forward_as_tuple(0), std::forward_as_tuple(microphone_handler::singstar));
-			mic_list.at(0).add_device(device_list[0]);
+			::at32(mic_list, 0).add_device(device_list[0]);
 			if (device_list.size() >= 2)
-				mic_list.at(0).add_device(device_list[1]);
+				::at32(mic_list, 0).add_device(device_list[1]);
 			break;
 		}
 		case microphone_handler::real_singstar:
 		case microphone_handler::rocksmith:
 		{
 			mic_list.emplace(std::piecewise_construct, std::forward_as_tuple(0), std::forward_as_tuple(g_cfg.audio.microphone_type));
-			mic_list.at(0).add_device(device_list[0]);
+			::at32(mic_list, 0).add_device(device_list[0]);
 			break;
 		}
 		case microphone_handler::null:
@@ -563,7 +563,7 @@ error_code cellMicOpen(s32 dev_num, s32 sampleRate)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	if (device.is_opened())
 		return CELL_MICIN_ERROR_ALREADY_OPEN;
@@ -583,7 +583,7 @@ error_code cellMicOpenRaw(s32 dev_num, s32 sampleRate, s32 maxChannels)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	if (device.is_opened())
 		return CELL_MICIN_ERROR_ALREADY_OPEN;
@@ -604,7 +604,7 @@ error_code cellMicOpenEx(s32 dev_num, s32 rawSampleRate, s32 rawChannel, s32 DSP
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	if (device.is_opened())
 		return CELL_MICIN_ERROR_ALREADY_OPEN;
@@ -626,7 +626,7 @@ u8 cellMicIsOpen(s32 dev_num)
 	if (!mic_thr.mic_list.count(dev_num))
 		return false;
 
-	return mic_thr.mic_list.at(dev_num).is_opened();
+	return ::at32(mic_thr.mic_list, dev_num).is_opened();
 }
 
 s32 cellMicIsAttached(s32 dev_num)
@@ -647,7 +647,7 @@ error_code cellMicClose(s32 dev_num)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	if (!device.is_opened())
 		return CELL_MICIN_ERROR_NOT_OPEN;
@@ -669,7 +669,7 @@ error_code cellMicStart(s32 dev_num)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	if (!device.is_opened())
 		return CELL_MICIN_ERROR_NOT_OPEN;
@@ -691,7 +691,7 @@ error_code cellMicStartEx(s32 dev_num, u32 iflags)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	if (!device.is_opened())
 		return CELL_MICIN_ERROR_NOT_OPEN;
@@ -713,7 +713,7 @@ error_code cellMicStop(s32 dev_num)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	if (!device.is_opened())
 		return CELL_MICIN_ERROR_NOT_OPEN;
@@ -743,7 +743,7 @@ error_code cellMicGetDeviceAttr(s32 dev_num, CellMicDeviceAttr deviceAttributes,
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	switch (deviceAttributes)
 	{
@@ -771,7 +771,7 @@ error_code cellMicSetDeviceAttr(s32 dev_num, CellMicDeviceAttr deviceAttributes,
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	switch (deviceAttributes)
 	{
@@ -854,7 +854,7 @@ error_code cellMicGetFormatRaw(s32 dev_num, vm::ptr<CellMicInputFormatI> format)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& device = mic_thr.mic_list.at(dev_num);
+	auto& device = ::at32(mic_thr.mic_list, dev_num);
 
 	format->subframeSize  = device.get_bit_resolution() / 8; // Probably?
 	format->bitResolution = device.get_bit_resolution();
@@ -956,7 +956,7 @@ error_code cellMicReadRaw(s32 dev_num, vm::ptr<void> data, s32 max_bytes)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& mic = mic_thr.mic_list.at(dev_num);
+	auto& mic = ::at32(mic_thr.mic_list, dev_num);
 
 	if (!mic.is_opened() || !(mic.get_signal_types() & CELLMIC_SIGTYPE_RAW))
 		return CELL_MICIN_ERROR_NOT_OPEN;
@@ -978,7 +978,7 @@ error_code cellMicRead(s32 dev_num, vm::ptr<void> data, u32 max_bytes)
 	if (!mic_thr.mic_list.count(dev_num))
 		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
 
-	auto& mic = mic_thr.mic_list.at(dev_num);
+	auto& mic = ::at32(mic_thr.mic_list, dev_num);
 
 	if (!mic.is_opened() || !(mic.get_signal_types() & CELLMIC_SIGTYPE_DSP))
 		return CELL_MICIN_ERROR_NOT_OPEN;

--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -161,8 +161,8 @@ struct music_state
 
 				if (next_track < playlist.size())
 				{
-					path = vfs::get(playlist.at(next_track));
-					cellMusic.notice("set_playback_command: current vfs path: '%s' (unresolved='%s')", path, playlist.at(next_track));
+					path = vfs::get(::at32(playlist, next_track));
+					cellMusic.notice("set_playback_command: current vfs path: '%s' (unresolved='%s')", path, ::at32(playlist, next_track));
 				}
 				else
 				{
@@ -244,7 +244,7 @@ error_code cellMusicGetSelectionContext(vm::ptr<CellMusicSelectionContext> conte
 
 	if (!context)
 		return CELL_MUSIC_ERROR_PARAM;
-	
+
 	auto& music = g_fxo->get<music_state>();
 	std::lock_guard lock(music.mtx);
 

--- a/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
@@ -235,7 +235,7 @@ error_code cell_music_decode_read(vm::ptr<void> buf, vm::ptr<u32> startTime, u64
 	{
 		start_time_ms = dec.decoder.timestamps_ms.front().second;
 
-		while (dec.decoder.timestamps_ms.size() > 1 && dec.read_pos >= dec.decoder.timestamps_ms.at(1).first)
+		while (dec.decoder.timestamps_ms.size() > 1 && dec.read_pos >= ::at32(dec.decoder.timestamps_ms, 1).first)
 		{
 			dec.decoder.timestamps_ms.pop_front();
 		}
@@ -274,7 +274,7 @@ error_code cell_music_decode_read(vm::ptr<void> buf, vm::ptr<u32> startTime, u64
 error_code cellMusicDecodeInitialize(s32 mode, u32 container, s32 spuPriority, vm::ptr<CellMusicDecodeCallback> func, vm::ptr<void> userData)
 {
 	cellMusicDecode.warning("cellMusicDecodeInitialize(mode=0x%x, container=0x%x, spuPriority=0x%x, func=*0x%x, userData=*0x%x)", mode, container, spuPriority, func, userData);
-	
+
 	if (mode != CELL_MUSIC_DECODE2_MODE_NORMAL || (spuPriority - 0x10U > 0xef) || !func)
 	{
 		return CELL_MUSIC_DECODE_ERROR_PARAM;

--- a/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
@@ -47,7 +47,7 @@ std::string music_selection_context::to_string() const
 
 	for (usz i = 0; i < playlist.size(); i++)
 	{
-		fmt::append(str, "\n - Track %d: %s", i, playlist.at(i));
+		fmt::append(str, "\n - Track %d: %s", i, ::at32(playlist, i));
 	}
 
 	return str;

--- a/rpcs3/Emu/Cell/Modules/cellSearch.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSearch.cpp
@@ -1297,7 +1297,7 @@ error_code cellSearchStartSceneSearch(CellSearchSceneSearchType searchType, vm::
 		return CELL_SEARCH_ERROR_PARAM;
 	}
 
-	if (tagNum) // TODO: find out if this is the correct location for these checks 
+	if (tagNum) // TODO: find out if this is the correct location for these checks
 	{
 		if (tagNum > CELL_SEARCH_TAG_NUM_MAX || !tags)
 		{
@@ -1580,7 +1580,7 @@ error_code cellSearchGetContentIdByOffset(CellSearchId searchId, s32 offset, vm:
 
 	if (offset >= 0 && offset + 0u < searchObject->content_ids.size())
 	{
-		auto& content_id = searchObject->content_ids.at(offset);
+		auto& content_id = ::at32(searchObject->content_ids, offset);
 		const u128 content_id_128 = content_id.first;
 		*outContentType = content_id.second->type;
 		std::memcpy(outContentId->data, &content_id_128, CELL_SEARCH_CONTENT_ID_SIZE);

--- a/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoOut.cpp
@@ -123,10 +123,10 @@ error_code cellVideoOutGetState(u32 videoOut, u32 deviceIndex, vm::ptr<CellVideo
 		const auto& conf = g_fxo->get<rsx::avconf>();
 		state->state = CELL_VIDEO_OUT_OUTPUT_STATE_ENABLED;
 		state->colorSpace = CELL_VIDEO_OUT_COLOR_SPACE_RGB;
-		state->displayMode.resolutionId = conf.state ? conf.resolution_id : g_video_out_resolution_id.at(g_cfg.video.resolution);
+		state->displayMode.resolutionId = conf.state ? conf.resolution_id : ::at32(g_video_out_resolution_id, g_cfg.video.resolution);
 		state->displayMode.scanMode = CELL_VIDEO_OUT_SCAN_MODE_PROGRESSIVE;
 		state->displayMode.conversion = CELL_VIDEO_OUT_DISPLAY_CONVERSION_NONE;
-		state->displayMode.aspect = conf.state ? conf.aspect : g_video_out_aspect_id.at(g_cfg.video.aspect_ratio);
+		state->displayMode.aspect = conf.state ? conf.aspect : ::at32(g_video_out_aspect_id, g_cfg.video.aspect_ratio);
 		state->displayMode.refreshRates = CELL_VIDEO_OUT_REFRESH_RATE_59_94HZ;
 
 		return CELL_OK;
@@ -207,7 +207,7 @@ error_code cellVideoOutConfigure(u32 videoOut, vm::ptr<CellVideoOutConfiguration
 		}
 
 		// Resolve 'auto' or unknown options to actual aspect ratio
-		conf.aspect = g_video_out_aspect_id.at(g_cfg.video.aspect_ratio);
+		conf.aspect = ::at32(g_video_out_aspect_id, g_cfg.video.aspect_ratio);
 	}
 
 	cellSysutil.notice("Selected video configuration: resolutionId=0x%x, aspect=0x%x=>0x%x, format=0x%x", config->resolutionId, config->aspect, conf.aspect, config->format);
@@ -242,9 +242,9 @@ error_code cellVideoOutGetConfiguration(u32 videoOut, vm::ptr<CellVideoOutConfig
 		}
 		else
 		{
-			config->resolutionId = g_video_out_resolution_id.at(g_cfg.video.resolution);
+			config->resolutionId = ::at32(g_video_out_resolution_id, g_cfg.video.resolution);
 			config->format = CELL_VIDEO_OUT_BUFFER_COLOR_FORMAT_X8R8G8B8;
-			config->aspect = g_video_out_aspect_id.at(g_cfg.video.aspect_ratio);
+			config->aspect = ::at32(g_video_out_aspect_id, g_cfg.video.aspect_ratio);
 
 			CellVideoOutResolution res;
 			ensure(_IntGetResolutionInfo(config->resolutionId, &res) == CELL_OK); // "Invalid video configuration"
@@ -295,10 +295,10 @@ error_code cellVideoOutGetDeviceInfo(u32 videoOut, u32 deviceIndex, vm::ptr<Cell
 	info->colorInfo.whiteX = 0xFFFF;
 	info->colorInfo.whiteY = 0xFFFF;
 	info->colorInfo.gamma = 100;
-	info->availableModes[0].aspect = g_video_out_aspect_id.at(g_cfg.video.aspect_ratio);
+	info->availableModes[0].aspect = ::at32(g_video_out_aspect_id, g_cfg.video.aspect_ratio);
 	info->availableModes[0].conversion = CELL_VIDEO_OUT_DISPLAY_CONVERSION_NONE;
 	info->availableModes[0].refreshRates =  CELL_VIDEO_OUT_REFRESH_RATE_60HZ | CELL_VIDEO_OUT_REFRESH_RATE_59_94HZ;
-	info->availableModes[0].resolutionId = g_video_out_resolution_id.at(g_cfg.video.resolution);
+	info->availableModes[0].resolutionId = ::at32(g_video_out_resolution_id, g_cfg.video.resolution);
 	info->availableModes[0].scanMode = CELL_VIDEO_OUT_SCAN_MODE_PROGRESSIVE;
 
 	if (g_cfg.video.enable_3d && g_cfg.video.resolution == video_resolution::_720)
@@ -335,12 +335,12 @@ error_code cellVideoOutGetResolutionAvailability(u32 videoOut, u32 resolutionId,
 	case CELL_VIDEO_OUT_PRIMARY:
 	{
 		// NOTE: Result is boolean
-		if (aspect != CELL_VIDEO_OUT_ASPECT_AUTO && aspect != static_cast<u32>(g_video_out_aspect_id.at(g_cfg.video.aspect_ratio)))
+		if (aspect != CELL_VIDEO_OUT_ASPECT_AUTO && aspect != static_cast<u32>(::at32(g_video_out_aspect_id, g_cfg.video.aspect_ratio)))
 		{
 			return not_an_error(0);
 		}
 
-		if (resolutionId == static_cast<u32>(g_video_out_resolution_id.at(g_cfg.video.resolution)))
+		if (resolutionId == static_cast<u32>(::at32(g_video_out_resolution_id, g_cfg.video.resolution)))
 		{
 			// Perfect match
 			return not_an_error(1);

--- a/rpcs3/Emu/Cell/Modules/sceNpTus.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTus.cpp
@@ -58,7 +58,7 @@ sce_np_tus_title_context* sce_np_tus_manager::get_title_context(s32 titleCtxId)
 {
 	if (title_contexts.find(titleCtxId) != title_contexts.end())
 	{
-		return &title_contexts.at(titleCtxId);
+		return &::at32(title_contexts, titleCtxId);
 	}
 
 	return nullptr;
@@ -81,7 +81,7 @@ s32 sce_np_tus_manager::add_transaction_context(s32 titleCtxId)
 			sce_np_tus_transaction_context new_transaction;
 			new_transaction.id = next_transaction_context_id;
 
-			if (title_contexts.at(titleCtxId).transaction_contexts.emplace(next_transaction_context_id, new_transaction).second)
+			if (::at32(title_contexts, titleCtxId).transaction_contexts.emplace(next_transaction_context_id, new_transaction).second)
 			{
 				return next_transaction_context_id++;
 			}
@@ -122,7 +122,7 @@ sce_np_tus_transaction_context* sce_np_tus_manager::get_transaction_context(s32 
 
 		if (transactions.find(transId) != transactions.end())
 		{
-			return &transactions.at(transId);
+			return &::at32(transactions, transId);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -85,7 +85,7 @@ void ppu_module_manager::register_module(ppu_static_module* _module)
 
 ppu_static_function& ppu_module_manager::access_static_function(const char* _module, u32 fnid)
 {
-	auto& res = ppu_module_manager::s_module_map.at(_module)->functions[fnid];
+	auto& res = ::at32(ppu_module_manager::s_module_map, _module)->functions[fnid];
 
 	if (res.name)
 	{
@@ -97,7 +97,7 @@ ppu_static_function& ppu_module_manager::access_static_function(const char* _mod
 
 ppu_static_variable& ppu_module_manager::access_static_variable(const char* _module, u32 vnid)
 {
-	auto& res = ppu_module_manager::s_module_map.at(_module)->variables[vnid];
+	auto& res = ::at32(ppu_module_manager::s_module_map, _module)->variables[vnid];
 
 	if (res.name)
 	{
@@ -347,13 +347,13 @@ static void ppu_initialize_modules(ppu_linkage_info* link, utils::serial* ar = n
 					break;
 				}
 
-				const auto _module = manager.at(name);
+				const auto _module = ::at32(manager, name);
 
 				auto& variable = _module->variables;
 
 				for (u32 i = 0, end = ar.operator usz(); i < end; i++)
 				{
-					auto* ptr = &variable.at(ar.operator u32());
+					auto* ptr = &::at32(variable, ar.operator u32());
 					ptr->addr = ar.operator u32();
 					ensure(!!ptr->var);
 				}
@@ -699,7 +699,7 @@ static auto ppu_load_exports(ppu_linkage_info* link, u32 exports_start, u32 expo
 			//else
 			{
 				// Static function
-				const auto _sf = _sm && _sm->functions.count(fnid) ? &_sm->functions.at(fnid) : nullptr;
+				const auto _sf = _sm && _sm->functions.count(fnid) ? &::at32(_sm->functions, fnid) : nullptr;
 
 				if (_sf && (_sf->flags & MFF_FORCED_HLE))
 				{
@@ -1217,12 +1217,12 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 			{
 				const auto& rel = reinterpret_cast<const ppu_prx_relocation_info&>(prog.bin[i]);
 
-				if (rel.offset >= prx->segs.at(rel.index_addr).size)
+				if (rel.offset >= ::at32(prx->segs, rel.index_addr).size)
 				{
 					fmt::throw_exception("Relocation offset out of segment memory! (offset=0x%x, index_addr=%u)", rel.offset, rel.index_addr);
 				}
 
-				const u32 data_base = rel.index_value == 0xFF ? 0 : prx->segs.at(rel.index_value).addr;
+				const u32 data_base = rel.index_value == 0xFF ? 0 : ::at32(prx->segs, rel.index_value).addr;
 
 				if (rel.index_value != 0xFF && !data_base)
 				{
@@ -1230,7 +1230,7 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, const std::stri
 				}
 
 				ppu_reloc _rel;
-				const u32 raddr = _rel.addr = vm::cast(prx->segs.at(rel.index_addr).addr + rel.offset);
+				const u32 raddr = _rel.addr = vm::cast(::at32(prx->segs, rel.index_addr).addr + rel.offset);
 				const u32 rtype = _rel.type = rel.type;
 				const u64 rdata = _rel.data = data_base + rel.ptr.addr();
 				prx->relocs.emplace_back(_rel);

--- a/rpcs3/Emu/Cell/PPUOpcodes.h
+++ b/rpcs3/Emu/Cell/PPUOpcodes.h
@@ -117,7 +117,7 @@ class ppu_decoder
 					for (u32 j = 0; j < 1u << sh; j++)
 					{
 						const u32 k = (((i << (count - v.magn)) | v.value) << sh) | j;
-						m_table.at((k << 6) | main_op) = k & 1 ? v.ptr_rc : v.ptr0;
+						::at32(m_table, (k << 6) | main_op) = k & 1 ? v.ptr_rc : v.ptr0;
 					}
 				}
 			}
@@ -129,7 +129,7 @@ class ppu_decoder
 			{
 				for (u32 i = 0; i < 1u << 11; i++)
 				{
-					m_table.at(i << 6 | v.value) = i & 1 ? v.ptr_rc : v.ptr0;
+					::at32(m_table, i << 6 | v.value) = i & 1 ? v.ptr_rc : v.ptr0;
 				}
 			}
 		}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1411,7 +1411,7 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::hle_call:
 		{
-			cmd_pop(), ppu_function_manager::get().at(arg)(*this, {arg}, vm::_ptr<u32>(cia - 4), &ppu_ret);
+			cmd_pop(), ::at32(ppu_function_manager::get(), arg)(*this, {arg}, vm::_ptr<u32>(cia - 4), &ppu_ret);
 			break;
 		}
 		case ppu_cmd::opd_call:
@@ -2930,7 +2930,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				extern const std::map<std::string_view, int> g_prx_list;
 
 				// Use list
-				return g_prx_list.count(entry.name) && g_prx_list.at(entry.name) != 0;
+				return g_prx_list.count(entry.name) && ::at32(g_prx_list, entry.name) != 0;
 			};
 
 			// Check .sprx filename
@@ -3378,7 +3378,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 	usz fpos = 0;
 
 	// Difference between function name and current location
-	const u32 reloc = info.relocs.empty() ? 0 : info.segs.at(0).addr;
+	const u32 reloc = info.relocs.empty() ? 0 : ::at32(info.segs, 0).addr;
 
 	// Info sent to threads
 	std::vector<std::pair<std::string, ppu_module>> workload;

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -675,7 +675,7 @@ spu_function_t spu_recompiler::compile(spu_program&& _func)
 			}
 
 			// Determine which value will be duplicated at hole positions
-			const u32 w3 = func.data.at((j - start + ~static_cast<u32>(std::countl_zero(cmask)) % 4 * 4) / 4);
+			const u32 w3 = ::at32(func.data, (j - start + ~static_cast<u32>(std::countl_zero(cmask)) % 4 * 4) / 4);
 			words.push_back(cmask & 1 ? func.data[(j - start + 0) / 4] : w3);
 			words.push_back(cmask & 2 ? func.data[(j - start + 4) / 4] : w3);
 			words.push_back(cmask & 4 ? func.data[(j - start + 8) / 4] : w3);

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
@@ -126,7 +126,7 @@ s32 lv2_socket_p2p::bind(const sys_net_sockaddr& addr)
 			nc.list_p2p_ports.emplace(std::piecewise_construct, std::forward_as_tuple(p2p_port), std::forward_as_tuple(p2p_port));
 		}
 
-		auto& pport = nc.list_p2p_ports.at(p2p_port);
+		auto& pport = ::at32(nc.list_p2p_ports, p2p_port);
 		real_socket = pport.p2p_socket;
 		{
 			std::lock_guard lock(pport.bound_p2p_vports_mutex);
@@ -301,7 +301,7 @@ void lv2_socket_p2p::close()
 	{
 		std::lock_guard lock(nc.list_p2p_ports_mutex);
 		ensure(nc.list_p2p_ports.contains(port));
-		auto& p2p_port = nc.list_p2p_ports.at(port);
+		auto& p2p_port = ::at32(nc.list_p2p_ports, port);
 		{
 			std::lock_guard lock(p2p_port.bound_p2p_vports_mutex);
 			p2p_port.bound_p2p_vports.erase(vport);

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
@@ -274,7 +274,7 @@ bool lv2_socket_p2ps::handle_connected(p2ps_encapsulated_tcp* tcp_header, u8* da
 		auto final_ack = data_beg_seq;
 		while (received_data.contains(final_ack))
 		{
-			final_ack += received_data.at(final_ack).size();
+			final_ack += ::at32(received_data, final_ack).size();
 		}
 		data_available = final_ack - data_beg_seq;
 
@@ -417,7 +417,7 @@ bool lv2_socket_p2ps::handle_listening(p2ps_encapsulated_tcp* tcp_header, [[mayb
 
 		{
 			auto& nc    = g_fxo->get<network_context>();
-			auto& pport = nc.list_p2p_ports.at(port);
+			auto& pport = ::at32(nc.list_p2p_ports, port);
 			pport.bound_p2p_streams.emplace(key_connected, new_sock_id);
 		}
 
@@ -562,7 +562,7 @@ s32 lv2_socket_p2ps::bind(const sys_net_sockaddr& addr)
 			nc.list_p2p_ports.emplace(std::piecewise_construct, std::forward_as_tuple(p2p_port), std::forward_as_tuple(p2p_port));
 		}
 
-		auto& pport = nc.list_p2p_ports.at(p2p_port);
+		auto& pport = ::at32(nc.list_p2p_ports, p2p_port);
 		real_socket = pport.p2p_socket;
 		{
 			// Ensures the socket & the bound list are updated at the same time to avoid races
@@ -640,7 +640,7 @@ std::optional<s32> lv2_socket_p2ps::connect(const sys_net_sockaddr& addr)
 		if (!nc.list_p2p_ports.contains(port))
 			nc.list_p2p_ports.emplace(std::piecewise_construct, std::forward_as_tuple(port), std::forward_as_tuple(port));
 
-		auto& pport = nc.list_p2p_ports.at(port);
+		auto& pport = ::at32(nc.list_p2p_ports, port);
 		real_socket = pport.p2p_socket;
 		{
 			std::lock_guard lock(pport.bound_p2p_vports_mutex);
@@ -812,7 +812,7 @@ void lv2_socket_p2ps::close()
 	{
 		std::lock_guard lock(nc.list_p2p_ports_mutex);
 		ensure(nc.list_p2p_ports.contains(port));
-		auto& p2p_port = nc.list_p2p_ports.at(port);
+		auto& p2p_port = ::at32(nc.list_p2p_ports, port);
 		{
 			std::lock_guard lock(p2p_port.bound_p2p_vports_mutex);
 			for (auto it = p2p_port.bound_p2p_streams.begin(); it != p2p_port.bound_p2p_streams.end();)

--- a/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
@@ -17,7 +17,7 @@ s32 send_packet_from_p2p_port(const std::vector<u8>& data, const sockaddr_in& ad
 		std::lock_guard list_lock(nc.list_p2p_ports_mutex);
 		if (nc.list_p2p_ports.contains(SCE_NP_PORT))
 		{
-			auto& def_port = nc.list_p2p_ports.at(SCE_NP_PORT);
+			auto& def_port = ::at32(nc.list_p2p_ports, SCE_NP_PORT);
 			res            = ::sendto(def_port.p2p_socket, reinterpret_cast<const char*>(data.data()), data.size(), 0, reinterpret_cast<const sockaddr*>(&addr), sizeof(sockaddr_in));
 		}
 		else
@@ -37,7 +37,7 @@ std::vector<std::vector<u8>> get_rpcn_msgs()
 		std::lock_guard list_lock(nc.list_p2p_ports_mutex);
 		if (nc.list_p2p_ports.contains(SCE_NP_PORT))
 		{
-			auto& def_port = nc.list_p2p_ports.at(SCE_NP_PORT);
+			auto& def_port = ::at32(nc.list_p2p_ports, SCE_NP_PORT);
 			{
 				std::lock_guard lock(def_port.s_rpcn_mutex);
 				msgs = std::move(def_port.rpcn_msgs);
@@ -61,7 +61,7 @@ std::vector<std::pair<std::pair<u32, u16>, std::vector<u8>>> get_sign_msgs()
 		std::lock_guard list_lock(nc.list_p2p_ports_mutex);
 		if (nc.list_p2p_ports.contains(SCE_NP_PORT))
 		{
-			auto& def_port = nc.list_p2p_ports.at(SCE_NP_PORT);
+			auto& def_port = ::at32(nc.list_p2p_ports, SCE_NP_PORT);
 			{
 				std::lock_guard lock(def_port.s_sign_mutex);
 				msgs = std::move(def_port.sign_msgs);

--- a/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
@@ -165,7 +165,7 @@ bool nt_p2p_port::recv_data()
 			std::vector<u8> p2p_data(recv_res - sizeof(u16));
 			memcpy(p2p_data.data(), p2p_recv_data.data() + sizeof(u16), recv_res - sizeof(u16));
 
-			const auto sock = idm::check<lv2_socket>(bound_p2p_vports.at(dst_vport), [&](lv2_socket& sock)
+			const auto sock = idm::check<lv2_socket>(::at32(bound_p2p_vports, dst_vport), [&](lv2_socket& sock)
 				{
 					ensure(sock.get_type() == SYS_NET_SOCK_DGRAM_P2P);
 					auto& sock_p2p = reinterpret_cast<lv2_socket_p2p&>(sock);
@@ -231,7 +231,7 @@ bool nt_p2p_port::recv_data()
 		std::lock_guard lock(bound_p2p_vports_mutex);
 		if (bound_p2p_streams.contains(key_connected))
 		{
-			const auto sock_id = bound_p2p_streams.at(key_connected);
+			const auto sock_id = ::at32(bound_p2p_streams, key_connected);
 			sys_net.trace("Received packet for connected STREAM-P2P socket(s=%d)", sock_id);
 			handle_connected(sock_id, tcp_header, sp_data + sizeof(p2ps_encapsulated_tcp), &native_addr);
 			return true;
@@ -239,7 +239,7 @@ bool nt_p2p_port::recv_data()
 
 		if (bound_p2p_streams.contains(key_listening))
 		{
-			const auto sock_id = bound_p2p_streams.at(key_listening);
+			const auto sock_id = ::at32(bound_p2p_streams, key_listening);
 			sys_net.trace("Received packet for listening STREAM-P2P socket(s=%d)", sock_id);
 			handle_listening(sock_id, tcp_header, sp_data + sizeof(p2ps_encapsulated_tcp), &native_addr);
 			return true;

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -221,14 +221,14 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 		else
 		{
 			// Use list
-			ignore = g_prx_list.at(name) != 0;
+			ignore = ::at32(g_prx_list, name) != 0;
 		}
 	}
 	else if (vpath0.starts_with("/"))
 	{
 		// Special case : HLE for files outside of "/dev_flash/sys/external/"
 		// Have to specify full path for them
-		ignore = g_prx_list.count(vpath0) && g_prx_list.at(vpath0);
+		ignore = g_prx_list.count(vpath0) && ::at32(g_prx_list, vpath0);
 	}
 
 	auto hle_load = [&]()

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -484,7 +484,7 @@ bool usb_handler_thread::is_pipe(u32 pipe_id) const
 
 const UsbPipe& usb_handler_thread::get_pipe(u32 pipe_id) const
 {
-	return open_pipes.at(pipe_id);
+	return ::at32(open_pipes, pipe_id);
 }
 
 void usb_handler_thread::check_devices_vs_ldds()

--- a/rpcs3/Emu/Io/GHLtar.cpp
+++ b/rpcs3/Emu/Io/GHLtar.cpp
@@ -107,7 +107,7 @@ void usb_device_ghltar::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint
 
 	std::lock_guard lock(pad::g_pad_mutex);
 	const auto handler = pad::get_current_handler();
-	const auto& pad    = handler->GetPads().at(m_controller_index);
+	const auto& pad    = ::at32(handler->GetPads(), m_controller_index);
 
 	if (!(pad->m_port_status & CELL_PAD_STATUS_CONNECTED))
 	{

--- a/rpcs3/Emu/Io/camera_config.cpp
+++ b/rpcs3/Emu/Io/camera_config.cpp
@@ -83,7 +83,7 @@ void cfg_camera::camera_setting::from_string(const std::string& text)
 		camera_log.error("String '%s' cannot be interpreted as camera_setting.", text);
 		return;
 	}
-	
+
 	const auto to_integer = [](const std::string& str, int& out) -> bool
 	{
 		auto [ptr, ec] = std::from_chars(str.c_str(), str.c_str() + str.size(), out);
@@ -107,13 +107,13 @@ void cfg_camera::camera_setting::from_string(const std::string& text)
 		return true;
 	};
 
-	if (!to_integer(list.at(0), width) ||
-		!to_integer(list.at(1), height) ||
-		!to_double(list.at(2), min_fps) ||
-		!to_double(list.at(3), max_fps) ||
-		!to_integer(list.at(4), format) ||
-		!to_integer(list.at(5), pixel_aspect_width) ||
-		!to_integer(list.at(6), pixel_aspect_height))
+	if (!to_integer(::at32(list, 0), width) ||
+		!to_integer(::at32(list, 1), height) ||
+		!to_double(::at32(list, 2), min_fps) ||
+		!to_double(::at32(list, 3), max_fps) ||
+		!to_integer(::at32(list, 4), format) ||
+		!to_integer(::at32(list, 5), pixel_aspect_width) ||
+		!to_integer(::at32(list, 6), pixel_aspect_height))
 	{
 		width = 0;
 		height = 0;

--- a/rpcs3/Emu/NP/np_allocator.h
+++ b/rpcs3/Emu/NP/np_allocator.h
@@ -98,7 +98,7 @@ namespace np
 			const u32 offset = addr - m_pool.addr();
 			ensure(m_allocs.contains(offset), "memory_allocator::free: m_allocs doesn't contain the allocation!");
 
-			m_avail += m_allocs.at(offset);
+			m_avail += ::at32(m_allocs, offset);
 			m_allocs.erase(offset);
 		}
 
@@ -112,7 +112,7 @@ namespace np
 			ensure(m_allocs.contains(offset), "memory_allocator::reduce_allocation: m_allocs doesn't contain the allocation!");
 			ensure(m_allocs[offset] >= new_size, "memory_allocator::reduce_allocation: New size is bigger than current allocation!");
 
-			m_avail += (m_allocs.at(offset) - new_size);
+			m_avail += (::at32(m_allocs, offset) - new_size);
 			m_allocs[offset] = new_size;
 		}
 

--- a/rpcs3/Emu/NP/np_cache.cpp
+++ b/rpcs3/Emu/NP/np_cache.cpp
@@ -218,8 +218,8 @@ namespace np
 			return SCE_NP_MATCHING2_ERROR_ROOM_MEMBER_NOT_FOUND;
 		}
 
-		const auto& room = rooms.at(room_id);
-		const auto& member = room.members.at(member_id);
+		const auto& room = ::at32(rooms, room_id);
+		const auto& member = ::at32(room.members, member_id);
 
 		if (ptr_member)
 		{
@@ -263,7 +263,7 @@ namespace np
 		if (member.group_id)
 		{
 			ptr_member->roomGroup.set(mem.allocate(sizeof(SceNpMatching2RoomGroup)));
-			memcpy(ptr_member->roomGroup.get_ptr(), &room.groups.at(member.group_id), sizeof(SceNpMatching2RoomGroup));
+			memcpy(ptr_member->roomGroup.get_ptr(), &::at32(room.groups, member.group_id), sizeof(SceNpMatching2RoomGroup));
 		}
 
 		u32 num_binattrs = 0;
@@ -286,7 +286,7 @@ namespace np
 			{
 				if (member.bins.contains(binattrs_list[i]))
 				{
-					const auto& bin = member.bins.at(binattrs_list[i]);
+					const auto& bin = ::at32(member.bins, binattrs_list[i]);
 					bin_ptr[actual_cnt].updateDate.tick = bin.updateDate.tick;
 					bin_ptr[actual_cnt].data.id = bin.id;
 					bin_ptr[actual_cnt].data.size = bin.data.size();

--- a/rpcs3/Emu/NP/np_dnshook.cpp
+++ b/rpcs3/Emu/NP/np_dnshook.cpp
@@ -71,14 +71,14 @@ namespace np
 	bool dnshook::is_dns_queue(u32 sock)
 	{
 		std::lock_guard lock(mutex);
-		return !m_dns_spylist.at(sock).empty();
+		return !::at32(m_dns_spylist, sock).empty();
 	}
 
 	std::vector<u8> dnshook::get_dns_packet(u32 sock)
 	{
 		std::lock_guard lock(mutex);
-		auto ret_vec = std::move(m_dns_spylist.at(sock).front());
-		m_dns_spylist.at(sock).pop();
+		auto ret_vec = std::move(::at32(m_dns_spylist, sock).front());
+		::at32(m_dns_spylist, sock).pop();
 
 		return ret_vec;
 	}

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -689,7 +689,7 @@ namespace np
 		if (!match2_req_results.contains(event_key))
 			return 0;
 
-		auto& data = match2_req_results.at(event_key);
+		auto& data = ::at32(match2_req_results, event_key);
 		data.apply_relocations(dest_addr);
 
 		vm::ptr<void> dest = vm::cast(dest_addr);
@@ -921,7 +921,7 @@ namespace np
 	{
 		std::lock_guard lock(mutex_pending_requests);
 
-		const auto cb_info = std::move(pending_requests.at(req_id));
+		const auto cb_info = std::move(::at32(pending_requests, req_id));
 		pending_requests.erase(req_id);
 
 		return cb_info;
@@ -931,7 +931,7 @@ namespace np
 	{
 		std::lock_guard lock(mutex_match2_req_results);
 		match2_req_results.emplace(std::piecewise_construct, std::forward_as_tuple(event_key), std::forward_as_tuple(np_memory.allocate(max_size), initial_size, max_size));
-		return match2_req_results.at(event_key);
+		return ::at32(match2_req_results, event_key);
 	}
 
 	u32 np_handler::add_players_to_history(vm::cptr<SceNpId> /*npids*/, u32 /*count*/)

--- a/rpcs3/Emu/NP/np_requests.cpp
+++ b/rpcs3/Emu/NP/np_requests.cpp
@@ -637,7 +637,7 @@ namespace np
 		u32 conn_id;
 		{
 			std::lock_guard lock(mutex_pending_sign_infos_requests);
-			conn_id = pending_sign_infos_requests.at(req_id);
+			conn_id = ::at32(pending_sign_infos_requests, req_id);
 			pending_sign_infos_requests.erase(req_id);
 		}
 

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -1939,7 +1939,7 @@ namespace rpcn
 	{
 		{
 			std::lock_guard lock(mutex_messages);
-			return messages.at(id);
+			return ::at32(messages, id);
 		}
 	}
 
@@ -1950,7 +1950,7 @@ namespace rpcn
 			std::lock_guard lock(mutex_messages);
 			for (auto id : active_messages)
 			{
-				const auto& entry = messages.at(id);
+				const auto& entry = ::at32(messages, id);
 				const auto& msg   = entry->second;
 				if (msg.mainType == type_filter && (include_bootable || !(msg.msgFeatures & SCE_NP_BASIC_MESSAGE_FEATURES_BOOTABLE)))
 				{

--- a/rpcs3/Emu/RSX/Common/ranged_map.hpp
+++ b/rpcs3/Emu/RSX/Common/ranged_map.hpp
@@ -7,7 +7,7 @@
 
 namespace rsx
 {
-	template<typename T, int BlockSize>
+	template <typename T, int BlockSize>
 	class ranged_map
 	{
 	protected:
@@ -60,7 +60,7 @@ namespace rsx
 			block_metadata_t* m_metadata_ptr = nullptr;
 			inner_iterator m_it{};
 
-			inline void forward_scan()
+			void forward_scan()
 			{
 				while (m_current < m_end)
 				{
@@ -91,14 +91,14 @@ namespace rsx
 				forward_scan();
 			}
 
-			inline void begin_range(u32 address, inner_iterator& where)
+			void begin_range(u32 address, inner_iterator& where)
 			{
 				m_current = &m_data_ptr[address / BlockSize];
 				m_end = m_current;
 				m_it = where;
 			}
 
-			inline void begin_range(const utils::address_range& range)
+			void begin_range(const utils::address_range& range)
 			{
 				const auto start_block_id = range.start / BlockSize;
 				const auto& metadata = m_metadata_ptr[start_block_id];
@@ -109,7 +109,7 @@ namespace rsx
 				forward_scan();
 			}
 
-			inline void erase()
+			void erase()
 			{
 				m_it = m_current->erase(m_it);
 				if (m_it != m_current->end())
@@ -126,43 +126,43 @@ namespace rsx
 			{}
 
 		public:
-			inline bool operator == (const iterator& other) const
+			bool operator == (const iterator& other) const
 			{
 				return m_it == other.m_it;
 			}
 
-			inline auto* operator -> ()
+			auto* operator -> ()
 			{
 				ensure(m_current);
 				return m_it.operator->();
 			}
 
-			inline auto& operator * ()
+			auto& operator * ()
 			{
 				ensure(m_current);
 				return m_it.operator*();
 			}
 
-			inline auto* operator -> () const
+			auto* operator -> () const
 			{
 				ensure(m_current);
 				return m_it.operator->();
 			}
 
-			inline auto& operator * () const
+			auto& operator * () const
 			{
 				ensure(m_current);
 				return m_it.operator*();
 			}
 
-			inline iterator& operator ++ ()
+			iterator& operator ++ ()
 			{
 				ensure(m_current);
 				next();
 				return *this;
 			}
 
-			inline T& operator ++ (int)
+			T& operator ++ (int)
 			{
 				ensure(m_current);
 				auto old = *this;
@@ -177,13 +177,25 @@ namespace rsx
 			std::for_each(m_metadata.begin(), m_metadata.end(), [&](auto& meta) { meta.id = static_cast<u32>(&meta - m_metadata.data()); });
 		}
 
-		inline void emplace(const utils::address_range& range, T&& value)
+		void emplace(const utils::address_range& range, T&& value)
 		{
 			broadcast_insert(range);
 			m_data[block_for(range.start)].insert_or_assign(range.start, std::forward<T>(value));
 		}
 
-		inline iterator find(const u32 key)
+		usz count(const u32 key)
+		{
+			auto& block = m_data[block_for(key)];
+			if (auto found = block.find(key);
+				found != block.end())
+			{
+				return 1;
+			}
+
+			return 0;
+		}
+
+		iterator find(const u32 key)
 		{
 			auto& block = m_data[block_for(key)];
 			iterator ret = { this };
@@ -197,43 +209,31 @@ namespace rsx
 			return ret;
 		}
 
-		inline T& at(const u32 key)
-		{
-			auto& block = m_data[block_for(key)];
-			if (auto found = block.find(key);
-				found != block.end())
-			{
-				return (*found).second;
-			}
-
-			fmt::throw_exception("Object not found");
-		}
-
-		inline iterator erase(iterator& where)
+		iterator erase(iterator& where)
 		{
 			where.erase();
 			return where;
 		}
 
-		inline void erase(u32 address)
+		void erase(u32 address)
 		{
 			m_data[block_for(address)].erase(address);
 		}
 
-		inline iterator begin_range(const utils::address_range& range)
+		iterator begin_range(const utils::address_range& range)
 		{
 			iterator ret = { this };
 			ret.begin_range(range);
 			return ret;
 		}
 
-		inline iterator end()
+		iterator end()
 		{
 			iterator ret = { this };
 			return ret;
 		}
 
-		inline void clear()
+		void clear()
 		{
 			for (auto& e : m_data)
 			{

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -374,7 +374,7 @@ namespace rsx
 				{
 					// This has been 'swallowed' by the new surface and can be safely freed
 					auto &storage = surface->is_depth_surface() ? m_depth_stencil_storage : m_render_targets_storage;
-					auto &object = storage.at(e.first);
+					auto &object = ::at32(storage, e.first);
 
 					ensure(object);
 

--- a/rpcs3/Emu/RSX/Common/texture_cache_predictor.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_predictor.h
@@ -346,8 +346,6 @@ namespace rsx
 		constexpr const_iterator begin() const noexcept { return m_entries.begin(); }
 		inline iterator end() noexcept { return m_entries.end(); }
 		inline const_iterator end() const noexcept { return m_entries.end(); }
-		inline iterator at(size_type pos) { return m_entries.at(pos); }
-		inline const_iterator at(size_type pos) const { return m_entries.at(pos); }
 		bool empty() const noexcept { return m_entries.empty(); }
 		size_type size() const noexcept { return m_entries.size(); }
 		void clear() { m_entries.clear(); }

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -280,8 +280,6 @@ namespace rsx
 		constexpr const_iterator begin() const noexcept { return sections.begin(); }
 		inline iterator end() noexcept { return sections.end(); }
 		inline const_iterator end() const noexcept { return sections.end(); }
-		inline iterator at(size_type pos) { return sections.data(pos); }
-		inline const_iterator at(size_type pos) const { return sections.data(pos); }
 		inline bool empty() const { return sections.empty(); }
 		inline size_type size() const { return sections.size(); }
 		inline u32 get_exists_count() const { return exists_count; }

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -176,7 +176,7 @@ namespace rsx
 						// Enable key repeat
 						std::vector<Keyboard>& keyboards = handler.GetKeyboards();
 						ensure(!keyboards.empty());
-						keyboards.at(0).m_key_repeat = true;
+						::at32(keyboards, 0).m_key_repeat = true;
 					}
 				}
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -2981,7 +2981,7 @@ namespace rsx
 
 		auto bind = [](u32 id, rsx_method_t func)
 		{
-			methods.at(id) = func;
+			::at32(methods, id) = func;
 		};
 
 		auto bind_array = [](u32 id, u32 step, u32 count, rsx_method_t func)

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -152,7 +152,7 @@ bool vfs::unmount(std::string_view vpath)
 		}
 
 		// Get the current name based on the depth
-		const std::string& name = entry_list.at(depth);
+		const std::string& name = ::at32(entry_list, depth);
 
 		// Go through all children of this node
 		for (auto it = dir.dirs.begin(); it != dir.dirs.end();)

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -202,33 +202,33 @@ void ds3_pad_handler::init_config(cfg_pad* cfg)
 	if (!cfg) return;
 
 	// Set default button mapping
-	cfg->ls_left.def = button_list.at(DS3KeyCodes::LSXNeg);
-	cfg->ls_down.def = button_list.at(DS3KeyCodes::LSYNeg);
-	cfg->ls_right.def = button_list.at(DS3KeyCodes::LSXPos);
-	cfg->ls_up.def = button_list.at(DS3KeyCodes::LSYPos);
-	cfg->rs_left.def = button_list.at(DS3KeyCodes::RSXNeg);
-	cfg->rs_down.def = button_list.at(DS3KeyCodes::RSYNeg);
-	cfg->rs_right.def = button_list.at(DS3KeyCodes::RSXPos);
-	cfg->rs_up.def = button_list.at(DS3KeyCodes::RSYPos);
-	cfg->start.def = button_list.at(DS3KeyCodes::Start);
-	cfg->select.def = button_list.at(DS3KeyCodes::Select);
-	cfg->ps.def = button_list.at(DS3KeyCodes::PSButton);
-	cfg->square.def = button_list.at(DS3KeyCodes::Square);
-	cfg->cross.def = button_list.at(DS3KeyCodes::Cross);
-	cfg->circle.def = button_list.at(DS3KeyCodes::Circle);
-	cfg->triangle.def = button_list.at(DS3KeyCodes::Triangle);
-	cfg->left.def = button_list.at(DS3KeyCodes::Left);
-	cfg->down.def = button_list.at(DS3KeyCodes::Down);
-	cfg->right.def = button_list.at(DS3KeyCodes::Right);
-	cfg->up.def = button_list.at(DS3KeyCodes::Up);
-	cfg->r1.def = button_list.at(DS3KeyCodes::R1);
-	cfg->r2.def = button_list.at(DS3KeyCodes::R2);
-	cfg->r3.def = button_list.at(DS3KeyCodes::R3);
-	cfg->l1.def = button_list.at(DS3KeyCodes::L1);
-	cfg->l2.def = button_list.at(DS3KeyCodes::L2);
-	cfg->l3.def = button_list.at(DS3KeyCodes::L3);
+	cfg->ls_left.def = ::at32(button_list, DS3KeyCodes::LSXNeg);
+	cfg->ls_down.def = ::at32(button_list, DS3KeyCodes::LSYNeg);
+	cfg->ls_right.def = ::at32(button_list, DS3KeyCodes::LSXPos);
+	cfg->ls_up.def = ::at32(button_list, DS3KeyCodes::LSYPos);
+	cfg->rs_left.def = ::at32(button_list, DS3KeyCodes::RSXNeg);
+	cfg->rs_down.def = ::at32(button_list, DS3KeyCodes::RSYNeg);
+	cfg->rs_right.def = ::at32(button_list, DS3KeyCodes::RSXPos);
+	cfg->rs_up.def = ::at32(button_list, DS3KeyCodes::RSYPos);
+	cfg->start.def = ::at32(button_list, DS3KeyCodes::Start);
+	cfg->select.def = ::at32(button_list, DS3KeyCodes::Select);
+	cfg->ps.def = ::at32(button_list, DS3KeyCodes::PSButton);
+	cfg->square.def = ::at32(button_list, DS3KeyCodes::Square);
+	cfg->cross.def = ::at32(button_list, DS3KeyCodes::Cross);
+	cfg->circle.def = ::at32(button_list, DS3KeyCodes::Circle);
+	cfg->triangle.def = ::at32(button_list, DS3KeyCodes::Triangle);
+	cfg->left.def = ::at32(button_list, DS3KeyCodes::Left);
+	cfg->down.def = ::at32(button_list, DS3KeyCodes::Down);
+	cfg->right.def = ::at32(button_list, DS3KeyCodes::Right);
+	cfg->up.def = ::at32(button_list, DS3KeyCodes::Up);
+	cfg->r1.def = ::at32(button_list, DS3KeyCodes::R1);
+	cfg->r2.def = ::at32(button_list, DS3KeyCodes::R2);
+	cfg->r3.def = ::at32(button_list, DS3KeyCodes::R3);
+	cfg->l1.def = ::at32(button_list, DS3KeyCodes::L1);
+	cfg->l2.def = ::at32(button_list, DS3KeyCodes::L2);
+	cfg->l3.def = ::at32(button_list, DS3KeyCodes::L3);
 
-	cfg->pressure_intensity_button.def = button_list.at(DS3KeyCodes::None);
+	cfg->pressure_intensity_button.def = ::at32(button_list, DS3KeyCodes::None);
 
 	// Set default misc variables
 	cfg->lstickdeadzone.def    = 40; // between 0 and 255
@@ -367,7 +367,7 @@ ds3_pad_handler::DataStatus ds3_pad_handler::get_data(ds3_device* ds3dev)
 			}
 			else
 			{
-				ds3dev->battery_level = battery_capacity.at(std::min<usz>(battery_status, battery_capacity.size() - 1));
+				ds3dev->battery_level = ::at32(battery_capacity, std::min<usz>(battery_status, battery_capacity.size() - 1));
 				ds3dev->cable_state   = 0;
 			}
 
@@ -437,12 +437,12 @@ std::unordered_map<u64, u16> ds3_pad_handler::get_button_values(const std::share
 pad_preview_values ds3_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
 {
 	return {
-		data.at(L2),
-		data.at(R2),
-		data.at(LSXPos) - data.at(LSXNeg),
-		data.at(LSYPos) - data.at(LSYNeg),
-		data.at(RSXPos) - data.at(RSXNeg),
-		data.at(RSYPos) - data.at(RSYNeg)
+		::at32(data, L2),
+		::at32(data, R2),
+		::at32(data, LSXPos) - ::at32(data, LSXNeg),
+		::at32(data, LSYPos) - ::at32(data, LSYNeg),
+		::at32(data, RSXPos) - ::at32(data, RSXNeg),
+		::at32(data, RSYPos) - ::at32(data, RSYNeg)
 	};
 }
 

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -137,33 +137,33 @@ void ds4_pad_handler::init_config(cfg_pad* cfg)
 	if (!cfg) return;
 
 	// Set default button mapping
-	cfg->ls_left.def  = button_list.at(DS4KeyCodes::LSXNeg);
-	cfg->ls_down.def  = button_list.at(DS4KeyCodes::LSYNeg);
-	cfg->ls_right.def = button_list.at(DS4KeyCodes::LSXPos);
-	cfg->ls_up.def    = button_list.at(DS4KeyCodes::LSYPos);
-	cfg->rs_left.def  = button_list.at(DS4KeyCodes::RSXNeg);
-	cfg->rs_down.def  = button_list.at(DS4KeyCodes::RSYNeg);
-	cfg->rs_right.def = button_list.at(DS4KeyCodes::RSXPos);
-	cfg->rs_up.def    = button_list.at(DS4KeyCodes::RSYPos);
-	cfg->start.def    = button_list.at(DS4KeyCodes::Options);
-	cfg->select.def   = button_list.at(DS4KeyCodes::Share);
-	cfg->ps.def       = button_list.at(DS4KeyCodes::PSButton);
-	cfg->square.def   = button_list.at(DS4KeyCodes::Square);
-	cfg->cross.def    = button_list.at(DS4KeyCodes::Cross);
-	cfg->circle.def   = button_list.at(DS4KeyCodes::Circle);
-	cfg->triangle.def = button_list.at(DS4KeyCodes::Triangle);
-	cfg->left.def     = button_list.at(DS4KeyCodes::Left);
-	cfg->down.def     = button_list.at(DS4KeyCodes::Down);
-	cfg->right.def    = button_list.at(DS4KeyCodes::Right);
-	cfg->up.def       = button_list.at(DS4KeyCodes::Up);
-	cfg->r1.def       = button_list.at(DS4KeyCodes::R1);
-	cfg->r2.def       = button_list.at(DS4KeyCodes::R2);
-	cfg->r3.def       = button_list.at(DS4KeyCodes::R3);
-	cfg->l1.def       = button_list.at(DS4KeyCodes::L1);
-	cfg->l2.def       = button_list.at(DS4KeyCodes::L2);
-	cfg->l3.def       = button_list.at(DS4KeyCodes::L3);
+	cfg->ls_left.def  = ::at32(button_list, DS4KeyCodes::LSXNeg);
+	cfg->ls_down.def  = ::at32(button_list, DS4KeyCodes::LSYNeg);
+	cfg->ls_right.def = ::at32(button_list, DS4KeyCodes::LSXPos);
+	cfg->ls_up.def    = ::at32(button_list, DS4KeyCodes::LSYPos);
+	cfg->rs_left.def  = ::at32(button_list, DS4KeyCodes::RSXNeg);
+	cfg->rs_down.def  = ::at32(button_list, DS4KeyCodes::RSYNeg);
+	cfg->rs_right.def = ::at32(button_list, DS4KeyCodes::RSXPos);
+	cfg->rs_up.def    = ::at32(button_list, DS4KeyCodes::RSYPos);
+	cfg->start.def    = ::at32(button_list, DS4KeyCodes::Options);
+	cfg->select.def   = ::at32(button_list, DS4KeyCodes::Share);
+	cfg->ps.def       = ::at32(button_list, DS4KeyCodes::PSButton);
+	cfg->square.def   = ::at32(button_list, DS4KeyCodes::Square);
+	cfg->cross.def    = ::at32(button_list, DS4KeyCodes::Cross);
+	cfg->circle.def   = ::at32(button_list, DS4KeyCodes::Circle);
+	cfg->triangle.def = ::at32(button_list, DS4KeyCodes::Triangle);
+	cfg->left.def     = ::at32(button_list, DS4KeyCodes::Left);
+	cfg->down.def     = ::at32(button_list, DS4KeyCodes::Down);
+	cfg->right.def    = ::at32(button_list, DS4KeyCodes::Right);
+	cfg->up.def       = ::at32(button_list, DS4KeyCodes::Up);
+	cfg->r1.def       = ::at32(button_list, DS4KeyCodes::R1);
+	cfg->r2.def       = ::at32(button_list, DS4KeyCodes::R2);
+	cfg->r3.def       = ::at32(button_list, DS4KeyCodes::R3);
+	cfg->l1.def       = ::at32(button_list, DS4KeyCodes::L1);
+	cfg->l2.def       = ::at32(button_list, DS4KeyCodes::L2);
+	cfg->l3.def       = ::at32(button_list, DS4KeyCodes::L3);
 
-	cfg->pressure_intensity_button.def = button_list.at(DS4KeyCodes::None);
+	cfg->pressure_intensity_button.def = ::at32(button_list, DS4KeyCodes::None);
 
 	// Set default misc variables
 	cfg->lstickdeadzone.def    = 40; // between 0 and 255
@@ -361,12 +361,12 @@ std::unordered_map<u64, u16> ds4_pad_handler::get_button_values(const std::share
 pad_preview_values ds4_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
 {
 	return {
-		data.at(L2),
-		data.at(R2),
-		data.at(LSXPos) - data.at(LSXNeg),
-		data.at(LSYPos) - data.at(LSYNeg),
-		data.at(RSXPos) - data.at(RSXNeg),
-		data.at(RSYPos) - data.at(RSYNeg)
+		::at32(data, L2),
+		::at32(data, R2),
+		::at32(data, LSXPos) - ::at32(data, LSXNeg),
+		::at32(data, LSYPos) - ::at32(data, LSYNeg),
+		::at32(data, RSXPos) - ::at32(data, RSXNeg),
+		::at32(data, RSYPos) - ::at32(data, RSYNeg)
 	};
 }
 

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -46,7 +46,7 @@ namespace
 		LIGHTBAR_SETUP_LIGHT_ON                      = 0x01,
 		LIGHTBAR_SETUP_LIGHT_OUT                     = 0x02,
 	};
-	
+
 	struct output_report_common
 	{
 		u8 valid_flag_0;
@@ -258,33 +258,33 @@ void dualsense_pad_handler::init_config(cfg_pad* cfg)
 	if (!cfg) return;
 
 	// Set default button mapping
-	cfg->ls_left.def  = button_list.at(DualSenseKeyCodes::LSXNeg);
-	cfg->ls_down.def  = button_list.at(DualSenseKeyCodes::LSYNeg);
-	cfg->ls_right.def = button_list.at(DualSenseKeyCodes::LSXPos);
-	cfg->ls_up.def    = button_list.at(DualSenseKeyCodes::LSYPos);
-	cfg->rs_left.def  = button_list.at(DualSenseKeyCodes::RSXNeg);
-	cfg->rs_down.def  = button_list.at(DualSenseKeyCodes::RSYNeg);
-	cfg->rs_right.def = button_list.at(DualSenseKeyCodes::RSXPos);
-	cfg->rs_up.def    = button_list.at(DualSenseKeyCodes::RSYPos);
-	cfg->start.def    = button_list.at(DualSenseKeyCodes::Options);
-	cfg->select.def   = button_list.at(DualSenseKeyCodes::Share);
-	cfg->ps.def       = button_list.at(DualSenseKeyCodes::PSButton);
-	cfg->square.def   = button_list.at(DualSenseKeyCodes::Square);
-	cfg->cross.def    = button_list.at(DualSenseKeyCodes::Cross);
-	cfg->circle.def   = button_list.at(DualSenseKeyCodes::Circle);
-	cfg->triangle.def = button_list.at(DualSenseKeyCodes::Triangle);
-	cfg->left.def     = button_list.at(DualSenseKeyCodes::Left);
-	cfg->down.def     = button_list.at(DualSenseKeyCodes::Down);
-	cfg->right.def    = button_list.at(DualSenseKeyCodes::Right);
-	cfg->up.def       = button_list.at(DualSenseKeyCodes::Up);
-	cfg->r1.def       = button_list.at(DualSenseKeyCodes::R1);
-	cfg->r2.def       = button_list.at(DualSenseKeyCodes::R2);
-	cfg->r3.def       = button_list.at(DualSenseKeyCodes::R3);
-	cfg->l1.def       = button_list.at(DualSenseKeyCodes::L1);
-	cfg->l2.def       = button_list.at(DualSenseKeyCodes::L2);
-	cfg->l3.def       = button_list.at(DualSenseKeyCodes::L3);
+	cfg->ls_left.def  = ::at32(button_list, DualSenseKeyCodes::LSXNeg);
+	cfg->ls_down.def  = ::at32(button_list, DualSenseKeyCodes::LSYNeg);
+	cfg->ls_right.def = ::at32(button_list, DualSenseKeyCodes::LSXPos);
+	cfg->ls_up.def    = ::at32(button_list, DualSenseKeyCodes::LSYPos);
+	cfg->rs_left.def  = ::at32(button_list, DualSenseKeyCodes::RSXNeg);
+	cfg->rs_down.def  = ::at32(button_list, DualSenseKeyCodes::RSYNeg);
+	cfg->rs_right.def = ::at32(button_list, DualSenseKeyCodes::RSXPos);
+	cfg->rs_up.def    = ::at32(button_list, DualSenseKeyCodes::RSYPos);
+	cfg->start.def    = ::at32(button_list, DualSenseKeyCodes::Options);
+	cfg->select.def   = ::at32(button_list, DualSenseKeyCodes::Share);
+	cfg->ps.def       = ::at32(button_list, DualSenseKeyCodes::PSButton);
+	cfg->square.def   = ::at32(button_list, DualSenseKeyCodes::Square);
+	cfg->cross.def    = ::at32(button_list, DualSenseKeyCodes::Cross);
+	cfg->circle.def   = ::at32(button_list, DualSenseKeyCodes::Circle);
+	cfg->triangle.def = ::at32(button_list, DualSenseKeyCodes::Triangle);
+	cfg->left.def     = ::at32(button_list, DualSenseKeyCodes::Left);
+	cfg->down.def     = ::at32(button_list, DualSenseKeyCodes::Down);
+	cfg->right.def    = ::at32(button_list, DualSenseKeyCodes::Right);
+	cfg->up.def       = ::at32(button_list, DualSenseKeyCodes::Up);
+	cfg->r1.def       = ::at32(button_list, DualSenseKeyCodes::R1);
+	cfg->r2.def       = ::at32(button_list, DualSenseKeyCodes::R2);
+	cfg->r3.def       = ::at32(button_list, DualSenseKeyCodes::R3);
+	cfg->l1.def       = ::at32(button_list, DualSenseKeyCodes::L1);
+	cfg->l2.def       = ::at32(button_list, DualSenseKeyCodes::L2);
+	cfg->l3.def       = ::at32(button_list, DualSenseKeyCodes::L3);
 
-	cfg->pressure_intensity_button.def = button_list.at(DualSenseKeyCodes::None);
+	cfg->pressure_intensity_button.def = ::at32(button_list, DualSenseKeyCodes::None);
 
 	// Set default misc variables
 	cfg->lstickdeadzone.def    = 40; // between 0 and 255
@@ -889,12 +889,12 @@ std::unordered_map<u64, u16> dualsense_pad_handler::get_button_values(const std:
 pad_preview_values dualsense_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
 {
 	return {
-		data.at(L2),
-		data.at(R2),
-		data.at(LSXPos) - data.at(LSXNeg),
-		data.at(LSYPos) - data.at(LSYNeg),
-		data.at(RSXPos) - data.at(RSXNeg),
-		data.at(RSYPos) - data.at(RSYNeg)
+		::at32(data, L2),
+		::at32(data, R2),
+		::at32(data, LSXPos) - ::at32(data, LSXNeg),
+		::at32(data, LSYPos) - ::at32(data, LSYNeg),
+		::at32(data, RSXPos) - ::at32(data, RSXNeg),
+		::at32(data, RSYPos) - ::at32(data, RSYNeg)
 	};
 }
 
@@ -1038,7 +1038,7 @@ void dualsense_pad_handler::apply_pad_data(const pad_ensemble& binding)
 	const bool wireless    = dualsense_dev->cable_state == 0;
 	const bool low_battery = dualsense_dev->battery_level <= 1;
 	const bool is_blinking = dualsense_dev->led_delay_on > 0 || dualsense_dev->led_delay_off > 0;
-	
+
 	// Blink LED when battery is low
 	if (config->led_low_battery_blink)
 	{

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -53,38 +53,38 @@ void evdev_joystick_handler::init_config(cfg_pad* cfg)
 	if (!cfg) return;
 
 	// Set default button mapping
-	cfg->ls_left.def  = rev_axis_list.at(ABS_X);
-	cfg->ls_down.def  = axis_list.at(ABS_Y);
-	cfg->ls_right.def = axis_list.at(ABS_X);
-	cfg->ls_up.def    = rev_axis_list.at(ABS_Y);
-	cfg->rs_left.def  = rev_axis_list.at(ABS_RX);
-	cfg->rs_down.def  = axis_list.at(ABS_RY);
-	cfg->rs_right.def = axis_list.at(ABS_RX);
-	cfg->rs_up.def    = rev_axis_list.at(ABS_RY);
-	cfg->start.def    = button_list.at(BTN_START);
-	cfg->select.def   = button_list.at(BTN_SELECT);
-	cfg->ps.def       = button_list.at(BTN_MODE);
-	cfg->square.def   = button_list.at(BTN_X);
-	cfg->cross.def    = button_list.at(BTN_A);
-	cfg->circle.def   = button_list.at(BTN_B);
-	cfg->triangle.def = button_list.at(BTN_Y);
-	cfg->left.def     = rev_axis_list.at(ABS_HAT0X);
-	cfg->down.def     = axis_list.at(ABS_HAT0Y);
-	cfg->right.def    = axis_list.at(ABS_HAT0X);
-	cfg->up.def       = rev_axis_list.at(ABS_HAT0Y);
-	cfg->r1.def       = button_list.at(BTN_TR);
-	cfg->r2.def       = axis_list.at(ABS_RZ);
-	cfg->r3.def       = button_list.at(BTN_THUMBR);
-	cfg->l1.def       = button_list.at(BTN_TL);
-	cfg->l2.def       = axis_list.at(ABS_Z);
-	cfg->l3.def       = button_list.at(BTN_THUMBL);
+	cfg->ls_left.def  = ::at32(rev_axis_list, ABS_X);
+	cfg->ls_down.def  = ::at32(axis_list, ABS_Y);
+	cfg->ls_right.def = ::at32(axis_list, ABS_X);
+	cfg->ls_up.def    = ::at32(rev_axis_list, ABS_Y);
+	cfg->rs_left.def  = ::at32(rev_axis_list, ABS_RX);
+	cfg->rs_down.def  = ::at32(axis_list, ABS_RY);
+	cfg->rs_right.def = ::at32(axis_list, ABS_RX);
+	cfg->rs_up.def    = ::at32(rev_axis_list, ABS_RY);
+	cfg->start.def    = ::at32(button_list, BTN_START);
+	cfg->select.def   = ::at32(button_list, BTN_SELECT);
+	cfg->ps.def       = ::at32(button_list, BTN_MODE);
+	cfg->square.def   = ::at32(button_list, BTN_X);
+	cfg->cross.def    = ::at32(button_list, BTN_A);
+	cfg->circle.def   = ::at32(button_list, BTN_B);
+	cfg->triangle.def = ::at32(button_list, BTN_Y);
+	cfg->left.def     = ::at32(rev_axis_list, ABS_HAT0X);
+	cfg->down.def     = ::at32(axis_list, ABS_HAT0Y);
+	cfg->right.def    = ::at32(axis_list, ABS_HAT0X);
+	cfg->up.def       = ::at32(rev_axis_list, ABS_HAT0Y);
+	cfg->r1.def       = ::at32(button_list, BTN_TR);
+	cfg->r2.def       = ::at32(axis_list, ABS_RZ);
+	cfg->r3.def       = ::at32(button_list, BTN_THUMBR);
+	cfg->l1.def       = ::at32(button_list, BTN_TL);
+	cfg->l2.def       = ::at32(axis_list, ABS_Z);
+	cfg->l3.def       = ::at32(button_list, BTN_THUMBL);
 
-	cfg->motion_sensor_x.axis.def = motion_axis_list.at(ABS_X);
-	cfg->motion_sensor_y.axis.def = motion_axis_list.at(ABS_Y);
-	cfg->motion_sensor_z.axis.def = motion_axis_list.at(ABS_Z);
-	cfg->motion_sensor_g.axis.def = motion_axis_list.at(ABS_RX);
+	cfg->motion_sensor_x.axis.def = ::at32(motion_axis_list, ABS_X);
+	cfg->motion_sensor_y.axis.def = ::at32(motion_axis_list, ABS_Y);
+	cfg->motion_sensor_z.axis.def = ::at32(motion_axis_list, ABS_Z);
+	cfg->motion_sensor_g.axis.def = ::at32(motion_axis_list, ABS_RX);
 
-	cfg->pressure_intensity_button.def = button_list.at(NO_BUTTON);
+	cfg->pressure_intensity_button.def = ::at32(button_list, NO_BUTTON);
 
 	// Set default misc variables
 	cfg->lstickdeadzone.def    = 30; // between 0 and 255
@@ -727,7 +727,7 @@ std::vector<pad_list_entry> evdev_joystick_handler::list_devices()
 std::shared_ptr<evdev_joystick_handler::EvdevDevice> evdev_joystick_handler::add_device(const std::string& device, bool in_settings)
 {
 	if (in_settings && m_settings_added.count(device))
-		return m_settings_added.at(device);
+		return ::at32(m_settings_added, device);
 
 	// Now we need to find the device with the same name, and make sure not to grab any duplicates.
 	std::unordered_map<std::string, u32> unique_names;
@@ -804,7 +804,7 @@ std::shared_ptr<evdev_joystick_handler::EvdevDevice> evdev_joystick_handler::add
 		return nullptr;
 
 	if (in_settings && m_motion_settings_added.count(device))
-		return m_motion_settings_added.at(device);
+		return ::at32(m_motion_settings_added, device);
 
 	// Now we need to find the device with the same name, and make sure not to grab any duplicates.
 	std::unordered_map<std::string, u32> unique_names;

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -31,33 +31,33 @@ void mm_joystick_handler::init_config(cfg_pad* cfg)
 	if (!cfg) return;
 
 	// Set default button mapping
-	cfg->ls_left.def  = axis_list.at(mmjoy_axis::joy_x_neg);
-	cfg->ls_down.def  = axis_list.at(mmjoy_axis::joy_y_neg);
-	cfg->ls_right.def = axis_list.at(mmjoy_axis::joy_x_pos);
-	cfg->ls_up.def    = axis_list.at(mmjoy_axis::joy_y_pos);
-	cfg->rs_left.def  = axis_list.at(mmjoy_axis::joy_z_neg);
-	cfg->rs_down.def  = axis_list.at(mmjoy_axis::joy_r_neg);
-	cfg->rs_right.def = axis_list.at(mmjoy_axis::joy_z_pos);
-	cfg->rs_up.def    = axis_list.at(mmjoy_axis::joy_r_pos);
-	cfg->start.def    = button_list.at(JOY_BUTTON9);
-	cfg->select.def   = button_list.at(JOY_BUTTON10);
-	cfg->ps.def       = button_list.at(JOY_BUTTON17);
-	cfg->square.def   = button_list.at(JOY_BUTTON4);
-	cfg->cross.def    = button_list.at(JOY_BUTTON3);
-	cfg->circle.def   = button_list.at(JOY_BUTTON2);
-	cfg->triangle.def = button_list.at(JOY_BUTTON1);
-	cfg->left.def     = pov_list.at(JOY_POVLEFT);
-	cfg->down.def     = pov_list.at(JOY_POVBACKWARD);
-	cfg->right.def    = pov_list.at(JOY_POVRIGHT);
-	cfg->up.def       = pov_list.at(JOY_POVFORWARD);
-	cfg->r1.def       = button_list.at(JOY_BUTTON8);
-	cfg->r2.def       = button_list.at(JOY_BUTTON6);
-	cfg->r3.def       = button_list.at(JOY_BUTTON12);
-	cfg->l1.def       = button_list.at(JOY_BUTTON7);
-	cfg->l2.def       = button_list.at(JOY_BUTTON5);
-	cfg->l3.def       = button_list.at(JOY_BUTTON11);
+	cfg->ls_left.def  = ::at32(axis_list, mmjoy_axis::joy_x_neg);
+	cfg->ls_down.def  = ::at32(axis_list, mmjoy_axis::joy_y_neg);
+	cfg->ls_right.def = ::at32(axis_list, mmjoy_axis::joy_x_pos);
+	cfg->ls_up.def    = ::at32(axis_list, mmjoy_axis::joy_y_pos);
+	cfg->rs_left.def  = ::at32(axis_list, mmjoy_axis::joy_z_neg);
+	cfg->rs_down.def  = ::at32(axis_list, mmjoy_axis::joy_r_neg);
+	cfg->rs_right.def = ::at32(axis_list, mmjoy_axis::joy_z_pos);
+	cfg->rs_up.def    = ::at32(axis_list, mmjoy_axis::joy_r_pos);
+	cfg->start.def    = ::at32(button_list, JOY_BUTTON9);
+	cfg->select.def   = ::at32(button_list, JOY_BUTTON10);
+	cfg->ps.def       = ::at32(button_list, JOY_BUTTON17);
+	cfg->square.def   = ::at32(button_list, JOY_BUTTON4);
+	cfg->cross.def    = ::at32(button_list, JOY_BUTTON3);
+	cfg->circle.def   = ::at32(button_list, JOY_BUTTON2);
+	cfg->triangle.def = ::at32(button_list, JOY_BUTTON1);
+	cfg->left.def     = ::at32(pov_list, JOY_POVLEFT);
+	cfg->down.def     = ::at32(pov_list, JOY_POVBACKWARD);
+	cfg->right.def    = ::at32(pov_list, JOY_POVRIGHT);
+	cfg->up.def       = ::at32(pov_list, JOY_POVFORWARD);
+	cfg->r1.def       = ::at32(button_list, JOY_BUTTON8);
+	cfg->r2.def       = ::at32(button_list, JOY_BUTTON6);
+	cfg->r3.def       = ::at32(button_list, JOY_BUTTON12);
+	cfg->l1.def       = ::at32(button_list, JOY_BUTTON7);
+	cfg->l2.def       = ::at32(button_list, JOY_BUTTON5);
+	cfg->l3.def       = ::at32(button_list, JOY_BUTTON11);
 
-	cfg->pressure_intensity_button.def = button_list.at(NO_BUTTON);
+	cfg->pressure_intensity_button.def = ::at32(button_list, NO_BUTTON);
 
 	// Set default misc variables
 	cfg->lstickdeadzone.def    = 0; // between 0 and 255
@@ -486,7 +486,7 @@ std::shared_ptr<PadDevice> mm_joystick_handler::get_device(const std::string& de
 	if (id < 0)
 		return nullptr;
 
-	std::shared_ptr<MMJOYDevice> joy_device = std::make_shared<MMJOYDevice>(m_devices.at(id));
+	std::shared_ptr<MMJOYDevice> joy_device = std::make_shared<MMJOYDevice>(::at32(m_devices, id));
 	return joy_device;
 }
 

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -88,33 +88,33 @@ void xinput_pad_handler::init_config(cfg_pad* cfg)
 	if (!cfg) return;
 
 	// Set default button mapping
-	cfg->ls_left.def  = button_list.at(XInputKeyCodes::LSXNeg);
-	cfg->ls_down.def  = button_list.at(XInputKeyCodes::LSYNeg);
-	cfg->ls_right.def = button_list.at(XInputKeyCodes::LSXPos);
-	cfg->ls_up.def    = button_list.at(XInputKeyCodes::LSYPos);
-	cfg->rs_left.def  = button_list.at(XInputKeyCodes::RSXNeg);
-	cfg->rs_down.def  = button_list.at(XInputKeyCodes::RSYNeg);
-	cfg->rs_right.def = button_list.at(XInputKeyCodes::RSXPos);
-	cfg->rs_up.def    = button_list.at(XInputKeyCodes::RSYPos);
-	cfg->start.def    = button_list.at(XInputKeyCodes::Start);
-	cfg->select.def   = button_list.at(XInputKeyCodes::Back);
-	cfg->ps.def       = button_list.at(XInputKeyCodes::Guide);
-	cfg->square.def   = button_list.at(XInputKeyCodes::X);
-	cfg->cross.def    = button_list.at(XInputKeyCodes::A);
-	cfg->circle.def   = button_list.at(XInputKeyCodes::B);
-	cfg->triangle.def = button_list.at(XInputKeyCodes::Y);
-	cfg->left.def     = button_list.at(XInputKeyCodes::Left);
-	cfg->down.def     = button_list.at(XInputKeyCodes::Down);
-	cfg->right.def    = button_list.at(XInputKeyCodes::Right);
-	cfg->up.def       = button_list.at(XInputKeyCodes::Up);
-	cfg->r1.def       = button_list.at(XInputKeyCodes::RB);
-	cfg->r2.def       = button_list.at(XInputKeyCodes::RT);
-	cfg->r3.def       = button_list.at(XInputKeyCodes::RS);
-	cfg->l1.def       = button_list.at(XInputKeyCodes::LB);
-	cfg->l2.def       = button_list.at(XInputKeyCodes::LT);
-	cfg->l3.def       = button_list.at(XInputKeyCodes::LS);
+	cfg->ls_left.def  = ::at32(button_list, XInputKeyCodes::LSXNeg);
+	cfg->ls_down.def  = ::at32(button_list, XInputKeyCodes::LSYNeg);
+	cfg->ls_right.def = ::at32(button_list, XInputKeyCodes::LSXPos);
+	cfg->ls_up.def    = ::at32(button_list, XInputKeyCodes::LSYPos);
+	cfg->rs_left.def  = ::at32(button_list, XInputKeyCodes::RSXNeg);
+	cfg->rs_down.def  = ::at32(button_list, XInputKeyCodes::RSYNeg);
+	cfg->rs_right.def = ::at32(button_list, XInputKeyCodes::RSXPos);
+	cfg->rs_up.def    = ::at32(button_list, XInputKeyCodes::RSYPos);
+	cfg->start.def    = ::at32(button_list, XInputKeyCodes::Start);
+	cfg->select.def   = ::at32(button_list, XInputKeyCodes::Back);
+	cfg->ps.def       = ::at32(button_list, XInputKeyCodes::Guide);
+	cfg->square.def   = ::at32(button_list, XInputKeyCodes::X);
+	cfg->cross.def    = ::at32(button_list, XInputKeyCodes::A);
+	cfg->circle.def   = ::at32(button_list, XInputKeyCodes::B);
+	cfg->triangle.def = ::at32(button_list, XInputKeyCodes::Y);
+	cfg->left.def     = ::at32(button_list, XInputKeyCodes::Left);
+	cfg->down.def     = ::at32(button_list, XInputKeyCodes::Down);
+	cfg->right.def    = ::at32(button_list, XInputKeyCodes::Right);
+	cfg->up.def       = ::at32(button_list, XInputKeyCodes::Up);
+	cfg->r1.def       = ::at32(button_list, XInputKeyCodes::RB);
+	cfg->r2.def       = ::at32(button_list, XInputKeyCodes::RT);
+	cfg->r3.def       = ::at32(button_list, XInputKeyCodes::RS);
+	cfg->l1.def       = ::at32(button_list, XInputKeyCodes::LB);
+	cfg->l2.def       = ::at32(button_list, XInputKeyCodes::LT);
+	cfg->l3.def       = ::at32(button_list, XInputKeyCodes::LS);
 
-	cfg->pressure_intensity_button.def = button_list.at(XInputKeyCodes::None);
+	cfg->pressure_intensity_button.def = ::at32(button_list, XInputKeyCodes::None);
 
 	// Set default misc variables
 	cfg->lstickdeadzone.def    = XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE;  // between 0 and 32767
@@ -329,12 +329,12 @@ xinput_pad_handler::PadButtonValues xinput_pad_handler::get_button_values_scp(co
 pad_preview_values xinput_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
 {
 	return {
-		data.at(LT),
-		data.at(RT),
-		data.at(LSXPos) - data.at(LSXNeg),
-		data.at(LSYPos) - data.at(LSYNeg),
-		data.at(RSXPos) - data.at(RSXNeg),
-		data.at(RSYPos) - data.at(RSYNeg)
+		::at32(data, LT),
+		::at32(data, RT),
+		::at32(data, LSXPos) - ::at32(data, LSXNeg),
+		::at32(data, LSYPos) - ::at32(data, LSYNeg),
+		::at32(data, RSXPos) - ::at32(data, RSXNeg),
+		::at32(data, RSYPos) - ::at32(data, RSYNeg)
 	};
 }
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -1117,7 +1117,7 @@ int main(int argc, char** argv)
 	}
 	else if (const QStringList args = parser.positionalArguments(); !args.isEmpty() && !is_updating && !parser.isSet(arg_installfw) && !parser.isSet(arg_installpkg))
 	{
-		sys_log.notice("Booting application from command line: %s", args.at(0).toStdString());
+		sys_log.notice("Booting application from command line: %s", ::at32(args, 0).toStdString());
 
 		// Propagate command line arguments
 		std::vector<std::string> rpcs3_argv;
@@ -1147,7 +1147,7 @@ int main(int argc, char** argv)
 		}
 
 		// Postpone startup to main event loop
-		Emu.CallFromMainThread([path = sstr(QFileInfo(args.at(0)).absoluteFilePath()), rpcs3_argv = std::move(rpcs3_argv), config_path = std::move(config_path)]() mutable
+		Emu.CallFromMainThread([path = sstr(QFileInfo(::at32(args, 0)).absoluteFilePath()), rpcs3_argv = std::move(rpcs3_argv), config_path = std::move(config_path)]() mutable
 		{
 			Emu.argv = std::move(rpcs3_argv);
 			Emu.SetForceBoot(true);

--- a/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp
@@ -194,7 +194,7 @@ void auto_pause_settings_dialog::OnRemove()
 	std::sort(selection.begin(), selection.end());
 	for (int i = selection.count() - 1; i >= 0; i--)
 	{
-		m_entries.erase(m_entries.begin() + selection.at(i).row());
+		m_entries.erase(m_entries.begin() + ::at32(selection, i).row());
 	}
 	UpdateList();
 }

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -216,7 +216,7 @@ void breakpoint_list::OnBreakpointListDelete()
 {
 	for (int i = selectedItems().count() - 1; i >= 0; i--)
 	{
-		RemoveBreakpoint(selectedItems().at(i)->data(Qt::UserRole).value<u32>());
+		RemoveBreakpoint(::at32(selectedItems(), i)->data(Qt::UserRole).value<u32>());
 	}
 
 	if (m_context_menu)

--- a/rpcs3/rpcs3qt/cheat_manager.cpp
+++ b/rpcs3/rpcs3qt/cheat_manager.cpp
@@ -166,7 +166,7 @@ std::string cheat_engine::export_cheats_to_str() const
 
 	for (const auto& game : cheats)
 	{
-		for (const auto& offset : cheats.at(game.first))
+		for (const auto& offset : ::at32(cheats, game.first))
 		{
 			cheats_str += offset.second.to_str();
 			cheats_str += "^^^";
@@ -178,7 +178,7 @@ std::string cheat_engine::export_cheats_to_str() const
 
 bool cheat_engine::exist(const std::string& game, const u32 offset) const
 {
-	return cheats.contains(game) && cheats.at(game).contains(offset);
+	return cheats.contains(game) && ::at32(cheats, game).contains(offset);
 }
 
 void cheat_engine::add(const std::string& game, const std::string& description, const cheat_type type, const u32 offset, const std::string& red_script)

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -80,7 +80,7 @@ bool emu_settings::Init()
 	// Make Vulkan default setting if it is supported
 	if (m_render_creator->Vulkan.supported && !m_render_creator->Vulkan.adapters.empty())
 	{
-		const std::string adapter = sstr(m_render_creator->Vulkan.adapters.at(0));
+		const std::string adapter = sstr(::at32(m_render_creator->Vulkan.adapters, 0));
 		cfg_log.notice("Setting the default renderer to Vulkan. Default GPU: '%s'", adapter);
 		Emu.SetDefaultRenderer(video_renderer::vulkan);
 		Emu.SetDefaultGraphicsAdapter(adapter);

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -123,7 +123,7 @@ bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_downl
 		QJsonObject json_result = json_results[key].toObject();
 
 		// Retrieve compatibility information from json
-		compat::status status = Status_Data.at(json_result.value("status").toString("NoResult"));
+		compat::status status = ::at32(Status_Data, json_result.value("status").toString("NoResult"));
 
 		// Add date if possible
 		status.date = json_result.value("date").toString();
@@ -236,19 +236,19 @@ compat::status game_compatibility::GetCompatibility(const std::string& title_id)
 {
 	if (m_compat_database.empty())
 	{
-		return Status_Data.at("NoData");
+		return ::at32(Status_Data, "NoData");
 	}
 	else if (m_compat_database.count(title_id) > 0)
 	{
 		return m_compat_database[title_id];
 	}
 
-	return Status_Data.at("NoResult");
+	return ::at32(Status_Data, "NoResult");
 }
 
 compat::status game_compatibility::GetStatusData(const QString& status) const
 {
-	return Status_Data.at(status);
+	return ::at32(Status_Data, status);
 }
 
 compat::package_info game_compatibility::GetPkgInfo(const QString& pkg_path, game_compatibility* compat)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1150,7 +1150,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 			hover_gif,
 			shader_load
 		};
-		
+
 		const auto handle_icon = [this, serial](const QString& game_icon_path, const QString& suffix, icon_action action, icon_type type)
 		{
 			QString icon_path;
@@ -2621,7 +2621,7 @@ std::string game_list_frame::GetStringFromU32(const u32& key, const std::map<u32
 	{
 		if (map.find(key) != map.end())
 		{
-			string << map.at(key);
+			string << ::at32(map, key);
 		}
 	}
 

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -97,7 +97,7 @@ bool gui_application::Init()
 		const auto language = m_gui_settings->GetValue(gui::loc_language).toString();
 		const auto index    = codes.indexOf(language);
 
-		LoadLanguage(index < 0 ? QLocale(QLocale::English).bcp47Name() : codes.at(index));
+		LoadLanguage(index < 0 ? QLocale(QLocale::English).bcp47Name() : ::at32(codes, index));
 	}
 
 	// Create callbacks from the emulator, which reference the handlers.
@@ -277,7 +277,7 @@ std::unique_ptr<gs_frame> gui_application::get_gs_frame()
 {
 	extern const std::unordered_map<video_resolution, std::pair<int, int>, value_hash<video_resolution>> g_video_out_resolution_map;
 
-	auto [w, h] = g_video_out_resolution_map.at(g_cfg.video.resolution);
+	auto [w, h] = ::at32(g_video_out_resolution_map, g_cfg.video.resolution);
 
 	if (m_gui_settings->GetValue(gui::gs_resize).toBool())
 	{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -851,7 +851,7 @@ void main_window::HandlePackageInstallation(QStringList file_paths)
 	{
 		progress = 0.;
 
-		const compat::package_info& package = packages.at(i);
+		const compat::package_info& package = ::at32(packages, i);
 		QString app_info = package.title; // This should always be non-empty
 
 		if (!package.title_id.isEmpty() || !package.version.isEmpty())
@@ -1762,11 +1762,11 @@ void main_window::BootRecentAction(const QAction* act)
 	int idx = -1;
 	for (int i = 0; i < m_rg_entries.count(); i++)
 	{
-		if (m_rg_entries.at(i).first == pth)
+		if (::at32(m_rg_entries, i).first == pth)
 		{
 			idx = i;
 			contains_path = true;
-			name = m_rg_entries.at(idx).second;
+			name = ::at32(m_rg_entries, idx).second;
 			break;
 		}
 	}
@@ -1794,7 +1794,7 @@ void main_window::BootRecentAction(const QAction* act)
 			for (int i = 0; i < m_recent_game_acts.count(); i++)
 			{
 				m_recent_game_acts[i]->setShortcut(tr("Ctrl+%1").arg(i + 1));
-				m_recent_game_acts[i]->setToolTip(m_rg_entries.at(i).second);
+				m_recent_game_acts[i]->setToolTip(::at32(m_rg_entries, i).second);
 				ui->bootRecentMenu->addAction(m_recent_game_acts[i]);
 			}
 
@@ -1905,7 +1905,7 @@ void main_window::AddRecentAction(const q_string_pair& entry)
 	for (int i = 0; i < m_recent_game_acts.count(); i++)
 	{
 		m_recent_game_acts[i]->setShortcut(tr("Ctrl+%1").arg(i + 1));
-		m_recent_game_acts[i]->setToolTip(m_rg_entries.at(i).second);
+		m_recent_game_acts[i]->setToolTip(::at32(m_rg_entries, i).second);
 		ui->bootRecentMenu->addAction(m_recent_game_acts[i]);
 	}
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1549,7 +1549,7 @@ void pad_settings_dialog::ChangeDevice(int index)
 {
 	if (index < 0)
 		return;
-	
+
 	const QVariant user_data = ui->chooseDevice->itemData(index);
 
 	if (!user_data.canConvert<pad_device_info>())
@@ -1860,7 +1860,7 @@ bool pad_settings_dialog::GetIsLddPad(u32 index) const
 		{
 			ensure(index < handler->GetPads().size());
 
-			if (const std::shared_ptr<Pad> pad = handler->GetPads().at(index))
+			if (const std::shared_ptr<Pad> pad = ::at32(handler->GetPads(), index))
 			{
 				return pad->ldd;
 			}

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -392,7 +392,7 @@ void patch_manager_dialog::filter_patches(const QString& term)
 				const std::string app_version = item->data(0, app_version_role).toString().toStdString();
 
 				if (serial != patch_key::all &&
-					(m_owned_games.find(serial) == m_owned_games.end() || (app_version != patch_key::all && !m_owned_games.at(serial).contains(app_version))))
+					(m_owned_games.find(serial) == m_owned_games.end() || (app_version != patch_key::all && !::at32(m_owned_games, serial).contains(app_version))))
 				{
 					item->setHidden(true);
 					return 0;
@@ -518,11 +518,11 @@ void patch_manager_dialog::handle_item_selected(QTreeWidgetItem *current, QTreeW
 		// Find the patch for this item and get its metadata
 		if (m_map.find(hash) != m_map.end())
 		{
-			const auto& container = m_map.at(hash);
+			const auto& container = ::at32(m_map, hash);
 
 			if (container.patch_info_map.find(description) != container.patch_info_map.end())
 			{
-				const auto& found_info = container.patch_info_map.at(description);
+				const auto& found_info = ::at32(container.patch_info_map, description);
 				info.author = QString::fromStdString(found_info.author);
 				info.notes = QString::fromStdString(found_info.notes);
 				info.description = QString::fromStdString(found_info.description);
@@ -624,11 +624,11 @@ void patch_manager_dialog::handle_custom_context_menu_requested(const QPoint &po
 
 		if (m_map.find(hash) != m_map.end())
 		{
-			const auto& container = m_map.at(hash);
+			const auto& container = ::at32(m_map, hash);
 
 			if (container.patch_info_map.find(description) != container.patch_info_map.end())
 			{
-				const auto& info = container.patch_info_map.at(description);
+				const auto& info = ::at32(container.patch_info_map, description);
 
 				QAction* open_filepath = new QAction(tr("Show Patch File"));
 				menu->addAction(open_filepath);

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -147,13 +147,13 @@ namespace gui
 
 		QIcon get_colorized_icon(const QIcon& old_icon, const QColor& old_color, const QColor& new_color, bool use_special_masks, bool colorize_all)
 		{
-			return QIcon(get_colorized_pixmap(old_icon.pixmap(old_icon.availableSizes().at(0)), old_color, new_color, use_special_masks, colorize_all));
+			return QIcon(get_colorized_pixmap(old_icon.pixmap(::at32(old_icon.availableSizes(), 0)), old_color, new_color, use_special_masks, colorize_all));
 		}
 
 		QIcon get_colorized_icon(const QIcon& old_icon, const QColor& old_color, const std::map<QIcon::Mode, QColor>& new_colors, bool use_special_masks, bool colorize_all)
 		{
 			QIcon icon{};
-			const QPixmap old_pixmap = old_icon.pixmap(old_icon.availableSizes().at(0));
+			const QPixmap old_pixmap = old_icon.pixmap(::at32(old_icon.availableSizes(), 0));
 			for (const auto& [mode, color] : new_colors)
 			{
 				icon.addPixmap(get_colorized_pixmap(old_pixmap, old_color, color, use_special_masks, colorize_all), mode);

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -65,11 +65,11 @@ namespace
 			}
 
 			SaveDataEntry save_entry2;
-			save_entry2.dirName = psf.at("SAVEDATA_DIRECTORY").as_string();
-			save_entry2.listParam = psf.at("SAVEDATA_LIST_PARAM").as_string();
-			save_entry2.title = psf.at("TITLE").as_string();
-			save_entry2.subtitle = psf.at("SUB_TITLE").as_string();
-			save_entry2.details = psf.at("DETAIL").as_string();
+			save_entry2.dirName = ::at32(psf, "SAVEDATA_DIRECTORY").as_string();
+			save_entry2.listParam = ::at32(psf, "SAVEDATA_LIST_PARAM").as_string();
+			save_entry2.title = ::at32(psf, "TITLE").as_string();
+			save_entry2.subtitle = ::at32(psf, "SUB_TITLE").as_string();
+			save_entry2.details = ::at32(psf, "DETAIL").as_string();
 
 			save_entry2.size = 0;
 

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -618,7 +618,7 @@ void trophy_manager_dialog::ResizeTrophyIcons()
 
 	ReadjustTrophyTable();
 
-	const std::function<QPixmap(const int&)> get_scaled = [this, data = m_trophies_db.at(db_pos).get(), dpr, new_height](const int& trophy_id) -> QPixmap
+	const std::function<QPixmap(const int&)> get_scaled = [this, data = ::at32(m_trophies_db, db_pos).get(), dpr, new_height](const int& trophy_id) -> QPixmap
 	{
 		QPixmap icon;
 

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -38,7 +38,7 @@ namespace utils
 	{
 		if (metadata.contains(key))
 		{
-			return metadata.at(key);
+			return ::at32(metadata, key);
 		}
 
 		return def;
@@ -50,7 +50,7 @@ namespace utils
 		if (metadata.contains(key))
 		{
 			s64 result{};
-			if (try_to_int64(&result, metadata.at(key), smin, smax))
+			if (try_to_int64(&result, ::at32(metadata, key), smin, smax))
 			{
 				return result;
 			}
@@ -468,9 +468,9 @@ namespace utils
 			while (thread_ctrl::state() != thread_state::aborting)
 			{
 				ensure(m_context.current_track < m_context.playlist.size());
-				media_log.notice("audio_decoder: about to decode: %s (index=%d)", m_context.playlist.at(m_context.current_track), m_context.current_track);
+				media_log.notice("audio_decoder: about to decode: %s (index=%d)", ::at32(m_context.playlist, m_context.current_track), m_context.current_track);
 
-				decode_track(m_context.playlist.at(m_context.current_track));
+				decode_track(::at32(m_context.playlist, m_context.current_track));
 				track_fully_decoded = true;
 
 				if (has_error)


### PR DESCRIPTION
Adds a supplement for common STL .at() methods but which also provides source location.