### PR TITLE
sys_net: Implement sys_net_bnet_sendmsg for native sockets

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
@@ -94,6 +94,7 @@ public:
 
 	virtual std::optional<std::tuple<s32, std::vector<u8>, sys_net_sockaddr>> recvfrom(s32 flags, u32 len, bool is_lock = true)                = 0;
 	virtual std::optional<s32> sendto(s32 flags, const std::vector<u8>& buf, std::optional<sys_net_sockaddr> opt_sn_addr, bool is_lock = true) = 0;
+	virtual std::optional<s32> sendmsg(s32 flags, const sys_net_msghdr& msg, bool is_lock = true) = 0;
 
 	virtual void close()          = 0;
 	virtual s32 shutdown(s32 how) = 0;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
@@ -48,6 +48,7 @@ public:
 	s32 setsockopt(s32 level, s32 optname, const std::vector<u8>& optval) override;
 	std::optional<std::tuple<s32, std::vector<u8>, sys_net_sockaddr>> recvfrom(s32 flags, u32 len, bool is_lock = true) override;
 	std::optional<s32> sendto(s32 flags, const std::vector<u8>& buf, std::optional<sys_net_sockaddr> opt_sn_addr, bool is_lock = true) override;
+	std::optional<s32> sendmsg(s32 flags, const sys_net_msghdr& msg, bool is_lock = true) override;
 
 	s32 poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
 	std::tuple<bool, bool, bool> select(bs_t<poll_t> selected, pollfd& native_pfd) override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
@@ -284,6 +284,12 @@ std::optional<s32> lv2_socket_p2p::sendto(s32 flags, const std::vector<u8>& buf,
 	return std::nullopt;
 }
 
+std::optional<s32> lv2_socket_p2p::sendmsg([[maybe_unused]] s32 flags, [[maybe_unused]] const sys_net_msghdr& msg, [[maybe_unused]] bool is_lock)
+{
+	sys_net.todo("lv2_socket_p2p::sendmsg");
+	return {};
+}
+
 void lv2_socket_p2p::close()
 {
 	if (!port || !vport)

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.h
@@ -25,6 +25,7 @@ public:
 
 	std::optional<std::tuple<s32, std::vector<u8>, sys_net_sockaddr>> recvfrom(s32 flags, u32 len, bool is_lock = true) override;
 	std::optional<s32> sendto(s32 flags, const std::vector<u8>& buf, std::optional<sys_net_sockaddr> opt_sn_addr, bool is_lock = true) override;
+	std::optional<s32> sendmsg(s32 flags, const sys_net_msghdr& msg, bool is_lock = true) override;
 
 	void close() override;
 	s32 shutdown(s32 how) override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
@@ -795,6 +795,12 @@ std::optional<s32> lv2_socket_p2ps::sendto([[maybe_unused]] s32 flags, const std
 	return {buf.size()};
 }
 
+std::optional<s32> lv2_socket_p2ps::sendmsg([[maybe_unused]] s32 flags, [[maybe_unused]] const sys_net_msghdr& msg, [[maybe_unused]] bool is_lock)
+{
+	sys_net.todo("lv2_socket_p2ps::sendmsg");
+	return {};
+}
+
 void lv2_socket_p2ps::close()
 {
 	if (!port || !vport)

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
@@ -79,6 +79,7 @@ public:
 
 	std::optional<std::tuple<s32, std::vector<u8>, sys_net_sockaddr>> recvfrom(s32 flags, u32 len, bool is_lock = true) override;
 	std::optional<s32> sendto(s32 flags, const std::vector<u8>& buf, std::optional<sys_net_sockaddr> opt_sn_addr, bool is_lock = true) override;
+	std::optional<s32> sendmsg(s32 flags, const sys_net_msghdr& msg, bool is_lock = true) override;
 
 	void close() override;
 	s32 shutdown(s32 how) override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
@@ -84,6 +84,12 @@ std::optional<s32> lv2_socket_raw::sendto([[maybe_unused]] s32 flags, [[maybe_un
 	return buf.size();
 }
 
+std::optional<s32> lv2_socket_raw::sendmsg([[maybe_unused]] s32 flags, [[maybe_unused]] const sys_net_msghdr& msg, [[maybe_unused]] bool is_lock)
+{
+	sys_net.todo("lv2_socket_raw::sendmsg");
+	return {};
+}
+
 void lv2_socket_raw::close()
 {
 	sys_net.todo("lv2_socket_raw::close");

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.h
@@ -25,6 +25,7 @@ public:
 
 	std::optional<std::tuple<s32, std::vector<u8>, sys_net_sockaddr>> recvfrom(s32 flags, u32 len, bool is_lock = true) override;
 	std::optional<s32> sendto(s32 flags, const std::vector<u8>& buf, std::optional<sys_net_sockaddr> opt_sn_addr, bool is_lock = true) override;
+	std::optional<s32> sendmsg(s32 flags, const sys_net_msghdr& msg, bool is_lock = true) override;
 
 	void close() override;
 	s32 shutdown(s32 how) override;


### PR DESCRIPTION
Used by Destiny for server communication.

The implementation does not support control messages, as it uses the `send` function instead of `sendmsg` for native sockets because the sendmsg function does not appear to exist on Windows.