### PR TITLE
overlays/osk: allow key input of all available pages

### DIFF
--- a/rpcs3/Emu/Io/KeyboardHandler.h
+++ b/rpcs3/Emu/Io/KeyboardHandler.h
@@ -4,6 +4,7 @@
 
 #include <mutex>
 #include <vector>
+#include <set>
 
 #include "util/init_mutex.hpp"
 
@@ -52,6 +53,11 @@ struct KbData
 	std::array<KbButton, CELL_KB_MAX_KEYCODES> buttons{};
 };
 
+struct KbExtraData
+{
+	std::set<std::u32string> pressed_keys{};
+};
+
 struct KbConfig
 {
 	u32 arrange = CELL_KB_MAPPING_101;
@@ -63,6 +69,7 @@ struct Keyboard
 {
 	bool m_key_repeat = false;
 	KbData m_data{};
+	KbExtraData m_extra_data{};
 	KbConfig m_config{};
 	std::vector<KbButton> m_buttons;
 };
@@ -81,7 +88,7 @@ public:
 
 	SAVESTATE_INIT_POS(19);
 
-	void Key(u32 code, bool pressed);
+	void Key(u32 code, bool pressed, const std::u32string& key);
 	void SetIntercepted(bool intercepted);
 
 	static bool IsMetaKey(u32 code);
@@ -90,6 +97,7 @@ public:
 	std::vector<Keyboard>& GetKeyboards() { return m_keyboards; }
 	std::vector<KbButton>& GetButtons(const u32 keyboard) { return m_keyboards[keyboard].m_buttons; }
 	KbData& GetData(const u32 keyboard) { return m_keyboards[keyboard].m_data; }
+	KbExtraData& GetExtraData(const u32 keyboard) { return m_keyboards[keyboard].m_extra_data; }
 	KbConfig& GetConfig(const u32 keyboard) { return m_keyboards[keyboard].m_config; }
 
 	stx::init_mutex init;

--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.cpp
@@ -173,6 +173,27 @@ namespace rsx
 			refresh();
 		}
 
+		void edit_text::del()
+		{
+			if (caret_position >= text.length())
+			{
+				return;
+			}
+
+			if (caret_position == 0)
+			{
+				value = value.length() > 1 ? value.substr(1) : U"";
+			}
+			else
+			{
+				value = value.substr(0, caret_position) + value.substr(caret_position + 1);
+			}
+
+			m_reset_caret_pulse = true;
+			set_unicode_text(value);
+			refresh();
+		}
+
 		compiled_resource& edit_text::get_compiled()
 		{
 			if (!is_compiled)

--- a/rpcs3/Emu/RSX/Overlays/overlay_edit_text.hpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_edit_text.hpp
@@ -33,6 +33,7 @@ namespace rsx
 			void move_caret(direction dir);
 			void insert_text(const std::u32string& str);
 			void erase();
+			void del();
 
 			compiled_resource& get_compiled() override;
 		};

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -593,56 +593,12 @@ namespace rsx
 
 			const bool use_key_string_fallback = !key.empty();
 
