### PR TITLE
Input: refactoring and bugfixes

### DIFF
--- a/rpcs3/Emu/Io/Null/NullPadHandler.h
+++ b/rpcs3/Emu/Io/Null/NullPadHandler.h
@@ -64,7 +64,7 @@ public:
 		return true;
 	}
 
-	void ThreadProc() override
+	void process() override
 	{
 	}
 };

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -323,7 +323,7 @@ void PadHandlerBase::init_configs()
 	}
 }
 
-void PadHandlerBase::get_next_button_press(const std::string& pad_id, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& /*buttons*/)
+PadHandlerBase::connection PadHandlerBase::get_next_button_press(const std::string& pad_id, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& /*buttons*/)
 {
 	if (get_blacklist)
 		blacklist.clear();
@@ -335,12 +335,12 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const pad_
 	{
 		if (fail_callback)
 			fail_callback(pad_id);
-		return;
+		return status;
 	}
 
 	if (status == connection::no_data)
 	{
-		return;
+		return status;
 	}
 
 	// Get the current button values
@@ -384,19 +384,21 @@ void PadHandlerBase::get_next_button_press(const std::string& pad_id, const pad_
 	{
 		if (blacklist.empty())
 			input_log.success("%s Calibration: Blacklist is clear. No input spam detected", m_type);
-		return;
+		return status;
 	}
-
-	const pad_preview_values preview_values = get_preview_values(data);
-	const u32 battery_level = get_battery_level(pad_id);
 
 	if (callback)
 	{
+		const pad_preview_values preview_values = get_preview_values(data);
+		const u32 battery_level = get_battery_level(pad_id);
+
 		if (pressed_button.value > 0)
-			return callback(pressed_button.value, pressed_button.name, pad_id, battery_level, preview_values);
+			callback(pressed_button.value, pressed_button.name, pad_id, battery_level, preview_values);
 		else
-			return callback(0, "", pad_id, battery_level, preview_values);
+			callback(0, "", pad_id, battery_level, preview_values);
 	}
+
+	return status;
 }
 
 void PadHandlerBase::get_motion_sensors(const std::string& pad_id, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& /*sensors*/)

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -708,7 +708,7 @@ void PadHandlerBase::get_mapping(const pad_ensemble& binding)
 	}
 }
 
