### PR TITLE
Restrained PRX fixes

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3192,6 +3192,13 @@ extern void ppu_initialize()
 			if (ptr->path.starts_with(firmware_sprx_path))
 			{
 				compile_fw |= ppu_initialize(*ptr, true);
+
+				// Fixup for compatibility with old savestates
+				if (Emu.DeserialManager() && ptr->name == "liblv2.sprx")
+				{
+					static_cast<lv2_prx*>(ptr)->state = PRX_STATE_STARTED;
+					static_cast<lv2_prx*>(ptr)->load_exports();
+				}
 			}
 		}
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -169,6 +169,7 @@ enum : u32
 	PRX_STATE_STARTED,
 	PRX_STATE_STOPPING, // In-between state between started and stopped (internal)
 	PRX_STATE_STOPPED, // Last state, the module cannot be restarted
+	PRX_STATE_DESTROYED, // Last state, the module cannot be restarted
 };
 
 struct lv2_prx final : lv2_obj, ppu_module
@@ -176,6 +177,7 @@ struct lv2_prx final : lv2_obj, ppu_module
 	static const u32 id_base = 0x23000000;
 
 	atomic_t<u32> state = PRX_STATE_INITIALIZED;
+	shared_mutex mutex;
 
 	std::unordered_map<u32, u32> specials;
 	std::unordered_map<u32, void*> imports;
@@ -189,6 +191,11 @@ struct lv2_prx final : lv2_obj, ppu_module
 	char module_info_name[28];
 	u8 module_info_version[2];
 	be_t<u16> module_info_attributes;
+
+	u32 exports_start = umax;
+	u32 exports_end = 0;
+
+	void load_exports(); // (Re)load exports
 
 	lv2_prx() noexcept = default;
 	lv2_prx(utils::serial&) {}

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -42,7 +42,7 @@ SERIALIZATION_VER(lv2_sync, 3,                                  1)
 SERIALIZATION_VER(lv2_vm, 4,                                    1)
 SERIALIZATION_VER(lv2_net, 5,                                   1)
 SERIALIZATION_VER(lv2_fs, 6,                                    1)
-SERIALIZATION_VER(lv2_prx_overlay, 7,                           1)
+SERIALIZATION_VER(lv2_prx_overlay, 7,                           1, 2/*PRX dynamic exports*/)
 SERIALIZATION_VER(lv2_memory, 8,                                1)
 SERIALIZATION_VER(lv2_config, 9,                                1)
 


### PR DESCRIPTION
* Make PRX functions thread-safe, odd that they weren't before.
* Use std::map instead of std::unordered_map to fix potential pointer invalidation on insert where matters.
* Export PRX functions on start_module() instead of load_module().

Fixes #5080