### PR TITLE
[3rdParty] Pine: Replace sprintf with snprintf to silence compiler warning

### DIFF
--- a/3rdparty/pine/pine_server.h
+++ b/3rdparty/pine/pine_server.h
@@ -267,7 +267,6 @@ namespace pine
 					char version[256] = {};
 					snprintf(version, sizeof(version), "RPCS3 %s", Impl::get_version_and_branch().c_str());
 					const u32 size = strlen(version) + 1;
-					version[size] = 0x00;
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 						goto error;
 					ToArray(ret_buffer, size, ret_cnt);
@@ -291,8 +290,7 @@ namespace pine
 					const auto title_string = Impl::get_title();
 					const auto size = title_string.size() + 1;
 					char* title = new char[size];
-					snprintf(title, sizeof(title), "%s", title_string.c_str());
-					title[size] = 0x00;
+					snprintf(title, size, "%s", title_string.c_str());
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 						goto error;
 					ToArray(ret_buffer, size, ret_cnt);
@@ -307,8 +305,7 @@ namespace pine
 					const auto title_id_string = Impl::get_title_ID();
 					const auto size = title_id_string.size() + 1;
 					char* title_id = new char[size];
-					snprintf(title_id, sizeof(title_id), "%s", title_id_string.c_str());
-					title_id[size] = 0x00;
+					snprintf(title_id, size, "%s", title_id_string.c_str());
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 						goto error;
 					ToArray(ret_buffer, size, ret_cnt);
@@ -323,8 +320,7 @@ namespace pine
 					const auto hash_string = Impl::get_executable_hash();
 					const auto size = hash_string.size() + 1;
 					char* hash = new char[size];
-					snprintf(hash, sizeof(hash), "%s", hash_string.c_str());
-					hash[size] = 0x00;
+					snprintf(hash, size, "%s", hash_string.c_str());
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 						goto error;
 					ToArray(ret_buffer, size, ret_cnt);
@@ -339,8 +335,7 @@ namespace pine
 					const auto game_version_string = Impl::get_app_version();
 					const auto size = game_version_string.size() + 1;
 					char* game_version = new char[size];
-					snprintf(game_version, sizeof(game_version), "%s", game_version_string.c_str());
-					game_version[size] = 0x00;
+					snprintf(game_version, size, "%s", game_version_string.c_str());
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size, buf_size))
 						goto error;
 					ToArray(ret_buffer, size, ret_cnt);

--- a/3rdparty/pine/pine_server.h
+++ b/3rdparty/pine/pine_server.h
@@ -265,7 +265,7 @@ namespace pine
 				case MsgVersion:
 				{
 					char version[256] = {};
-					sprintf(version, "RPCS3 %s", Impl::get_version_and_branch().c_str());
+					snprintf(version, sizeof(version), "RPCS3 %s", Impl::get_version_and_branch().c_str());
 					const u32 size = strlen(version) + 1;
 					version[size] = 0x00;
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
@@ -291,7 +291,7 @@ namespace pine
 					const auto title_string = Impl::get_title();
 					const auto size = title_string.size() + 1;
 					char* title = new char[size];
-					sprintf(title, "%s", title_string.c_str());
+					snprintf(title, sizeof(title), "%s", title_string.c_str());
 					title[size] = 0x00;
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 						goto error;
@@ -307,7 +307,7 @@ namespace pine
 					const auto title_id_string = Impl::get_title_ID();
 					const auto size = title_id_string.size() + 1;
 					char* title_id = new char[size];
-					sprintf(title_id, "%s", title_id_string.c_str());
+					snprintf(title_id, sizeof(title_id), "%s", title_id_string.c_str());
 					title_id[size] = 0x00;
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 						goto error;
@@ -323,7 +323,7 @@ namespace pine
 					const auto hash_string = Impl::get_executable_hash();
 					const auto size = hash_string.size() + 1;
 					char* hash = new char[size];
-					sprintf(hash, "%s", hash_string.c_str());
+					snprintf(hash, sizeof(hash), "%s", hash_string.c_str());
 					hash[size] = 0x00;
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size + 4, buf_size))
 						goto error;
@@ -339,7 +339,7 @@ namespace pine
 					const auto game_version_string = Impl::get_app_version();
 					const auto size = game_version_string.size() + 1;
 					char* game_version = new char[size];
-					sprintf(game_version, "%s", game_version_string.c_str());
+					snprintf(game_version, sizeof(game_version), "%s", game_version_string.c_str());
 					game_version[size] = 0x00;
 					if (!SafetyChecks(buf_cnt, 0, ret_cnt, size, buf_size))
 						goto error;


### PR DESCRIPTION
This fixes the following compiler deprecation warning

`warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.`