### PR TITLE
VSH: implement sys_fs_mount() and sys_fs_unmount()

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -790,7 +790,7 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	BIND_SYSC(sys_fs_chown),                                //835 (0x343)
 	NULL_FUNC(sys_fs_newfs),                                //836 (0x344)
 	BIND_SYSC(sys_fs_mount),                                //837 (0x345)
-	NULL_FUNC(sys_fs_unmount),                              //838 (0x346)
+	BIND_SYSC(sys_fs_unmount),                              //838 (0x346)
 	NULL_FUNC(sys_fs_sync),                                 //839 (0x347)
 	BIND_SYSC(sys_fs_disk_free),                            //840 (0x348)
 	BIND_SYSC(sys_fs_get_mount_info_size),                  //841 (0x349)

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -186,7 +186,9 @@ public:
 
 	lv2_fs_object& operator=(const lv2_fs_object&) = delete;
 
+	static std::string_view get_device_path(std::string_view filename);
 	static lv2_fs_mount_point* get_mp(std::string_view filename);
+	static std::string get_vfs(std::string_view filename);
 
 	static std::array<char, 0x420> get_name(std::string_view filename)
 	{
@@ -615,5 +617,6 @@ error_code sys_fs_mapped_allocate(ppu_thread& ppu, u32 fd, u64, vm::pptr<void> o
 error_code sys_fs_mapped_free(ppu_thread& ppu, u32 fd, vm::ptr<void> ptr);
 error_code sys_fs_truncate2(ppu_thread& ppu, u32 fd, u64 size);
 error_code sys_fs_mount(ppu_thread& ppu, vm::cptr<char> dev_name, vm::cptr<char> file_system, vm::cptr<char> path, s32 unk1, s32 prot, s32 unk3, vm::cptr<char> str1, u32 str_len);
+error_code sys_fs_unmount(ppu_thread&, vm::cptr<char> path, s32 unk1, s32 unk2);
 error_code sys_fs_get_mount_info_size(ppu_thread& ppu, vm::ptr<u64> len);
 error_code sys_fs_get_mount_info(ppu_thread& ppu, vm::ptr<CellFsMountInfo> info, u32 len, vm::ptr<u64> out_len);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -245,14 +245,14 @@ void Emulator::Init(bool add_only)
 	const std::string dev_bdvd = g_cfg_vfs.get(g_cfg_vfs.dev_bdvd, emu_dir); // Only used for make_path
 	const std::string dev_hdd0 = g_cfg_vfs.get(g_cfg_vfs.dev_hdd0, emu_dir);
 	const std::string dev_hdd1 = g_cfg_vfs.get(g_cfg_vfs.dev_hdd1, emu_dir);
-	const std::string dev_flsh = g_cfg_vfs.get_dev_flash();
-	const std::string dev_flsh2 = g_cfg_vfs.get_dev_flash2();
-	const std::string dev_flsh3 = g_cfg_vfs.get_dev_flash3();
+	const std::string dev_flash = g_cfg_vfs.get_dev_flash();
+	const std::string dev_flash2 = g_cfg_vfs.get_dev_flash2();
+	const std::string dev_flash3 = g_cfg_vfs.get_dev_flash3();
 
 	vfs::mount("/dev_hdd0", dev_hdd0);
-	vfs::mount("/dev_flash", dev_flsh);
-	vfs::mount("/dev_flash2", dev_flsh2);
-	vfs::mount("/dev_flash3", dev_flsh3);
+	vfs::mount("/dev_flash", dev_flash);
+	vfs::mount("/dev_flash2", dev_flash2);
+	vfs::mount("/dev_flash3", dev_flash3);
 	vfs::mount("/app_home", g_cfg_vfs.app_home.to_string().empty() ? elf_dir + '/' : g_cfg_vfs.get(g_cfg_vfs.app_home, emu_dir));
 
 	std::string dev_usb;
@@ -351,9 +351,9 @@ void Emulator::Init(bool add_only)
 		make_path_verbose(dev_bdvd);
 		make_path_verbose(dev_hdd0);
 		make_path_verbose(dev_hdd1);
-		make_path_verbose(dev_flsh);
-		make_path_verbose(dev_flsh2);
-		make_path_verbose(dev_flsh3);
+		make_path_verbose(dev_flash);
+		make_path_verbose(dev_flash2);
+		make_path_verbose(dev_flash3);
 		make_path_verbose(dev_usb);
 		make_path_verbose(dev_hdd0 + "game/");
 		make_path_verbose(dev_hdd0 + reinterpret_cast<const char*>(u8"game/＄locks/"));

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -33,12 +33,18 @@ struct vfs_manager
 	vfs_directory root{};
 };
 
-bool vfs::mount(std::string_view vpath, std::string_view path)
+bool vfs::mount(std::string_view vpath, std::string_view path, bool create_dir)
 {
 	if (vpath.empty())
 	{
 		// Empty relative path, should set relative path base; unsupported
 		vfs_log.error("Cannot mount empty path to \"%s\"", path);
+		return false;
+	}
+
+	if (create_dir && !fs::is_dir(std::string(path)) && !fs::create_dir(std::string(path)))
+	{
+		vfs_log.error("Cannot create directory \"%s\"", path);
 		return false;
 	}
 

--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -10,7 +10,7 @@ struct vfs_directory;
 namespace vfs
 {
 	// Mount VFS device
-	bool mount(std::string_view vpath, std::string_view path);
+	bool mount(std::string_view vpath, std::string_view path, bool create_dir = false);
 
 	// Unmount VFS device
 	bool unmount(std::string_view vpath);


### PR DESCRIPTION
Implemented sys_fs_mount() and sys_fs_unmount() for VSH.
Solve:
```
SYS: 'sys_fs_stat' failed with 0x8001003a : CELL_ENOTMOUNTED, “/dev_hdd1/crash_report/kernel/ps3crash-kernel.dat.tmp”
SYS: 'sys_fs_disk_free' failed with 0x80010002 : CELL_EINVAL, “/dev_hdd1”
SYS: 'sys_fs_open' failed with 0x8001003a : CELL_ENOTMOUNTED, “/dev_hdd1”
SYS: 'sys_fs_unlink' failed with 0x8001003a : CELL_ENOTMOUNTED, “/dev_hdd1/PS3UPDATE/ps3version.txt”
SYS: 'sys_fs_rmdir' failed with 0x8001003a : CELL_ENOTMOUNTED, “/dev_hdd1/PS3UPDATE”
```
Also corrected some existing typos of `dev_flash` things in System.cpp by the way.