### PR TITLE
Misc improvements for arcade games

### DIFF
--- a/rpcs3/Emu/Io/usb_device.cpp
+++ b/rpcs3/Emu/Io/usb_device.cpp
@@ -228,6 +228,7 @@ void usb_device_emulated::control_transfer(u8 bmRequestType, u8 bRequest, u16 wV
 		default: sys_usbd.fatal("Unhandled control transfer(0): 0x%x", bRequest); break;
 		}
 		break;
+	case 0x80: sys_usbd.todo("Unimplemented control transfer: 0x%x", bmRequestType); break;
 	default: sys_usbd.fatal("Unhandled control transfer: 0x%x", bmRequestType); break;
 	}
 }

--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -80,6 +80,7 @@ usb_device_usio::usb_device_usio(const std::array<u8, 7>& location)
 			.bInterval        = 16}));
 
 	g_fxo->get<usio_memory>().backup_memory.resize(0xB8);
+	g_fxo->get<usio_memory>().last_game_status.clear();
 	g_fxo->get<usio_memory>().last_game_status.resize(0x28);
 	load_backup();
 }
@@ -115,7 +116,7 @@ void usb_device_usio::load_backup()
 		return;
 	}
 
-	const u64 file_size = g_fxo->get<usio_memory>().backup_memory.size() + g_fxo->get<usio_memory>().last_game_status.size();
+	const u64 file_size = g_fxo->get<usio_memory>().backup_memory.size();
 
 	if (usio_backup_file.size() != file_size)
 	{
@@ -125,7 +126,6 @@ void usb_device_usio::load_backup()
 	}
 
 	usio_backup_file.read(g_fxo->get<usio_memory>().backup_memory.data(), g_fxo->get<usio_memory>().backup_memory.size());
-	usio_backup_file.read(g_fxo->get<usio_memory>().last_game_status.data(), g_fxo->get<usio_memory>().last_game_status.size());
 }
 
 void usb_device_usio::save_backup()
@@ -137,7 +137,6 @@ void usb_device_usio::save_backup()
 
 	usio_backup_file.seek(0, fs::seek_set);
 	usio_backup_file.write(g_fxo->get<usio_memory>().backup_memory.data(), g_fxo->get<usio_memory>().backup_memory.size());
-	usio_backup_file.write(g_fxo->get<usio_memory>().last_game_status.data(), g_fxo->get<usio_memory>().last_game_status.size());
 }
 
 void usb_device_usio::translate_input()


### PR DESCRIPTION
A few games (e.g. Tekken) will call control_transfer with bmRequestType=0x80 when booting up, which caused the whole booting up process to be frozen by sys_usbd.fatal() as the request type (0x80) was unhandled.
I added 0x80 to the switch-case and gave it a sys_usbd.todo() so that the booting up process will no longer be frozen by sys_usbd.fatal().

Also added USB passthrough for H050 USJ PCB, which is used on System 369 PS3-based arcade systems.

In addition, according to the game manual, last_game_status in the USIO SRAM is not kept after power off, so we shouldn't save it in the backup file either.