-			osk.notice("osk_dialog::on_key_pressed(led=%d, mkey=%d, key_code=%d, out_key_code=%d, pressed=%d, use_key_string_fallback=%d)", led, mkey, key_code, out_key_code, pressed, use_key_string_fallback);
+			osk.error("osk_dialog::on_key_pressed(led=%d, mkey=%d, key_code=%d, out_key_code=%d, pressed=%d, use_key_string_fallback=%d)", led, mkey, key_code, out_key_code, pressed, use_key_string_fallback);
 
 			if (!use_key_string_fallback)
 			{
 				// Get keyboard layout
-				u32 kb_mapping = CELL_KB_MAPPING_101;
-				u32 osk_panel_mode = CELL_OSKDIALOG_PANELMODE_DEFAULT;
-				for (usz i = 0; i < m_panels.size(); ++i)
-				{
-					if (m_panel_index == i)
-					{
-						osk_panel_mode = m_panels[i].osk_panel_mode;
-						break;
-					}
-				}
-
-				switch (osk_panel_mode)
-				{
-				case CELL_OSKDIALOG_PANELMODE_DEFAULT: kb_mapping = CELL_KB_MAPPING_101; break;
-				case CELL_OSKDIALOG_PANELMODE_GERMAN: kb_mapping = CELL_KB_MAPPING_GERMAN_GERMANY; break;
-				case CELL_OSKDIALOG_PANELMODE_ENGLISH: kb_mapping = CELL_KB_MAPPING_ENGLISH_UK; break;
-				case CELL_OSKDIALOG_PANELMODE_SPANISH: kb_mapping = CELL_KB_MAPPING_SPANISH_SPAIN; break;
-				case CELL_OSKDIALOG_PANELMODE_FRENCH: kb_mapping = CELL_KB_MAPPING_FRENCH_FRANCE; break;
-				case CELL_OSKDIALOG_PANELMODE_ITALIAN: kb_mapping = CELL_KB_MAPPING_ITALIAN_ITALY; break;
-				case CELL_OSKDIALOG_PANELMODE_DUTCH: kb_mapping = CELL_KB_MAPPING_DUTCH_NETHERLANDS; break;
-				case CELL_OSKDIALOG_PANELMODE_PORTUGUESE: kb_mapping = CELL_KB_MAPPING_PORTUGUESE_PORTUGAL; break;
-				case CELL_OSKDIALOG_PANELMODE_RUSSIAN: kb_mapping = CELL_KB_MAPPING_RUSSIAN_RUSSIA; break;
-				case CELL_OSKDIALOG_PANELMODE_JAPANESE: kb_mapping = CELL_KB_MAPPING_106; break;
-				case CELL_OSKDIALOG_PANELMODE_DEFAULT_NO_JAPANESE: kb_mapping = CELL_KB_MAPPING_106; break;
-				case CELL_OSKDIALOG_PANELMODE_POLISH: kb_mapping = CELL_KB_MAPPING_POLISH_POLAND; break;
-				case CELL_OSKDIALOG_PANELMODE_KOREAN: kb_mapping = CELL_KB_MAPPING_KOREAN_KOREA; break;
-				case CELL_OSKDIALOG_PANELMODE_TURKEY: kb_mapping = CELL_KB_MAPPING_TURKISH_TURKEY; break;
-				case CELL_OSKDIALOG_PANELMODE_TRADITIONAL_CHINESE: kb_mapping = CELL_KB_MAPPING_CHINESE_TRADITIONAL; break;
-				case CELL_OSKDIALOG_PANELMODE_SIMPLIFIED_CHINESE: kb_mapping = CELL_KB_MAPPING_CHINESE_SIMPLIFIED; break;
-				case CELL_OSKDIALOG_PANELMODE_PORTUGUESE_BRAZIL: kb_mapping = CELL_KB_MAPPING_PORTUGUESE_BRAZIL; break;
-				case CELL_OSKDIALOG_PANELMODE_DANISH: kb_mapping = CELL_KB_MAPPING_DANISH_DENMARK; break;
-				case CELL_OSKDIALOG_PANELMODE_SWEDISH: kb_mapping = CELL_KB_MAPPING_SWEDISH_SWEDEN; break;
-				case CELL_OSKDIALOG_PANELMODE_NORWEGIAN: kb_mapping = CELL_KB_MAPPING_NORWEGIAN_NORWAY; break;
-				case CELL_OSKDIALOG_PANELMODE_FINNISH: kb_mapping = CELL_KB_MAPPING_FINNISH_FINLAND; break;
-				case CELL_OSKDIALOG_PANELMODE_JAPANESE_HIRAGANA: kb_mapping = CELL_KB_MAPPING_106; break;
-				case CELL_OSKDIALOG_PANELMODE_JAPANESE_KATAKANA: kb_mapping = CELL_KB_MAPPING_106_KANA; break;
-				case CELL_OSKDIALOG_PANELMODE_ALPHABET_FULL_WIDTH: kb_mapping = CELL_KB_MAPPING_106; break;
-				case CELL_OSKDIALOG_PANELMODE_ALPHABET: kb_mapping = CELL_KB_MAPPING_101; break;
-				case CELL_OSKDIALOG_PANELMODE_LATIN: kb_mapping = CELL_KB_MAPPING_101; break;
-				case CELL_OSKDIALOG_PANELMODE_NUMERAL_FULL_WIDTH: kb_mapping = CELL_KB_MAPPING_101; break;
-				case CELL_OSKDIALOG_PANELMODE_NUMERAL: kb_mapping = CELL_KB_MAPPING_101; break;
-				case CELL_OSKDIALOG_PANELMODE_URL: kb_mapping = CELL_KB_MAPPING_101; break;
-				case CELL_OSKDIALOG_PANELMODE_PASSWORD: kb_mapping = CELL_KB_MAPPING_101; break;
-				default: kb_mapping = CELL_KB_MAPPING_101; break;
-				}
+				const u32 kb_mapping = static_cast<u32>(g_cfg.sys.keyboard_type.get());
 
 				// Convert key to its u32string presentation
 				const u16 converted_out_key = cellKbCnvRawCode(kb_mapping, mkey, led, out_key_code);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -706,6 +706,18 @@ namespace rsx
 				case CELL_KEYC_ESCAPE:
 					Close(CELL_OSKDIALOG_CLOSE_CANCEL);
 					break;
+				case CELL_KEYC_RIGHT_ARROW:
+					on_move_cursor(key, edit_text::direction::right);
+					break;
+				case CELL_KEYC_LEFT_ARROW:
+					on_move_cursor(key, edit_text::direction::left);
+					break;
+				case CELL_KEYC_DOWN_ARROW:
+					on_move_cursor(key, edit_text::direction::down);
+					break;
+				case CELL_KEYC_UP_ARROW:
+					on_move_cursor(key, edit_text::direction::up);
+					break;
 				case CELL_KEYC_ENTER:
 					if ((flags & CELL_OSKDIALOG_NO_RETURN))
 					{
@@ -831,6 +843,12 @@ namespace rsx
 			{
 				// Beep or give some other kind of visual feedback
 			}
+		}
+
+		void osk_dialog::on_move_cursor(const std::u32string&, edit_text::direction dir)
+		{
+			m_preview.move_caret(dir);
+			m_update = true;
 		}
 
 		std::u32string osk_dialog::get_placeholder() const

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -700,6 +700,9 @@ namespace rsx
 				case CELL_KEYC_BS:
 					on_backspace(key);
 					break;
+				case CELL_KEYC_DELETE:
+					on_delete(key);
+					break;
 				case CELL_KEYC_ESCAPE:
 					Close(CELL_OSKDIALOG_CLOSE_CANCEL);
 					break;
@@ -809,6 +812,12 @@ namespace rsx
 		void osk_dialog::on_backspace(const std::u32string&)
 		{
 			m_preview.erase();
+			on_text_changed();
+		}
+
+		void osk_dialog::on_delete(const std::u32string&)
+		{
+			m_preview.del();
 			on_text_changed();
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -586,98 +586,107 @@ namespace rsx
 			}
 		}
 
