### PR TITLE
PPU: Add new patch function for SONIC 06

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -718,7 +718,7 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 			// Always executable
 			u64 flags = vm::alloc_executable | vm::alloc_unwritable;
 
-			switch (p.offset % patch_engine::mem_protection::mask)
+			switch (p.offset & patch_engine::mem_protection::mask)
 			{
 			case patch_engine::mem_protection::rw:
 			case patch_engine::mem_protection::wx:
@@ -754,15 +754,26 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 			// Register code
 			ppu_register_range(addr, alloc_size);
 
-			// Write branch to code
-			ppu_form_branch_to_code(out_branch, addr);
 			resval = out_branch & -4;
+
+			// Write branch to return to code
+			if (!ppu_form_branch_to_code(addr + static_cast<u32>(p.value.long_value) * 4, resval + 4))
+			{
+				patch_log.error("Failed to write return jump at 0x%x", addr + static_cast<u32>(p.value.long_value) * 4);
+				ensure(alloc_map->dealloc(addr));
+				continue;
+			}
+
+			// Write branch to code
+			if (!ppu_form_branch_to_code(out_branch, addr))
+			{
+				patch_log.error("Failed to jump to code cave at 0x%x", out_branch);
+				ensure(alloc_map->dealloc(addr));
+				continue;
+			}
 
 			// Write address of the allocated memory to the code entry
 			*vm::get_super_ptr<u32>(resval) = addr;
-
-			// Write branch to return to code
-			ppu_form_branch_to_code(addr + static_cast<u32>(p.value.long_value) * 4, resval + 4);
 			relocate_instructions_at = addr;
 			break;
 		}

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -703,8 +703,6 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 		}
 		case patch_type::code_alloc:
 		{
-			relocate_instructions_at = 0;
-
 			const u32 out_branch = vm::try_get_addr(dst + (offset & -4)).first;
 
 			// Allow only if points to a PPU executable instruction
@@ -714,6 +712,13 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 			}
 
 			const u32 alloc_size = utils::align(static_cast<u32>(p.value.long_value + 1) * 4, 0x10000);
+
+			// Check if should maybe reuse previous code cave allocation (0 size)
+			if (alloc_size - 4 != 0)
+			{
+				// Nope
+				relocate_instructions_at = 0;
+			}
 
 			// Always executable
 			u64 flags = vm::alloc_executable | vm::alloc_unwritable;
@@ -738,7 +743,7 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 
 			// Range allowed for absolute branches to operate at
 			// It takes into account that we need to put a branch for return at the end of memory space
-			const u32 addr = p.alloc_addr = alloc_map->alloc(alloc_size, nullptr, 0x10000, flags);
+			const u32 addr = p.alloc_addr = (relocate_instructions_at ? relocate_instructions_at : alloc_map->alloc(alloc_size, nullptr, 0x10000, flags));
 
 			if (!addr)
 			{
@@ -751,8 +756,12 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 			// NOP filled
 			std::fill_n(vm::get_super_ptr<u32>(addr), p.value.long_value, 0x60000000);
 
-			// Register code
-			ppu_register_range(addr, alloc_size);
+			// Check if already registered by previous code allocation 
+			if (relocate_instructions_at != addr)
+			{
+				// Register code
+				ppu_register_range(addr, alloc_size);
+			}
 
 			resval = out_branch & -4;
 
@@ -772,8 +781,6 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 				continue;
 			}
 
