### PR TITLE
Qt: pad settings: clear input data on thread pause

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -37,7 +37,6 @@ target_include_directories(rpcs3_emu
     PUBLIC
         ${RPCS3_SRC_DIR})
 
-
 # Utilities
 target_sources(rpcs3_emu PRIVATE
     ../util/atomic.cpp
@@ -116,7 +115,6 @@ target_sources(rpcs3_emu PRIVATE
     ../Loader/TROPUSR.cpp
     ../Loader/TRP.cpp
 )
-
 
 # Audio
 target_sources(rpcs3_emu PRIVATE
@@ -416,7 +414,6 @@ target_sources(rpcs3_emu PRIVATE
     Memory/vm.cpp
 )
 
-
 # RSX
 target_sources(rpcs3_emu PRIVATE
     RSX/gcm_enums.cpp
@@ -551,7 +548,7 @@ target_link_libraries(rpcs3_emu
 if(APPLE)
     check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
     if (${HAVE_CLOCK_GETTIME})
-	    target_compile_definitions(rpcs3_emu PUBLIC -DHAVE_CLOCK_GETTIME)
+        target_compile_definitions(rpcs3_emu PUBLIC -DHAVE_CLOCK_GETTIME)
     endif()
 endif()
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -512,6 +512,8 @@ void pad_settings_dialog::InitButtons()
 			{
 				if (m_input_thread_state == input_thread_state::pausing)
 				{
+					std::lock_guard lock(m_input_mutex);
+					m_input_callback_data = {};
 					m_input_thread_state = input_thread_state::paused;
 				}
 


### PR DESCRIPTION
Fixes incorrectly disabled buttons when changing from a handler with a disconnected pad to any other handler