### PR TITLE
Disable unsupported PPU settings on boot

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
@@ -298,7 +298,7 @@ error_code cellAudioOutGetAvailableDeviceInfo(u32 count, vm::ptr<CellAudioOutDev
 
 error_code cellVideoOutSetGamma(u32 videoOut, f32 gamma)
 {
-	cellAvconfExt.warning("cellVideoOutSetGamma(videoOut=%d, gamma=%f)", videoOut, gamma);
+	cellAvconfExt.trace("cellVideoOutSetGamma(videoOut=%d, gamma=%f)", videoOut, gamma);
 
 	if (gamma < 0.8f || gamma > 1.2f)
 	{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2807,35 +2807,31 @@ extern fs::file make_file_view(fs::file&& _file, u64 offset)
 
 extern void ppu_finalize(const ppu_module& info)
 {
-	// Get cache path for this executable
-	std::string cache_path;
-
 	if (info.name.empty())
 	{
 		// Don't remove main module from memory
 		return;
 	}
-	else
+
+	const std::string dev_flash = vfs::get("/dev_flash/sys/");
+
+	if (info.path.starts_with(dev_flash) || Emu.GetCat() == "1P")
 	{
-		// Get PPU cache location
-		cache_path = fs::get_cache_dir() + "cache/";
-
-		const std::string dev_flash = vfs::get("/dev_flash/sys/");
-
-		if (info.path.starts_with(dev_flash) || Emu.GetCat() == "1P")
-		{
-			// Don't remove dev_flash prx from memory
-			return;
-		}
-		else if (!Emu.GetTitleID().empty())
-		{
-			cache_path += Emu.GetTitleID();
-			cache_path += '/';
-		}
-
-		// Add PPU hash and filename
-		fmt::append(cache_path, "ppu-%s-%s/", fmt::base57(info.sha1), info.path.substr(info.path.find_last_of('/') + 1));
+		// Don't remove dev_flash prx from memory
+		return;
 	}
+
+	// Get cache path for this executable
+	std::string cache_path = fs::get_cache_dir() + "cache/";
+
+	if (!Emu.GetTitleID().empty())
+	{
+		cache_path += Emu.GetTitleID();
+		cache_path += '/';
+	}
+
+	// Add PPU hash and filename
+	fmt::append(cache_path, "ppu-%s-%s/", fmt::base57(info.sha1), info.path.substr(info.path.find_last_of('/') + 1));
 
 #ifdef LLVM_AVAILABLE
 	g_fxo->get<jit_module_manager>().remove(cache_path + info.name);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -721,36 +721,39 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 {
 	m_ar.reset();
 
-	if (m_config_mode == cfg_mode::continuous)
+	if (!add_only)
 	{
-		// The program is being booted from another running program
-		// CELL_GAME_GAMETYPE_GAMEDATA is not used as boot type
+		if (m_config_mode == cfg_mode::continuous)
+		{
+			// The program is being booted from another running program
+			// CELL_GAME_GAMETYPE_GAMEDATA is not used as boot type
 
-		if (m_cat == "DG"sv)
-		{
-			m_boot_source_type = CELL_GAME_GAMETYPE_DISC;
-		}
-		else if (m_cat == "HM"sv)
-		{
-			m_boot_source_type = CELL_GAME_GAMETYPE_HOME;
+			if (m_cat == "DG"sv)
+			{
+				m_boot_source_type = CELL_GAME_GAMETYPE_DISC;
+			}
+			else if (m_cat == "HM"sv)
+			{
+				m_boot_source_type = CELL_GAME_GAMETYPE_HOME;
+			}
+			else
+			{
+				m_boot_source_type = CELL_GAME_GAMETYPE_HDD;
+			}
 		}
 		else
 		{
-			m_boot_source_type = CELL_GAME_GAMETYPE_HDD;
-		}
-	}
-	else
-	{
-		if (fs::file save{m_path, fs::isfile + fs::read}; save && save.size() >= 8 && save.read<u64>() == "RPCS3SAV"_u64)
-		{
-			m_ar = std::make_shared<utils::serial>();
-			m_ar->set_reading_state();
-			save.seek(0);
-			save.read(m_ar->data, save.size());
-			m_ar->data.shrink_to_fit();
-		}
+			if (fs::file save{m_path, fs::isfile + fs::read}; save && save.size() >= 8 && save.read<u64>() == "RPCS3SAV"_u64)
+			{
+				m_ar = std::make_shared<utils::serial>();
+				m_ar->set_reading_state();
+				save.seek(0);
+				save.read(m_ar->data, save.size());
+				m_ar->data.shrink_to_fit();
+			}
 
-		m_boot_source_type = CELL_GAME_GAMETYPE_SYS;
+			m_boot_source_type = CELL_GAME_GAMETYPE_SYS;
+		}
 	}
 
 	if (!IsStopped())
@@ -1423,8 +1426,8 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 			argv[7] = "2";                        // ??? arg7 2 -- full screen on/off 2/1 ?
 			argv[8] = "1";                        // ??? arg8 2 -- smoothing	on/off	= 1/0 ?
 
-			//TODO, this seems like it would normally be done by sysutil etc
-			//Basically make 2 128KB memory cards 0 filled and let the games handle formatting.
+			// TODO, this seems like it would normally be done by sysutil etc
+			// Basically make 2 128KB memory cards 0 filled and let the games handle formatting.
 
 			fs::file card_1_file(vfs::get("/dev_hdd0/savedata/vmc/" + argv[1]), fs::write + fs::create);
 			card_1_file.trunc(128 * 1024);

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -294,7 +294,7 @@ std::vector<u8> tar_object::save_directory(const std::string& src_dir, std::vect
 			return;
 		}
 
-		ptr += utils::aligned_div(std::bit_width(i), 3) - 1;
+		ptr += utils::aligned_div(static_cast<u32>(std::bit_width(i)), 3) - 1;
 
 		for (; i; ptr--, i /= 8)
 		{


### PR DESCRIPTION
- Disable unsupported PPU settings on boot and log a TODO message
- aligned_div only takes unsigned values. fixes compilation on VS 17.4

fixes #12832