### PR TITLE
[HOTFIX] vk: Fixup for scissor/viewport invalidation rules

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -211,6 +211,7 @@ void VKGSRender::update_draw_state()
 	//TODO: Set up other render-state parameters into the program pipeline
 
 	m_current_command_buffer->flags &= ~vk::command_buffer::cb_reload_dynamic_state;
+	m_graphics_state &= ~rsx::pipeline_state::polygon_offset_state_dirty;
 	m_frame_stats.setup_time += m_profiler.duration();
 }
 
@@ -1044,7 +1045,6 @@ void VKGSRender::end()
 	if (m_graphics_state & rsx::pipeline_state::invalidate_vk_dynamic_state)
 	{
 		m_current_command_buffer->flags |= vk::command_buffer::cb_reload_dynamic_state;
-		m_graphics_state &= ~rsx::pipeline_state::invalidate_vk_dynamic_state;
 	}
 
 	rsx::method_registers.current_draw_clause.begin();


### PR DESCRIPTION
Do not release the invalidation flags just because the backend saw them. They need to get loaded as well which happens asynchronously. Deleting the flags makes the bind operation skip updates incorrectly.

Fixes https://github.com/RPCS3/rpcs3/issues/12766
Fixes https://github.com/RPCS3/rpcs3/issues/12765