### PR TITLE
More accurate PS3 memory consumption

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sysPrxForUser.h
+++ b/rpcs3/Emu/Cell/Modules/sysPrxForUser.h
@@ -62,6 +62,9 @@ error_code sys_lwcond_wait(ppu_thread& CPU, vm::ptr<sys_lwcond_t> lwcond, u64 ti
 error_code sys_ppu_thread_create(ppu_thread& ppu, vm::ptr<u64> thread_id, u32 entry, u64 arg, s32 prio, u32 stacksize, u64 flags, vm::cptr<char> threadname);
 error_code sys_interrupt_thread_disestablish(ppu_thread& ppu, u32 ih);
 
+u32 _sys_malloc(ppu_thread& ppu, u32 size);
+error_code _sys_free(ppu_thread& ppu, u32 addr);
+
 void sys_ppu_thread_exit(ppu_thread& CPU, u64 val);
 void sys_game_process_exitspawn(ppu_thread& ppu, vm::cptr<char> path, vm::cpptr<char> argv, vm::cpptr<char> envp, u32 data, u32 data_size, s32 prio, u64 flags);
 void sys_game_process_exitspawn2(ppu_thread& ppu, vm::cptr<char> path, vm::cpptr<char> argv, vm::cpptr<char> envp, u32 data, u32 data_size, s32 prio, u64 flags);

--- a/rpcs3/Emu/Cell/Modules/sys_libc_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_libc_.cpp
@@ -367,8 +367,10 @@ vm::cptr<char> _sys_strrchr(vm::cptr<char> str, char ch)
 	return res;
 }
 
-u32 _sys_malloc(u32 size)
+u32 _sys_malloc(ppu_thread& ppu, u32 size)
 {
+	ppu.state += cpu_flag::wait;
+
 	sysPrxForUser.warning("_sys_malloc(size=0x%x)", size);
 
 	return vm::alloc(size, vm::main);
@@ -381,8 +383,10 @@ u32 _sys_memalign(u32 align, u32 size)
 	return vm::alloc(size, vm::main, std::max<u32>(align, 0x10000));
 }
 
-error_code _sys_free(u32 addr)
+error_code _sys_free(ppu_thread& ppu, u32 addr)
 {
+	ppu.state += cpu_flag::wait;
+
 	sysPrxForUser.warning("_sys_free(addr=0x%x)", addr);
 
 	vm::dealloc(addr, vm::main);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -24,6 +24,7 @@
 #include "lv2/sys_prx.h"
 #include "lv2/sys_overlay.h"
 #include "lv2/sys_process.h"
+#include "lv2/sys_memory.h"
 #include "lv2/sys_spu.h"
 
 #ifdef LLVM_AVAILABLE
@@ -178,7 +179,7 @@ static void ppu_initialize2(class jit_compiler& jit, const ppu_module& module_pa
 extern bool ppu_load_exec(const ppu_exec_object&, bool virtual_load, const std::string&, utils::serial* = nullptr);
 extern std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object&, bool virtual_load, const std::string& path, s64 file_offset, utils::serial* = nullptr);
 extern void ppu_unload_prx(const lv2_prx&);
-extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, bool virtual_load, const std::string&, s64 file_offset, utils::serial* = nullptr);
+extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, bool virtual_load, const std::string&, s64 file_offset, bool is_hle = false, utils::serial* = nullptr);
 extern void ppu_execute_syscall(ppu_thread& ppu, u64 code);
 static void ppu_break(ppu_thread&, ppu_opcode_t, be_t<u32>*, ppu_intrp_func*);
 
@@ -3663,6 +3664,24 @@ extern void ppu_initialize()
 		{
 			// Postpone testing
 			compile_fw = false;
+		}
+
+		if (!Emu.DeserialManager())
+		{
+			// Moved here for backwards compatibility with savestates
+
+			u32 segs_size = 0;
+
+			for (auto& seg : _module.segs)
+			{
+				segs_size += utils::align<u32>(seg.size, 0x10000);
+			}
+
+			if (segs_size)
+			{
+				_module.mem_ct = g_fxo->try_get<lv2_memory_container>();
+				ensure(_module.mem_ct->take(segs_size));
+			}
 		}
 
 		module_list.emplace_back(&_module);

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -172,6 +172,8 @@ enum : u32
 	PRX_STATE_DESTROYED, // Last state, the module cannot be restarted
 };
 