-void PadHandlerBase::ThreadProc()
+void PadHandlerBase::process()
 {
 	for (usz i = 0; i < m_bindings.size(); ++i)
 	{

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -18,6 +18,8 @@ public:
 	virtual ~PadDevice() = default;
 	cfg_pad* config{ nullptr };
 	u8 player_id{0};
+	u8 large_motor{0};
+	u8 small_motor{0};
 	u64 trigger_code_left = 0;
 	u64 trigger_code_right = 0;
 	std::array<u64, 4> axis_code_left{};
@@ -172,8 +174,6 @@ public:
 	s32 thumb_max = 255; // NOTE: Better keep this positive
 	s32 trigger_min = 0;
 	s32 trigger_max = 255;
-	s32 vibration_min = 0;
-	s32 vibration_max = 255;
 	u32 connected_devices = 0;
 
 	pad_handler m_type;
@@ -197,7 +197,7 @@ public:
 	PadHandlerBase(pad_handler type = pad_handler::null);
 	virtual ~PadHandlerBase() = default;
 	// Sets window to config the controller(optional)
-	virtual void SetPadData(const std::string& /*padId*/, u8 /*player_id*/, u32 /*largeMotor*/, u32 /*smallMotor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/, bool /*player_led*/, bool /*battery_led*/, u32 /*battery_led_brightness*/) {}
+	virtual void SetPadData(const std::string& /*padId*/, u8 /*player_id*/, u8 /*large_motor*/, u8 /*small_motor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/, bool /*player_led*/, bool /*battery_led*/, u32 /*battery_led_brightness*/) {}
 	virtual u32 get_battery_level(const std::string& /*padId*/) { return 0; }
 	// Return list of devices for that handler
 	virtual std::vector<pad_list_entry> list_devices() = 0;

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -203,7 +203,7 @@ public:
 	// Return list of devices for that handler
 	virtual std::vector<pad_list_entry> list_devices() = 0;
 	// Callback called during pad_thread::ThreadFunc
-	virtual void ThreadProc();
+	virtual void process();
 	// Binds a Pad to a device
 	virtual bool bindPadToDevice(std::shared_ptr<Pad> pad, u8 player_id);
 	virtual void init_config(cfg_pad* cfg) = 0;

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -57,6 +57,14 @@ using motion_fail_callback = std::function<void(std::string /*pad_name*/, motion
 
 class PadHandlerBase
 {
+public:
+	enum connection
+	{
+		no_data,
+		connected,
+		disconnected
+	};
+
 protected:
 	enum button
 	{
@@ -90,13 +98,6 @@ protected:
 		pressure_intensity_button,
 
 		button_count
-	};
-
-	enum connection
-	{
-		no_data,
-		connected,
-		disconnected
 	};
 
 	static constexpr u32 MAX_GAMEPADS = 7;
@@ -207,7 +208,7 @@ public:
 	// Binds a Pad to a device
 	virtual bool bindPadToDevice(std::shared_ptr<Pad> pad, u8 player_id);
 	virtual void init_config(cfg_pad* cfg) = 0;
-	virtual void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons = {});
+	virtual connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons = {});
 	virtual void get_motion_sensors(const std::string& pad_id, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors);
 	virtual std::unordered_map<u32, std::string> get_motion_axis_list() const { return {}; }
 

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -177,6 +177,7 @@ public:
 	u32 connected_devices = 0;
 
 	pad_handler m_type;
+	bool m_is_init = false;
 
 	std::string name_string() const;
 	usz max_devices() const;

--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -250,11 +250,11 @@ struct AnalogSensor
 
 struct VibrateMotor
 {
-	bool m_isLargeMotor = false;
-	u16 m_value = 0;
+	bool m_is_large_motor = false;
+	u8 m_value = 0;
 
-	VibrateMotor(bool largeMotor, u16 value)
-		: m_isLargeMotor(largeMotor)
+	VibrateMotor(bool is_large_motor, u8 value)
+		: m_is_large_motor(is_large_motor)
 		, m_value(value)
 	{}
 };

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
@@ -239,7 +239,7 @@ namespace rsx
 		{
 			if (sinus_modifier >= 0)
 			{
-				static const f32 PI = 3.14159265f;
+				static constexpr f32 PI = 3.14159265f;
 				const f32 pulse_sinus_x = static_cast<f32>(get_system_time() / 1000) * pulse_speed_modifier;
 				pulse_sinus_offset = fmod(pulse_sinus_x + sinus_modifier * PI, 2.0f * PI);
 			}

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -120,15 +120,15 @@ u32 ds3_pad_handler::get_battery_level(const std::string& padId)
 	return std::clamp<u32>(device->battery_level, 0, 100);
 }
 
-void ds3_pad_handler::SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32 /* b*/, bool player_led, bool /*battery_led*/, u32 /*battery_led_brightness*/)
+void ds3_pad_handler::SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32/* r*/, s32/* g*/, s32 /* b*/, bool player_led, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
 	std::shared_ptr<ds3_device> device = get_hid_device(padId);
 	if (device == nullptr || device->hidDevice == nullptr)
 		return;
 
 	// Set the device's motor speeds to our requested values 0-255
-	device->large_motor = largeMotor;
-	device->small_motor = smallMotor;
+	device->large_motor = large_motor;
+	device->small_motor = small_motor;
 	device->player_id = player_id;
 
 	int index = 0;
@@ -585,8 +585,8 @@ void ds3_pad_handler::apply_pad_data(const pad_ensemble& binding)
 	const int idx_l = config->switch_vibration_motors ? 1 : 0;
 	const int idx_s = config->switch_vibration_motors ? 0 : 1;
 
-	const int speed_large = config->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : vibration_min;
-	const int speed_small = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : vibration_min;
+	const u8 speed_large = config->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : 0;
+	const u8 speed_small = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : 0;
 
 	const bool wireless    = dev->cable_state == 0;
 	const bool low_battery = dev->battery_level < 25;

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -80,7 +80,7 @@ public:
 	ds3_pad_handler();
 	~ds3_pad_handler();
 
-	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(cfg_pad* cfg) override;
 

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -113,8 +113,6 @@ ds4_pad_handler::ds4_pad_handler()
 	thumb_max = 255;
 	trigger_min = 0;
 	trigger_max = 255;
-	vibration_min = 0;
-	vibration_max = 255;
 
 	// set capabilities
 	b_has_config = true;
@@ -197,15 +195,15 @@ u32 ds4_pad_handler::get_battery_level(const std::string& padId)
 	return std::min<u32>(device->battery_level * 10, 100);
 }
 
