### PR TITLE
rsx: Do not clobber CELL memory when a surface is partially inherited

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4326,7 +4326,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 					atomic_wait_engine::set_one_time_use_wait_callback(mask1 != SPU_EVENT_LR ? nullptr : +[](u64 attempts) -> bool
 					{
 						const auto _this = static_cast<spu_thread*>(cpu_thread::get_current());
-						AUDIT(_this->id_type() == 1);
+						AUDIT(_this->id_type() == 2);
 
 						const auto old = +_this->state;
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1544,7 +1544,7 @@ namespace vm
 
 	static void load_memory_bytes(utils::serial& ar, u8* ptr, usz size)
 	{
-		AUDIT(ar.is_writing() && !(size % 128));
+		AUDIT(!ar.is_writing() && !(size % 128));
 
 		for (; size; ptr += 128 * 8, size -= 128 * 8)
 		{

--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <util/types.hpp>
+#include <functional>
 
 namespace rsx
 {

--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -282,5 +282,35 @@ namespace rsx
 		{
 			return _data ? _data + _size : nullptr;
 		}
+
+		bool any(std::predicate<const Ty&> auto predicate) const
+		{
+			for (auto it = begin(); it != end(); ++it)
+			{
+				if (std::invoke(predicate, *it))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		void filter(std::predicate<const Ty&> auto predicate)
+		{
+			if (!_size)
+			{
+				return;
+			}
+
+			for (auto ptr = _data, last = _data + _size - 1; ptr < last; ptr++)
+			{
+				if (!predicate(*ptr))
+				{
+					// Move item to the end of the list and shrink by 1
+					std::memcpy(ptr, last, sizeof(Ty));
+					last = _data + (--_size);
+				}
+			}
+		}
 	};
 }

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -68,7 +68,7 @@ namespace rsx
 		std::pair<u32, surface_type> m_bound_depth_stencil = {};
 
 		// List of sections derived from a section that has been split and invalidated
-		std::vector<surface_type> orphaned_surfaces;
+		std::vector<std::pair<u32, surface_type>> orphaned_surfaces;
 
 		// List of sections that have been wholly inherited and invalidated
 		std::vector<surface_type> superseded_surfaces;
@@ -156,7 +156,7 @@ namespace rsx
 				}
 
 				ensure(region.target == Traits::get(sink));
-				orphaned_surfaces.push_back(region.target);
+				orphaned_surfaces.push_back({ address, region.target });
 				data.emplace(region.target->get_memory_range(), std::move(sink));
 			};
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -3237,6 +3237,22 @@ namespace rsx
 			return m_predictor;
 		}
 
+		bool is_protected(u32 section_base_address)
+		{
+			reader_lock lock(m_cache_mutex);
+
+			const auto& block = m_storage.block_for(section_base_address);
+			for (const auto& tex : block)
+			{
+				if (tex.get_section_base() == section_base_address)
+				{
+					return tex.is_locked();
+				}
+			}
+
+			return false;
+		}
+
 
 		/**
 		 * The read only texture invalidate flag is set if a read only texture is trampled by framebuffer memory

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -3237,7 +3237,7 @@ namespace rsx
 			return m_predictor;
 		}
 
-		bool is_protected(u32 section_base_address)
+		bool is_protected(u32 section_base_address, const address_range& test_range, rsx::texture_upload_context context)
 		{
 			reader_lock lock(m_cache_mutex);
 
@@ -3246,7 +3246,9 @@ namespace rsx
 			{
 				if (tex.get_section_base() == section_base_address)
 				{
-					return tex.is_locked();
+					return tex.get_context() == context &&
+						tex.is_locked() &&
+						test_range.inside(tex.get_section_range());
 				}
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -310,6 +310,47 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool /*
 		m_rtts.superseded_surfaces.clear();
 	}
 
+	if (!m_rtts.orphaned_surfaces.empty())
+	{
+		gl::texture::format format;
+		gl::texture::type type;
+		bool swap_bytes;
+
+		for (auto& [base_addr, surface] : m_rtts.orphaned_surfaces)
+		{
+			const bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
+				!!g_cfg.video.write_color_buffers;
+
+			if (!lock) [[likely]]
+			{
+				m_gl_texture_cache.commit_framebuffer_memory_region(cmd, surface->get_memory_range());
+				continue;
+			}
+
+			if (surface->is_depth_surface())
+			{
+				const auto depth_format_gl = rsx::internals::surface_depth_format_to_gl(surface->get_surface_depth_format());
+				format = depth_format_gl.format;
+				type = depth_format_gl.type;
+				swap_bytes = (type != gl::texture::type::uint_24_8);
+			}
+			else
+			{
+				const auto color_format_gl = rsx::internals::surface_color_format_to_gl(surface->get_surface_color_format());
+				format = color_format_gl.format;
+				type = color_format_gl.type;
+				swap_bytes = color_format_gl.swap_bytes;
+			}
+
+			m_gl_texture_cache.lock_memory_region(
+				cmd, surface, surface->get_memory_range(), false,
+				surface->get_surface_width<rsx::surface_metrics::pixels>(), surface->get_surface_height<rsx::surface_metrics::pixels>(), surface->get_rsx_pitch(),
+				format, type, swap_bytes);
+		}
+
+		m_rtts.orphaned_surfaces.clear();
+	}
+
 	const auto color_format = rsx::internals::surface_color_format_to_gl(m_framebuffer_layout.color_format);
 	for (u8 i = 0; i < rsx::limits::color_buffers_count; ++i)
 	{
@@ -345,47 +386,6 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool /*
 		{
 			m_gl_texture_cache.commit_framebuffer_memory_region(cmd, surface_range);
 		}
-	}
-
-	if (!m_rtts.orphaned_surfaces.empty())
-	{
-		gl::texture::format format;
-		gl::texture::type type;
-		bool swap_bytes;
-
-		for (auto& surface : m_rtts.orphaned_surfaces)
-		{
-			const bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
-				!!g_cfg.video.write_color_buffers;
-
-			if (!lock) [[likely]]
-			{
-				m_gl_texture_cache.commit_framebuffer_memory_region(cmd, surface->get_memory_range());
-				continue;
-			}
-
-			if (surface->is_depth_surface())
-			{
-				const auto depth_format_gl = rsx::internals::surface_depth_format_to_gl(surface->get_surface_depth_format());
-				format = depth_format_gl.format;
-				type = depth_format_gl.type;
-				swap_bytes = (type != gl::texture::type::uint_24_8);
-			}
-			else
-			{
-				const auto color_format_gl = rsx::internals::surface_color_format_to_gl(surface->get_surface_color_format());
-				format = color_format_gl.format;
-				type = color_format_gl.type;
-				swap_bytes = color_format_gl.swap_bytes;
-			}
-
-			m_gl_texture_cache.lock_memory_region(
-				cmd, surface, surface->get_memory_range(), false,
-				surface->get_surface_width<rsx::surface_metrics::pixels>(), surface->get_surface_height<rsx::surface_metrics::pixels>(), surface->get_rsx_pitch(),
-				format, type, swap_bytes);
-		}
-
-		m_rtts.orphaned_surfaces.clear();
 	}
 
 	if (m_gl_texture_cache.get_ro_tex_invalidate_intr())

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -318,8 +318,13 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool /*
 
 		for (auto& [base_addr, surface] : m_rtts.orphaned_surfaces)
 		{
-			const bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
+			bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
 				!!g_cfg.video.write_color_buffers;
+
+			if (lock && !m_gl_texture_cache.is_protected(base_addr))
+			{
+				lock = false;
+			}
 
 			if (!lock) [[likely]]
 			{

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -321,7 +321,11 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool /*
 			bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
 				!!g_cfg.video.write_color_buffers;
 
-			if (lock && !m_gl_texture_cache.is_protected(base_addr))
+			if (lock &&
+				!m_gl_texture_cache.is_protected(
+					base_addr,
+					surface->get_memory_range(),
+					rsx::texture_upload_context::framebuffer_storage))
 			{
 				lock = false;
 			}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2423,8 +2423,13 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 
 		for (auto& [base_addr, surface] : m_rtts.orphaned_surfaces)
 		{
-			const bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
+			bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
 				!!g_cfg.video.write_color_buffers;
+
+			if (lock && !m_texture_cache.is_protected(base_addr))
+			{
+				lock = false;
+			}
 
 			if (!lock) [[likely]]
 			{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2426,7 +2426,11 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 			bool lock = surface->is_depth_surface() ? !!g_cfg.video.write_depth_buffer :
 				!!g_cfg.video.write_color_buffers;
 
-			if (lock && !m_texture_cache.is_protected(base_addr))
+			if (lock &&
+				!m_texture_cache.is_protected(
+					base_addr,
+					surface->get_memory_range(),
+					rsx::texture_upload_context::framebuffer_storage))
 			{
 				lock = false;
 			}


### PR DESCRIPTION
This one is a bit annoying, but sometimes, games will reuse the same 2D surface address for a smaller region and we have to split the memory into separate chunks. However, sometimes the program is planning to reuse the leftover memory for something else, such as regular system memory. To prevent data loss, we lock these leftover chunks together with the new parent to recreate an atlas of the original image area, but this can cause race conditions where CELL is already reusing the memory and we lock it up and flush back old data due to our faulty tamper detection on surface memory. This can break game memory and cause strange behavior and instability.
In this scenario, let's just be paranoid with the relock and avoid it unless the original area is still protected. If the data is already flushed anyway, we just reupload the data from system memory at a small cost every once in a while.

Fixes https://github.com/RPCS3/rpcs3/issues/12665