### PR TITLE
Update sys_game_board_storage_read()

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -18,26 +18,12 @@ error_code _sys_game_board_storage_read(vm::ptr<u8> buffer, u8 code)
 
 	be_t<u64> psid[2] = { +g_cfg.sys.console_psid_high, +g_cfg.sys.console_psid_low };
 	u8* psid_bytes = reinterpret_cast<u8*>(psid);
-
-	switch (code)
+	u8 response[16] = { 0x01, 0xFC, 0x43, 0x50, 0xA7, 0x9B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+	for (int i = 0; i < 16; i++)
 	{
-	case 0xC0:
-	case 0xF0:
-	{
-		u8 response[16] = { 0x01, 0xFC, 0x43, 0x50, 0xA7, 0x9B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-		for (int i = 0; i < 16; i++)
-		{
-			response[i] ^= psid_bytes[i];
-		}
-		memcpy(buffer.get_ptr(), response, 16);
-		break;
+		response[i] ^= psid_bytes[i];
 	}
-	default:
-	{
-		sys_game.error("sys_game_board_storage_read(): Unknown code 0x%02x", code);
-		break;
-	}
-	}
+	memcpy(buffer.get_ptr(), response, 16);
 
 	return CELL_OK;
 }


### PR DESCRIPTION
So far, I have already discovered that there are 3 codes (0x40, 0xC0, and 0xF0), all of which expect exactly the same data.
As a result, I think it is appropriate to remove the switch-case conditions, as the algorithm seems to be generic for this syscall.