### PR TITLE
VSH: sys_fs: Minor fixup

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -788,7 +788,7 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	BIND_SYSC(sys_fs_symbolic_link),                        //833 (0x341)
 	BIND_SYSC(sys_fs_chmod),                                //834 (0x342)
 	BIND_SYSC(sys_fs_chown),                                //835 (0x343)
-	NULL_FUNC(sys_fs_newfs),                                //836 (0x344)
+	BIND_SYSC(sys_fs_newfs),                                //836 (0x344)
 	BIND_SYSC(sys_fs_mount),                                //837 (0x345)
 	BIND_SYSC(sys_fs_unmount),                              //838 (0x346)
 	NULL_FUNC(sys_fs_sync),                                 //839 (0x347)

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -617,6 +617,7 @@ error_code sys_fs_lsn_write(ppu_thread& ppu, u32 fd, vm::cptr<void>, u64);
 error_code sys_fs_mapped_allocate(ppu_thread& ppu, u32 fd, u64, vm::pptr<void> out_ptr);
 error_code sys_fs_mapped_free(ppu_thread& ppu, u32 fd, vm::ptr<void> ptr);
 error_code sys_fs_truncate2(ppu_thread& ppu, u32 fd, u64 size);
+error_code sys_fs_newfs(ppu_thread& ppu, vm::cptr<char> dev_name, vm::cptr<char> file_system, s32 unk1, vm::cptr<char> str1);
 error_code sys_fs_mount(ppu_thread& ppu, vm::cptr<char> dev_name, vm::cptr<char> file_system, vm::cptr<char> path, s32 unk1, s32 prot, s32 unk3, vm::cptr<char> str1, u32 str_len);
 error_code sys_fs_unmount(ppu_thread&, vm::cptr<char> path, s32 unk1, s32 unk2);
 error_code sys_fs_get_mount_info_size(ppu_thread& ppu, vm::ptr<u64> len);


### PR DESCRIPTION
Fixed up some code in sys_fs_mount().
Also captured sys_fs_newfs(), which is used when the VSH attempts to format a device, for logging.
Log example:
`sys_fs TODO: sys_fs_newfs(dev_name=“CELL_FS_UTILITY:HDD1”, file_system=“CELL_FS_FAT”, unk1=0x0, str1=“”)`