### PR TITLE
USIO Backup Minor Optimization

### DIFF
--- a/rpcs3/Emu/Io/usio.h
+++ b/rpcs3/Emu/Io/usio.h
@@ -14,13 +14,14 @@ public:
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 
 private:
-	void load_backup(const std::string& path);
+	void load_backup();
 	void save_backup();
 	void translate_input();
 	void usio_write(u8 channel, u16 reg, const std::vector<u8>& data);
 	void usio_read(u8 channel, u16 reg, u16 size);
 
 private:
+	std::string usio_backup_path;
 	fs::file usio_backup_file;
 	std::queue<std::vector<u8>> q_replies;
 };


### PR DESCRIPTION
Do not create a new USIO Backup file (when one doesn't exist) if USIO is not actually used by the game.