### PR TITLE
rsx: Maintenance fixes [2]

### DIFF
--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -109,10 +109,12 @@ namespace rsx
 			_capacity = size;
 		}
 
-		void resize(u32 size)
+		template <typename T> requires UnsignedInt<T>
+		void resize(T size)
 		{
-			reserve(size);
-			_size = size;
+			const auto new_size = static_cast<u32>(size);
+			reserve(new_size);
+			_size = new_size;
 		}
 
 		void push_back(const Ty& val)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1605,6 +1605,12 @@ namespace rsx
 
 	void thread::on_framebuffer_options_changed(u32 opt)
 	{
+		if (m_rtts_dirty)
+		{
+			// Nothing to do
+			return;
+		}
+
 		auto evaluate_depth_buffer_state = [&]()
 		{
 			m_framebuffer_layout.zeta_write_enabled =
@@ -1677,12 +1683,6 @@ namespace rsx
 
 			return false;
 		};
-
-		if (m_rtts_dirty)
-		{
-			// Nothing to do
-			return;
-		}
 
 		switch (opt)
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -467,6 +467,19 @@ namespace rsx
 
 	struct sampled_image_descriptor_base;
 
+	struct desync_fifo_cmd_info
+	{
+		u32 cmd;
+		u64 timestamp;
+	};
+
+	struct frame_time_t
+	{
+		u64 preempt_count;
+		u64 timestamp;
+		u64 tsc;
+	};
+
 	class thread : public cpu_thread
 	{
 		u64 timestamp_ctrl = 0;
@@ -681,24 +694,10 @@ namespace rsx
 		atomic_t<bool> sync_point_request = false;
 		bool in_begin_end = false;
 
-		struct desync_fifo_cmd_info
-		{
-			u32 cmd;
-			u64 timestamp;
-		};
-
 		std::queue<desync_fifo_cmd_info> recovered_fifo_cmds_history;
-
-		struct frame_time_t
-		{
-			u64 preempt_count;
-			u64 timestamp;
-			u64 tsc;
-		};
-
 		std::deque<frame_time_t> frame_times;
 		u32 prevent_preempt_increase_tickets = 0;
-		u32 preempt_fail_old_preempt_count = 0;
+		u64 preempt_fail_old_preempt_count = 0;
 
 		atomic_t<s32> async_tasks_pending{ 0 };
 

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -153,9 +153,9 @@ namespace vk
 
 			for (u32 i = 0, layout_offset = 0; i < 5; ++i, layout_offset += 3)
 			{
-				if (const auto layout = VkImageLayout((layout_blob >> layout_offset) & 0x7))
+				if (const auto layout_encoding = (layout_blob >> layout_offset) & 0x7)
 				{
-					result.push_back(layout);
+					result.push_back(decode_layout(layout_encoding));
 				}
 				else
 				{

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -103,6 +103,12 @@ namespace vk
 				return {};
 			}
 
+			// If we have driver support for FBO loops, set the usage flag for it.
+			if (vk::get_current_renderer()->get_framebuffer_loops_support())
+			{
+				return { VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT, 0 };
+			}
+
 			// Workarounds to force transition to GENERAL to decompress.
 			// Fixes corruption in FBO loops for ANV and RADV.
 			switch (vk::get_driver_vendor())
@@ -117,8 +123,7 @@ namespace vk
 				break;
 			case driver_vendor::AMD:
 			case driver_vendor::RADV:
-				if ((vk::get_chip_family() >= chip_class::AMD_navi1x) &&
-					!vk::get_current_renderer()->get_framebuffer_loops_support())
+				if (vk::get_chip_family() >= chip_class::AMD_navi1x)
 				{
 					// Only needed for GFX10+
 					return { 0, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT };

--- a/rpcs3/Emu/RSX/VK/VulkanAPI.h
+++ b/rpcs3/Emu/RSX/VK/VulkanAPI.h
@@ -27,6 +27,7 @@
 #define VK_EXT_attachment_feedback_loop_layout 1
 #define VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME "VK_EXT_attachment_feedback_loop_layout"
 #define VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT static_cast<VkImageLayout>(1000339000)
+#define VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT 0x00080000
 #define VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT static_cast<VkStructureType>(1000339000)
 
 typedef struct VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT {

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -451,6 +451,11 @@ namespace vk
 			requested_extensions.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
 		}
 
+		if (pgpu->framebuffer_loops_support)
+		{
+			requested_extensions.push_back(VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME);
+		}
+
 		enabled_features.robustBufferAccess = VK_TRUE;
 		enabled_features.fullDrawIndexUint32 = VK_TRUE;
 		enabled_features.independentBlend = VK_TRUE;
@@ -614,6 +619,15 @@ namespace vk
 			indexing_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT;
 			indexing_features.pNext = const_cast<void*>(device.pNext);
 			device.pNext = &indexing_features;
+		}
+
+		VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT fbo_loop_features{};
+		if (pgpu->framebuffer_loops_support)
+		{
+			fbo_loop_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT;
+			fbo_loop_features.attachmentFeedbackLoopLayout = VK_TRUE;
+			fbo_loop_features.pNext = const_cast<void*>(device.pNext);
+			device.pNext = &fbo_loop_features;
 		}
 
 		CHECK_RESULT_EX(vkCreateDevice(*pgpu, &device, nullptr, &dev), message_on_error);

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -3382,6 +3382,7 @@ namespace rsx
 		bind(NV4097_SET_SURFACE_COLOR_BOFFSET, nv4097::set_surface_dirty_bit);
 		bind(NV4097_SET_SURFACE_COLOR_COFFSET, nv4097::set_surface_dirty_bit);
 		bind(NV4097_SET_SURFACE_COLOR_DOFFSET, nv4097::set_surface_dirty_bit);
+		bind(NV4097_SET_SURFACE_COLOR_TARGET, nv4097::set_surface_dirty_bit);
 		bind(NV4097_SET_SURFACE_ZETA_OFFSET, nv4097::set_surface_dirty_bit);
 		bind(NV4097_SET_CONTEXT_DMA_COLOR_A, nv4097::set_surface_dirty_bit);
 		bind(NV4097_SET_CONTEXT_DMA_COLOR_B, nv4097::set_surface_dirty_bit);

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -507,7 +507,7 @@ namespace rsx
 
 				if (fifo_span.size() < rcount)
 				{
-					rcount = fifo_span.size();
+					rcount = ::size32(fifo_span);
 				}
 
 				if (rsx->m_graphics_state & rsx::pipeline_state::transform_constants_dirty)
@@ -560,7 +560,7 @@ namespace rsx
 
 				if (fifo_span.size() < rcount)
 				{
-					rcount = fifo_span.size();
+					rcount = ::size32(fifo_span);
 				}
 
 				copy_data_swap_u32(&rsx::method_registers.transform_program[load_pos * 4 + index % 4], fifo_span.data(), rcount);
@@ -1030,7 +1030,7 @@ namespace rsx
 
 				if (fifo_span.size() < count)
 				{
-					count = fifo_span.size();
+					count = ::size32(fifo_span);
 				}
 
 				// Skip "handled methods"


### PR DESCRIPTION
- Fix framebuffer configuration notification on surface target change. Fixes broken graphics in FUSE.
- Silence a ton of compiler warnings coming from RSX code.
- Update vulkan framebuffer loop handling to match the current version of the VK_EXT_attachment_feedback_loop_layout specification. Fixes some VK_ERROR_DEVICE_LOST errors on linux + mesa-git.

Fixes https://github.com/RPCS3/rpcs3/issues/10766