### PR TITLE
gl: Explicitly declare gl_Position as invariant when using mesa drivers

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -58,8 +58,6 @@ void GLVertexDecompilerThread::insertInputs(std::stringstream& OS, const std::ve
 
 void GLVertexDecompilerThread::insertConstants(std::stringstream& OS, const std::vector<ParamType>& constants)
 {
-
-
 	for (const ParamType &PT: constants)
 	{
 		for (const ParamItem &PI : PT.items)
@@ -131,6 +129,7 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	properties2.emulate_zclip_transform = true;
 	properties2.emulate_depth_clip_only = dev_caps.NV_depth_buffer_float_supported;
 	properties2.low_precision_tests = dev_caps.vendor_NVIDIA;
+	properties2.require_explicit_invariance = dev_caps.vendor_MESA;
 
 	insert_glsl_legacy_function(OS, properties2);
 	glsl::insert_vertex_input_fetch(OS, glsl::glsl_rules_opengl4, dev_caps.vendor_INTEL == false);

--- a/rpcs3/Emu/RSX/Program/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Program/GLSLTypes.h
@@ -31,6 +31,7 @@ namespace glsl
 		bool require_texture_expand : 1;
 		bool require_srgb_to_linear : 1;
 		bool require_linear_to_srgb : 1;
+		bool require_explicit_invariance: 1;
 		bool emulate_coverage_tests : 1;
 		bool emulate_shadow_compare : 1;
 		bool emulate_zclip_transform : 1;


### PR DESCRIPTION
Mostly relates to radeonsi. This fixes some awful Z-fighting when a game is running depth-prepass.
Fixes https://github.com/RPCS3/rpcs3/issues/12752