+struct lv2_memory_container;
+
 struct lv2_prx final : lv2_obj, ppu_module
 {
 	static const u32 id_base = 0x23000000;
@@ -201,6 +203,9 @@ struct lv2_prx final : lv2_obj, ppu_module
 	void load_exports(); // (Re)load exports
 	void restore_exports(); // For savestates
 	void unload_exports();
+
+	lv2_memory_container* mem_ct{};
+	bool is_hle = false;
 
 	lv2_prx() noexcept = default;
 	lv2_prx(utils::serial&) {}

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -417,6 +417,11 @@ namespace np
 
 		np_memory.save(ar);
 
+		if (GET_SERIALIZATION_VERSION(sceNp) >= 2)
+		{
+			ar(np2_match2_thread_id);
+		}
+
 		// TODO: IDM-tied objects are not yet saved
 	}
 
@@ -466,6 +471,8 @@ namespace np
 		ar(is_NP_Lookup_init, is_NP_Score_init, is_NP2_init, is_NP2_Match2_init, is_NP_Auth_init, manager_cb, manager_cb_arg, std::as_bytes(std::span(&basic_handler, 1)), is_connected, is_psn_active, hostname, ether_address, local_ip_addr, public_ip_addr, dns_ip);
 
 		np_memory.save(ar);
+
+		ar(np2_match2_thread_id);
 	}
 
 	void memory_allocator::save(utils::serial& ar)

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -111,6 +111,8 @@ namespace np
 		vm::ptr<SceNpManagerCallback> manager_cb{}; // Connection status and tickets
 		vm::ptr<void> manager_cb_arg{};
 
+		u32 np2_match2_thread_id = 0;
+
 		// Basic event handler;
 		struct
 		{

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -77,8 +77,8 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 extern bool ppu_initialize(const ppu_module&, bool = false);
 extern void ppu_finalize(const ppu_module&);
 extern void ppu_unload_prx(const lv2_prx&);
-extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, bool virtual_load, const std::string&, s64 = 0, utils::serial* = nullptr);
 extern std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object&, bool virtual_load, const std::string& path, s64 = 0, utils::serial* = nullptr);
+extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, bool virtual_load, const std::string&, s64 = 0, bool = false, utils::serial* = nullptr);
 extern bool ppu_load_rel_exec(const ppu_rel_object&);
 extern bool is_savestate_version_compatible(const std::vector<std::pair<u16, u16>>& data, bool is_boot_check);
 extern std::vector<std::pair<u16, u16>> read_used_savestate_versions();

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -42,7 +42,7 @@ SERIALIZATION_VER(lv2_sync, 3,                                  1)
 SERIALIZATION_VER(lv2_vm, 4,                                    1)
 SERIALIZATION_VER(lv2_net, 5,                                   1)
 SERIALIZATION_VER(lv2_fs, 6,                                    1)
-SERIALIZATION_VER(lv2_prx_overlay, 7,                           1)
+SERIALIZATION_VER(lv2_prx_overlay, 7,                           1, 2/*Add HLE memory allocs*/)
 SERIALIZATION_VER(lv2_memory, 8,                                1)
 SERIALIZATION_VER(lv2_config, 9,                                1)
 
@@ -53,7 +53,7 @@ namespace rsx
 
 namespace np
 {
-	SERIALIZATION_VER(sceNp, 11,                                1)
+	SERIALIZATION_VER(sceNp, 11,                                1, 2/*PPU match2 ID*/)
 }
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Take the following into the total reported and observed PS3 memory amount:
* Executable memory.
* PRX memory. (even HLE'd modules)
* libio thread, sceNpMatching2Init2 thread and calling malloc with a more than half a megabyte allocation size.
* cellAudio initialization and port creation, add out-of-memory checks there as well. (SHAREDMEMORY error)

Makes Brink fail to execute some bugged and unused audio code that used to crash it on rpcs3 because now the memory allocations required for it fail and the whole section is skipped.
Fixes #11945 
Draft because needs proper hw tests.