### PR TITLE
Improved some sys_game syscalls

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3296,6 +3296,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 		std::unordered_map<std::string, u64> link_table
 		{
 			{ "sys_game_board_storage_read", reinterpret_cast<u64>(ppu_execute_syscall) },
+			{ "sys_game_get_system_sw_version", reinterpret_cast<u64>(ppu_execute_syscall) },
 			{ "__trap", reinterpret_cast<u64>(&ppu_trap) },
 			{ "__error", reinterpret_cast<u64>(&ppu_error) },
 			{ "__check", reinterpret_cast<u64>(&ppu_check) },

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -424,7 +424,7 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	NULL_FUNC(sys_game_watchdog_stop),                      //373 (0x175)
 	NULL_FUNC(sys_game_watchdog_clear),                     //374 (0x176)
 	NULL_FUNC(sys_game_set_system_sw_version),              //375 (0x177)  ROOT
-	NULL_FUNC(sys_game_get_system_sw_version),              //376 (0x178)  ROOT
+	BIND_SYSC(_sys_game_get_system_sw_version),              //376 (0x178)  ROOT
 	NULL_FUNC(sys_sm_set_shop_mode),                        //377 (0x179)  ROOT
 	BIND_SYSC(sys_sm_get_ext_event2),                       //378 (0x17A)  ROOT
 	BIND_SYSC(sys_sm_shutdown),                             //379 (0x17B)  ROOT

--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "util/sysinfo.hpp"
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/system_config.h"
@@ -33,4 +34,9 @@ error_code _sys_game_board_storage_read(vm::ptr<u8> buffer1, vm::ptr<u8> buffer2
 	*buffer2 = 0x00;
 
 	return CELL_OK;
+}
+
+u64 _sys_game_get_system_sw_version()
+{
+	return stof(utils::get_firmware_version()) * 10000;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -7,11 +7,11 @@
 
 LOG_CHANNEL(sys_game);
 
-error_code _sys_game_board_storage_read(vm::ptr<u8> buffer, u8 code)
+error_code _sys_game_board_storage_read(vm::ptr<u8> buffer1, vm::ptr<u8> buffer2)
 {
-	sys_game.trace("sys_game_board_storage_read(buffer=*0x%x, code=0x%02x)", buffer, code);
+	sys_game.trace("sys_game_board_storage_read(buffer1=*0x%x, buffer2=*0x%x)", buffer1, buffer2);
 
-	if (!buffer)
+	if (!buffer1)
 	{
 		return CELL_EFAULT;
 	}
@@ -23,7 +23,14 @@ error_code _sys_game_board_storage_read(vm::ptr<u8> buffer, u8 code)
 	{
 		response[i] ^= psid_bytes[i];
 	}
-	memcpy(buffer.get_ptr(), response, 16);
+	memcpy(buffer1.get_ptr(), response, 16);
+
+	if (!buffer2)
+	{
+		return CELL_EFAULT;
+	}
+
+	*buffer2 = 0x00;
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_game.h
+++ b/rpcs3/Emu/Cell/lv2/sys_game.h
@@ -1,3 +1,4 @@
 #pragma once
 
 error_code _sys_game_board_storage_read(vm::ptr<u8> buffer1, vm::ptr<u8> buffer2);
+u64 _sys_game_get_system_sw_version();

--- a/rpcs3/Emu/Cell/lv2/sys_game.h
+++ b/rpcs3/Emu/Cell/lv2/sys_game.h
@@ -1,3 +1,3 @@
 #pragma once
 
-error_code _sys_game_board_storage_read(vm::ptr<u8> data, u8 type);
+error_code _sys_game_board_storage_read(vm::ptr<u8> buffer1, vm::ptr<u8> buffer2);


### PR DESCRIPTION
Corrected the implementation of sys_game_board_storage_read() according to @elad335's suggestion in #12769.
After doing some experiments, I came to the conclusion that the value of *buffer2 must be always set to 0x00 (regardless of the PSID, unlike *buffer1), otherwise the game will throw an error saying the check has failed.

Also implemented sys_game_get_system_sw_version(), which represents the PS3 firmware version in an u64 form (firmware_version * 10000), e.g. 48900 for 4.89.