-void ds4_pad_handler::SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool /*player_led*/, bool battery_led, u32 battery_led_brightness)
+void ds4_pad_handler::SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool /*player_led*/, bool battery_led, u32 battery_led_brightness)
 {
 	std::shared_ptr<DS4Device> device = get_hid_device(padId);
 	if (!device || !device->hidDevice || !device->config)
 		return;
 
 	// Set the device's motor speeds to our requested values 0-255
-	device->large_motor = largeMotor;
-	device->small_motor = smallMotor;
+	device->large_motor = large_motor;
+	device->small_motor = small_motor;
 	device->player_id = player_id;
 
 	int index = 0;
@@ -888,8 +886,8 @@ void ds4_pad_handler::apply_pad_data(const pad_ensemble& binding)
 	const int idx_l = config->switch_vibration_motors ? 1 : 0;
 	const int idx_s = config->switch_vibration_motors ? 0 : 1;
 
-	const int speed_large = config->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : vibration_min;
-	const int speed_small = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : vibration_min;
+	const u8 speed_large = config->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : 0;
+	const u8 speed_small = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : 0;
 
 	const bool wireless    = ds4_dev->cable_state == 0;
 	const bool low_battery = ds4_dev->battery_level < 2;

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -56,7 +56,7 @@ public:
 	ds4_pad_handler();
 	~ds4_pad_handler();
 
-	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(cfg_pad* cfg) override;
 

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -131,8 +131,6 @@ dualsense_pad_handler::dualsense_pad_handler()
 	thumb_max = 255;
 	trigger_min = 0;
 	trigger_max = 255;
-	vibration_min = 0;
-	vibration_max = 255;
 
 	// Set capabilities
 	b_has_config = true;
@@ -1040,8 +1038,8 @@ void dualsense_pad_handler::apply_pad_data(const pad_ensemble& binding)
 	const int idx_l = config->switch_vibration_motors ? 1 : 0;
 	const int idx_s  = config->switch_vibration_motors ? 0 : 1;
 
-	const int speed_large = config->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : vibration_min;
-	const int speed_small = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : vibration_min;
+	const u8 speed_large = config->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : 0;
+	const u8 speed_small = config->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : 0;
 
 	const bool wireless    = dualsense_dev->cable_state == 0;
 	const bool low_battery = dualsense_dev->battery_level <= 1;
@@ -1118,15 +1116,15 @@ void dualsense_pad_handler::apply_pad_data(const pad_ensemble& binding)
 	}
 }
 
-void dualsense_pad_handler::SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness)
+void dualsense_pad_handler::SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness)
 {
 	std::shared_ptr<DualSenseDevice> device = get_hid_device(padId);
 	if (device == nullptr || device->hidDevice == nullptr)
 		return;
 
 	// Set the device's motor speeds to our requested values 0-255
-	device->large_motor = largeMotor;
-	device->small_motor = smallMotor;
+	device->large_motor = large_motor;
+	device->small_motor = small_motor;
 	device->player_id = player_id;
 
 	int index = 0;

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -69,7 +69,7 @@ public:
 	dualsense_pad_handler();
 	~dualsense_pad_handler();
 
-	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(cfg_pad* cfg) override;
 

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -292,7 +292,7 @@ std::shared_ptr<evdev_joystick_handler::EvdevDevice> evdev_joystick_handler::get
 	return evdev_device;
 }
 
-void evdev_joystick_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
 {
 	if (get_blacklist)
 		m_blacklist.clear();
@@ -303,7 +303,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 	{
 		if (fail_callback)
 			fail_callback(padId);
-		return;
+		return connection::disconnected;
 	}
 	libevdev* dev = device->device;
 
@@ -357,7 +357,7 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 	{
 		if (callback)
 			callback(0, "", padId, 0, preview_values);
-		return;
+		return connection::no_data;
 	}
 
 	struct
@@ -448,16 +448,18 @@ void evdev_joystick_handler::get_next_button_press(const std::string& padId, con
 	{
 		if (m_blacklist.empty())
 			evdev_log.success("Evdev Calibration: Blacklist is clear. No input spam detected");
-		return;
+		return connection::connected;
 	}
 
 	if (callback)
 	{
 		if (pressed_button.value > 0)
-			return callback(pressed_button.value, pressed_button.name, padId, 0, preview_values);
+			callback(pressed_button.value, pressed_button.name, padId, 0, preview_values);
 		else
-			return callback(0, "", padId, 0, preview_values);
+			callback(0, "", padId, 0, preview_values);
 	}
+
+	return connection::connected;
 }
 
 void evdev_joystick_handler::get_motion_sensors(const std::string& padId, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors)

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -408,7 +408,6 @@ private:
 	std::shared_ptr<EvdevDevice> m_dev;
 	bool m_is_button_or_trigger;
 	bool m_is_negative;
-	bool m_is_init = false;
 
 	bool check_button(const EvdevButton& b, const u32 code);
 	bool check_buttons(const std::array<EvdevButton, 4>& b, const u32 code);

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -370,8 +370,6 @@ class evdev_joystick_handler final : public PadHandlerBase
 		int effect_id = -1;
 		bool has_rumble = false;
 		bool has_motion = false;
-		u16 force_large = 0;
-		u16 force_small = 0;
 		clock_t last_vibration = 0;
 	};
 
@@ -386,7 +384,7 @@ public:
 	void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
 	void get_motion_sensors(const std::string& padId, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors) override;
 	std::unordered_map<u32, std::string> get_motion_axis_list() const override;
-	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
 
 private:
 	void close_devices();
