### PR TITLE
rsx: Fix underflow in ZCULL sync

### DIFF
--- a/rpcs3/Emu/RSX/RSXZCULL.cpp
+++ b/rpcs3/Emu/RSX/RSXZCULL.cpp
@@ -490,7 +490,8 @@ namespace rsx
 
 			// Delete all statistics caches but leave the current one
 			const u32 current_index = m_statistics_tag_id;
-			for (u32 index = current_index - 1; index != current_index;)
+			const u32 previous_index = (current_index + max_stat_registers - 1) % max_stat_registers;
+			for (u32 index = previous_index; index != current_index;)
 			{
 				if (m_statistics_map[index].flags == 0)
 				{


### PR DESCRIPTION
Silly computational error when I switched from signed arithmetic to unsigned. Generates an invalid index when the stars align and you get a start index of 0 during a hard sync (0.012% chance).

Fixes https://github.com/RPCS3/rpcs3/issues/12729