### PR TITLE
 rsx/cfg: Unlimit texture LOD bias addend, add custom frame limit

### DIFF
--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -27,6 +27,9 @@ bool try_to_int64(s64* out, std::string_view value, s64 min, s64 max);
 // Convert string to unsigned integer
 bool try_to_uint64(u64* out, std::string_view value, u64 min, u64 max);
 
+// Convert string to float
+bool try_to_float(f64* out, std::string_view value, f64 min, f64 max);
+
 // Get the file extension of a file path ("png", "jpg", etc.)
 std::string get_file_extension(const std::string& file_path);
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3399,6 +3399,12 @@ namespace rsx
 			break;
 		}
 
+		if (double limit2 = g_cfg.video.second_frame_limit; limit2 >= 0.1 && (limit2 < limit || !limit))
+		{
+			// Apply a second limit
+			limit = limit2;
+		}
+
 		if (limit)
 		{
 			const u64 needed_us = static_cast<u64>(1000000 / limit);

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -166,7 +166,7 @@ struct cfg_root : cfg::node
 		cfg::_int<1, 8> consecutive_frames_to_skip{ this, "Consecutive Frames To Skip", 1, true};
 		cfg::_int<50, 800> resolution_scale_percent{ this, "Resolution Scale", 100 };
 		cfg::uint<0, 16> anisotropic_level_override{ this, "Anisotropic Filter Override", 0, true };
-		cfg::_int<-32, 32> texture_lod_bias{ this, "Texture LOD Bias Addend", 0, true };
+		cfg::_float<-32, 32> texture_lod_bias{ this, "Texture LOD Bias Addend", 0, true };
 		cfg::_int<1, 1024> min_scalable_dimension{ this, "Minimum Scalable Dimension", 16 };
 		cfg::_int<0, 16> shader_compiler_threads_count{ this, "Shader Compiler Threads", 0 };
 		cfg::_int<0, 30000000> driver_recovery_timeout{ this, "Driver Recovery Timeout", 1000000, true };

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -130,6 +130,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<video_resolution> resolution{ this, "Resolution", video_resolution::_720 };
 		cfg::_enum<video_aspect> aspect_ratio{ this, "Aspect ratio", video_aspect::_16_9 };
 		cfg::_enum<frame_limit_type> frame_limit{ this, "Frame limit", frame_limit_type::_auto, true };
+		cfg::_float<0, 1000> second_frame_limit{ this, "Second Frame Limit", 0, true }; // 0 disables its effect
 		cfg::_enum<msaa_level> antialiasing_level{ this, "MSAA", msaa_level::_auto };
 		cfg::_enum<shader_mode> shadermode{ this, "Shader Mode", shader_mode::async_recompiler };
 		cfg::_enum<gpu_preset_level> shader_precision{ this, "Shader Precision", gpu_preset_level::high };

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -166,7 +166,7 @@ struct cfg_root : cfg::node
 		cfg::_int<1, 8> consecutive_frames_to_skip{ this, "Consecutive Frames To Skip", 1, true};
 		cfg::_int<50, 800> resolution_scale_percent{ this, "Resolution Scale", 100 };
 		cfg::uint<0, 16> anisotropic_level_override{ this, "Anisotropic Filter Override", 0, true };
-		cfg::_int<-16, 16> texture_lod_bias{ this, "Texture LOD Bias Addend", 0, true };
+		cfg::_int<-32, 32> texture_lod_bias{ this, "Texture LOD Bias Addend", 0, true };
 		cfg::_int<1, 1024> min_scalable_dimension{ this, "Minimum Scalable Dimension", 16 };
 		cfg::_int<0, 16> shader_compiler_threads_count{ this, "Shader Compiler Threads", 0 };
 		cfg::_int<0, 30000000> driver_recovery_timeout{ this, "Driver Recovery Timeout", 1000000, true };


### PR DESCRIPTION
* Unlimited Texture LOD Bias Addend to values from -32 to +32 instead of the old limit of -16 to +16, which are the maximum values that have an effect. This is because even though the actual range is -16 to 16 if the game value is currently 16, adding -16 can only make it go to 0 and not -16 like we want it to be able to at max limit.
* Implemented fractional value support in config making this setting able to support non-integral values such as `0.5`.
* Implement a custom fractional second frame limiter in the config entry "Second Frame Limit", when it's 0 it has no effect but when it's positive it limits further maximum fps.  