@@ -397,7 +395,7 @@ private:
 	std::shared_ptr<evdev_joystick_handler::EvdevDevice> add_motion_device(const std::string& device, bool in_settings);
 	u32 GetButtonInfo(const input_event& evt, const std::shared_ptr<EvdevDevice>& device, int& button_code);
 	std::unordered_map<u64, std::pair<u16, bool>> GetButtonValues(const std::shared_ptr<EvdevDevice>& device);
-	void SetRumble(EvdevDevice* device, u16 large, u16 small);
+	void SetRumble(EvdevDevice* device, u8 large, u8 small);
 
 	// Search axis_orientations map for the direction by index, returns -1 if not found, 0 for positive and 1 for negative
 	int FindAxisDirection(const std::unordered_map<int, bool>& map, int index);

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -381,7 +381,7 @@ public:
 	bool Init() override;
 	std::vector<pad_list_entry> list_devices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, u8 player_id) override;
-	void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
+	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
 	void get_motion_sensors(const std::string& padId, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors) override;
 	std::unordered_map<u32, std::string> get_motion_axis_list() const override;
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -98,11 +98,11 @@ bool hid_pad_handler<Device>::Init()
 }
 
 template <class Device>
-void hid_pad_handler<Device>::ThreadProc()
+void hid_pad_handler<Device>::process()
 {
 	update_devices();
 
-	PadHandlerBase::ThreadProc();
+	PadHandlerBase::process();
 }
 
 template <class Device>

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -240,9 +240,9 @@ std::shared_ptr<PadDevice> hid_pad_handler<Device>::get_device(const std::string
 }
 
 template <class Device>
-u32 hid_pad_handler<Device>::get_battery_color(u8 battery_level, int brightness)
+u32 hid_pad_handler<Device>::get_battery_color(u8 battery_level, u32 brightness)
 {
-	static const std::array<u32, 12> battery_level_clr = {0xff00, 0xff33, 0xff66, 0xff99, 0xffcc, 0xffff, 0xccff, 0x99ff, 0x66ff, 0x33ff, 0x00ff, 0x00ff};
+	static constexpr std::array<u32, 12> battery_level_clr = {0xff00, 0xff33, 0xff66, 0xff99, 0xffcc, 0xffff, 0xccff, 0x99ff, 0x66ff, 0x33ff, 0x00ff, 0x00ff};
 
 	const u32 combined_color = battery_level_clr[battery_level < battery_level_clr.size() ? battery_level : 0];
 

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -58,7 +58,7 @@ public:
 	~hid_pad_handler();
 
 	bool Init() override;
-	void ThreadProc() override;
+	void process() override;
 	std::vector<pad_list_entry> list_devices() override;
 
 protected:

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -76,7 +76,6 @@ protected:
 	// pseudo 'controller id' to keep track of unique controllers
 	std::map<std::string, std::shared_ptr<Device>> m_controllers;
 
-	bool m_is_init = false;
 	std::set<std::string> m_last_enumerated_devices;
 	std::set<std::string> m_new_enumerated_devices;
 	std::map<std::string, std::wstring_view> m_enumerated_serials;

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -110,7 +110,7 @@ protected:
 		return *static_cast<const u32*>(buf);
 	}
 
-	static u32 get_battery_color(u8 battery_level, int brightness);
+	static u32 get_battery_color(u8 battery_level, u32 brightness);
 
 private:
 	std::shared_ptr<PadDevice> get_device(const std::string& device) override;

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -37,8 +37,6 @@ public:
 	std::array<u8, 64> padData{};
 	bool new_output_data{true};
 	bool enable_player_leds{false};
-	u8 large_motor{0};
-	u8 small_motor{0};
 	u8 led_delay_on{0};
 	u8 led_delay_off{0};
 	u8 battery_level{0};

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -889,7 +889,7 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad, u8 player_i
 	return true;
 }
 
-void keyboard_pad_handler::ThreadProc()
+void keyboard_pad_handler::process()
 {
 	static const double stick_interval = 10.0;
 	static const double button_interval = 10.0;

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -86,7 +86,7 @@ public:
 	std::vector<pad_list_entry> list_devices() override;
 	void get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) override {}
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, u8 player_id) override;
-	void ThreadProc() override;
+	void process() override;
 
 	std::string GetMouseName(const QMouseEvent* event) const;
 	std::string GetMouseName(u32 button) const;

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -84,7 +84,7 @@ public:
 
 	void init_config(cfg_pad* cfg) override;
 	std::vector<pad_list_entry> list_devices() override;
-	void get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) override {}
+	connection get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) override { return connection::connected; }
 	bool bindPadToDevice(std::shared_ptr<Pad> pad, u8 player_id) override;
 	void process() override;
 

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -70,7 +70,7 @@ void mm_joystick_handler::init_config(cfg_pad* cfg)
 
 bool mm_joystick_handler::Init()
 {
-	if (is_init)
+	if (m_is_init)
 		return true;
 
 	m_devices.clear();
@@ -94,7 +94,7 @@ bool mm_joystick_handler::Init()
 		m_devices.emplace(i, dev);
 	}
 
