### PR TITLE
Changed the log level of LV2 Watchdog's being triggered

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -65,7 +65,7 @@ struct watchdog_t
 
 			if (old.active && current_time - start_time >= old.timeout)
 			{
-				sys_game.warning("Watchdog timeout! Restarting the game...");
+				sys_game.success("Watchdog timeout! Restarting the game...");
 
 				Emu.CallFromMainThread([]()
 				{


### PR DESCRIPTION
Changed the log level of LV2 Watchdog's being triggered from `warning` to `success`.