### PR TITLE
Savestates/System.cpp: Realized fix for suspend mode

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1962,7 +1962,7 @@ void Emulator::FixGuestTime()
 			// Mark a known savestate location and the one we try to boot (in case we boot a moved/copied savestate)
 			if (g_cfg.savestate.suspend_emu)
 			{
-				for (std::string old_path : std::initializer_list<std::string>{m_ar ? m_path_old : "", m_title_id.empty() ? "" : get_savestate_path(m_title_id, path)})
+				for (std::string old_path : std::initializer_list<std::string>{m_ar ? m_path_old : "", m_title_id.empty() ? "" : get_savestate_path(m_title_id, m_path_old)})
 				{
 					if (old_path.empty())
 					{

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -666,34 +666,7 @@ game_boot_result Emulator::BootGame(const std::string& path, const std::string& 
 	{
 		m_path = path;
 
-		auto error = Load(title_id, add_only);
-
-		if (g_cfg.savestate.suspend_emu && error == game_boot_result::no_errors)
-		{
-			for (std::string old_path : std::initializer_list<std::string>{m_ar ? path : "", m_title_id.empty() ? "" : get_savestate_path(m_title_id, path)})
-			{
-				if (old_path.empty())
-				{
-					continue;
-				}
-
-				std::string new_path = old_path.substr(0, old_path.find_last_not_of(fs::delim) + 1);
-				const usz insert_pos = new_path.find_last_of(fs::delim) + 1;
-				const auto prefix = "used_"sv;
-
-				if (new_path.compare(insert_pos, prefix.size(), prefix) != 0)
-				{
-					new_path.insert(insert_pos, prefix);
-
-					if (fs::rename(old_path, new_path, true))
-					{
-						sys_log.notice("Savestate has been moved to path='%s'", new_path);
-					}
-				}
-			}
-		}
-
-		return error;
+		return Load(title_id, add_only);
 	}
 
 	game_boot_result result = game_boot_result::nothing_to_boot;
@@ -944,6 +917,8 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 
 				m_cat.clear();
 			}
+
+			m_path_old = m_path:
 
 			if (argv[0].starts_with("/dev_hdd0"sv))
 			{
@@ -1997,8 +1972,35 @@ void Emulator::FixGuestTime()
 		initialize_timebased_time(0);
 	}
 }
+
 void Emulator::FinalizeRunRequest()
 {
+	// Mark a known savestate location and the one we try to boot (in case we boot a moved/copied savestate)
+	if (g_cfg.savestate.suspend_emu)
+	{
+		for (std::string old_path : std::initializer_list<std::string>{m_ar ? m_path_old : "", m_title_id.empty() ? "" : get_savestate_path(m_title_id, path)})
+		{
+			if (old_path.empty())
+			{
+				continue;
+			}
+
+			std::string new_path = old_path.substr(0, old_path.find_last_not_of(fs::delim) + 1);
+			const usz insert_pos = new_path.find_last_of(fs::delim) + 1;
+			const auto prefix = "used_"sv;
+
+			if (new_path.compare(insert_pos, prefix.size(), prefix) != 0)
+			{
+				new_path.insert(insert_pos, prefix);
+
+				if (fs::rename(old_path, new_path, true))
+				{
+					sys_log.success("Savestate has been moved (hidden) to path='%s'", new_path);
+				}
+			}
+		}
+	}
+
 	auto on_select = [](u32, spu_thread& spu)
 	{
 		if (spu.group && spu.index == spu.group->waiter_spu_index)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1966,7 +1966,7 @@ void Emulator::FixGuestTime()
 				{
 					if (old_path.empty())
 					{
-					continue;
+						continue;
 					}
 
 					std::string new_path = old_path.substr(0, old_path.find_last_not_of(fs::delim) + 1);


### PR DESCRIPTION
Third time trying to implement it correctly, this time is because I have heard that the bug was only affecting game collections. This made me realize that savestate hiding was not done for all games when booting regularly.
Also move savestate hiding to after SPU/PPU cache were built which makes more sense.