-	is_init = true;
+	m_is_init = true;
 	return true;
 }
 

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -12,12 +12,9 @@ mm_joystick_handler::mm_joystick_handler() : PadHandlerBase(pad_handler::mm)
 	thumb_max = 255;
 	trigger_min = 0;
 	trigger_max = 255;
-	vibration_min = 0;
-	vibration_max = 65535;
 
 	// set capabilities
 	b_has_config = true;
-	b_has_rumble = true;
 	b_has_deadzones = true;
 
 	m_name_string = "Joystick #";

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -173,7 +173,7 @@ std::array<u32, PadHandlerBase::button::button_count> mm_joystick_handler::get_m
 	return mapping;
 }
 
-void mm_joystick_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+PadHandlerBase::connection mm_joystick_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
 {
 	if (get_blacklist)
 		m_blacklist.clear();
@@ -182,7 +182,7 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 	{
 		if (fail_callback)
 			fail_callback(padId);
-		return;
+		return connection::disconnected;
 	}
 
 	static std::string cur_pad;
@@ -197,7 +197,7 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 			input_log.error("MMJOY get_next_button_press for device [%s] failed with id = %d", padId, id);
 			if (fail_callback)
 				fail_callback(padId);
-			return;
+			return connection::disconnected;
 		}
 	}
 
@@ -215,7 +215,7 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 	{
 		if (fail_callback)
 			fail_callback(padId);
-		return;
+		return connection::disconnected;
 	}
 	case JOYERR_NOERROR:
 	{
@@ -304,33 +304,35 @@ void mm_joystick_handler::get_next_button_press(const std::string& padId, const 
 		{
 			if (m_blacklist.empty())
 				input_log.success("MMJOY Calibration: Blacklist is clear. No input spam detected");
-			return;
-		}
-
-		pad_preview_values preview_values{};
-		if (buttons.size() == 10)
-		{
-			preview_values[0] = data[find_key(buttons[0])];
-			preview_values[1] = data[find_key(buttons[1])];
-			preview_values[2] = data[find_key(buttons[3])] - data[find_key(buttons[2])];
-			preview_values[3] = data[find_key(buttons[5])] - data[find_key(buttons[4])];
-			preview_values[4] = data[find_key(buttons[7])] - data[find_key(buttons[6])];
-			preview_values[5] = data[find_key(buttons[9])] - data[find_key(buttons[8])];
+			return connection::connected;
 		}
 
 		if (callback)
 		{
+			pad_preview_values preview_values{};
+			if (buttons.size() == 10)
+			{
+				preview_values[0] = data[find_key(buttons[0])];
+				preview_values[1] = data[find_key(buttons[1])];
+				preview_values[2] = data[find_key(buttons[3])] - data[find_key(buttons[2])];
+				preview_values[3] = data[find_key(buttons[5])] - data[find_key(buttons[4])];
+				preview_values[4] = data[find_key(buttons[7])] - data[find_key(buttons[6])];
+				preview_values[5] = data[find_key(buttons[9])] - data[find_key(buttons[8])];
+			}
+
 			if (pressed_button.value > 0)
-				return callback(pressed_button.value, pressed_button.name, padId, 0, preview_values);
+				callback(pressed_button.value, pressed_button.name, padId, 0, preview_values);
 			else
-				return callback(0, "", padId, 0, preview_values);
+				callback(0, "", padId, 0, preview_values);
 		}
 
-		break;
+		return connection::connected;
 	}
 	default:
 		break;
 	}
+
+	return connection::no_data;
 }
 
 std::unordered_map<u64, u16> mm_joystick_handler::GetButtonValues(const JOYINFOEX& js_info, const JOYCAPS& js_caps)

--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -121,7 +121,7 @@ private:
 	int GetIDByName(const std::string& name);
 	bool GetMMJOYDevice(int index, MMJOYDevice* dev) const;
 
-	bool is_init = false;
+	bool m_is_init = false;
 
 	std::vector<u64> m_blacklist;
 	std::unordered_map<int, MMJOYDevice> m_devices;

--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -113,7 +113,7 @@ public:
 	bool Init() override;
 
 	std::vector<pad_list_entry> list_devices() override;
-	void get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
+	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
 	void init_config(cfg_pad* cfg) override;
 
 private:

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -197,15 +197,15 @@ void pad_thread::Init()
 	}
 }
 
-void pad_thread::SetRumble(const u32 pad, u8 largeMotor, bool smallMotor)
+void pad_thread::SetRumble(const u32 pad, u8 large_motor, bool small_motor)
 {
 	if (pad >= m_pads.size())
 		return;
 
 	if (m_pads[pad]->m_vibrateMotors.size() >= 2)
 	{
-		m_pads[pad]->m_vibrateMotors[0].m_value = largeMotor;
-		m_pads[pad]->m_vibrateMotors[1].m_value = smallMotor ? 255 : 0;
+		m_pads[pad]->m_vibrateMotors[0].m_value = large_motor;
+		m_pads[pad]->m_vibrateMotors[1].m_value = small_motor ? 255 : 0;
 	}
 }
 

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -278,7 +278,7 @@ void pad_thread::operator()()
 						continue;
 					}
 
