### PR TITLE
[HOTFIX] vk: Reload state if depth bounds changes

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -149,6 +149,7 @@ namespace rsx
 		push_buffer_arrays_dirty = 0x20000,   // Push buffers have data written to them (immediate mode vertex buffers)
 
 		polygon_offset_state_dirty = 0x40000, // Polygon offset config was changed
+		depth_bounds_state_dirty   = 0x80000, // Depth bounds configuration changed
 
 		fragment_program_dirty = fragment_program_ucode_dirty | fragment_program_state_dirty,
 		vertex_program_dirty = vertex_program_ucode_dirty | vertex_program_state_dirty,
@@ -157,7 +158,7 @@ namespace rsx
 		memory_barrier_bits = framebuffer_reads_dirty,
 
 		// Vulkan-specific signals
-		invalidate_vk_dynamic_state = zclip_config_state_dirty | scissor_config_state_dirty | polygon_offset_state_dirty,
+		invalidate_vk_dynamic_state = zclip_config_state_dirty | scissor_config_state_dirty | polygon_offset_state_dirty | depth_bounds_state_dirty,
 
 		all_dirty = ~0u
 	};

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -208,10 +208,8 @@ void VKGSRender::update_draw_state()
 
 	bind_viewport();
 
-	//TODO: Set up other render-state parameters into the program pipeline
-
 	m_current_command_buffer->flags &= ~vk::command_buffer::cb_reload_dynamic_state;
-	m_graphics_state &= ~rsx::pipeline_state::polygon_offset_state_dirty;
+	m_graphics_state &= ~(rsx::pipeline_state::polygon_offset_state_dirty | rsx::pipeline_state::depth_bounds_state_dirty);
 	m_frame_stats.setup_time += m_profiler.duration();
 }
 

--- a/rpcs3/Emu/RSX/VK/VKOverlays.cpp
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.cpp
@@ -325,6 +325,9 @@ namespace vk
 
 	void overlay_pass::run(vk::command_buffer& cmd, const areau& viewport, vk::framebuffer* fbo, const std::vector<vk::image_view*>& src, VkRenderPass render_pass)
 	{
+		// This call clobbers dynamic state
+		cmd.flags |= vk::command_buffer::cb_reload_dynamic_state;
+
 		load_program(cmd, render_pass, src);
 		set_up_viewport(cmd, viewport.x1, viewport.y1, viewport.width(), viewport.height());
 

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -3476,6 +3476,9 @@ namespace rsx
 		bind(NV4097_SET_POLY_OFFSET_FILL_ENABLE, nv4097::notify_state_changed<polygon_offset_state_dirty>);
 		bind(NV4097_SET_POLYGON_OFFSET_SCALE_FACTOR, nv4097::notify_state_changed<polygon_offset_state_dirty>);
 		bind(NV4097_SET_POLYGON_OFFSET_BIAS, nv4097::notify_state_changed<polygon_offset_state_dirty>);
+		bind(NV4097_SET_DEPTH_BOUNDS_TEST_ENABLE, nv4097::notify_state_changed<depth_bounds_state_dirty>);
+		bind(NV4097_SET_DEPTH_BOUNDS_MIN, nv4097::notify_state_changed<depth_bounds_state_dirty>);
+		bind(NV4097_SET_DEPTH_BOUNDS_MAX, nv4097::notify_state_changed<depth_bounds_state_dirty>);
 
 		//NV308A (0xa400..0xbffc!)
 		bind_array(NV308A_COLOR, 1, 256 * 7, nv308a::color::impl);


### PR DESCRIPTION
This feature is rarely used, but affects GOWA shadows on some GPUs.

Fixes https://github.com/RPCS3/rpcs3/issues/12778