### PR TITLE
SPU: Inline and batch MFC list transfers

### DIFF
--- a/rpcs3/Emu/Memory/vm_locking.h
+++ b/rpcs3/Emu/Memory/vm_locking.h
@@ -50,7 +50,7 @@ namespace vm
 		// Old-style conditional constexpr
 		const u32 size = Size ? Size : _size;
 
-		if (size <= 4096u && !((begin | size) & (size - 1)) ? !vm::check_addr(begin) : !vm::check_addr(begin, vm::page_readable, size))
+		if (Size == 1 || (begin % 4096 + size % 4096) / 4096 == 0 ? !vm::check_addr(begin) : !vm::check_addr(begin, vm::page_readable, size))
 		{
 			range_lock->release(0);
 			range_lock_internal(range_lock, begin, _size);

--- a/rpcs3/Emu/perf_meter.hpp
+++ b/rpcs3/Emu/perf_meter.hpp
@@ -93,6 +93,16 @@ public:
 		restart();
 	}
 
+	FORCE_INLINE SAFE_BUFFERS() perf_meter(int) noexcept
+	{
+		std::fill(std::begin(m_timestamps), std::end(m_timestamps), 0);
+	}
+
+	FORCE_INLINE SAFE_BUFFERS(operator bool) () const noexcept
+	{
+		return m_timestamps[0] != 0;
+	}
+
 	// Copy first timestamp
 	template <auto SN, auto... S>
 	FORCE_INLINE SAFE_BUFFERS() perf_meter(const perf_meter<SN, S...>& r) noexcept


### PR DESCRIPTION
Reduces overall CPU profiling load of this function from 9.6% to 6.8% and grants me about 2 fps in Sly 4. ~~This has a bit more effect when disabling Atomic RSX FIFO although it's partially active without it.~~