-			// Write address of the allocated memory to the code entry
-			*vm::get_super_ptr<u32>(resval) = addr;
 			relocate_instructions_at = addr;
 			break;
 		}

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -322,6 +322,7 @@ target_sources(rpcs3_emu PRIVATE
     Cell/Modules/cellVoice.cpp
     Cell/Modules/cellVpost.cpp
     Cell/Modules/cellWebBrowser.cpp
+    Cell/Modules/HLE_PATCHES.cpp
     Cell/Modules/libad_async.cpp
     Cell/Modules/libad_core.cpp
     Cell/Modules/libmedi.cpp

--- a/rpcs3/Emu/Cell/Modules/HLE_PATCHES.cpp
+++ b/rpcs3/Emu/Cell/Modules/HLE_PATCHES.cpp
@@ -1,0 +1,58 @@
+#include "stdafx.h"
+#include "Emu/IdManager.h"
+#include "Emu/Cell/PPUModule.h"
+#include "Utilities/Thread.h"
+
+#include "Emu/Cell/lv2/sys_spu.h"
+#include "Emu/Cell/lv2/sys_sync.h"
+
+#include <thread>
+
+// SONIC THE HEDGEDOG: a fix for a race condition between SPUs and PPUs causing missing graphics (SNR is overriden when non-empty) 
+void WaitForSPUsToEmptySNRs(ppu_thread& ppu, u32 spu_id, u32 snr_mask)
+{
+	ppu.state += cpu_flag::wait;
+
+	auto [spu, group] = lv2_spu_group::get_thread(spu_id);
+
+	if ((!spu && spu_id != umax) || snr_mask % 4 == 0)
+	{
+		return;
+	}
+
+	// Wait until specified SNRs are reported empty at least once
+	for (bool has_busy = true; has_busy && !ppu.is_stopped(); std::this_thread::yield())
+	{
+		has_busy = false;
+
+		auto for_one = [&](u32, spu_thread& spu)
+		{
+			if ((snr_mask & 1) && spu.ch_snr1.get_count())
+			{
+				has_busy = true;
+				return;
+			}
+
+			if ((snr_mask & 2) && spu.ch_snr2.get_count())
+			{
+				has_busy = true;
+			}
+		};
+
+		if (spu)
+		{
+			// Wait for a single SPU
+			for_one(spu->id, *spu);
+		}
+		else
+		{
+			// Wait for all SPUs
+			idm::select<named_thread<spu_thread>>(for_one);
+		}
+	}
+}
+
+DECLARE(ppu_module_manager::hle_patches)("RPCS3_HLE_LIBRARY", []()
+{
+	REG_FUNC(RPCS3_HLE_LIBRARY, WaitForSPUsToEmptySNRs);
+});

--- a/rpcs3/Emu/Cell/Modules/StaticHLE.cpp
+++ b/rpcs3/Emu/Cell/Modules/StaticHLE.cpp
@@ -163,7 +163,7 @@ bool statichle_handler::check_against_patterns(vm::cptr<u8>& data, u32 size, u32
 		}
 
 		const auto sfunc   = &::at32(smodule->functions, pat.fnid);
-		const u32 target   = g_fxo->get<ppu_function_manager>().func_addr(sfunc->index) + 4;
+		const u32 target   = g_fxo->get<ppu_function_manager>().func_addr(sfunc->index, true);
 
 		// write stub
 		vm::write32(addr, ppu_instructions::LIS(0, (target&0xFFFF0000)>>16));

--- a/rpcs3/Emu/Cell/PPUFunction.h
+++ b/rpcs3/Emu/Cell/PPUFunction.h
@@ -290,14 +290,14 @@ public:
 		return access(llvm);
 	}
 
-	u32 func_addr(u32 index) const
+	u32 func_addr(u32 index, bool is_code_addr = false) const
 	{
 		if (index >= access().size() || !addr)
 		{
 			return 0;
 		}
 
-		return addr + index * 8;
+		return addr + index * 8 + (is_code_addr ? 4 : 0);
 	}
 
 	// Allocation address

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -80,9 +80,9 @@ public:
 	std::unordered_map<u32, ppu_static_function, value_hash<u32>> functions{};
 	std::unordered_map<u32, ppu_static_variable, value_hash<u32>> variables{};
 
-public:
 	ppu_static_module(const char* name);
 
