### PR TITLE
rsx: Maintenance fixes [5]

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -498,6 +498,8 @@ namespace gl
 				gl::get_overlay_pass<gl::rp_ssbo_to_generic_texture>()->run(cmd, transfer_buf, scratch_view.get(), out_offset, image_region, unpack_info);
 			}
 
+			glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT | GL_TEXTURE_UPDATE_BARRIER_BIT);
+
 			switch (dst->get_target())
 			{
 			case texture::target::texture1D:

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -1012,7 +1012,7 @@ namespace vk
 					{
 						// D-S aspect requires a load section that can fit a separated block => D(4) + S(1)
 						// Due to reverse processing of inputs, only enough space to fit one layer is needed here.
-						scratch_buf_size += dst_image->width() * dst_image->height() * 5;
+						scratch_buf_size += (image_linear_size * 5) / 4;
 					}
 
 					// Must acquire scratch buffer owned by the processing command queue!


### PR DESCRIPTION
- Add missing OpenGL memory barrier after a CS dispatch on the image decoder.
- Fix scratch buffer calculation. Fixes a "verification failed" exception in VKTexture.cpp that randomly happens in games when WDB is enabled.

Fixes https://github.com/RPCS3/rpcs3/issues/12561