### PR TITLE
rsx: Maintenance fixes [7]

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -529,7 +529,7 @@ void cellGcmSetFlipHandler(vm::ptr<void(u32)> handler)
 {
 	cellGcmSys.warning("cellGcmSetFlipHandler(handler=*0x%x)", handler);
 
-	if (const auto rsx = rsx::get_current_renderer(); rsx->is_inited)
+	if (const auto rsx = rsx::get_current_renderer(); rsx->is_initialized)
 	{
 		rsx->flip_handler = handler;
 	}
@@ -681,7 +681,7 @@ void cellGcmSetUserHandler(vm::ptr<void(u32)> handler)
 {
 	cellGcmSys.warning("cellGcmSetUserHandler(handler=*0x%x)", handler);
 
-	if (const auto rsx = rsx::get_current_renderer(); rsx->is_inited)
+	if (const auto rsx = rsx::get_current_renderer(); rsx->is_initialized)
 	{
 		rsx->user_handler = handler;
 	}
@@ -707,7 +707,7 @@ void cellGcmSetVBlankHandler(vm::ptr<void(u32)> handler)
 {
 	cellGcmSys.warning("cellGcmSetVBlankHandler(handler=*0x%x)", handler);
 
-	if (const auto rsx = rsx::get_current_renderer(); rsx->is_inited)
+	if (const auto rsx = rsx::get_current_renderer(); rsx->is_initialized)
 	{
 		rsx->vblank_handler = handler;
 	}
@@ -923,7 +923,7 @@ void cellGcmSetQueueHandler(vm::ptr<void(u32)> handler)
 {
 	cellGcmSys.warning("cellGcmSetQueueHandler(handler=*0x%x)", handler);
 
-	if (const auto rsx = rsx::get_current_renderer(); rsx->is_inited)
+	if (const auto rsx = rsx::get_current_renderer(); rsx->is_initialized)
 	{
 		rsx->queue_handler = handler;
 	}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -769,8 +769,8 @@ namespace rsx
 		g_fxo->get<rsx::dma_manager>().init();
 		on_init_thread();
 
-		is_inited = true;
-		is_inited.notify_all();
+		is_initialized = true;
+		is_initialized.notify_all();
 
 		if (!zcull_ctrl)
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -553,7 +553,7 @@ namespace rsx
 		u32 last_known_code_start = 0;
 		atomic_t<u32> external_interrupt_lock{ 0 };
 		atomic_t<bool> external_interrupt_ack{ false };
-		atomic_t<bool> is_inited{ false };
+		atomic_t<bool> is_initialized{ false };
 		bool is_fifo_idle() const;
 		void flush_fifo();
 

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -62,7 +62,7 @@ void progress_dialog_server::operator()()
 		std::shared_ptr<MsgDialogBase> dlg;
 
 		if (const auto renderer = rsx::get_current_renderer();
-		    renderer && renderer->is_inited)
+		    renderer && renderer->is_initialized)
 		{
 			auto manager  = g_fxo->try_get<rsx::overlays::display_manager>();
 			skip_this_one = g_fxo->get<progress_dialog_workaround>().skip_the_progress_dialog || (manager && manager->get<rsx::overlays::message_dialog>());

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -5,6 +5,7 @@
 #include "Emu/RSX/Overlays/overlay_message_dialog.h"
 #include "Emu/System.h"
 
+
 LOG_CHANNEL(sys_log, "SYS");
 
 // Progress display server synchronization variables
@@ -61,11 +62,14 @@ void progress_dialog_server::operator()()
 		bool skip_this_one = false; // Workaround: do not open a progress dialog if there is already a cell message dialog open.
 		std::shared_ptr<MsgDialogBase> dlg;
 
-		if (const auto renderer = rsx::get_current_renderer();
-		    renderer && renderer->is_initialized)
+		if (const auto renderer = rsx::get_current_renderer())
 		{
+			// Some backends like OpenGL actually initialize a lot of driver objects in the "on_init" method.
+			// Wait for init to complete within reasonable time. Abort just in case we have hardware/driver issues.
+			renderer->is_initialized.wait(false, atomic_wait_timeout(5 * 1000000000ull));
+
 			auto manager  = g_fxo->try_get<rsx::overlays::display_manager>();
-			skip_this_one = g_fxo->get<progress_dialog_workaround>().skip_the_progress_dialog || (manager && manager->get<rsx::overlays::message_dialog>());
+			skip_this_one = !renderer->is_initialized || g_fxo->get<progress_dialog_workaround>().skip_the_progress_dialog || (manager && manager->get<rsx::overlays::message_dialog>());
 
 			if (manager && !skip_this_one)
 			{

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -5,7 +5,6 @@
 #include "Emu/RSX/Overlays/overlay_message_dialog.h"
 #include "Emu/System.h"
 
-
 LOG_CHANNEL(sys_log, "SYS");
 
 // Progress display server synchronization variables


### PR DESCRIPTION
Actually wait for the renderer to initialize when creating the system progress dialog.
- Fixes a crash when compiling PPU cache more than once.
- Fixes a bug where the system progress always falls back to the Qt dialogs when OpenGL is selected.

Fixes https://github.com/RPCS3/rpcs3/issues/12933