### PR TITLE
rsx: Improve ROP output handling

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -214,7 +214,7 @@ void GLFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	m_shader_props.low_precision_tests = ::gl::get_driver_caps().vendor_NVIDIA;
 	m_shader_props.disable_early_discard = !::gl::get_driver_caps().vendor_NVIDIA;
 	m_shader_props.supports_native_fp16 = device_props.has_native_half_support;
-	m_shader_props.srgb_output_rounding = ::gl::get_driver_caps().vendor_NVIDIA;
+	m_shader_props.ROP_output_rounding = ::gl::get_driver_caps().vendor_NVIDIA;
 
 	glsl::insert_glsl_legacy_function(OS, m_shader_props);
 }

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.h
@@ -31,6 +31,46 @@ namespace rsx
 		EXPAND_MASK = (1 << EXPAND_R) | (1 << EXPAND_G) | (1 << EXPAND_B) | (1 << EXPAND_A),
 		EXPAND_OFFSET = EXPAND_A
 	};
+
+	enum ROP_control_bits : u32
+	{
+		// Commands. These trigger explicit action.
+		ALPHA_TEST_ENABLE_BIT        = 0,
+		SRGB_FRAMEBUFFER_BIT         = 1,
+		ALPHA_TO_COVERAGE_ENABLE_BIT = 2,
+		POLYGON_STIPPLE_ENABLE_BIT   = 3,
+
+		// Auxilliary config
+		INT_FRAMEBUFFER_BIT          = 16,
+		MSAA_WRITE_ENABLE_BIT        = 17,
+
+		// Data
+		ALPHA_FUNC_OFFSET            = 18,
+		MSAA_SAMPLE_CTRL_OFFSET      = 21,
+
+		// Data lengths
+		ALPHA_FUNC_NUM_BITS          = 3,
+		MSAA_SAMPLE_CTRL_NUM_BITS    = 2,
+
+		// Meta
+		ROP_CMD_MASK                 = 0xF // Commands are encoded in the lower 16 bits
+	};
+
+	struct ROP_control_t
+	{
+		u32 value = 0;
+
+		void enable_alpha_test() { value |= (1u << ROP_control_bits::ALPHA_TEST_ENABLE_BIT); }
+		void enable_framebuffer_sRGB() { value |= (1u << ROP_control_bits::SRGB_FRAMEBUFFER_BIT); }
+		void enable_alpha_to_coverage() { value |= (1u << ROP_control_bits::ALPHA_TO_COVERAGE_ENABLE_BIT); }
+		void enable_polygon_stipple() { value |= (1u << ROP_control_bits::POLYGON_STIPPLE_ENABLE_BIT); }
+
+		void enable_framebuffer_INT() { value |= (1u << ROP_control_bits::INT_FRAMEBUFFER_BIT); }
+		void enable_MSAA_writes() { value |= (1u << ROP_control_bits::MSAA_WRITE_ENABLE_BIT); }
+
+		void set_alpha_test_func(uint func) { value |= (func << ROP_control_bits::ALPHA_FUNC_OFFSET); }
+		void set_msaa_control(uint ctrl) { value |= (ctrl << ROP_control_bits::MSAA_SAMPLE_CTRL_OFFSET); }
+	};
 }
 
 namespace program_common

--- a/rpcs3/Emu/RSX/Program/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Program/GLSLTypes.h
@@ -39,6 +39,6 @@ namespace glsl
 		bool low_precision_tests : 1;
 		bool disable_early_discard : 1;
 		bool supports_native_fp16 : 1;
-		bool srgb_output_rounding : 1;
+		bool ROP_output_rounding : 1;
 	};
 };

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -198,17 +198,6 @@ namespace rsx
 		result_zcull_intr = 2
 	};
 
-	enum ROP_control : u32
-	{
-		alpha_test_enable       = (1u << 0),
-		framebuffer_srgb_enable = (1u << 1),
-		csaa_enable             = (1u << 4),
-		msaa_mask_enable        = (1u << 5),
-		msaa_config_mask        = (3u << 6),
-		polygon_stipple_enable  = (1u << 9),
-		alpha_func_mask         = (7u << 16)
-	};
-
 	u32 get_vertex_type_size_on_host(vertex_base_type type, u32 size);
 
 	u32 get_address(u32 offset, u32 location, u32 size_to_check = 0,

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -273,7 +273,7 @@ void VKFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	m_shader_props.low_precision_tests = device_props.has_low_precision_rounding;
 	m_shader_props.disable_early_discard = vk::get_driver_vendor() != vk::driver_vendor::NVIDIA;
 	m_shader_props.supports_native_fp16 = device_props.has_native_half_support;
-	m_shader_props.srgb_output_rounding = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
+	m_shader_props.ROP_output_rounding = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
 
 	glsl::insert_glsl_legacy_function(OS, m_shader_props);
 }


### PR DESCRIPTION
- Perform 8-bit quantization/rounding before emulated operations like ALPHA_TEST.
- Refactor ROP emulation code a bit. This thing was a mess with magic constants all over the GPU code.

Fixes https://github.com/RPCS3/rpcs3/issues/8370