### PR TITLE
Qt: throw exception if settings translation is missing

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLOverlays.cpp
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.cpp
@@ -433,10 +433,8 @@ namespace gl
 		{
 			return cached->second.get();
 		}
-		else
-		{
-			return load_simple_image(desc, true, owner_uid);
-		}
+
+		return load_simple_image(desc, true, owner_uid);
 	}
 
 	void ui_overlay_renderer::set_primitive_type(rsx::overlays::primitive_type type)

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -40,6 +40,8 @@ namespace rsx
 			image_info(const char* filename);
 			image_info(const std::vector<u8>& bytes);
 			~image_info();
+
+			void load_data(const std::vector<u8>& bytes);
 		};
 
 		struct resource_config
@@ -87,8 +89,8 @@ namespace rsx
 				bool clip_region = false;
 
 				u8 texture_ref = image_resource_id::none;
-				font *font_ref = nullptr;
-				void *external_data_ref = nullptr;
+				font* font_ref = nullptr;
+				void* external_data_ref = nullptr;
 
 				u8 blur_strength = 0;
 
@@ -243,7 +245,7 @@ namespace rsx
 		{
 		private:
 			u8 image_resource_ref = image_resource_id::none;
-			void *external_ref = nullptr;
+			void* external_ref = nullptr;
 
 			// Strength of blur effect
 			u8 blur_strength = 0;

--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
@@ -131,17 +131,12 @@ namespace rsx
 			m_dim_background->set_size(1280, 720);
 			m_dim_background->back_color.a = 0.5f;
 
-			m_list = std::make_unique<list_view>(1240, 540);
-			m_list->set_pos(20, 85);
-
 			m_description = std::make_unique<label>();
 			m_description->set_font("Arial", 20);
 			m_description->set_pos(20, 37);
 			m_description->set_text("Select media"); // Fallback. I don't think this will ever be used, so I won't localize it.
 			m_description->auto_resize();
 			m_description->back_color.a	= 0.f;
-
-			return_code = selection_code::canceled;
 		}
 
 		void media_list_dialog::on_button_pressed(pad_button button_press)
@@ -152,11 +147,11 @@ namespace rsx
 				if (m_no_media_text)
 					break;
 				return_code = m_list->get_selected_index();
-				close(false, true);
+				m_stop_input_loop = true;
 				break;
 			case pad_button::circle:
 				return_code = selection_code::canceled;
-				close(false, true);
+				m_stop_input_loop = true;
 				break;
 			case pad_button::dpad_up:
 				m_list->select_previous();
@@ -194,11 +189,12 @@ namespace rsx
 			return result;
 		}
 
