### PR TITLE
SPU: fix atomicity of inaccurate GETLLAR

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -3451,7 +3451,7 @@ bool spu_thread::process_mfc_cmd()
 					// Need to check twice for it to be accurate, the code is before and not after this check for:
 					// 1. Reduce time between reservation accesses so TSX panelty would be lowered
 					// 2. Increase the chance of change detection: if GETLLAR has been called again new data is probably wanted
-					if (!g_cfg.core.spu_accurate_getllar || (rtime == vm::reservation_acquire(addr) && cmp_rdata(rdata, data)))
+					if (rtime == vm::reservation_acquire(addr) && (!g_cfg.core.spu_accurate_getllar || cmp_rdata(rdata, data)))
 					{
 						if ([&]() -> bool
 						{


### PR DESCRIPTION
The idea was that if we have pulled an atomic state of memory in the past we can declare new data as atomic as well if it matches its bytes without further checks. But this doesn't work if there was a GET or PUT command in between 2 GETLLARs with different data. This hopefully fixes some games needing "Accurate SPU GETLLAR" set to true that hadn't needed the setting before.