### PR TITLE
rsx: Minor fixes

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -715,6 +715,7 @@ namespace gl
 					mem_layout.swap_bytes = op.require_swap;
 					mem_layout.format = gl_format;
 					mem_layout.type = gl_type;
+					mem_layout.size = block_size_in_bytes;
 
 					// 2. Upload memory to GPU
 					if (!op.require_deswizzle)

--- a/rpcs3/Emu/RSX/VK/VKCompute.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCompute.cpp
@@ -3,7 +3,7 @@
 #include "VKRenderPass.h"
 #include "vkutils/buffer_object.h"
 
-#define VK_MAX_COMPUTE_TASKS 4096   // Max number of jobs per frame
+#define VK_MAX_COMPUTE_TASKS 8192   // Max number of jobs per frame
 
 namespace vk
 {


### PR DESCRIPTION
- Properly configure memory layout size field. Fixes a rare crash when using OpenGL.
- Bump compute descriptor pool allocation count. Fixes a crash in Dirt 2. A followup ticket to handle the count dynamically has been opened.

Fixes https://github.com/RPCS3/rpcs3/issues/12699
Fixes https://github.com/RPCS3/rpcs3/issues/12189