+public:
 	ppu_static_module(const char* name, void(*init)())
 		: ppu_static_module(name)
 	{
@@ -278,6 +278,7 @@ public:
 	static const ppu_static_module sys_libc;
 	static const ppu_static_module sys_lv2dbg;
 	static const ppu_static_module static_hle;
+	static const ppu_static_module hle_patches;
 
 private:
 	inline static std::unordered_map<std::string, ppu_static_module*> s_module_map;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -617,34 +617,20 @@ struct ppu_far_jumps_t
 		bool with_toc;
 		std::string module_name;
 		ppu_intrp_func_t func;
-	};
-
-	ppu_far_jumps_t(int) noexcept {}
-
-	std::unordered_map<u32, all_info_t> vals;
-	::jit_runtime rt;
-
-	mutable shared_mutex mutex;
-
-	// Get target address, 'ppu' is used in ppu_far_jump in order to modify registers
-	u32 get_target(const u32 pc, ppu_thread* ppu = nullptr)
-	{
-		reader_lock lock(mutex);
-
-		if (auto it = vals.find(pc); it != vals.end())
+	
+		u32 get_target(u32 pc, ppu_thread* ppu = nullptr) const
 		{
-			all_info_t& all_info = it->second;
-			u32 target = all_info.target;
+			u32 direct_target = this->target;
 
-			bool link = all_info.link;
-			bool from_opd = all_info.with_toc;
+			bool to_link = this->link;
+			bool from_opd = this->with_toc;
 
-			if (!all_info.module_name.empty())
+			if (!this->module_name.empty())
 			{
-				target = ppu_get_exported_func_addr(target, all_info.module_name);
+				direct_target = ppu_get_exported_func_addr(direct_target, this->module_name);
 			}
 
-			if (from_opd && !vm::check_addr<sizeof(ppu_func_opd_t)>(target))
+			if (from_opd && !vm::check_addr<sizeof(ppu_func_opd_t)>(direct_target))
 			{
 				// Avoid reading unmapped memory under mutex
 				from_opd = false;
@@ -652,11 +638,11 @@ struct ppu_far_jumps_t
 
 			if (from_opd)
 			{
-				auto& opd = vm::_ref<ppu_func_opd_t>(target);
-				target = opd.addr;
+				auto& opd = vm::_ref<ppu_func_opd_t>(direct_target);
+				direct_target = opd.addr;
 
 				// We modify LR to custom values here
-				link = false;
+				to_link = false;
 
 				if (ppu)
 				{
@@ -670,20 +656,71 @@ struct ppu_far_jumps_t
 					saved_info.saved_lr = std::exchange(ppu->lr, g_fxo->get<ppu_function_manager>().func_addr(FIND_FUNC(ppu_return_from_far_jump), true));
 					saved_info.saved_r2 = std::exchange(ppu->gpr[2], opd.rtoc);
 				}
-
 			}
 
-			if (link && ppu)
+			if (to_link && ppu)
 			{
 				ppu->lr = pc + 4;
 			}
 
-			return target;
+			return direct_target;
+		}
+	};
+
+	ppu_far_jumps_t(int) noexcept {}
+
+	std::map<u32, all_info_t> vals;
+	::jit_runtime rt;
+
+	mutable shared_mutex mutex;
+
+	// Get target address, 'ppu' is used in ppu_far_jump in order to modify registers
+	u32 get_target(u32 pc, ppu_thread* ppu = nullptr)
+	{
+		reader_lock lock(mutex);
+
+		if (auto it = vals.find(pc); it != vals.end())
+		{
+			all_info_t& all_info = it->second;
+			return all_info.get_target(pc, ppu);
 		}
 
 		return {};
 	}
 
+	// Get function patches in range (entry -> target)
+	std::vector<std::pair<u32, u32>> get_targets(u32 pc, u32 size)
+	{
+		std::vector<std::pair<u32, u32>> targets;
+
+		reader_lock lock(mutex);
+
+		auto it = vals.lower_bound(pc);
+
+		if (it == vals.end())
+		{
+			return targets;
+		}
+
+		if (it->first >= pc + size)
+		{
+			return targets;
+		}
+		
+		for (auto end = vals.lower_bound(pc + size); it != end; it++)
+		{
+			all_info_t& all_info = it->second;
+
+			if (u32 target = all_info.get_target(it->first))
+			{
+				targets.emplace_back(it->first, target);
+			}
+		}
+
+		return targets;
+	}
+
+	// Generate a mini-function which updates PC (for LLVM) and jumps to ppu_far_jump to handle redirections
 	template <bool Locked = true>
 	ppu_intrp_func_t gen_jump(u32 pc)
 	{
@@ -1019,7 +1056,7 @@ void ppu_thread::dump_regs(std::string& ret) const
 
 		if (const_value != reg)
 		{
-			// Expectation of pretictable code path has not been met (such as a branch directly to the instruction)
+			// Expectation of predictable code path has not been met (such as a branch directly to the instruction)
 			is_const = false;
 		}
 
@@ -3478,14 +3515,25 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 				}
 			}
 
