### PR TITLE
Misc improvements and bug fix for VSH for non-CEX firmware

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -3018,7 +3018,7 @@ error_code sys_fs_mount(ppu_thread&, vm::cptr<char> dev_name, vm::cptr<char> fil
 	const auto mp = lv2_fs_object::get_mp(vpath);
 	bool success = true;
 
-	auto vfs_mount = [&](std::string mount_path)
+	auto vfs_mount = [&vpath = vpath, &filesystem = filesystem, &mp = mp](std::string mount_path)
 	{
 		const u64 file_size = filesystem == "CELL_FS_SIMPLEFS" ? mp->sector_size * mp->sector_count : 0;
 		if (!mount_path.ends_with('/'))
@@ -3081,7 +3081,7 @@ error_code sys_fs_unmount(ppu_thread&, vm::cptr<char> path, s32 unk1, s32 unk2)
 	const auto mp = lv2_fs_object::get_mp(vpath);
 	bool success = true;
 
-	auto vfs_unmount = [&]()
+	auto vfs_unmount = [&vpath = vpath]()
 	{
 		const std::string local_path = vfs::get(vpath);
 		if (fs::is_file(local_path))

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -149,6 +149,7 @@ struct lv2_fs_mount_point
 {
 	const std::string_view root;
 	const u32 sector_size = 512;
+	const u64 sector_count = 256;
 	const u32 block_size = 4096;
 	const bs_t<lv2_mp_flag> flags{};
 

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -164,6 +164,8 @@ error_code sys_ss_appliance_info_manager(u32 code, vm::ptr<u8> buffer)
 		// AIM_get_device_id
 		constexpr u8 idps[] = { 0x00, 0x00, 0x00, 0x01, 0x00, 0x89, 0x00, 0x0B, 0x14, 0x00, 0xEF, 0xDD, 0xCA, 0x25, 0x52, 0x66 };
 		std::memcpy(buffer.get_ptr(), idps, 16);
+		if (g_cfg.core.debug_console_mode)
+			buffer[5] = 0x81;
 		break;
 	}
 	case 0x19004:

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -33,18 +33,12 @@ struct vfs_manager
 	vfs_directory root{};
 };
 
-bool vfs::mount(std::string_view vpath, std::string_view path, bool create_dir, bool is_dir)
+bool vfs::mount(std::string_view vpath, std::string_view path, bool is_dir)
 {
 	if (vpath.empty())
 	{
 		// Empty relative path, should set relative path base; unsupported
 		vfs_log.error("Cannot mount empty path to \"%s\"", path);
-		return false;
-	}
-
-	if (create_dir && !fs::is_dir(std::string(path)) && !fs::create_dir(std::string(path)))
-	{
-		vfs_log.error("Cannot create directory \"%s\"", path);
 		return false;
 	}
 

--- a/rpcs3/Emu/VFS.h
+++ b/rpcs3/Emu/VFS.h
@@ -10,7 +10,7 @@ struct vfs_directory;
 namespace vfs
 {
 	// Mount VFS device
-	bool mount(std::string_view vpath, std::string_view path, bool create_dir = false, bool is_dir = true);
+	bool mount(std::string_view vpath, std::string_view path, bool is_dir = true);
 
 	// Unmount VFS device
 	bool unmount(std::string_view vpath);


### PR DESCRIPTION
This solves error 80029519 when you come across FSELF or non-retail games in XMB.
XMB only accepts this kind of game when the console is DECR, DECH, or GECR; so by changing the Product Code to DECR's, the system will deem the emulator a DECR console.

Error 80029519 screenshot:
![screenshot_2022_10_28_22_05_23](https://user-images.githubusercontent.com/17809637/198632593-b3c46f39-0b9d-4d01-a640-8b832c9971fb.png)

This also adds support for mounting dev_hdd1 as a raw disk image file; With the file_system of sys_fs_mount() set to "CELL_FS_SIMPLEFS", the device is mounted as a file, instead of a directory.