### PR TITLE
Popularity fixes

### DIFF
--- a/Utilities/Config.h
+++ b/Utilities/Config.h
@@ -165,9 +165,17 @@ namespace cfg
 
 		bool from_string(std::string_view value, bool /*dynamic*/ = false) override
 		{
-			if (value == "false")
+			if (value.size() != 4 && value.size() != 5)
+			{
+				return false;
+			}
+
+			char copy[5];
+			std::transform(value.begin(), value.end(), std::begin(copy), ::tolower);
+
+			if (value.size() == 5 && std::string_view{copy, 5} == "false")
 				m_value = false;
-			else if (value == "true")
+			else if (value.size() == 4 && std::string_view{copy, 4} == "true")
 				m_value = true;
 			else
 				return false;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2644,13 +2644,6 @@ std::shared_ptr<utils::serial> Emulator::Kill(bool allow_autoexit, bool savestat
 	m_ar.reset();
 	read_used_savestate_versions();
 
-	if (savestate && !g_cfg.savestate.suspend_emu)
-	{
-		to_ar.reset();
-		BootGame(m_path);
-		return to_ar;
-	}
-
 	// Always Enable display sleep, not only if it was prevented.
 	enable_display_sleep();
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -315,7 +315,7 @@ struct cfg_root : cfg::node
 	{
 		node_savestate(cfg::node* _this) : cfg::node(_this, "Savestate") {}
 
-		cfg::_bool start_paused{ this, "Start Paused 2", true }; // Pause on first frame
+		cfg::_bool start_paused{ this, "Start Paused", false }; // Pause on first frame
 		cfg::_bool suspend_emu{ this, "Suspend Emulation Savestate Mode", false }; // Close emulation when saving, delete save after loading
 		cfg::_bool state_inspection_mode{ this, "Inspection Mode Savestates" }; // Save memory stored in executable files, thus allowing to view state without any files (for debugging)
 		cfg::_bool save_disc_game_data{ this, "Save Disc Game Data", false };

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -429,7 +429,7 @@ void pad_thread::operator()()
 
 			m_mask_start_press_to_unpause &= pressed_mask;
 
-			if (!pressed_mask || timestamp - m_track_start_press_begin_timestamp >= 1'000'000)
+			if (!pressed_mask || timestamp - m_track_start_press_begin_timestamp >= 700'000)
 			{
 				m_track_start_press_begin_timestamp = timestamp;
 

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -36,6 +36,7 @@ enum class emu_settings_type
 	DebugConsoleMode,
 	SilenceAllLogs,
 	SuspendEmulationSavestateMode,
+	StartSavestatePaused,
 	MaxSPURSThreads,
 	SleepTimersAccuracy,
 	ClocksScale,
@@ -360,4 +361,5 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 
 	// Savestates
 	{ emu_settings_type::SuspendEmulationSavestateMode,       { "Savestate", "Suspend Emulation Savestate Mode" }},
+	{ emu_settings_type::StartSavestatePaused,                { "Savestate", "Start Paused" }},
 };

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1336,6 +1336,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->suspendSavestates, emu_settings_type::SuspendEmulationSavestateMode);
 	SubscribeTooltip(ui->suspendSavestates, tooltips.settings.suspend_savestates);
 
+	m_emu_settings->EnhanceCheckBox(ui->pausedSavestates, emu_settings_type::StartSavestatePaused);
+	SubscribeTooltip(ui->pausedSavestates, tooltips.settings.paused_savestates);
+
 	m_emu_settings->EnhanceCheckBox(ui->silenceAllLogs, emu_settings_type::SilenceAllLogs);
 	SubscribeTooltip(ui->silenceAllLogs, tooltips.settings.silence_all_logs);
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2342,6 +2342,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="pausedSavestates">
+                 <property name="text">
+                  <string>Start Savestates Paused</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="silenceAllLogs">
                  <property name="text">
                   <string>Silence All Logs</string>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -43,6 +43,7 @@ public:
 		const QString allow_host_labels            = tr("Allows the host GPU to synchronize with CELL directly. This incurs a performance penalty, but exposes the true state of GPU objects to the guest CPU. Can help eliminate visual noise and glitching at the cost of performance. Use with caution.");
 		const QString disable_msl_fast_math        = tr("Disables Fast Math for MSL shaders, which may violate the IEEE 754 standard.\nDisabling it may fix some artefacts especially on Apple GPUs, at the cost of performance.");
 		const QString suspend_savestates           = tr("When this mode is on, emulation exits when saving and the savestate file is concealed after loading it, preventing reuse by RPCS3.\nThis mode is like hibernation of emulation: if you don't want to be able to cheat using savestates when playing the game, consider using this mode.\nDo note that the savestate file is not gone completely just ignored by RPCS3, you can manually relaunch it if needed.");
+		const QString paused_savestates            = tr("When this mode is on, savestates are loaded and paused on the first frame.\nThis allows players to prepare for gameplay without being thrown into the action immediately.");
 
 		// audio
 


### PR DESCRIPTION
Don't start savestates paused by default, lower pressing delay to unpause, move the setting to start paused to UI, don't automatically restart savestates.