### PR TITLE
sys_ppu_thread: Fix surmixer hack

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -405,7 +405,7 @@ error_code sys_event_queue_tryreceive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sy
 	lock.unlock();
 	ppu.check_state();
 
-	std::copy_n(event_array.get_ptr(), count, events.begin());
+	std::copy_n(events.begin(), event_array.get_ptr());
 	*number = count;
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -405,7 +405,7 @@ error_code sys_event_queue_tryreceive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sy
 	lock.unlock();
 	ppu.check_state();
 
-	std::copy_n(events.begin(), event_array.get_ptr());
+	std::copy_n(events.begin(), count, event_array.get_ptr());
 	*number = count;
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "sys_ppu_thread.h"
 
 #include "Emu/System.h"
@@ -536,6 +536,7 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 		// Dirty hack for sound: confirm the creation of _mxr000 event queue
 		if (*thread->ppu_tname.load() == "_cellsurMixerMain"sv)
 		{
+			ppu.check_state();
 			lv2_obj::sleep(ppu);
 
 			while (!idm::select<lv2_obj, lv2_event_queue>([](u32, lv2_event_queue& eq)


### PR DESCRIPTION
There was no check_state() call between awake and sleep, so cpu_flag::signal could have been set by awake and not been caught making sleep fail (rare and random bug). Thanks to @jenci8888 for reporting it, seen in the game dark souls 2 but it can happen in any game which uses surmix.