-		void osk_dialog::on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed)
+		void osk_dialog::on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed, std::u32string key)
 		{
 			if (!pressed || !keyboard_input_enabled || ignore_input_events)
 				return;
 
-			osk.notice("osk_dialog::on_key_pressed(led=%d, mkey=%d, key_code=%d, out_key_code=%d, pressed=%d)", led, mkey, key_code, out_key_code, pressed);
+			const bool use_key_string_fallback = !key.empty();
 
-			// Get keyboard layout
-			u32 kb_mapping = CELL_KB_MAPPING_101;
-			u32 osk_panel_mode = CELL_OSKDIALOG_PANELMODE_DEFAULT;
-			for (usz i = 0; i < m_panels.size(); ++i)
+			osk.notice("osk_dialog::on_key_pressed(led=%d, mkey=%d, key_code=%d, out_key_code=%d, pressed=%d, use_key_string_fallback=%d)", led, mkey, key_code, out_key_code, pressed, use_key_string_fallback);
+
+			if (!use_key_string_fallback)
 			{
-				if (m_panel_index == i)
+				// Get keyboard layout
+				u32 kb_mapping = CELL_KB_MAPPING_101;
+				u32 osk_panel_mode = CELL_OSKDIALOG_PANELMODE_DEFAULT;
+				for (usz i = 0; i < m_panels.size(); ++i)
 				{
-					osk_panel_mode = m_panels[i].osk_panel_mode;
-					break;
-				}
-			}
-
-			switch (osk_panel_mode)
-			{
-			case CELL_OSKDIALOG_PANELMODE_DEFAULT            : kb_mapping = CELL_KB_MAPPING_101; break;
-			case CELL_OSKDIALOG_PANELMODE_GERMAN             : kb_mapping = CELL_KB_MAPPING_GERMAN_GERMANY; break;
-			case CELL_OSKDIALOG_PANELMODE_ENGLISH            : kb_mapping = CELL_KB_MAPPING_ENGLISH_UK; break;
-			case CELL_OSKDIALOG_PANELMODE_SPANISH            : kb_mapping = CELL_KB_MAPPING_SPANISH_SPAIN; break;
-			case CELL_OSKDIALOG_PANELMODE_FRENCH             : kb_mapping = CELL_KB_MAPPING_FRENCH_FRANCE; break;
-			case CELL_OSKDIALOG_PANELMODE_ITALIAN            : kb_mapping = CELL_KB_MAPPING_ITALIAN_ITALY; break;
-			case CELL_OSKDIALOG_PANELMODE_DUTCH              : kb_mapping = CELL_KB_MAPPING_DUTCH_NETHERLANDS; break;
-			case CELL_OSKDIALOG_PANELMODE_PORTUGUESE         : kb_mapping = CELL_KB_MAPPING_PORTUGUESE_PORTUGAL; break;
-			case CELL_OSKDIALOG_PANELMODE_RUSSIAN            : kb_mapping = CELL_KB_MAPPING_RUSSIAN_RUSSIA; break;
-			case CELL_OSKDIALOG_PANELMODE_JAPANESE           : kb_mapping = CELL_KB_MAPPING_106; break;
-			case CELL_OSKDIALOG_PANELMODE_DEFAULT_NO_JAPANESE: kb_mapping = CELL_KB_MAPPING_106; break;
-			case CELL_OSKDIALOG_PANELMODE_POLISH             : kb_mapping = CELL_KB_MAPPING_POLISH_POLAND; break;
-			case CELL_OSKDIALOG_PANELMODE_KOREAN             : kb_mapping = CELL_KB_MAPPING_KOREAN_KOREA; break;
-			case CELL_OSKDIALOG_PANELMODE_TURKEY             : kb_mapping = CELL_KB_MAPPING_TURKISH_TURKEY; break;
-			case CELL_OSKDIALOG_PANELMODE_TRADITIONAL_CHINESE: kb_mapping = CELL_KB_MAPPING_CHINESE_TRADITIONAL; break;
-			case CELL_OSKDIALOG_PANELMODE_SIMPLIFIED_CHINESE : kb_mapping = CELL_KB_MAPPING_CHINESE_SIMPLIFIED; break;
-			case CELL_OSKDIALOG_PANELMODE_PORTUGUESE_BRAZIL  : kb_mapping = CELL_KB_MAPPING_PORTUGUESE_BRAZIL; break;
-			case CELL_OSKDIALOG_PANELMODE_DANISH             : kb_mapping = CELL_KB_MAPPING_DANISH_DENMARK; break;
-			case CELL_OSKDIALOG_PANELMODE_SWEDISH            : kb_mapping = CELL_KB_MAPPING_SWEDISH_SWEDEN; break;
-			case CELL_OSKDIALOG_PANELMODE_NORWEGIAN          : kb_mapping = CELL_KB_MAPPING_NORWEGIAN_NORWAY; break;
-			case CELL_OSKDIALOG_PANELMODE_FINNISH            : kb_mapping = CELL_KB_MAPPING_FINNISH_FINLAND; break;
-			case CELL_OSKDIALOG_PANELMODE_JAPANESE_HIRAGANA  : kb_mapping = CELL_KB_MAPPING_106; break;
-			case CELL_OSKDIALOG_PANELMODE_JAPANESE_KATAKANA  : kb_mapping = CELL_KB_MAPPING_106_KANA; break;
-			case CELL_OSKDIALOG_PANELMODE_ALPHABET_FULL_WIDTH: kb_mapping = CELL_KB_MAPPING_106; break;
-			case CELL_OSKDIALOG_PANELMODE_ALPHABET           : kb_mapping = CELL_KB_MAPPING_101; break;
-			case CELL_OSKDIALOG_PANELMODE_LATIN              : kb_mapping = CELL_KB_MAPPING_101; break;
-			case CELL_OSKDIALOG_PANELMODE_NUMERAL_FULL_WIDTH : kb_mapping = CELL_KB_MAPPING_101; break;
-			case CELL_OSKDIALOG_PANELMODE_NUMERAL            : kb_mapping = CELL_KB_MAPPING_101; break;
-			case CELL_OSKDIALOG_PANELMODE_URL                : kb_mapping = CELL_KB_MAPPING_101; break;
-			case CELL_OSKDIALOG_PANELMODE_PASSWORD           : kb_mapping = CELL_KB_MAPPING_101; break;
-			default                                          : kb_mapping = CELL_KB_MAPPING_101; break;
-			}
-
-			// Convert key to its u32string presentation
-			const u16 converted_out_key = cellKbCnvRawCode(kb_mapping, mkey, led, out_key_code);
-			std::u16string utf16_string;
-			utf16_string.push_back(converted_out_key);
-			const std::u32string u32_string = utf16_to_u32string(utf16_string);
-			const std::string out_key_string = utf16_to_ascii8(utf16_string);
-
-			// Find matching key in the OSK
-			bool found_key = false;
-			for (const cell& current_cell : m_grid)
-			{
-				// TODO: maybe just ignore the current charset and check all outputs
-				if (m_selected_charset < current_cell.outputs.size())
-				{
-					for (const auto& str : current_cell.outputs[m_selected_charset])
+					if (m_panel_index == i)
 					{
-						if (str == u32_string)
-						{
-							// Apply key press
-							if (current_cell.callback)
-							{
-								current_cell.callback(str);
-							}
-							else
-							{
-								on_default_callback(str);
-							}
-
-							found_key = true;
-							break;
-						}
-					}
-
-					if (found_key)
-					{
+						osk_panel_mode = m_panels[i].osk_panel_mode;
 						break;
 					}
 				}
+
+				switch (osk_panel_mode)
+				{
+				case CELL_OSKDIALOG_PANELMODE_DEFAULT: kb_mapping = CELL_KB_MAPPING_101; break;
+				case CELL_OSKDIALOG_PANELMODE_GERMAN: kb_mapping = CELL_KB_MAPPING_GERMAN_GERMANY; break;
+				case CELL_OSKDIALOG_PANELMODE_ENGLISH: kb_mapping = CELL_KB_MAPPING_ENGLISH_UK; break;
+				case CELL_OSKDIALOG_PANELMODE_SPANISH: kb_mapping = CELL_KB_MAPPING_SPANISH_SPAIN; break;
+				case CELL_OSKDIALOG_PANELMODE_FRENCH: kb_mapping = CELL_KB_MAPPING_FRENCH_FRANCE; break;
+				case CELL_OSKDIALOG_PANELMODE_ITALIAN: kb_mapping = CELL_KB_MAPPING_ITALIAN_ITALY; break;
+				case CELL_OSKDIALOG_PANELMODE_DUTCH: kb_mapping = CELL_KB_MAPPING_DUTCH_NETHERLANDS; break;
+				case CELL_OSKDIALOG_PANELMODE_PORTUGUESE: kb_mapping = CELL_KB_MAPPING_PORTUGUESE_PORTUGAL; break;
+				case CELL_OSKDIALOG_PANELMODE_RUSSIAN: kb_mapping = CELL_KB_MAPPING_RUSSIAN_RUSSIA; break;
+				case CELL_OSKDIALOG_PANELMODE_JAPANESE: kb_mapping = CELL_KB_MAPPING_106; break;
+				case CELL_OSKDIALOG_PANELMODE_DEFAULT_NO_JAPANESE: kb_mapping = CELL_KB_MAPPING_106; break;
+				case CELL_OSKDIALOG_PANELMODE_POLISH: kb_mapping = CELL_KB_MAPPING_POLISH_POLAND; break;
+				case CELL_OSKDIALOG_PANELMODE_KOREAN: kb_mapping = CELL_KB_MAPPING_KOREAN_KOREA; break;
+				case CELL_OSKDIALOG_PANELMODE_TURKEY: kb_mapping = CELL_KB_MAPPING_TURKISH_TURKEY; break;
+				case CELL_OSKDIALOG_PANELMODE_TRADITIONAL_CHINESE: kb_mapping = CELL_KB_MAPPING_CHINESE_TRADITIONAL; break;
+				case CELL_OSKDIALOG_PANELMODE_SIMPLIFIED_CHINESE: kb_mapping = CELL_KB_MAPPING_CHINESE_SIMPLIFIED; break;
+				case CELL_OSKDIALOG_PANELMODE_PORTUGUESE_BRAZIL: kb_mapping = CELL_KB_MAPPING_PORTUGUESE_BRAZIL; break;
+				case CELL_OSKDIALOG_PANELMODE_DANISH: kb_mapping = CELL_KB_MAPPING_DANISH_DENMARK; break;
+				case CELL_OSKDIALOG_PANELMODE_SWEDISH: kb_mapping = CELL_KB_MAPPING_SWEDISH_SWEDEN; break;
+				case CELL_OSKDIALOG_PANELMODE_NORWEGIAN: kb_mapping = CELL_KB_MAPPING_NORWEGIAN_NORWAY; break;
+				case CELL_OSKDIALOG_PANELMODE_FINNISH: kb_mapping = CELL_KB_MAPPING_FINNISH_FINLAND; break;
+				case CELL_OSKDIALOG_PANELMODE_JAPANESE_HIRAGANA: kb_mapping = CELL_KB_MAPPING_106; break;
+				case CELL_OSKDIALOG_PANELMODE_JAPANESE_KATAKANA: kb_mapping = CELL_KB_MAPPING_106_KANA; break;
+				case CELL_OSKDIALOG_PANELMODE_ALPHABET_FULL_WIDTH: kb_mapping = CELL_KB_MAPPING_106; break;
+				case CELL_OSKDIALOG_PANELMODE_ALPHABET: kb_mapping = CELL_KB_MAPPING_101; break;
+				case CELL_OSKDIALOG_PANELMODE_LATIN: kb_mapping = CELL_KB_MAPPING_101; break;
+				case CELL_OSKDIALOG_PANELMODE_NUMERAL_FULL_WIDTH: kb_mapping = CELL_KB_MAPPING_101; break;
+				case CELL_OSKDIALOG_PANELMODE_NUMERAL: kb_mapping = CELL_KB_MAPPING_101; break;
+				case CELL_OSKDIALOG_PANELMODE_URL: kb_mapping = CELL_KB_MAPPING_101; break;
+				case CELL_OSKDIALOG_PANELMODE_PASSWORD: kb_mapping = CELL_KB_MAPPING_101; break;
+				default: kb_mapping = CELL_KB_MAPPING_101; break;
+				}
+
+				// Convert key to its u32string presentation
+				const u16 converted_out_key = cellKbCnvRawCode(kb_mapping, mkey, led, out_key_code);
+				std::u16string utf16_string;
+				utf16_string.push_back(converted_out_key);
+				key = utf16_to_u32string(utf16_string);
+			}
+
+			// Find matching key in the OSK
+			const auto find_key = [&]() -> bool
+			{
+				for (const cell& current_cell : m_grid)
+				{
+					for (const auto& output : current_cell.outputs)
+					{
+						for (const auto& str : output)
+						{
+							if (str == key)
+							{
+								// Apply key press
+								if (current_cell.callback)
+								{
+									current_cell.callback(str);
+								}
+								else
+								{
+									on_default_callback(str);
+								}
+
+								return true;
+							}
+						}
+					}
+				}
+
+				return false;
+			};
+
+			const bool found_key = find_key();
+
+			if (use_key_string_fallback)
+			{
+				// We don't have a keycode, so there we can't process any of the following code anyway
+				return;
 			}
 
 			// Handle special input
@@ -686,10 +695,10 @@ namespace rsx
 				switch (out_key_code)
 				{
 				case CELL_KEYC_SPACE:
-					on_space(u32_string);
+					on_space(key);
 					break;
 				case CELL_KEYC_BS:
-					on_backspace(u32_string);
+					on_backspace(key);
 					break;
 				case CELL_KEYC_ESCAPE:
 					Close(CELL_OSKDIALOG_CLOSE_CANCEL);
@@ -701,7 +710,7 @@ namespace rsx
 					}
 					else
 					{
-						on_enter(u32_string);
+						on_enter(key);
 					}
 					break;
 				default:

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -104,6 +104,7 @@ namespace rsx
 			void on_layer(const std::u32string&);
 			void on_space(const std::u32string&);
 			void on_backspace(const std::u32string&);
+			void on_delete(const std::u32string&);
 			void on_enter(const std::u32string&);
 
 			std::u32string get_placeholder() const;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -96,7 +96,7 @@ namespace rsx
 			void update_selection_by_index(u32 index);
 
 			void on_button_pressed(pad_button button_press) override;
-			void on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed) override;
+			void on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed, std::u32string key) override;
 			void on_text_changed();
 
 			void on_default_callback(const std::u32string& str);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -106,6 +106,7 @@ namespace rsx
 			void on_backspace(const std::u32string&);
 			void on_delete(const std::u32string&);
 			void on_enter(const std::u32string&);
