### PR TITLE
Qt: throw exception if settings translation is missing

### DIFF
--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -10,6 +10,7 @@
 #include "Emu/system_config.h"
 #include "Emu/system_utils.hpp"
 #include "Emu/Cell/Modules/cellSysutil.h"
+#include "Emu/Io/Keyboard.h"
 
 #include "util/yaml.hpp"
 #include "Utilities/File.h"
@@ -300,7 +301,7 @@ void emu_settings::SaveSettings()
 	}
 }
 
-void emu_settings::EnhanceComboBox(QComboBox* combobox, emu_settings_type type, bool is_ranged, bool use_max, int max, bool sorted)
+void emu_settings::EnhanceComboBox(QComboBox* combobox, emu_settings_type type, bool is_ranged, bool use_max, int max, bool sorted, bool strict)
 {
 	if (!combobox)
 	{
@@ -330,7 +331,7 @@ void emu_settings::EnhanceComboBox(QComboBox* combobox, emu_settings_type type, 
 
 		for (int i = 0; i < settings.count(); i++)
 		{
-			const QString localized_setting = GetLocalizedSetting(settings[i], type, combobox->count());
+			const QString localized_setting = GetLocalizedSetting(settings[i], type, combobox->count(), strict);
 			combobox->addItem(localized_setting, QVariant({settings[i], i}));
 		}
 
@@ -788,7 +789,7 @@ void emu_settings::EnhanceRadioButton(QButtonGroup* button_group, emu_settings_t
 	for (int i = 0; i < options.count(); i++)
 	{
 		const QString& option = options[i];
-		const QString localized_setting = GetLocalizedSetting(option, type, i);
+		const QString localized_setting = GetLocalizedSetting(option, type, i, true);
 
 		QAbstractButton* button = button_group->button(i);
 		button->setText(localized_setting);
@@ -901,7 +902,7 @@ void emu_settings::OpenCorrectionDialog(QWidget* parent)
 	}
 }
 
-QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_type type, int index) const
+QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_type type, int index, bool strict) const
 {
 	switch (type)
 	{
@@ -1169,6 +1170,24 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 		case audio_format_flag::dts: return tr("DTS 5.1 Ch.", "Audio format flag");
 		}
 		break;
+	case emu_settings_type::AudioProvider:
+		switch (static_cast<audio_provider>(index))
+		{
+		case audio_provider::none: return tr("None", "Audio Provider");
+		case audio_provider::cell_audio: return tr("CellAudio", "Audio Provider");
+		case audio_provider::rsxaudio: return tr("RSXAudio", "Audio Provider");
+		}
+		break;
+	case emu_settings_type::AudioAvport:
+		switch (static_cast<audio_avport>(index))
+		{
+		case audio_avport::hdmi_0: return tr("HDMI 0", "Audio Avport");
+		case audio_avport::hdmi_1: return tr("HDMI 1", "Audio Avport");
+		case audio_avport::avmulti: return tr("AV multiout", "Audio Avport");
+		case audio_avport::spdif_0: return tr("SPDIF 0", "Audio Avport");
+		case audio_avport::spdif_1: return tr("SPDIF 1", "Audio Avport");
+		}
+		break;
 	case emu_settings_type::LicenseArea:
 		switch (static_cast<CellSysutilLicenseArea>(index))
 		{
@@ -1188,8 +1207,77 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 		case vk_gpu_scheduler_mode::fast: return tr("Fast", "Asynchronous Queue Scheduler");
 		}
 		break;
+	case emu_settings_type::Language:
+		switch (static_cast<CellSysutilLang>(index))
+		{
+		case CELL_SYSUTIL_LANG_JAPANESE: return tr("Japanese", "System Language");
+		case CELL_SYSUTIL_LANG_ENGLISH_US: return tr("English (US)", "System Language");
+		case CELL_SYSUTIL_LANG_FRENCH: return tr("French", "System Language");
+		case CELL_SYSUTIL_LANG_SPANISH: return tr("Spanish", "System Language");
+		case CELL_SYSUTIL_LANG_GERMAN: return tr("German", "System Language");
+		case CELL_SYSUTIL_LANG_ITALIAN: return tr("Italian", "System Language");
+		case CELL_SYSUTIL_LANG_DUTCH: return tr("Dutch", "System Language");
+		case CELL_SYSUTIL_LANG_PORTUGUESE_PT: return tr("Portuguese (Portugal)", "System Language");
+		case CELL_SYSUTIL_LANG_RUSSIAN: return tr("Russian", "System Language");
+		case CELL_SYSUTIL_LANG_KOREAN: return tr("Korean", "System Language");
+		case CELL_SYSUTIL_LANG_CHINESE_T: return tr("Chinese (Traditional)", "System Language");
+		case CELL_SYSUTIL_LANG_CHINESE_S: return tr("Chinese (Simplified)", "System Language");
+		case CELL_SYSUTIL_LANG_FINNISH: return tr("Finnish", "System Language");
+		case CELL_SYSUTIL_LANG_SWEDISH: return tr("Swedish", "System Language");
+		case CELL_SYSUTIL_LANG_DANISH: return tr("Danish", "System Language");
+		case CELL_SYSUTIL_LANG_NORWEGIAN: return tr("Norwegian", "System Language");
+		case CELL_SYSUTIL_LANG_POLISH: return tr("Polish", "System Language");
+		case CELL_SYSUTIL_LANG_ENGLISH_GB: return tr("English (UK)", "System Language");
+		case CELL_SYSUTIL_LANG_PORTUGUESE_BR: return tr("Portuguese (Brazil)", "System Language");
+		case CELL_SYSUTIL_LANG_TURKISH: return tr("Turkish", "System Language");
+		default:
+			break;
+		}
+	case emu_settings_type::KeyboardType:
+		switch (static_cast<CellKbMappingType>(index))
+		{
+		case CELL_KB_MAPPING_101: return tr("English keyboard (US standard)", "Keyboard Type");
+		case CELL_KB_MAPPING_106: return tr("Japanese keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_106_KANA: return tr("Japanese keyboard (Kana state)", "Keyboard Type");
+		case CELL_KB_MAPPING_GERMAN_GERMANY: return tr("German keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_SPANISH_SPAIN: return tr("Spanish keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_FRENCH_FRANCE: return tr("French keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_ITALIAN_ITALY: return tr("Italian keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_DUTCH_NETHERLANDS: return tr("Dutch keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_PORTUGUESE_PORTUGAL: return tr("Portuguese keyboard (Portugal)", "Keyboard Type");
+		case CELL_KB_MAPPING_RUSSIAN_RUSSIA: return tr("Russian keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_ENGLISH_UK: return tr("English keyboard (UK standard)", "Keyboard Type");
+		case CELL_KB_MAPPING_KOREAN_KOREA: return tr("Korean keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_NORWEGIAN_NORWAY: return tr("Norwegian keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_FINNISH_FINLAND: return tr("Finnish keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_DANISH_DENMARK: return tr("Danish keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_SWEDISH_SWEDEN: return tr("Swedish keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_CHINESE_TRADITIONAL: return tr("Chinese keyboard (Traditional)", "Keyboard Type");
+		case CELL_KB_MAPPING_CHINESE_SIMPLIFIED: return tr("Chinese keyboard (Simplified)", "Keyboard Type");
+		case CELL_KB_MAPPING_SWISS_FRENCH_SWITZERLAND: return tr("French keyboard (Switzerland)", "Keyboard Type");
+		case CELL_KB_MAPPING_SWISS_GERMAN_SWITZERLAND: return tr("German keyboard (Switzerland)", "Keyboard Type");
+		case CELL_KB_MAPPING_CANADIAN_FRENCH_CANADA: return tr("French keyboard (Canada)", "Keyboard Type");
+		case CELL_KB_MAPPING_BELGIAN_BELGIUM: return tr("French keyboard (Belgium)", "Keyboard Type");
+		case CELL_KB_MAPPING_POLISH_POLAND: return tr("Polish keyboard", "Keyboard Type");
+		case CELL_KB_MAPPING_PORTUGUESE_BRAZIL: return tr("Portuguese keyboard (Brazil)", "Keyboard Type");
+		case CELL_KB_MAPPING_TURKISH_TURKEY: return tr("Turkish keyboard", "Keyboard Type");
+		}
 	default:
 		break;
+	}
+
+	if (strict)
+	{
+		std::string type_string;
+		if (settings_location.contains(type))
+		{
+			for (const char* loc : settings_location.value(type))
+			{
+				if (!type_string.empty()) type_string += ": ";
+				type_string += loc;
+			}
+		}
+		fmt::throw_exception("Missing translation for emu setting (original=%s, type='%s'=%d, index=%d)", original.toStdString(), type_string.empty() ? "?" : type_string, static_cast<int>(type), index);
 	}
 
 	return original;

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -1184,8 +1184,8 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 	case emu_settings_type::VulkanAsyncSchedulerDriver:
 		switch (static_cast<vk_gpu_scheduler_mode>(index))
 		{
-		case vk_gpu_scheduler_mode::safe: return tr("Safe");
-		case vk_gpu_scheduler_mode::fast: return tr("Fast");
+		case vk_gpu_scheduler_mode::safe: return tr("Safe", "Asynchronous Queue Scheduler");
+		case vk_gpu_scheduler_mode::fast: return tr("Fast", "Asynchronous Queue Scheduler");
 		}
 		break;
 	default:

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -36,7 +36,7 @@ public:
 	bool Init();
 
 	/** Connects a combo box with the target settings type*/
-	void EnhanceComboBox(QComboBox* combobox, emu_settings_type type, bool is_ranged = false, bool use_max = false, int max = 0, bool sorted = false);
+	void EnhanceComboBox(QComboBox* combobox, emu_settings_type type, bool is_ranged = false, bool use_max = false, int max = 0, bool sorted = false, bool strict = true);
 
 	/** Connects a check box with the target settings type*/
 	void EnhanceCheckBox(QCheckBox* checkbox, emu_settings_type type);
@@ -87,7 +87,7 @@ public:
 	void OpenCorrectionDialog(QWidget* parent = Q_NULLPTR);
 
 	/** Get a localized and therefore freely adjustable version of the string used in config.yml.*/
-	QString GetLocalizedSetting(const QString& original, emu_settings_type type, int index) const;
+	QString GetLocalizedSetting(const QString& original, emu_settings_type type, int index, bool strict) const;
 
 	/** Validates the settings and logs unused entries or cleans up the yaml*/
 	bool ValidateSettings(bool cleanup);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -290,20 +290,20 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		if (!utils::has_mpx() || utils::has_tsx_force_abort())
 		{
 			const QString current_text = ui->enableTSX->currentText();
-			const QString localized_tsx_enabled = m_emu_settings->GetLocalizedSetting(tsx_enabled, emu_settings_type::EnableTSX, static_cast<int>(tsx_usage::enabled));
+			const QString localized_tsx_enabled = m_emu_settings->GetLocalizedSetting(tsx_enabled, emu_settings_type::EnableTSX, static_cast<int>(tsx_usage::enabled), true);
 
 			ui->enableTSX->removeItem(ui->enableTSX->findText(localized_tsx_enabled));
 
 			if (current_text == localized_tsx_enabled)
 			{
-				ui->enableTSX->setCurrentText(m_emu_settings->GetLocalizedSetting(tsx_default, emu_settings_type::EnableTSX, static_cast<int>(g_cfg.core.enable_TSX.def)));
+				ui->enableTSX->setCurrentText(m_emu_settings->GetLocalizedSetting(tsx_default, emu_settings_type::EnableTSX, static_cast<int>(g_cfg.core.enable_TSX.def), true));
 			}
 		}
 
 		// connect the toogled signal so that the stateChanged signal in EnhanceCheckBox can be prevented
 		connect(ui->enableTSX, &QComboBox::currentTextChanged, this, [this](const QString& text)
 		{
-			if (text == m_emu_settings->GetLocalizedSetting(tsx_forced, emu_settings_type::EnableTSX, static_cast<int>(tsx_usage::forced)) &&
+			if (text == m_emu_settings->GetLocalizedSetting(tsx_forced, emu_settings_type::EnableTSX, static_cast<int>(tsx_usage::forced), true) &&
 				(!utils::has_mpx() || utils::has_tsx_force_abort()))
 			{
 				QString title;
@@ -339,7 +339,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 				if (QMessageBox::No == QMessageBox::critical(this, title, message, QMessageBox::Yes, QMessageBox::No))
 				{
 					// Reset if the messagebox was answered with no. This prevents the currentIndexChanged signal in EnhanceComboBox
-					ui->enableTSX->setCurrentText(m_emu_settings->GetLocalizedSetting(tsx_default, emu_settings_type::EnableTSX, static_cast<int>(g_cfg.core.enable_TSX.def)));
+					ui->enableTSX->setCurrentText(m_emu_settings->GetLocalizedSetting(tsx_default, emu_settings_type::EnableTSX, static_cast<int>(g_cfg.core.enable_TSX.def), true));
 				}
 			}
 		});
@@ -447,9 +447,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	r_creator->update_names(
 	{
-		m_emu_settings->GetLocalizedSetting("Vulkan", emu_settings_type::Renderer, static_cast<int>(video_renderer::vulkan)),
-		m_emu_settings->GetLocalizedSetting("OpenGl", emu_settings_type::Renderer, static_cast<int>(video_renderer::opengl)),
-		m_emu_settings->GetLocalizedSetting("Null", emu_settings_type::Renderer, static_cast<int>(video_renderer::null))
+		m_emu_settings->GetLocalizedSetting("Vulkan", emu_settings_type::Renderer, static_cast<int>(video_renderer::vulkan), true),
+		m_emu_settings->GetLocalizedSetting("OpenGl", emu_settings_type::Renderer, static_cast<int>(video_renderer::opengl), true),
+		m_emu_settings->GetLocalizedSetting("Null", emu_settings_type::Renderer, static_cast<int>(video_renderer::null), true)
 	});
 
 	// Comboboxes
@@ -457,7 +457,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	SubscribeTooltip(ui->gb_renderer, tooltips.settings.renderer);
 	SubscribeTooltip(ui->gb_graphicsAdapter, tooltips.settings.graphics_adapter);
 
-	m_emu_settings->EnhanceComboBox(ui->resBox, emu_settings_type::Resolution);
+	m_emu_settings->EnhanceComboBox(ui->resBox, emu_settings_type::Resolution, false, false, 0, false, false);
 	SubscribeTooltip(ui->gb_default_resolution, tooltips.settings.resolution);
 	// remove unsupported resolutions from the dropdown
 	bool saved_index_removed = false;
@@ -515,7 +515,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	}
 
-	m_emu_settings->EnhanceComboBox(ui->aspectBox, emu_settings_type::AspectRatio);
+	m_emu_settings->EnhanceComboBox(ui->aspectBox, emu_settings_type::AspectRatio, false, false, 0, false, false);
 	SubscribeTooltip(ui->gb_aspectRatio, tooltips.settings.aspect_ratio);
 
 	m_emu_settings->EnhanceComboBox(ui->frameLimitBox, emu_settings_type::FrameLimit);
@@ -1016,7 +1016,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	};
 	for (const audio_format_flag& audio_fmt : audio_formats)
 	{
-		const QString audio_format_name = m_emu_settings->GetLocalizedSetting("", emu_settings_type::AudioFormats, static_cast<int>(audio_fmt));
+		const QString audio_format_name = m_emu_settings->GetLocalizedSetting("", emu_settings_type::AudioFormats, static_cast<int>(audio_fmt), true);
 		QListWidgetItem* item = new QListWidgetItem(audio_format_name, ui->list_audio_formats);
 		item->setData(Qt::UserRole, static_cast<u32>(audio_fmt));
 		if (audio_fmt == audio_format_flag::lpcm_2_48khz)


### PR DESCRIPTION
This will force developers to add translations to settings in case they are used in the settings dialog.