### PR TITLE
Add RPCS3/games/ for automatic games detection, support PSN games outside HDD0

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -437,6 +437,9 @@ std::string fs::get_parent_dir(std::string_view path, u32 levels)
 
 bool fs::stat(const std::string& path, stat_t& info)
 {
+	// Ensure consistent information on failure
+	info = {};
+
 	if (auto device = get_virtual_device(path))
 	{
 		return device->stat(path, info);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2943,7 +2943,7 @@ std::set<std::string> Emulator::GetGameDirs() const
 	return dirs;
 }
 
-void Emulator::AddGamesFromDir(std::string path)
+void Emulator::AddGamesFromDir(const std::string& path)
 {
 	if (!IsStopped())
 		return;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -329,6 +329,7 @@ public:
 	void ConfigurePPUCache() const;
 
 	std::set<std::string> GetGameDirs() const;
+	void AddGamesFromDir(std::string path);
 
 	// Check if path is inside the specified directory
 	bool IsPathInsideDir(std::string_view path, std::string_view dir) const;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -329,7 +329,7 @@ public:
 	void ConfigurePPUCache() const;
 
 	std::set<std::string> GetGameDirs() const;
-	void AddGamesFromDir(std::string path);
+	void AddGamesFromDir(const std::string& path);
 
 	// Check if path is inside the specified directory
 	bool IsPathInsideDir(std::string_view path, std::string_view dir) const;

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -251,6 +251,14 @@ namespace psf
 			PSF_CHECK(false, corrupt);
 		}
 
+		const auto tid = get_string(pair.sfo, "TITLE_ID", "");
+
+		if (std::count_if(tid.begin(), tid.end(), [](char ch){ return !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')); }) != 0)
+		{
+			psf_log.error("Invalid title ID ('%s')", tid);
+			PSF_CHECK(false, corrupt);
+		}
+
 #undef PSF_CHECK
 		return pair;
 	}

--- a/rpcs3/Loader/PSF.cpp
+++ b/rpcs3/Loader/PSF.cpp
@@ -253,7 +253,7 @@ namespace psf
 
 		const auto tid = get_string(pair.sfo, "TITLE_ID", "");
 
-		if (std::count_if(tid.begin(), tid.end(), [](char ch){ return !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')); }) != 0)
+		if (std::find_if(tid.begin(), tid.end(), [](char ch){ return !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')); }) != tid.end())
 		{
 			psf_log.error("Invalid title ID ('%s')", tid);
 			PSF_CHECK(false, corrupt);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -572,7 +572,7 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 			}
 			else
 			{
-				game_list_log.trace("Invalid disc path registered for %s: %s", pair.first.Scalar(), pair.second.Scalar());
+				game_list_log.trace("Invalid game path registered for %s: %s", pair.first.Scalar(), pair.second.Scalar());
 			}
 		}
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -449,6 +449,11 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 		m_notes.clear();
 		m_games.pop_all();
 
+		if (Emu.IsStopped())
+		{
+			Emu.AddGamesFromDir(fs::get_config_dir() + "/games");
+		}
+
 		const std::string _hdd =  rpcs3::utils::get_hdd0_dir();
 
 		const auto add_disc_dir = [&](const std::string& path)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -531,7 +531,14 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 
 			game_dir.resize(game_dir.find_last_not_of('/') + 1);
 
-			if (fs::is_file(game_dir + "/PS3_DISC.SFB"))
+			if (game_dir.empty())
+			{
+				continue;
+			}
+
+			const bool has_sfo = fs::is_file(game_dir + "/PARAM.SFO");
+
+			if (!has_sfo && fs::is_file(game_dir + "/PS3_DISC.SFB"))
 			{
 				// Check if a path loaded from games.yml is already registered in add_dir(_hdd + "disc/");
 				if (game_dir.starts_with(_hdd))
@@ -553,6 +560,10 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 				}
 
 				add_disc_dir(game_dir);
+			}
+			else if (has_sfo)
+			{
+				m_path_list.emplace_back(game_dir);
 			}
 			else
 			{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2871,27 +2871,11 @@ Add valid disc games to gamelist (games.yml)
 void main_window::AddGamesFromDir(const QString& path)
 {
 	if (!QFileInfo(path).isDir())
+	{
 		return;
-
-	const std::string s_path = sstr(path);
-
-	// search dropped path first or else the direct parent to an elf is wrongly skipped
-	if (const auto error = Emu.BootGame(s_path, "", false, true); error == game_boot_result::no_errors)
-	{
-		gui_log.notice("Returned from game addition by drag and drop: %s", s_path);
 	}
 
-	// search direct subdirectories, that way we can drop one folder containing all games
-	QDirIterator dir_iter(path, QDir::Dirs | QDir::NoDotAndDotDot);
-	while (dir_iter.hasNext())
-	{
-		const std::string dir_path = sstr(dir_iter.next());
-
-		if (const auto error = Emu.BootGame(dir_path, "", false, true); error == game_boot_result::no_errors)
-		{
-			gui_log.notice("Returned from game addition by drag and drop: %s", dir_path);
-		}
-	}
+	Emu.AddGamesFromDir(sstr(path));
 }
 
 /**

--- a/rpcs3/rpcs3qt/vfs_dialog_path_widget.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_path_widget.cpp
@@ -43,7 +43,7 @@ vfs_dialog_path_widget::vfs_dialog_path_widget(const QString& name, const QStrin
 
 	QHBoxLayout* selected_config_layout = new QHBoxLayout;
 	m_selected_config_label = new QLabel(current_path.isEmpty() ? EmptyPath : current_path);
-	selected_config_layout->addWidget(new QLabel(tr("%0 directory:").arg(name)));
+	selected_config_layout->addWidget(new QLabel(tr("Used %0 directory:").arg(name)));
 	selected_config_layout->addWidget(m_selected_config_label);
 	selected_config_layout->addStretch();
 	selected_config_layout->addWidget(add_directory_button);


### PR DESCRIPTION
* Create a directory called "games" in RPCS3 program directory which disc games can be put and automatically be added to the games list. 
* Support PSN games outside of /dev_hdd0/game. Technically RPCS3 never forbid it, it just crashed most of the time when attempting to load them. Updates are not installed for it. (meaning it can be used as a backup in case updating fails)
* Do not load PARAM.SFO with TITLE_ID that has non-alphabetic or non-digits characters, this is to protect from potential malware files with special filesystem redirections.