### PR TITLE
Add missing usio input mappings for Taiko

### DIFF
--- a/rpcs3/Emu/Io/usio.h
+++ b/rpcs3/Emu/Io/usio.h
@@ -24,4 +24,8 @@ private:
 	std::string usio_backup_path;
 	fs::file usio_backup_file;
 	std::queue<std::vector<u8>> q_replies;
+	bool is_test         = false;
+	bool is_test_pressed = false;
+	bool is_coin_pressed = false;
+	u8 coin_counter      = 0x00;
 };


### PR DESCRIPTION
This commits adds some of the missing button mappings for Taiko Green (and older system 357C Taikos, technically) like the test menu switch and buttons to navigate it. It also adds a working coin insert button. 

Technically the coin counter will overflow at 255 and return to 0, but that seems to be the expected behavior for Taiko. The game only looks for changes in said value, not the actual value.

I've also adjusted the values for small and heavy hits to be in line with the default sensitivity setting in the games test menu. 