-		s32 media_list_dialog::show(const media_entry& dir_entry, const std::string& title, u32 focused, bool enable_overlay)
+		s32 media_list_dialog::show(media_entry* root, media_entry& result, const std::string& title, u32 focused, bool enable_overlay)
 		{
-			rsx_log.warning("Media dialog: showing entry '%s' ('%s')", dir_entry.name, dir_entry.path);
+			auto ref = g_fxo->get<display_manager>().get(uid);
 
-			visible = false;
+			m_media = root;
+			result = {};
 
 			if (enable_overlay)
 			{
@@ -209,7 +205,69 @@ namespace rsx
 				m_dim_background->back_color.a = 0.5f;
 			}
 
-			for (const media_entry& child : dir_entry.children)
+			while (thread_ctrl::state() != thread_state::aborting && return_code >= 0 && m_media && m_media->type == media_list_dialog::media_type::directory)
+			{
+				reload(title, focused);
+				m_stop_input_loop = false;
+
+				if (const auto error = run_input_loop())
+				{
+					if (error != selection_code::canceled)
+					{
+						rsx_log.error("Media list dialog input loop exited with error code=%d", error);
+					}
+					return error;
+				}
+
+				if (return_code >= 0)
+				{
+					focused = 0;
+					ensure(static_cast<size_t>(return_code) < m_media->children.size());
+					m_media = &m_media->children[return_code];
+					rsx_log.notice("Media dialog: selected entry: %d ('%s')", return_code, m_media->path);
+					continue;
+				}
+
+				if (return_code == user_interface::selection_code::canceled)
+				{
+					if (m_media == root)
+					{
+						rsx_log.notice("Media list dialog canceled");
+						break;
+					}
+
+					focused = m_media->index;
+					m_media = m_media->parent;
+					return_code = 0;
+					rsx_log.notice("Media list dialog moving to parent directory (focused=%d)", focused);
+					continue;
+				}
+
+				rsx_log.error("Left media list dialog with error: %d", return_code);
+				break;
+			}
+
+			close(false, true);
+
+			if (return_code >= 0 && m_media && m_media->type != media_list_dialog::media_type::directory)
+			{
+				result = *m_media;
+				rsx_log.error("Left media list dialog: return_code=%d, type=%d, path=%d", return_code, static_cast<s32>(result.type), result.info.path);
+			}
+
+			return return_code;
+		}
+
+		void media_list_dialog::reload(const std::string& title, u32 focused)
+		{
+			ensure(m_media);
+
+			rsx_log.notice("Media dialog: showing entry '%s' ('%s')", m_media->name, m_media->path);
+
+			m_list = std::make_unique<list_view>(1240, 540);
+			m_list->set_pos(20, 85);
+
+			for (const media_entry& child : m_media->children)
 			{
 				std::unique_ptr<overlay_element> entry = std::make_unique<media_list_entry>(child);
 				m_list->add_entry(entry);
@@ -236,29 +294,6 @@ namespace rsx
 			m_description->auto_resize();
 
 			visible = true;
-
-			auto ref = g_fxo->get<display_manager>().get(uid);
-
-			if (const auto error = run_input_loop())
-			{
-				if (error != selection_code::canceled)
-				{
-					rsx_log.error("Media list dialog input loop exited with error code=%d", error);
-				}
-				return error;
-			}
-
-			if (return_code < 0)
-			{
-				rsx_log.notice("Media dialog canceled");
-			}
-			else
-			{
-				ensure(static_cast<size_t>(return_code) < dir_entry.children.size());
-				rsx_log.success("Media dialog: selected entry: %d ('%s')", return_code, dir_entry.children[return_code].path);
-			}
-
-			return return_code;
 		}
 
 		struct media_list_dialog_thread
@@ -326,7 +361,7 @@ namespace rsx
 				current_entry.path = media_path;
 				current_entry.name = name;
 			}
-		};
+		}
 
 		error_code show_media_list_dialog(media_list_dialog::media_type type, const std::string& path, const std::string& title, std::function<void(s32 status, utils::media_info info)> on_finished)
 		{
@@ -351,53 +386,23 @@ namespace rsx
 					rsx_log.error("Media list: Failed to open path: '%s'", path);
 				}
 
-				media_list_dialog::media_entry* media = &root_media_entry;
+				media_list_dialog::media_entry media{};
 				s32 result = 0;
 				u32 focused = 0;
 
-				while (thread_ctrl::state() != thread_state::aborting && result >= 0 && media && media->type == media_list_dialog::media_type::directory)
+				if (auto manager = g_fxo->try_get<rsx::overlays::display_manager>())
 				{
-					if (auto manager = g_fxo->try_get<rsx::overlays::display_manager>())
-					{
-						rsx_log.notice("Creating media list dialog with entry: '%s' (name='%s', path='%s')", title,  media->name, media->path);
-						result = manager->create<rsx::overlays::media_list_dialog>()->show(*media, title, focused, true);
-						if (result >= 0)
-						{
-							focused = 0;
-							ensure(static_cast<size_t>(result) < media->children.size());
-							media = &media->children[result];
-							rsx_log.notice("Left media list dialog with entry: '%s' ('%s')", media->name, media->path);
-							continue;
-						}
-
-						if (result == user_interface::selection_code::canceled)
-						{
-							if (media == &root_media_entry)
-							{
-								rsx_log.notice("Media list dialog canceled");
-								break;
-							}
-
-							focused = media->index;
-							media = media->parent;
-							result = 0;
-							rsx_log.notice("Media list dialog moving to parent directory (focused=%d)", focused);
-							continue;
-						}
-
-						rsx_log.error("Left media list dialog with error: '%d'", result);
-						break;
-					}
-
-					media = nullptr;
+					result = manager->create<rsx::overlays::media_list_dialog>()->show(&root_media_entry, media, title, focused, true);
+				}
+				else
+				{
 					result = user_interface::selection_code::canceled;
 					rsx_log.error("Media selection is only possible when the native user interface is enabled in the settings. The action will be canceled.");
-					break;
 				}
 
