### PR TITLE
[macOS] [Arm] Remove MVK Semaphore Support Style & Update MoltenVK

### DIFF
--- a/3rdparty/MoltenVK/CMakeLists.txt
+++ b/3rdparty/MoltenVK/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(moltenvk
 	GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-	GIT_TAG 250e1f9
+	GIT_TAG 260bad4
 	BUILD_IN_SOURCE 1
 	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK
 	CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK/fetchDependencies" --macos

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -151,7 +151,6 @@ namespace vk
 			CHECK_RESULT_EX(_vkGetMoltenVKConfigurationMVK(VK_NULL_HANDLE, &mvk_config, &mvk_config_size), std::string("Could not get MoltenVK configuration."));
 
 			mvk_config.resumeLostDevice = true;
-			mvk_config.semaphoreSupportStyle = MVKVkSemaphoreSupportStyle::MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE;
 			mvk_config.fastMathEnabled = !(g_cfg.video.disable_msl_fast_math.get());
 
 			CHECK_RESULT_EX(_vkSetMoltenVKConfigurationMVK(VK_NULL_HANDLE, &mvk_config, &mvk_config_size), std::string("Could not set MoltenVK configuration."));


### PR DESCRIPTION
Removed line that sets the Semaphore Support Style to Vulkan single queue. This line is no longer needed as MVK will select the appropriate support style automatically. See [here]( https://github.com/KhronosGroup/MoltenVK/pull/1738) for details. 

Fixes #12774 

Removal of the line was suggested by Tellowkrinkle [here](https://github.com/RPCS3/rpcs3/issues/12774#issuecomment-1288070314), but the PR should probably be looked over by @nastys as they wrote the initial code. 