### PR TITLE
Savestates: Improvements

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -1306,13 +1306,19 @@ u32 CPUDisAsm::DisAsmBranchTarget(s32 /*imm*/)
 	return 0;
 }
 
-extern bool try_lock_spu_threads_in_a_state_compatible_with_savestates()
+extern bool try_lock_spu_threads_in_a_state_compatible_with_savestates(bool revert_lock)
 {
 	const u64 start = get_system_time();
 
 	// Attempt to lock for half a second, if somehow takes longer abort it
 	do
 	{
+		if (revert_lock)
+		{
+			// Revert the operation of this function
+			break;
+		}
+
 		if (cpu_thread::suspend_all(nullptr, {}, []()
 		{
 			return idm::select<named_thread<spu_thread>>([](u32, spu_thread& spu)

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -294,7 +294,7 @@ inline RT ppu_execute(ppu_thread& ppu, Args... args)
 	return func(ppu, args...);
 }
 
-#define BIND_FUNC_WITH_BLR(func) BIND_FUNC(func, ppu.cia = static_cast<u32>(ppu.lr) & ~3)
+#define BIND_FUNC_WITH_BLR(func) BIND_FUNC(func, if (cpu_flag::again - ppu.state) ppu.cia = static_cast<u32>(ppu.lr) & ~3)
 
 #define REG_FNID(_module, nid, func) ppu_module_manager::register_static_function<&func>(#_module, ppu_select_name(#func, nid), BIND_FUNC_WITH_BLR(func), ppu_generate_id(nid))
 

--- a/rpcs3/Emu/RSX/Capture/rsx_replay.h
+++ b/rpcs3/Emu/RSX/Capture/rsx_replay.h
@@ -150,6 +150,7 @@ namespace rsx
 		{
 		}
 
+		using cpu_thread::operator=;
 		void cpu_task() override;
 	private:
 		be_t<u32> allocate_context();

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2222,7 +2222,7 @@ void Emulator::GracefulShutdown(bool allow_autoexit, bool async_op, bool savesta
 }
 
 extern bool try_lock_vdec_context_creation();
-extern bool try_lock_spu_threads_in_a_state_compatible_with_savestates();
+extern bool try_lock_spu_threads_in_a_state_compatible_with_savestates(bool revert_lock = false);
 
 std::shared_ptr<utils::serial> Emulator::Kill(bool allow_autoexit, bool savestate)
 {
@@ -2235,6 +2235,8 @@ std::shared_ptr<utils::serial> Emulator::Kill(bool allow_autoexit, bool savestat
 
 	if (savestate && !try_lock_vdec_context_creation())
 	{
+		try_lock_spu_threads_in_a_state_compatible_with_savestates(true);
+
 		sys_log.error("Failed to savestate: HLE VDEC (video decoder) context(s) exist."
 			"\nLLE libvdec.sprx by selecting it in Adavcned tab -> Firmware Libraries."
 			"\nYou need to close the game for to take effect."

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -279,6 +279,12 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 	case Qt::Key_R:
 		if (keyEvent->modifiers() == Qt::ControlModifier && !m_disable_kb_hotkeys)
 		{
+			if (Emu.IsStopped())
+			{
+				Emu.Restart();
+				return;
+			}
+
 			extern bool boot_last_savestate();
 			boot_last_savestate();
 		}


### PR DESCRIPTION
* Removed modification of CIA when saving inside HLE functions.
* Fix minor race of RSX abort when stopping emulation.
* Make Ctrl+R able to boot the last savestate when no game is running (in the same RPCS3 session) if no other game has booted since saving. Restore Ctrl+R when emulation is stopped to allow boot of the last game.
* Fix unintentional pause when saving with HLE VDEC contexts.