-					handler->ThreadProc();
+					handler->process();
 
 					thread_ctrl::wait_for(g_cfg.io.pad_sleep);
 				}
@@ -325,7 +325,7 @@ void pad_thread::operator()()
 		{
 			for (auto& handler : handlers)
 			{
-				handler.second->ThreadProc();
+				handler.second->process();
 				connected_devices += handler.second->connected_devices;
 			}
 		}

--- a/rpcs3/Input/pad_thread.h
+++ b/rpcs3/Input/pad_thread.h
@@ -26,7 +26,7 @@ public:
 
 	PadInfo& GetInfo() { return m_info; }
 	auto& GetPads() { return m_pads; }
-	void SetRumble(const u32 pad, u8 largeMotor, bool smallMotor);
+	void SetRumble(const u32 pad, u8 large_motor, bool small_motor);
 	void SetIntercepted(bool intercepted);
 
 	s32 AddLddPad();

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -338,7 +338,7 @@ pad_preview_values xinput_pad_handler::get_preview_values(const std::unordered_m
 
 bool xinput_pad_handler::Init()
 {
-	if (is_init)
+	if (m_is_init)
 		return true;
 
 	for (auto it : XINPUT_INFO::LIBRARY_FILENAMES)
@@ -357,7 +357,7 @@ bool xinput_pad_handler::Init()
 
 			if (xinputGetState && xinputSetState && xinputGetBatteryInformation)
 			{
-				is_init = true;
+				m_is_init = true;
 				break;
 			}
 
@@ -371,7 +371,7 @@ bool xinput_pad_handler::Init()
 		}
 	}
 
-	if (!is_init)
+	if (!m_is_init)
 		return false;
 
 	return true;

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -53,8 +53,6 @@ xinput_pad_handler::xinput_pad_handler() : PadHandlerBase(pad_handler::xinput)
 	thumb_max = 32767;
 	trigger_min = 0;
 	trigger_max = 255;
-	vibration_min = 0;
-	vibration_max = 65535;
 
 	// set capabilities
 	b_has_config = true;
@@ -128,7 +126,7 @@ void xinput_pad_handler::init_config(cfg_pad* cfg)
 	cfg->from_default();
 }
 