+			void on_move_cursor(const std::u32string&, edit_text::direction dir);
 
 			std::u32string get_placeholder() const;
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -151,17 +151,24 @@ namespace rsx
 					if (!handler.GetKeyboards().empty() && handler.GetInfo().status[0] == CELL_KB_STATUS_CONNECTED)
 					{
 						KbData& current_data = handler.GetData(0);
+						KbExtraData& extra_data = handler.GetExtraData(0);
 
-						if (current_data.len > 0)
+						if (current_data.len > 0 || !extra_data.pressed_keys.empty())
 						{
 							for (s32 i = 0; i < current_data.len; i++)
 							{
 								const KbButton& key = current_data.buttons[i];
-								on_key_pressed(current_data.led, current_data.mkey, key.m_keyCode, key.m_outKeyCode, key.m_pressed);
+								on_key_pressed(current_data.led, current_data.mkey, key.m_keyCode, key.m_outKeyCode, key.m_pressed, {});
+							}
+
+							for (const std::u32string& key : extra_data.pressed_keys)
+							{
+								on_key_pressed(0, 0, 0, 0, true, key);
 							}
 
 							// Flush buffer unconditionally. Otherwise we get a flood of key events.
 							current_data.len = 0;
+							extra_data.pressed_keys.clear();
 
 							// Ignore gamepad input if a key was recognized
 							refresh();

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -124,7 +124,7 @@ namespace rsx
 			compiled_resource get_compiled() override = 0;
 
 			virtual void on_button_pressed(pad_button /*button_press*/) {}
-			virtual void on_key_pressed(u32 /*led*/, u32 /*mkey*/, u32 /*key_code*/, u32 /*out_key_code*/, bool /*pressed*/) {}
+			virtual void on_key_pressed(u32 /*led*/, u32 /*mkey*/, u32 /*key_code*/, u32 /*out_key_code*/, bool /*pressed*/, std::u32string /*key*/) {}
 
 			virtual void close(bool use_callback, bool stop_pad_interception);
 

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -104,7 +104,7 @@ void basic_keyboard_handler::keyPressEvent(QKeyEvent* keyEvent)
 
 	if (key >= 0)
 	{
-		Key(static_cast<u32>(key), true);
+		Key(static_cast<u32>(key), true, keyEvent->text().toStdU32String());
 	}
 }
 
@@ -125,7 +125,7 @@ void basic_keyboard_handler::keyReleaseEvent(QKeyEvent* keyEvent)
 
 	if (key >= 0)
 	{
-		Key(static_cast<u32>(key), false);
+		Key(static_cast<u32>(key), false, keyEvent->text().toStdU32String());
 	}
 }
 


### PR DESCRIPTION
#### Additions:
- Added delete action to the overlay text edit and the OSK keyboard interaction
- Added cursor movement with arrow keys to the OSK keyboard interaction
- Added a string-based fallback for keys unknown to cellKbCnvRawCode to the OSK keyboard interaction.
This should fix input for stuff like öäü

#### Changes:
- Changed the language behaviour of the keypresses.
Before, we interpreted each keypress based on the current osk panel (you can actually change this with L2 and R2).
Now, we interpret each keypress based on the configured keyboard layout in the system settings.
- Changed the logic of how the keyboard interactions with the OSK panels.
Before, the OSK would only register keypresses that matched a letter that was currently visible on the current page.
Now, it will register any keypress that matches any letter in all pages of the current panel.

fixes #12897