### PR TITLE
sceNpTrophy: improve logging

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -604,7 +604,7 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 
 	if (!stream && Emu.GetCat() == "GD")
 	{
-		sceNpTrophy.warning("sceNpTrophyRegisterContext failed to open trophy file from boot path: '%s'", trp_path);
+		sceNpTrophy.warning("sceNpTrophyRegisterContext failed to open trophy file from boot path: '%s' (%s)", trp_path, fs::g_tls_error);
 		trp_path = vfs::get("/dev_bdvd/PS3_GAME/TROPDIR/" + ctxt->trp_name + "/TROPHY.TRP");
 		stream.open(trp_path);
 	}
@@ -612,7 +612,8 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 	// check if exists and opened
 	if (!stream)
 	{
-		return {SCE_NP_TROPHY_ERROR_CONF_DOES_NOT_EXIST, trp_path};
+		const std::string msg = fmt::format("Failed to open trophy file: '%s' (%s)", trp_path, fs::g_tls_error);
+		return {SCE_NP_TROPHY_ERROR_CONF_DOES_NOT_EXIST, msg};
 	}
 
 	TRPLoader trp(stream);

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -458,7 +458,7 @@ error_code sceNpTrophyCreateContext(vm::ptr<u32> context, vm::cptr<SceNpCommunic
 		name_sv = name_sv.substr(0, pos);
 	}
 
-	sceNpTrophy.warning("sceNpTrophyCreateContext(): data='%s' term='%c' (0x%x) num=%d", name_sv, commId->data[9], commId->data[9], commId->num);
+	sceNpTrophy.warning("sceNpTrophyCreateContext(): data='%s' term=0x%x (0x%x) num=%d", name_sv, commId->data[9], commId->data[9], commId->num);
 
 	// append the commId number as "_xx"
 	std::string name = fmt::format("%s_%02d", name_sv, commId->num);

--- a/rpcs3/rpcs3qt/log_viewer.cpp
+++ b/rpcs3/rpcs3qt/log_viewer.cpp
@@ -218,7 +218,9 @@ void log_viewer::show_log()
 		m_gui_settings->SetValue(gui::fd_log_viewer, m_path_last);
 
 		QTextStream stream(&file);
-		m_log_text->setPlainText(stream.readAll());
+		QString text = stream.readAll();
+		text.replace('\0', '0');
+		m_log_text->setPlainText(text);
 		file.close();
 	}
 	else


### PR DESCRIPTION
- Fix truncated log viewer caused by nul characters
- log tls error in sceNpTrophyRegisterContext