### PR TITLE
Qt: delay first log frame update

### DIFF
--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -46,6 +46,8 @@ private:
 
 	std::unique_ptr<find_dialog> m_find_dialog;
 
+	QTimer* m_timer = nullptr;
+
 	QList<QColor> m_color;
 	QColor m_color_stack;
 	QPlainTextEdit* m_log = nullptr;


### PR DESCRIPTION
This fixes the log not scrolling automatically when we first open RPCS3 with a low log level.