### PR TITLE
gui: Rename "Full Width AVX-512" setting

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -186,7 +186,7 @@
                <item>
                 <widget class="QCheckBox" name="fullWidthAVX512">
                  <property name="text">
-                  <string>Full Width AVX-512</string>
+                  <string>Increase AVX-512 instruction width</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
Some people think that this is a toggle to enable and disable AVX-512 support, let's make it more clear

Renamed to **Increase AVX-512 instruction width**