### PR TITLE
rsx/gl: Fixes and improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -1038,7 +1038,7 @@ namespace rsx
 				result.element_size = word_size;
 				result.block_length = words_per_block;
 
-				bool require_cpu_swizzle = !caps.supports_hw_deswizzle;
+				bool require_cpu_swizzle = !caps.supports_hw_deswizzle && is_swizzled;
 				bool require_cpu_byteswap = !caps.supports_byteswap;
 
 				if (is_swizzled && caps.supports_hw_deswizzle)

--- a/rpcs3/Emu/RSX/Common/surface_cache_dma.hpp
+++ b/rpcs3/Emu/RSX/Common/surface_cache_dma.hpp
@@ -43,7 +43,7 @@ namespace rsx
 	public:
 		surface_cache_dma()
 		{
-			for (usz i = 0; i < m_buffer_list.size(); ++i)
+			for (u32 i = 0; i < ::size32(m_buffer_list); ++i)
 			{
 				m_buffer_list[i].id = i;
 			}

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -718,7 +718,8 @@ namespace rsx
 				while (length >= 8)
 				{
 					auto& value = *utils::bless<u64>(dst_ptr);
-					mask |= (~value);                          // If the value is not all 1s, set valid to true
+					const u64 block_mask = ~value;              // If the value is not all 1s, set valid to true
+					mask |= block_mask;
 					value = umax;
 
 					dst_ptr += 8;
@@ -728,7 +729,8 @@ namespace rsx
 				if (length >= 4)
 				{
 					auto& value = *utils::bless<u32>(dst_ptr);
-					mask |= (~value);
+					const u32 block_mask = ~value;
+					mask |= block_mask;
 					value = umax;
 
 					dst_ptr += 4;
@@ -738,7 +740,8 @@ namespace rsx
 				if (length >= 2)
 				{
 					auto& value = *utils::bless<u16>(dst_ptr);
-					mask |= (~value);
+					const u16 block_mask = ~value;
+					mask |= block_mask;
 					value = umax;
 
 					dst_ptr += 2;
@@ -748,7 +751,8 @@ namespace rsx
 				if (length)
 				{
 					auto& value = *dst_ptr;
-					mask |= (~value);
+					const u8 block_mask = ~value;
+					mask |= block_mask;
 					value = umax;
 				}
 

--- a/rpcs3/Emu/RSX/GL/GLCompute.cpp
+++ b/rpcs3/Emu/RSX/GL/GLCompute.cpp
@@ -258,8 +258,8 @@ namespace gl
 		cs_shuffle_base::run(cmd, data, num_texels * 4, data_offset);
 	}
 
-	template class cs_shuffle_d32fx8_to_x8d24f<true>;
-	template class cs_shuffle_d32fx8_to_x8d24f<false>;
+	template struct cs_shuffle_d32fx8_to_x8d24f<true>;
+	template struct cs_shuffle_d32fx8_to_x8d24f<false>;
 
 	template <bool SwapBytes>
 	cs_shuffle_x8d24f_to_d32fx8<SwapBytes>::cs_shuffle_x8d24f_to_d32fx8()
@@ -313,8 +313,8 @@ namespace gl
 		cs_shuffle_base::run(cmd, data, num_texels * 4, data_offset);
 	}
 
-	template class cs_shuffle_x8d24f_to_d32fx8<true>;
-	template class cs_shuffle_x8d24f_to_d32fx8<false>;
+	template struct cs_shuffle_x8d24f_to_d32fx8<true>;
+	template struct cs_shuffle_x8d24f_to_d32fx8<false>;
 
 	cs_d24x8_to_ssbo::cs_d24x8_to_ssbo()
 	{

--- a/rpcs3/Emu/RSX/GL/GLCompute.cpp
+++ b/rpcs3/Emu/RSX/GL/GLCompute.cpp
@@ -258,8 +258,8 @@ namespace gl
 		cs_shuffle_base::run(cmd, data, num_texels * 4, data_offset);
 	}
 
-	template cs_shuffle_d32fx8_to_x8d24f<true>;
-	template cs_shuffle_d32fx8_to_x8d24f<false>;
+	template class cs_shuffle_d32fx8_to_x8d24f<true>;
+	template class cs_shuffle_d32fx8_to_x8d24f<false>;
 
 	template <bool SwapBytes>
 	cs_shuffle_x8d24f_to_d32fx8<SwapBytes>::cs_shuffle_x8d24f_to_d32fx8()
@@ -313,8 +313,8 @@ namespace gl
 		cs_shuffle_base::run(cmd, data, num_texels * 4, data_offset);
 	}
 
-	template cs_shuffle_x8d24f_to_d32fx8<true>;
-	template cs_shuffle_x8d24f_to_d32fx8<false>;
+	template class cs_shuffle_x8d24f_to_d32fx8<true>;
+	template class cs_shuffle_x8d24f_to_d32fx8<false>;
 
 	cs_d24x8_to_ssbo::cs_d24x8_to_ssbo()
 	{

--- a/rpcs3/Emu/RSX/GL/GLCompute.h
+++ b/rpcs3/Emu/RSX/GL/GLCompute.h
@@ -78,6 +78,7 @@ namespace gl
 		}
 	};
 