-void xinput_pad_handler::SetPadData(const std::string& padId, u8 /*player_id*/, u32 largeMotor, u32 smallMotor, s32/* r*/, s32/* g*/, s32/* b*/, bool /*player_led*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
+void xinput_pad_handler::SetPadData(const std::string& padId, u8 /*player_id*/, u8 large_motor, u8 small_motor, s32/* r*/, s32/* g*/, s32/* b*/, bool /*player_led*/, bool /*battery_led*/, u32 /*battery_led_brightness*/)
 {
 	const int device_number = GetDeviceNumber(padId);
 	if (device_number < 0)
@@ -138,8 +136,8 @@ void xinput_pad_handler::SetPadData(const std::string& padId, u8 /*player_id*/, 
 	// The two motors are not the same, and they create different vibration effects.
 	XINPUT_VIBRATION vibrate;
 
-	vibrate.wLeftMotorSpeed = largeMotor;  // between 0 to 65535
-	vibrate.wRightMotorSpeed = smallMotor; // between 0 to 65535
+	vibrate.wLeftMotorSpeed = large_motor * 257;  // between 0 to 65535
+	vibrate.wRightMotorSpeed = small_motor * 257; // between 0 to 65535
 
 	(*xinputSetState)(static_cast<u32>(device_number), &vibrate);
 }
@@ -532,20 +530,20 @@ void xinput_pad_handler::apply_pad_data(const pad_ensemble& binding)
 	const usz idx_l = cfg->switch_vibration_motors ? 1 : 0;
 	const usz idx_s = cfg->switch_vibration_motors ? 0 : 1;
 
-	const u16 speed_large = cfg->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : static_cast<u16>(vibration_min);
-	const u16 speed_small = cfg->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : static_cast<u16>(vibration_min);
+	const u8 speed_large = cfg->enable_vibration_motor_large ? pad->m_vibrateMotors[idx_l].m_value : 0;
+	const u8 speed_small = cfg->enable_vibration_motor_small ? pad->m_vibrateMotors[idx_s].m_value : 0;
 
-	dev->newVibrateData |= dev->largeVibrate != speed_large || dev->smallVibrate != speed_small;
+	dev->newVibrateData |= dev->large_motor != speed_large || dev->small_motor != speed_small;
 
-	dev->largeVibrate = speed_large;
-	dev->smallVibrate = speed_small;
+	dev->large_motor = speed_large;
+	dev->small_motor = speed_small;
 
 	// XBox One Controller can't handle faster vibration updates than ~10ms. Elite is even worse. So I'll use 20ms to be on the safe side. No lag was noticable.
 	if (dev->newVibrateData && steady_clock::now() - dev->last_vibration > 20ms)
 	{
 		XINPUT_VIBRATION vibrate;
-		vibrate.wLeftMotorSpeed = speed_large * 257;
-		vibrate.wRightMotorSpeed = speed_small * 257;
+		vibrate.wLeftMotorSpeed = speed_large * 257;  // between 0 to 65535
+		vibrate.wRightMotorSpeed = speed_small * 257; // between 0 to 65535
 
 		if ((*xinputSetState)(padnum, &vibrate) == ERROR_SUCCESS)
 		{

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -94,8 +94,6 @@ class xinput_pad_handler final : public PadHandlerBase
 	{
 		u32 deviceNumber{ 0 };
 		bool newVibrateData{ true };
-		u16 largeVibrate{ 0 };
-		u16 smallVibrate{ 0 };
 		steady_clock::time_point last_vibration;
 		bool is_scp_device{ false };
 		DWORD state{ ERROR_NOT_CONNECTED }; // holds internal controller state change
@@ -110,7 +108,7 @@ public:
 	bool Init() override;
 
 	std::vector<pad_list_entry> list_devices() override;
-	void SetPadData(const std::string& padId, u8 player_id, u32 largeMotor, u32 smallMotor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
+	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void init_config(cfg_pad* cfg) override;
 

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -119,12 +119,10 @@ private:
 	typedef DWORD (WINAPI * PFN_XINPUTSETSTATE)(DWORD, XINPUT_VIBRATION *);
 	typedef DWORD (WINAPI * PFN_XINPUTGETBATTERYINFORMATION)(DWORD, BYTE, XINPUT_BATTERY_INFORMATION *);
 
-private:
 	int GetDeviceNumber(const std::string& padId);
 	static PadButtonValues get_button_values_base(const XINPUT_STATE& state);
 	static PadButtonValues get_button_values_scp(const SCP_EXTN& state);
 
-	bool is_init{ false };
 	HMODULE library{ nullptr };
 	PFN_XINPUTGETEXTENDED xinputGetExtended{ nullptr };
 	PFN_XINPUTGETCUSTOMDATA xinputGetCustomData{ nullptr };

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -106,7 +106,8 @@ EmuCallbacks main_application::CreateCallbacks()
 	callbacks.init_pad_handler = [this](std::string_view title_id)
 	{
 		ensure(g_fxo->init<named_thread<pad_thread>>(get_thread(), m_game_window, title_id));
-		while (!pad::g_started) std::this_thread::yield();
+		extern void process_qt_events();
+		while (!pad::g_started) process_qt_events();
 	};
 
 	callbacks.get_audio = []() -> std::shared_ptr<AudioBackend>

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1367,8 +1367,8 @@ void pad_settings_dialog::ChangeHandler()
 	ui->l_description->setText(m_description);
 
 	// Update parameters
-	m_min_force = m_handler->vibration_min;
-	m_max_force = m_handler->vibration_max;
+	m_min_force = 0;
+	m_max_force = 255;
 
 	// Reset parameters
 	m_lx = 0;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -410,7 +410,7 @@ void pad_settings_dialog::InitButtons()
 	});
 
 	// Enable Button Remapping
-	const auto callback = [this](u16 val, std::string name, std::string pad_name, u32 battery_level, pad_preview_values preview_values)
+	const auto callback = [this](PadHandlerBase::connection status, u16 val, std::string name, std::string pad_name, u32 battery_level, pad_preview_values preview_values)
 	{
 		SwitchPadInfo(pad_name, true);
 
@@ -440,7 +440,7 @@ void pad_settings_dialog::InitButtons()
 
 		ui->pb_battery->setValue(m_enable_battery ? battery_level : 0);
 
-		if (val <= 0)
+		if (val <= 0 || status == PadHandlerBase::connection::no_data)
 		{
 			return;
 		}
@@ -499,13 +499,13 @@ void pad_settings_dialog::InitButtons()
 
 		if (data.has_new_data)
 		{
-			if (data.success)
+			if (data.status == PadHandlerBase::disconnected)
 			{
-				callback(data.val, std::move(data.name), std::move(data.pad_name), data.battery_level, std::move(data.preview_values));
+				fail_callback(data.pad_name);
 			}
 			else
 			{
-				fail_callback(data.pad_name);
+				callback(data.status, data.val, std::move(data.name), std::move(data.pad_name), data.battery_level, std::move(data.preview_values));
 			}
 		}
 	});
@@ -542,7 +542,7 @@ void pad_settings_dialog::InitButtons()
 				m_cfg_entries[button_ids::id_pad_rstick_up].key
 			};
 
-			m_handler->get_next_button_press(m_device_name,
+			const PadHandlerBase::connection status = m_handler->get_next_button_press(m_device_name,
 				[this](u16 val, std::string name, std::string pad_name, u32 battery_level, pad_preview_values preview_values)
 				{
 					std::lock_guard lock(m_input_mutex);
@@ -552,16 +552,24 @@ void pad_settings_dialog::InitButtons()
 					m_input_callback_data.battery_level = battery_level;
 					m_input_callback_data.preview_values = std::move(preview_values);
 					m_input_callback_data.has_new_data = true;
-					m_input_callback_data.success = true;
+					m_input_callback_data.status = PadHandlerBase::connection::connected;
 				},
 				[this](std::string pad_name)
 				{
 					std::lock_guard lock(m_input_mutex);
 					m_input_callback_data.pad_name = std::move(pad_name);
 					m_input_callback_data.has_new_data = true;
-					m_input_callback_data.success = false;
+					m_input_callback_data.status = PadHandlerBase::connection::disconnected;
 				},
 				false, buttons);
+
+			if (status == PadHandlerBase::connection::no_data)
+			{
+				std::lock_guard lock(m_input_mutex);
+				m_input_callback_data.pad_name = m_device_name;
+				m_input_callback_data.has_new_data = true;
+				m_input_callback_data.status = status;
+			}
 		}
 	});
 }