-			if (jit)
+			if (g_fxo->is_init<ppu_far_jumps_t>())
 			{
-				const auto far_jump = ppu_get_far_jump(func.addr) ? g_fxo->get<ppu_far_jumps_t>().gen_jump(func.addr) : nullptr;
+				auto targets = g_fxo->get<ppu_far_jumps_t>().get_targets(func.addr, func.size);
 
-				if (far_jump)
+				for (auto [source, target] : targets)
+				{
+					auto far_jump = ensure(g_fxo->get<ppu_far_jumps_t>().gen_jump(source));
+
+					if (source == func.addr && jit)
+					{
+						jit->update_global_mapping(fmt::format("__0x%x", func.addr - reloc), reinterpret_cast<u64>(far_jump));
+					}
+
+					ppu_register_function_at(source, 4, far_jump);
+				}
+
+				if (!targets.empty())
 				{
 					// Replace the function with ppu_far_jump
-					jit->update_global_mapping(fmt::format("__0x%x", func.addr - reloc), reinterpret_cast<u64>(far_jump));
 					fpos++;
 					continue;
 				}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -667,7 +667,7 @@ struct ppu_far_jumps_t
 					// NOTE: In order to clean up this information all calls must return in order
 					auto& saved_info = calls_info.emplace_back();
 					saved_info.cia = pc;
-					saved_info.saved_lr = std::exchange(ppu->lr, FIND_FUNC(ppu_return_from_far_jump));
+					saved_info.saved_lr = std::exchange(ppu->lr, g_fxo->get<ppu_function_manager>().func_addr(FIND_FUNC(ppu_return_from_far_jump), true));
 					saved_info.saved_r2 = std::exchange(ppu->gpr[2], opd.rtoc);
 				}
 
@@ -1243,7 +1243,7 @@ std::vector<std::pair<u32, u32>> ppu_thread::dump_callstack_list() const
 			}
 
 			// Ignore HLE stop address
-			return addr == g_fxo->get<ppu_function_manager>().func_addr(1) + 4;
+			return addr == g_fxo->get<ppu_function_manager>().func_addr(1, true);
 		};
 
 		if (is_invalid(addr))
@@ -1921,7 +1921,7 @@ void ppu_thread::fast_call(u32 addr, u64 rtoc)
 	interrupt_thread_executing = true;
 	cia = addr;
 	gpr[2] = rtoc;
-	lr = g_fxo->get<ppu_function_manager>().func_addr(1) + 4; // HLE stop address
+	lr = g_fxo->get<ppu_function_manager>().func_addr(1, true); // HLE stop address
 	current_function = nullptr;
 
 	if (std::exchange(loaded_from_savestate, false))

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -66,6 +66,7 @@
     <ClCompile Include="Emu\Cell\Modules\cellMusicSelectionContext.cpp" />
     <ClCompile Include="Emu\Cell\Modules\libfs_utility_init.cpp" />
     <ClCompile Include="Emu\Cell\Modules\sys_crashdump.cpp" />
+    <ClCompile Include="Emu\Cell\Modules\HLE_PATCHES.cpp" />
     <ClCompile Include="Emu\Io\camera_config.cpp" />
     <ClCompile Include="Emu\Io\recording_config.cpp" />
     <ClCompile Include="Emu\Io\Turntable.cpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1101,6 +1101,8 @@
     </ClCompile>
     <ClCompile Include="Emu\Io\recording_config.cpp">
       <Filter>Emu\Io</Filter>
+    <ClCompile Include="Emu\Cell\Modules\HLE_PATCHES.cpp">
+      <Filter>Emu\Cell\Modules</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I wanted to add a new patch type for sonic. But then I realized I already implemented the needed functionality in #10859 and #10779, just need to add the new function for waiting for SNRs to empty.

Fixes SONIC THE HEDGEHOG graphics with a patch.

Patch: (currently only BLUS30008 1.01 is supported)
```
PPU-4b46d0161ca657ab16b0a779d9062810ea5ea2dd:
  Graphics Fix:
    Games:
      "SONIC THE HEDGEHOG":
        BLUS30008: [ 01.01 ]
    Author: elad335
    Notes: "Fixes missing graphics ingame."
    Patch Version: 1.0
    Patch:
      - [ calloc, 0x00f07714, 0x4 ]
      - [ be32  , 0x0, 0x38800003 ] # LI r4, 3
      - [ jumpf , 0x0, "RPCS3_HLE_LIBRARY:WaitForSPUsToEmptySNRs"] # Args: (SPU ID, 3)
      - [ be32  , 0x0, 0x38800000 ] # LI r4, 0
      - [ be32  , 0x0, 0x44000002 ] # SC

```