+	template <bool SwapBytes>
 	struct cs_shuffle_d32fx8_to_x8d24f : cs_shuffle_base
 	{
 		u32 m_ssbo_length = 0;
@@ -89,6 +90,7 @@ namespace gl
 		void run(gl::command_context& cmd, const gl::buffer* data, u32 src_offset, u32 dst_offset, u32 num_texels);
 	};
 
+	template <bool SwapBytes>
 	struct cs_shuffle_x8d24f_to_d32fx8 : cs_shuffle_base
 	{
 		u32 m_ssbo_length = 0;

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -165,21 +165,21 @@ void GLGSRender::update_draw_state()
 
 		if (gl_state.enable(rsx::method_registers.stencil_test_enabled(), GL_STENCIL_TEST))
 		{
-			glStencilFunc(gl::comparison_op(rsx::method_registers.stencil_func()),
+			gl_state.stencil_func(gl::comparison_op(rsx::method_registers.stencil_func()),
 				rsx::method_registers.stencil_func_ref(),
 				rsx::method_registers.stencil_func_mask());
 
-			glStencilOp(gl::stencil_op(rsx::method_registers.stencil_op_fail()), gl::stencil_op(rsx::method_registers.stencil_op_zfail()),
+			gl_state.stencil_op(gl::stencil_op(rsx::method_registers.stencil_op_fail()), gl::stencil_op(rsx::method_registers.stencil_op_zfail()),
 				gl::stencil_op(rsx::method_registers.stencil_op_zpass()));
 
 			if (rsx::method_registers.two_sided_stencil_test_enabled())
 			{
-				glStencilMaskSeparate(GL_BACK, rsx::method_registers.back_stencil_mask());
+				gl_state.stencil_back_mask(rsx::method_registers.back_stencil_mask());
 
-				glStencilFuncSeparate(GL_BACK, gl::comparison_op(rsx::method_registers.back_stencil_func()),
+				gl_state.stencil_back_func(gl::comparison_op(rsx::method_registers.back_stencil_func()),
 					rsx::method_registers.back_stencil_func_ref(), rsx::method_registers.back_stencil_func_mask());
 
-				glStencilOpSeparate(GL_BACK, gl::stencil_op(rsx::method_registers.back_stencil_op_fail()),
+				gl_state.stencil_back_op(gl::stencil_op(rsx::method_registers.back_stencil_op_fail()),
 					gl::stencil_op(rsx::method_registers.back_stencil_op_zfail()), gl::stencil_op(rsx::method_registers.back_stencil_op_zpass()));
 			}
 		}

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -35,6 +35,10 @@ namespace gl
 		GLenum primitives = GL_TRIANGLE_STRIP;
 		GLenum input_filter = GL_NEAREST;
 
+		u32 m_write_aspect_mask = gl::image_aspect::color | gl::image_aspect::depth;
+		bool enable_depth_writes = false;
+		bool enable_stencil_writes = false;
+
 		void create();
 		void destroy();
 
@@ -52,7 +56,7 @@ namespace gl
 
 		virtual void emit_geometry();
 
-		void run(gl::command_context& cmd, const areau& region, GLuint target_texture, GLuint image_aspect_bits, bool use_blending = false);
+		void run(gl::command_context& cmd, const areau& region, GLuint target_texture, GLuint image_aspect_bits, bool enable_blending = false);
 	};
 
 	struct ui_overlay_renderer : public overlay_pass

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/CopyBufferToGenericImage.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/CopyBufferToGenericImage.glsl
@@ -14,8 +14,8 @@ R"(
 #define FMT_GL_BGR5_A1                0x99F0
 #define FMT_GL_RGBA4                  0x8056
 
-#define bswap_u16(bits) (bits & 0xFF) << 8 | (bits & 0xFF00) >> 8 | (bits & 0xFF0000) << 8 | (bits & 0xFF000000) >> 8
-#define bswap_u32(bits) (bits & 0xFF) << 24 | (bits & 0xFF00) << 8 | (bits & 0xFF0000) >> 8 | (bits & 0xFF000000) >> 24
+#define bswap_u16(bits) (bits & 0xFFu) << 8u | (bits & 0xFF00u) >> 8u | (bits & 0xFF0000u) << 8u | (bits & 0xFF000000u) >> 8u
+#define bswap_u32(bits) (bits & 0xFFu) << 24u | (bits & 0xFF00u) << 8u | (bits & 0xFF0000u) >> 8u | (bits & 0xFF000000u) >> 24u
 
 layout(location=0) out vec4 outColor;
 
@@ -73,18 +73,10 @@ uint readUint32(const in uint address)
 
 uvec2 readUint24_8(const in uint address)
 {
-	const uint raw_value = data[address];
-	const uint stencil = bitfieldExtract(raw_value, 0, 8);
-
-	if (swap_bytes != 0)
-	{
-		const uint depth = min(bswap_u32(raw_value), 0xffffff);
-		return uvec2(depth, stencil);
-	}
-
+	const uint raw_value = readUint32(address);
 	return uvec2(
 		bitfieldExtract(raw_value, 8, 24),
-		stencil
+		bitfieldExtract(raw_value, 0, 8)
 	);
 }
 


### PR DESCRIPTION
- Fix multiple broken image conversion routines for OpenGL
- Optimize/cleanup some suboptimal code in the GL state tracker
- Fix a bug that stopped hardware byteswap from working when deswizzling is unsupported. Affects texture upload performance.
- Fix a regression in overlays/compute caused by incorrect save-object initialization.

Fixes https://github.com/RPCS3/rpcs3/issues/12675