### PR TITLE
Sly Savestates Improvements 

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2393,20 +2393,13 @@ std::shared_ptr<utils::serial> Emulator::Kill(bool allow_autoexit, bool savestat
 
 				if (!_path.empty())
 				{
-					if (!g_cfg.savestate.suspend_emu)
-					{
-						save_tar(_path);
-					}
-					else
-					{
-						ar(usz{});
-					}
+					save_tar(_path);
 				}
 			};
 
 			auto save_hdd0 = [&]()
 			{
-				if (!g_cfg.savestate.suspend_emu && g_cfg.savestate.save_disc_game_data)
+				if (g_cfg.savestate.save_disc_game_data)
 				{
 					const std::string path = vfs::get("/dev_hdd0/game/");
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2550,6 +2550,13 @@ std::shared_ptr<utils::serial> Emulator::Kill(bool allow_autoexit, bool savestat
 		}
 
 		ar.set_reading_state();
+
+		if (!g_cfg.savestate.suspend_emu)
+		{
+			to_ar.reset();
+			Restart();
+			return to_ar;
+		}
 	}
 
 	// Boot arg cleanup (preserved in the case restarting)

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -146,6 +146,11 @@ bool is_savestate_version_compatible(const std::vector<std::pair<u16, u16>>& dat
 	return ok;
 }
 
+std::string get_savestate_path(std::string_view title_id, std::string_view boot_path)
+{
+	return fs::get_cache_dir() + "/savestates/" + std::string{title_id.empty() ? boot_path.substr(boot_path.find_last_of(fs::delim) + 1) : title_id} + ".SAVESTAT";
+}
+
 bool is_savestate_compatible(const fs::file& file)
 {
 	return is_savestate_version_compatible(get_savestate_versioning_data(file), false);

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -315,7 +315,7 @@ struct cfg_root : cfg::node
 		node_savestate(cfg::node* _this) : cfg::node(_this, "Savestate") {}
 
 		cfg::_bool start_paused{ this, "Start Paused" }; // Pause on first frame
-		cfg::_bool suspend_emu{ this, "Suspend Emulation Savestate Mode", true }; // Close emulation when saving, delete save after loading
+		cfg::_bool suspend_emu{ this, "Suspend Emulation Savestate Mode", false }; // Close emulation when saving, delete save after loading
 		cfg::_bool state_inspection_mode{ this, "Inspection Mode Savestates" }; // Save memory stored in executable files, thus allowing to view state without any files (for debugging)
 		cfg::_bool save_disc_game_data{ this, "Save Disc Game Data", false };
 	} savestate{this};

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -35,6 +35,7 @@ enum class emu_settings_type
 	SPUCache,
 	DebugConsoleMode,
 	SilenceAllLogs,
+	SuspendEmulationSavestateMode,
 	MaxSPURSThreads,
 	SleepTimersAccuracy,
 	ClocksScale,
@@ -354,4 +355,7 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::LimitCacheSize,        { "VFS", "Limit disk cache size"}},
 	{ emu_settings_type::MaximumCacheSize,      { "VFS", "Disk cache maximum size (MB)"}},
 	{ emu_settings_type::ConsoleTimeOffset,     { "System", "Console time offset (s)"}},
+
+	// Savestates
+	{ emu_settings_type::SuspendEmulationSavestateMode,       { "Savestate", "Suspend Emulation Savestate Mode" }},
 };

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1735,6 +1735,7 @@ void main_window::EnableMenus(bool enabled) const
 	ui->toolsRsxDebuggerAct->setEnabled(enabled);
 	ui->toolsStringSearchAct->setEnabled(enabled);
 	ui->actionCreate_RSX_Capture->setEnabled(enabled);
+	ui->actionCreate_Savestate->setEnabled(enabled);
 }
 
 void main_window::OnEnableDiscEject(bool enabled) const
@@ -2021,6 +2022,12 @@ void main_window::CreateConnects()
 	connect(ui->actionCreate_RSX_Capture, &QAction::triggered, this, []()
 	{
 		g_user_asked_for_frame_capture = true;
+	});
+
+	connect(ui->actionCreate_Savestate, &QAction::triggered, this, []()
+	{
+		gui_log.notice("User triggered savestate creation from utilities.");
+		Emu.Kill(false, true);
 	});
 
 	connect(ui->bootSavestateAct, &QAction::triggered, this, &main_window::BootSavestate);

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -1145,6 +1145,14 @@
     <string>Create RSX Capture</string>
    </property>
   </action>
+  <action name="actionCreate_Savestate">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Create Savestate</string>
+   </property>
+  </action>
   <action name="actionManage_Game_Patches">
    <property name="text">
     <string>Game Patches</string>

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1325,6 +1325,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->accuratePPUFPCC, emu_settings_type::AccuratePPUFPCC);
 	SubscribeTooltip(ui->accuratePPUFPCC, tooltips.settings.accurate_ppufpcc);
 
+	m_emu_settings->EnhanceCheckBox(ui->suspendSavestates, emu_settings_type::SuspendEmulationSavestateMode);
+	SubscribeTooltip(ui->suspendSavestates, tooltips.settings.suspend_savestates);
+
 	m_emu_settings->EnhanceCheckBox(ui->silenceAllLogs, emu_settings_type::SilenceAllLogs);
 	SubscribeTooltip(ui->silenceAllLogs, tooltips.settings.silence_all_logs);
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2335,6 +2335,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="suspendSavestates">
+                 <property name="text">
+                  <string>Suspend-Emulation Savestates Mode</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="silenceAllLogs">
                  <property name="text">
                   <string>Silence All Logs</string>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -42,6 +42,7 @@ public:
 		const QString vulkan_async_scheduler       = tr("Determines how to schedule GPU async compute jobs when using asynchronous streaming.\nUse 'Safe' mode for more spec compliant behavior at the cost of some CPU overhead. This setting works with all devices.\nUse 'Fast' to use a faster but hacky version. This option is internally disabled for NVIDIA GPUs due to causing GPU hangs.");
 		const QString allow_host_labels            = tr("Allows the host GPU to synchronize with CELL directly. This incurs a performance penalty, but exposes the true state of GPU objects to the guest CPU. Can help eliminate visual noise and glitching at the cost of performance. Use with caution.");
 		const QString disable_msl_fast_math        = tr("Disables Fast Math for MSL shaders, which may violate the IEEE 754 standard.\nDisabling it may fix some artefacts especially on Apple GPUs, at the cost of performance.");
+		const QString suspend_savestates           = tr("When this mode is on, emulation exits when saving and the savestate file is concealed after loading it, preventing reuse by RPCS3.\nThis mode is like hibernation of emulation: if you don't want to be able to cheat using savestates when playing the game, consider using this mode.\nDo note that the savestate file is not gone completely just ignored by RPCS3, you can manually relaunch it if needed.");
 
 		// audio
 


### PR DESCRIPTION
* Make RPCS3 not ignore savestates after their use by default, allowing their reuse.
* Import the "Suspend-Emulation Mode Savestates" setting to the Advanced tab.
* Fix a bug with savestates with HDD1 caused by naivety and ignorance.
* Automatic relaunch of savestate when suspend-emulation savestates mode is off.
* Add "Create Savestate" menu button in Utilities tab.
* Fix the logic of suspend-emulation savestates mode, ignore savestate after regular game boot as well.