### PR TITLE
Some minor optimizations

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -588,7 +588,7 @@ void cpu_thread::operator()()
 			continue;
 		}
 
-		thread_ctrl::wait_on(state, state0);
+		state.wait(state0);
 
 		if (state & cpu_flag::ret && state.test_and_reset(cpu_flag::ret))
 		{
@@ -640,7 +640,7 @@ cpu_thread::cpu_thread(u32 id)
 
 void cpu_thread::cpu_wait(bs_t<cpu_flag> old)
 {
-	thread_ctrl::wait_on(state, old);
+	state.wait(old);
 }
 
 static atomic_t<u32> s_dummy_atomic = 0;

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -245,7 +245,7 @@ error_code open_msg_dialog(bool is_blocking, u32 type, vm::cptr<char> msgString,
 			break;
 		}
 
-		thread_ctrl::wait_on(ppu.state, state);
+		ppu.state.wait(state);
 	}
 
 	if (is_blocking)

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1641,7 +1641,10 @@ void spu_thread::cleanup()
 	vm::free_range_lock(range_lock);
 
 	// Signal the debugger about the termination
-	state += cpu_flag::exit;
+	if (!state.test_and_set(cpu_flag::exit))
+	{
+		state.notify_one();
+	}
 }
 
 spu_thread::~spu_thread()

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1605,8 +1605,12 @@ void lv2_obj::schedule_all(u64 current_time)
 			if (target->state & cpu_flag::suspend)
 			{
 				ppu_log.trace("schedule(): %s", target->id);
-				target->state.atomic_op(FN(x += cpu_flag::signal, x -= cpu_flag::suspend));
 				target->start_time = 0;
+
+				if ((target->state.fetch_op(FN(x += cpu_flag::signal, x -= cpu_flag::suspend, void())) & (cpu_flag::wait + cpu_flag::signal)) != cpu_flag::wait)
+				{
+					continue;
+				}
 
 				if (notify_later_idx == std::size(g_to_notify))
 				{

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -451,7 +451,7 @@ error_code sys_cond_wait(ppu_thread& ppu, u32 cond_id, u64 timeout)
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -517,7 +517,7 @@ error_code sys_event_queue_receive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sys_e
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -249,7 +249,7 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -486,7 +486,7 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -246,7 +246,7 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -255,7 +255,7 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -415,7 +415,7 @@ error_code sys_net_bnet_accept(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr>
 				break;
 			}
 
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 
 		if (ppu.gpr[3] == static_cast<u64>(-SYS_NET_EINTR))
@@ -579,7 +579,7 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 				break;
 			}
 
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 
 		if (ppu.gpr[3] == static_cast<u64>(-SYS_NET_EINTR))
@@ -858,7 +858,7 @@ error_code sys_net_bnet_recvfrom(ppu_thread& ppu, s32 s, vm::ptr<void> buf, u32 
 				break;
 			}
 
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 
 		if (ppu.gpr[3] == static_cast<u64>(-SYS_NET_EINTR))
@@ -979,7 +979,7 @@ error_code sys_net_bnet_sendto(ppu_thread& ppu, s32 s, vm::cptr<void> buf, u32 l
 			{
 				break;
 			}
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 
 		if (ppu.gpr[3] == static_cast<u64>(-SYS_NET_EINTR))
@@ -1332,7 +1332,7 @@ error_code sys_net_bnet_poll(ppu_thread& ppu, vm::ptr<sys_net_pollfd> fds, s32 n
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 
@@ -1572,7 +1572,7 @@ error_code sys_net_bnet_select(ppu_thread& ppu, s32 nfds, vm::ptr<sys_net_fd_set
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -360,7 +360,7 @@ void _sys_process_exit(ppu_thread& ppu, s32 status, u32 arg2, u32 arg3)
 			break;
 		}
 
-		thread_ctrl::wait_on(ppu.state, state);
+		ppu.state.wait(state);
 	}
 }
 
@@ -472,7 +472,7 @@ void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> ar
 			break;
 		}
 
-		thread_ctrl::wait_on(ppu.state, state);
+		ppu.state.wait(state);
 	}
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -208,7 +208,7 @@ error_code sys_rwlock_rlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 
@@ -471,7 +471,7 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -213,7 +213,7 @@ error_code sys_semaphore_wait(ppu_thread& ppu, u32 sem_id, u64 timeout)
 		}
 		else
 		{
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1485,7 +1485,7 @@ error_code sys_spu_thread_group_join(ppu_thread& ppu, u32 id, vm::ptr<u32> cause
 				break;
 			}
 
-			thread_ctrl::wait_on(ppu.state, state);
+			ppu.state.wait(state);
 		}
 	}
 	while (false);

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -888,7 +888,7 @@ error_code sys_usbd_receive_event(ppu_thread& ppu, u32 handle, vm::ptr<u64> arg1
 			break;
 		}
 
-		thread_ctrl::wait_on(ppu.state, state);
+		ppu.state.wait(state);
 	}
 
 	*arg1 = ppu.gpr[4];

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -749,19 +749,20 @@ std::function<cpu_thread*()> debugger_frame::make_check_cpu(cpu_thread* cpu)
 
 void debugger_frame::UpdateUI()
 {
-	if (m_ui_update_ctr % 5 == 0)
+	const auto cpu = get_cpu();
+
+	// Refresh at a high rate during initialization (looks weird otherwise)
+	if (m_ui_update_ctr % (cpu || m_ui_update_ctr < 200 || m_debugger_list->m_dirty_flag ? 5 : 50) == 0)
 	{
 		// If no change to instruction position happened, update instruction list at 20hz
 		ShowPC();
-
-		if (m_ui_update_ctr % 20 == 0)
-		{
-			// Update threads list at 5hz (low priority)
-			UpdateUnitList();
-		}
 	}
 
-	const auto cpu = get_cpu();
+	if (m_ui_update_ctr % 20 == 0)
+	{
+		// Update threads list at 5hz (low priority)
+		UpdateUnitList();
+	}
 
 	if (!cpu)
 	{

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -120,6 +120,8 @@ void debugger_list::ShowAddress(u32 addr, bool select_addr, bool direct)
 		m_follow_thread = false;
 	}
 
+	m_dirty_flag = false;
+
 	u32 pc = m_start_addr;
 
 	if (!direct && (m_follow_thread || select_addr))
@@ -396,6 +398,7 @@ void debugger_list::resizeEvent(QResizeEvent* event)
 		for (u32 i = old_size; i < m_item_count; ++i)
 		{
 			insertItem(i, new QListWidgetItem(""));
+			m_dirty_flag = true;
 		}
 	}
 	else

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -23,6 +23,7 @@ public:
 	u32 m_selected_instruction = -1;
 	bool m_follow_thread = true; // If true, follow the selected thread to wherever it goes in code
 	bool m_showing_selected_instruction = false;
+	bool m_dirty_flag = false;
 	QColor m_color_bp;
 	QColor m_color_pc;
 	QColor m_text_color_bp;


### PR DESCRIPTION
* Don't refresh "No Thread" list in the RPCS3 debugger at a high rate because it wastes CPU time. This makes "No Thread" view nearly truly as optimized as if the debugger is completely disabled.
* Optimize SPU DMA transfers a bit in non-TSX path.
* Avoid using multi-variable atomic wait on cpu_thread::state wait, multi-variable waiting is slower and all the notifications we need go through cpu_thread::state already.