### PR TITLE
rsx: Maintenance fixes [3]

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -622,9 +622,17 @@ void GLGSRender::begin()
 	rsx::thread::begin();
 
 	if (skip_current_frame || cond_render_ctrl.disable_rendering())
+	{
 		return;
+	}
 
 	init_buffers(rsx::framebuffer_creation_context::context_draw);
+
+	if (m_graphics_state & rsx::pipeline_state::invalidate_pipeline_bits)
+	{
+		// Shaders need to be reloaded.
+		m_program = nullptr;
+	}
 }
 
 void GLGSRender::end()

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -558,7 +558,7 @@ namespace gl
 		gl::texture_view* generate_cubemap_from_images(gl::command_context& cmd, u32 gcm_format, u16 size, const std::vector<copy_region_descriptor>& sources, const rsx::texture_channel_remap_t& remap_vector) override
 		{
 			auto _template = get_template_from_collection_impl(sources);
-			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_3D, gcm_format, 0, 0, size, size, 1, 1, remap_vector, false);
+			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_CUBE_MAP, gcm_format, 0, 0, size, size, 1, 1, remap_vector, false);
 
 			copy_transfer_regions_impl(cmd, result->image(), sources);
 			return result;

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -148,11 +148,16 @@ namespace rsx
 
 		push_buffer_arrays_dirty = 0x20000,   // Push buffers have data written to them (immediate mode vertex buffers)
 
+		polygon_offset_state_dirty = 0x40000, // Polygon offset config was changed
+
 		fragment_program_dirty = fragment_program_ucode_dirty | fragment_program_state_dirty,
 		vertex_program_dirty = vertex_program_ucode_dirty | vertex_program_state_dirty,
 		invalidate_pipeline_bits = fragment_program_dirty | vertex_program_dirty,
 		invalidate_zclip_bits = vertex_state_dirty | zclip_config_state_dirty,
 		memory_barrier_bits = framebuffer_reads_dirty,
+
+		// Vulkan-specific signals
+		invalidate_vk_dynamic_state = zclip_config_state_dirty | scissor_config_state_dirty | polygon_offset_state_dirty,
 
 		all_dirty = ~0u
 	};

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -896,10 +896,21 @@ void VKGSRender::begin()
 
 	rsx::thread::begin();
 
-	if (skip_current_frame || swapchain_unavailable || cond_render_ctrl.disable_rendering())
+	if (skip_current_frame ||
+		swapchain_unavailable ||
+		cond_render_ctrl.disable_rendering())
+	{
 		return;
+	}
 
 	init_buffers(rsx::framebuffer_creation_context::context_draw);
+
+	if (m_graphics_state & rsx::pipeline_state::invalidate_pipeline_bits)
+	{
+		// Shaders need to be reloaded.
+		m_prev_program = m_program;
+		m_program = nullptr;
+	}
 }
 
 void VKGSRender::end()

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1731,7 +1731,6 @@ bool VKGSRender::load_program()
 
 	auto &vertex_program = current_vertex_program;
 	auto &fragment_program = current_fragment_program;
-	auto old_program = m_program;
 
 	vk::pipeline_props properties{};
 
@@ -1929,7 +1928,7 @@ bool VKGSRender::load_program()
 
 	if (!m_program && (shadermode == shader_mode::async_with_interpreter || shadermode == shader_mode::interpreter_only))
 	{
-		if (!m_shader_interpreter.is_interpreter(old_program))
+		if (!m_shader_interpreter.is_interpreter(m_prev_program))
 		{
 			m_interpreter_state = rsx::invalidate_pipeline_bits;
 		}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1169,6 +1169,7 @@ void VKGSRender::set_viewport()
 		m_viewport.maxDepth = 1.f;
 	}
 
+	m_current_command_buffer->flags |= vk::command_buffer::cb_reload_dynamic_state;
 	m_graphics_state &= ~(rsx::pipeline_state::zclip_config_state_dirty);
 }
 
@@ -1181,6 +1182,8 @@ void VKGSRender::set_scissor(bool clip_viewport)
 		m_scissor.extent.width = scissor.width();
 		m_scissor.offset.x = scissor.x1;
 		m_scissor.offset.y = scissor.y1;
+
+		m_current_command_buffer->flags |= vk::command_buffer::cb_reload_dynamic_state;
 	}
 }
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -63,6 +63,7 @@ private:
 	const VKFragmentProgram *m_fragment_prog = nullptr;
 	const VKVertexProgram *m_vertex_prog = nullptr;
 	vk::glsl::program *m_program = nullptr;
+	vk::glsl::program *m_prev_program = nullptr;
 	vk::pipeline_props m_pipeline_properties;
 
 	vk::texture_cache m_texture_cache;

--- a/rpcs3/Emu/RSX/VK/vkutils/commands.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/commands.h
@@ -81,12 +81,13 @@ namespace vk
 
 		enum command_buffer_data_flag : u32
 		{
-			cb_has_occlusion_task = 1,
-			cb_has_blit_transfer = 2,
-			cb_has_dma_transfer = 4,
-			cb_has_open_query = 8,
-			cb_load_occluson_task = 16,
-			cb_has_conditional_render = 32
+			cb_has_occlusion_task = 0x01,
+			cb_has_blit_transfer  = 0x02,
+			cb_has_dma_transfer   = 0x04,
+			cb_has_open_query     = 0x08,
+			cb_load_occluson_task = 0x10,
+			cb_has_conditional_render = 0x20,
+			cb_reload_dynamic_state   = 0x40
 		};
 		u32 flags = 0;
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -3473,6 +3473,9 @@ namespace rsx
 		bind(NV4097_SET_BLEND_FUNC_DFACTOR, nv4097::set_blend_factor);
 		bind(NV4097_SET_POLYGON_STIPPLE, nv4097::notify_state_changed<fragment_state_dirty>);
 		bind_array(NV4097_SET_POLYGON_STIPPLE_PATTERN, 1, 32, nv4097::notify_state_changed<polygon_stipple_pattern_dirty>);
+		bind(NV4097_SET_POLY_OFFSET_FILL_ENABLE, nv4097::notify_state_changed<polygon_offset_state_dirty>);
+		bind(NV4097_SET_POLYGON_OFFSET_SCALE_FACTOR, nv4097::notify_state_changed<polygon_offset_state_dirty>);
+		bind(NV4097_SET_POLYGON_OFFSET_BIAS, nv4097::notify_state_changed<polygon_offset_state_dirty>);
 
 		//NV308A (0xa400..0xbffc!)
 		bind_array(NV308A_COLOR, 1, 256 * 7, nv308a::color::impl);


### PR DESCRIPTION
- Fix program invalidation. Avoids referencing the wrong backend shader when the current pipeline is changed for a similar one.
- vk: Avoid unnecessary dynamic state updates every draw call. Improves performance and makes debug traces easier to follow.
- gl: Fix texture slice gather/reconstruction for cubemap and 3D. Fixes broken reflections in most games when using OpenGL.

Fixes https://github.com/RPCS3/rpcs3/issues/12580