### PR TITLE
Input: Fix Dualsense gyro axis

### DIFF
--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -13,7 +13,7 @@ constexpr id_pair ZEROPLUS_ID_0 = {0x0C12, 0x0E20};
 namespace
 {
 	constexpr u32 DS4_ACC_RES_PER_G = 8192;
-	constexpr u32 DS4_GYRO_RES_PER_DEG_S = 16; // technically this could be 1024, but keeping it at 16 keeps us within 16 bits of precision
+	constexpr u32 DS4_GYRO_RES_PER_DEG_S = 86; // technically this could be 1024, but keeping it at 86 keeps us within 16 bits of precision
 	constexpr u32 DS4_FEATURE_REPORT_0x02_SIZE = 37;
 	constexpr u32 DS4_FEATURE_REPORT_0x05_SIZE = 41;
 	constexpr u32 DS4_FEATURE_REPORT_0x12_SIZE = 16;
@@ -862,15 +862,15 @@ void ds4_pad_handler::get_extended_info(const pad_ensemble& binding)
 	pad->m_sensors[1].m_value = Clamp0To1023(accelY);
 	pad->m_sensors[2].m_value = Clamp0To1023(accelZ);
 
-	// gyroX is yaw, which is all that we need
-	f32 gyroX = static_cast<s16>((buf[16] << 8) | buf[15]) / static_cast<f32>(DS4_GYRO_RES_PER_DEG_S) * -1;
-	//const int gyroY = ((u16)(buf[14] << 8) | buf[13]) / 256;
-	//const int gyroZ = ((u16)(buf[18] << 8) | buf[17]) / 256;
+	// gyroY is yaw, which is all that we need
+	//f32 gyroX = static_cast<s16>((u16)(buf[14] << 8) | buf[13]) / static_cast<f32>(DS4_GYRO_RES_PER_DEG_S) * -1;
+	f32 gyroY = static_cast<s16>((buf[16] << 8) | buf[15]) / static_cast<f32>(DS4_GYRO_RES_PER_DEG_S) * -1;
+	//f32 gyroZ = static_cast<s16>((u16)(buf[18] << 8) | buf[17]) / static_cast<f32>(DS4_GYRO_RES_PER_DEG_S) * -1;
 
-	// convert to ds3
-	gyroX = gyroX * (123.f / 90.f) + 512;
+	// Convert to ds3. The ds3 resolution is 123/90°/sec.
+	gyroY = gyroY * (123.f / 90.f) + 512;
 
-	pad->m_sensors[3].m_value = Clamp0To1023(gyroX);
+	pad->m_sensors[3].m_value = Clamp0To1023(gyroY);
 }
 
 void ds4_pad_handler::apply_pad_data(const pad_ensemble& binding)

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -22,7 +22,7 @@ void fmt_class_string<DualSenseDevice::DualSenseDataMode>::format(std::string& o
 namespace
 {
 	constexpr u32 DUALSENSE_ACC_RES_PER_G = 8192;
-	constexpr u32 DUALSENSE_GYRO_RES_PER_DEG_S = 1024;
+	constexpr u32 DUALSENSE_GYRO_RES_PER_DEG_S = 86; // technically this could be 1024, but keeping it at 86 keeps us within 16 bits of precision
 	constexpr u32 DUALSENSE_CALIBRATION_REPORT_SIZE = 41;
 	constexpr u32 DUALSENSE_VERSION_REPORT_SIZE = 64;
 	constexpr u32 DUALSENSE_BLUETOOTH_REPORT_SIZE = 78;
@@ -642,10 +642,10 @@ void dualsense_pad_handler::get_extended_info(const pad_ensemble& binding)
 
 	// these values come already calibrated, all we need to do is convert to ds3 range
 
-	// gyroX is yaw, which is all that we need
-	f32 gyroX = static_cast<s16>((buf[16] << 8) | buf[15]) / static_cast<f32>(DUALSENSE_GYRO_RES_PER_DEG_S) * -1;
-	//const int gyroY = ((u16)(buf[18] << 8) | buf[17]) / 256;
-	//const int gyroZ = ((u16)(buf[20] << 8) | buf[19]) / 256;
+	// gyroY is yaw, which is all that we need
+	//f32 gyroX = static_cast<s16>((buf[16] << 8) | buf[15]) / static_cast<f32>(DUALSENSE_GYRO_RES_PER_DEG_S) * -1.f;
+	f32 gyroY = static_cast<s16>((buf[18] << 8) | buf[17]) / static_cast<f32>(DUALSENSE_GYRO_RES_PER_DEG_S) * -1.f;
+	//f32 gyroZ = static_cast<s16>((buf[20] << 8) | buf[19]) / static_cast<f32>(DUALSENSE_GYRO_RES_PER_DEG_S) * -1.f;
 
 	// accel
 	f32 accelX = static_cast<s16>((buf[22] << 8) | buf[21]) / static_cast<f32>(DUALSENSE_ACC_RES_PER_G) * -1;
@@ -657,13 +657,13 @@ void dualsense_pad_handler::get_extended_info(const pad_ensemble& binding)
 	accelY = accelY * 113 + 512;
 	accelZ = accelZ * 113 + 512;
 
-	// convert to ds3
-	gyroX  = gyroX * (123.f / 90.f) + 512;
+	// Convert to ds3. The ds3 resolution is 123/90°/sec.
+	gyroY = gyroY * (123.f / 90.f) + 512;
 
 	pad->m_sensors[0].m_value = Clamp0To1023(accelX);
 	pad->m_sensors[1].m_value = Clamp0To1023(accelY);
 	pad->m_sensors[2].m_value = Clamp0To1023(accelZ);
-	pad->m_sensors[3].m_value = Clamp0To1023(gyroX);
+	pad->m_sensors[3].m_value = Clamp0To1023(gyroY);
 }
 
 std::unordered_map<u64, u16> dualsense_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -82,7 +82,7 @@ void evdev_joystick_handler::init_config(cfg_pad* cfg)
 	cfg->motion_sensor_x.axis.def = ::at32(motion_axis_list, ABS_X);
 	cfg->motion_sensor_y.axis.def = ::at32(motion_axis_list, ABS_Y);
 	cfg->motion_sensor_z.axis.def = ::at32(motion_axis_list, ABS_Z);
-	cfg->motion_sensor_g.axis.def = ::at32(motion_axis_list, ABS_RX);
+	cfg->motion_sensor_g.axis.def = ::at32(motion_axis_list, ABS_RY); // DS3 uses the yaw axis for gyros
 
 	cfg->pressure_intensity_button.def = ::at32(button_list, NO_BUTTON);
 


### PR DESCRIPTION
Fixes DualSense handler gyro yaw axis.

The gyro yaw axis of the Dualsense was mixed up with the pitch axis.
This seems to have been a copy pasta error from the DS4, which had the order of axis mixed up, but used the proper axis anyway.

Additionally, the used gyro resolution of 1024 seems to be way too high.
This means that we could never get the full range of the DS3, since the s16 dataype maxed out too early.
I calculated the best value for our purposes to be 86 and also applied that to the DualShock4 handler to get a smoother resolution.

fixes #12504 