### PR TITLE
DualSense improvements

### DIFF
--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -913,6 +913,7 @@ dualsense_pad_handler::~dualsense_pad_handler()
 			// Disable vibration
 			controller.second->small_motor = 0;
 			controller.second->large_motor = 0;
+			controller.second->release_leds = true;
 			send_output_report(controller.second.get());
 		}
 	}
@@ -938,6 +939,11 @@ int dualsense_pad_handler::send_output_report(DualSenseDevice* device)
 
 		common.valid_flag_2 |= VALID_FLAG_2_LIGHTBAR_SETUP_CONTROL_ENABLE;
 		common.lightbar_setup = LIGHTBAR_SETUP_LIGHT_OUT; // Fade light out.
+	}
+	else if (device->release_leds)
+	{
+		common.valid_flag_1 |= VALID_FLAG_1_RELEASE_LEDS;
+		device->release_leds = false;
 	}
 	else
 	{
@@ -1109,7 +1115,7 @@ void dualsense_pad_handler::apply_pad_data(const pad_ensemble& binding)
 		dualsense_dev->update_player_leds = true;
 	}
 
-	dualsense_dev->new_output_data |= dualsense_dev->update_player_leds || dualsense_dev->update_lightbar || dualsense_dev->large_motor != speed_large || dualsense_dev->small_motor != speed_small;
+	dualsense_dev->new_output_data |= dualsense_dev->release_leds || dualsense_dev->update_player_leds || dualsense_dev->update_lightbar || dualsense_dev->large_motor != speed_large || dualsense_dev->small_motor != speed_small;
 
 	dualsense_dev->large_motor = speed_large;
 	dualsense_dev->small_motor = speed_small;

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -42,6 +42,7 @@ namespace
 		VALID_FLAG_1_RELEASE_LEDS                    = 0x08,
 		VALID_FLAG_1_PLAYER_INDICATOR_CONTROL_ENABLE = 0x10,
 		VALID_FLAG_2_LIGHTBAR_SETUP_CONTROL_ENABLE   = 0x02,
+		VALID_FLAG_2_IMPROVED_RUMBLE_EMULATION       = 0x04,
 		POWER_SAVE_CONTROL_MIC_MUTE                  = 0x10,
 		LIGHTBAR_SETUP_LIGHT_ON                      = 0x01,
 		LIGHTBAR_SETUP_LIGHT_OUT                     = 0x02,
@@ -949,6 +950,9 @@ int dualsense_pad_handler::send_output_report(DualSenseDevice* device)
 	{
 		common.valid_flag_0 |= VALID_FLAG_0_COMPATIBLE_VIBRATION;
 		common.valid_flag_0 |= VALID_FLAG_0_HAPTICS_SELECT;
+		common.valid_flag_1 |= VALID_FLAG_1_POWER_SAVE_CONTROL_ENABLE;
+		common.valid_flag_2 |= VALID_FLAG_2_IMPROVED_RUMBLE_EMULATION;
+
 		common.motor_left  = device->large_motor;
 		common.motor_right = device->small_motor;
 

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -221,7 +221,8 @@ void dualsense_pad_handler::check_add_device(hid_device* hidDevice, std::string_
 	}
 
 	u32 hw_version{};
-	u32 fw_version{};
+	u16 fw_version{};
+	u32 fw_version2{};
 
 	buf = {};
 	buf[0] = 0x20;
@@ -234,7 +235,8 @@ void dualsense_pad_handler::check_add_device(hid_device* hidDevice, std::string_
 	else
 	{
 		hw_version = read_u32(&buf[24]);
-		fw_version = read_u32(&buf[28]);
+		fw_version2 = read_u32(&buf[28]);
+		fw_version = static_cast<u16>(buf[44]) | (static_cast<u16>(buf[45]) << 8);
 	}
 
 	if (hid_set_nonblocking(hidDevice, 1) == -1)
@@ -254,7 +256,7 @@ void dualsense_pad_handler::check_add_device(hid_device* hidDevice, std::string_
 	// Get bluetooth information
 	get_data(device);
 
-	dualsense_log.notice("Added device: bluetooth=%d, data_mode=%s, serial='%s', hw_version: 0x%x, fw_version: 0x%x, path='%s'", device->bt_controller, device->data_mode, serial, hw_version, fw_version, device->path);
+	dualsense_log.notice("Added device: bluetooth=%d, data_mode=%s, serial='%s', hw_version: 0x%x, fw_version: 0x%x (0x%x), path='%s'", device->bt_controller, device->data_mode, serial, hw_version, fw_version, fw_version2, device->path);
 }
 
 void dualsense_pad_handler::init_config(cfg_pad* cfg)

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -53,10 +53,15 @@ namespace
 		u8 valid_flag_1;
 		u8 motor_right;
 		u8 motor_left;
-		u8 reserved[4];
+		u8 headphone_volume;
+		u8 speaker_volume;
+		u8 microphone_volume;
+		u8 audio_enable_bits;
 		u8 mute_button_led;
 		u8 power_save_control;
-		u8 reserved_2[28];
+		u8 right_trigger_effect[11];
+		u8 left_trigger_effect[11];
+		u8 reserved[6];
 		u8 valid_flag_2;
 		u8 reserved_3[2];
 		u8 lightbar_setup;

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -21,6 +21,7 @@ public:
 	bool init_lightbar{true};
 	bool update_lightbar{true};
 	bool update_player_leds{true};
+	bool release_leds{false};
 
 	// Controls for lightbar pulse. This seems somewhat hacky for now, as I haven't found out a nicer way.
 	bool lightbar_on{false};


### PR DESCRIPTION
- Name some more output report bytes based on SDL2 information.
- Read the firmware version as seen in the official firmware installer and log it.
- Release the LEDs when the the game is closed.
- Enable improved rumble emulation to stop your hands from aching.
- Disable unused audio haptics to save some power.