@@ -578,18 +586,8 @@ void pad_settings_dialog::RefreshPads()
 		}
 
 		std::lock_guard lock(m_handler_mutex);
-
-		m_handler->get_next_button_press(info.name,
-			[&](u16, std::string, std::string pad_name, u32, pad_preview_values)
-			{
-				info.name = std::move(pad_name);
-				switch_pad_info(i, info, true);
-			},
-			[&](std::string pad_name)
-			{
-				info.name = std::move(pad_name);
-				switch_pad_info(i, info, false);
-			}, false);
+		const PadHandlerBase::connection status = m_handler->get_next_button_press(info.name, nullptr, nullptr, false);
+		switch_pad_info(i, info, status != PadHandlerBase::connection::disconnected);
 	}
 }
 
@@ -1220,7 +1218,7 @@ void pad_settings_dialog::OnPadButtonClicked(int id)
 	case button_ids::id_blacklist:
 	{
 		std::lock_guard lock(m_handler_mutex);
-		m_handler->get_next_button_press(m_device_name, nullptr, nullptr, true);
+		[[maybe_unused]] const PadHandlerBase::connection status = m_handler->get_next_button_press(m_device_name, nullptr, nullptr, true);
 		return;
 	}
 	default:

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1443,7 +1443,7 @@ void pad_settings_dialog::ChangeHandler()
 	ui->chooseDevice->blockSignals(false);
 
 	// Handle empty device list
-	bool config_enabled = force_enable || (m_handler->m_type != pad_handler::null && ui->chooseDevice->count() > 0);
+	const bool config_enabled = force_enable || (m_handler->m_type != pad_handler::null && ui->chooseDevice->count() > 0);
 
 	if (config_enabled)
 	{
@@ -1454,7 +1454,13 @@ void pad_settings_dialog::ChangeHandler()
 			if (pad_device_info info = get_pad_info(ui->chooseDevice, i); info.name == device)
 			{
 				ui->chooseDevice->setCurrentIndex(i);
+				break;
 			}
+		}
+
+		if (ui->chooseDevice->currentIndex() < 0 && ui->chooseDevice->count() > 0)
+		{
+			ui->chooseDevice->setCurrentIndex(0);
 		}
 
 		// Force Refresh
@@ -1466,6 +1472,8 @@ void pad_settings_dialog::ChangeHandler()
 		{
 			ui->chooseDevice->setPlaceholderText(tr("No Device Detected"));
 		}
+
+		m_device_name.clear();
 	}
 
 	// Handle running timers

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -8,6 +8,7 @@
 
 #include <mutex>
 
+#include "Emu/Io/PadHandler.h"
 #include "Emu/Io/pad_config.h"
 #include "Emu/GameInfo.h"
 #include "Utilities/Thread.h"
@@ -161,7 +162,7 @@ private:
 	std::mutex m_input_mutex;
 	struct input_callback_data
 	{
-		bool success = false;
+		PadHandlerBase::connection status = PadHandlerBase::disconnected;
 		bool has_new_data = false;
 		u16 val = 0;
 		std::string name;


### PR DESCRIPTION
- Refactors pad rumble propagation: There's no need to deal with vibration levels outside of the handlers. All we need to know is the 0-255 DS3 range which is given by the u8 type.
- Fixes a rare issue that causes a newly selected pad handler with no pads to try to connect a previously selected pad from another handler.
- Fixes some minor race condition in the UI that had no real consequences just by chance.