### PR TITLE
PPU Precompilation: fix really long wait to abort VSH/firmware compilation

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3741,6 +3741,11 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 				// Allocate "core"
 				std::lock_guard jlock(g_fxo->get<jit_core_allocator>().sem);
 
+				if (Emu.IsStopped())
+				{
+					continue;
+				}
+
 				ppu_log.warning("LLVM: Compiling module %s%s", cache_path, obj_name);
 
 				// Use another JIT instance

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -2346,7 +2346,6 @@ error_code raw_spu_destroy(ppu_thread& ppu, u32 id)
 		}
 
 		// Stop thread
-		thread.state += cpu_flag::exit;
 		thread = thread_state::aborting;
 		return true;
 	});


### PR DESCRIPTION
Improves massively the speed of emulation stopping because it skips the compilation of modules after the user has specified he wants to abort it, this only applies when there is more than one file to compile.