-				if (result >= 0 && media && media->type == type)
+				if (result >= 0 && media.type == type)
 				{
-					on_finished(CELL_OK, media->info);
+					on_finished(CELL_OK, media.info);
 				}
 				else
 				{

--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.h
@@ -39,9 +39,11 @@ namespace rsx
 
 			compiled_resource get_compiled() override;
 
-			s32 show(const media_entry& dir_entry, const std::string& title, u32 focused, bool enable_overlay);
+			s32 show(media_entry* root, media_entry& result, const std::string& title, u32 focused, bool enable_overlay);
 
 		private:
+			void reload(const std::string& title, u32 focused);
+
 			struct media_list_entry : horizontal_layout
 			{
 			public:
@@ -50,6 +52,8 @@ namespace rsx
 			private:
 				std::unique_ptr<image_info> icon_data;
 			};
+
+			media_entry* m_media = nullptr;
 
 			std::unique_ptr<overlay_element> m_dim_background;
 			std::unique_ptr<list_view> m_list;

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -268,7 +268,7 @@ namespace rsx
 				}
 				else
 				{
-					while (!exit)
+					while (!m_stop_input_loop)
 					{
 						refresh();
 
@@ -279,7 +279,7 @@ namespace rsx
 			}
 			else
 			{
-				if (!exit)
+				if (!m_stop_input_loop)
 				{
 					auto& dlg_thread = g_fxo->get<named_thread<msg_dialog_thread>>();
 
@@ -307,7 +307,7 @@ namespace rsx
 						}
 						else
 						{
-							while (!exit && thread_ctrl::state() != thread_state::aborting)
+							while (!m_stop_input_loop && thread_ctrl::state() != thread_state::aborting)
 							{
 								refresh();
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -300,7 +300,7 @@ namespace rsx
 
 			m_update = true;
 			visible = true;
-			exit = false;
+			m_stop_input_loop = false;
 
 			fade_animation.current = color4f(0.f);
 			fade_animation.end = color4f(1.f);

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -120,7 +120,7 @@ namespace rsx
 				last_button_state[pad_index][button_id] = pressed;
 			};
 
-			while (!exit)
+			while (!m_stop_input_loop)
 			{
 				if (Emu.IsStopped())
 				{
@@ -196,7 +196,7 @@ namespace rsx
 				int pad_index = -1;
 				for (const auto& pad : handler->GetPads())
 				{
-					if (exit)
+					if (m_stop_input_loop)
 						break;
 
 					if (++pad_index >= CELL_PAD_MAX_PORT_NUM)
@@ -294,7 +294,7 @@ namespace rsx
 
 						handle_button_press(button_id, button.m_pressed, pad_index);
 
-						if (exit)
+						if (m_stop_input_loop)
 							break;
 					}
 
@@ -334,7 +334,7 @@ namespace rsx
 						// Handle currently pressed stick direction
 						handle_button_press(button_id, pressed, pad_index);
 
-						if (exit)
+						if (m_stop_input_loop)
 							break;
 					}
 				}
@@ -360,7 +360,7 @@ namespace rsx
 		{
 			// Force unload
 			m_stop_pad_interception.release(stop_pad_interception);
-			exit.release(true);
+			m_stop_input_loop.release(true);
 
 			while (u64 b = thread_bits)
 			{

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -92,7 +92,7 @@ namespace rsx
 				pad_button::ls_left,
 				pad_button::ls_right
 			};
-			atomic_t<bool> exit = false;
+			atomic_t<bool> m_stop_input_loop = false;
 			atomic_t<bool> m_interactive = false;
 			bool m_start_pad_interception = true;
 			atomic_t<bool> m_stop_pad_interception = false;


### PR DESCRIPTION
This will force developers to add translations to settings in case they are used in the settings dialog.