### PR TITLE
Improve error_code, make HDD1 errors be warnings

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2065,7 +2065,7 @@ void thread_base::set_name(std::string name)
 u64 thread_base::finalize(thread_state result_state) noexcept
 {
 	// Report pending errors
-	error_code::error_report(0, 0, 0, 0);
+	error_code::error_report(0, nullptr, nullptr, nullptr, nullptr);
 
 #ifdef _WIN32
 	static thread_local ULONG64 tls_cycles{};

--- a/rpcs3/Emu/Cell/ErrorCodes.h
+++ b/rpcs3/Emu/Cell/ErrorCodes.h
@@ -3,35 +3,54 @@
 #include "util/types.hpp"
 #include "Utilities/StrFmt.h"
 
+namespace logs
+{
+	struct message;
+}
+
 // Error code type (return type), implements error reporting.
 class error_code
 {
 	s32 value;
 
-public:
-	error_code() = default;
-
-	// Implementation must be provided independently
-	static s32 error_report(s32 result, const char* fmt, const fmt_type_info* sup, const u64* args);
-
 	// Common constructor
-	template<typename ET>
-	error_code(const ET& value)
-		: value(error_report(static_cast<s32>(value), " : %s", fmt::type_info_v<ET>, fmt_args_t<ET>{fmt_unveil<ET>::get(value)}))
+	template <typename ET> requires requires (ET v) { static_cast<s32>(v); }
+	error_code(const logs::message* ch, const ET& value) noexcept
+		: value(error_report(static_cast<s32>(value), ch, " : %s", fmt::type_info_v<ET>, fmt_args_t<ET>{fmt_unveil<ET>::get(value)}))
 	{
 	}
 
 	// Error constructor (2 args)
-	template<typename ET, typename T>
-	error_code(const ET& value, const T& arg)
-		: value(error_report(static_cast<s32>(value), " : %s, %s", fmt::type_info_v<ET, T>, fmt_args_t<ET, T>{fmt_unveil<ET>::get(value), fmt_unveil<T>::get(arg)}))
+	template <typename ET, typename T> requires requires (ET v) { static_cast<s32>(v); }
+	error_code(const logs::message* ch, const ET& value, const T& arg) noexcept
+		: value(error_report(static_cast<s32>(value), ch, " : %s, %s", fmt::type_info_v<ET, T>, fmt_args_t<ET, T>{fmt_unveil<ET>::get(value), fmt_unveil<T>::get(arg)}))
 	{
 	}
 
 	// Formatting constructor (error, format string, variadic list)
-	template <typename ET, typename... Args> requires (sizeof...(Args) > 0)
-	error_code(const ET& value, const const_str& fmt, const Args&... args)
-		: value(error_report(static_cast<s32>(value), fmt, fmt::type_info_v<Args...>, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...}))
+	template <typename ET, typename... Args> requires requires (ET v) { static_cast<s32>(v); }
+	error_code(const logs::message* ch, const ET& value, const const_str& fmt, const Args&... args) noexcept
+		: value(error_report(static_cast<s32>(value), ch, fmt, fmt::type_info_v<Args...>, fmt_args_t<Args...>{fmt_unveil<Args>::get(args)...}))
+	{
+	}
+
+public:	
+	// Implementation must be provided independently
+	static s32 error_report(s32 result, const logs::message* channel, const char* fmt, const fmt_type_info* sup, const u64* args);
+
+	error_code() = default;
+
+	// Constructor without channel
+	template <typename... Args> requires (sizeof...(Args) > 0 && !(std::is_same_v<std::decay_t<std::remove_pointer_t<Args>>, logs::message> || ...))
+	error_code(const Args&... args) noexcept
+		: error_code(std::add_pointer_t<const logs::message>{}, args...)
+	{
+	}
+
+	// Constructor with channel
+	template <typename... Args>
+	error_code(const logs::message& ch, const Args&... args) noexcept
+		: error_code(std::addressof(ch), args...)
 	{
 	}
 
@@ -51,7 +70,7 @@ enum CellNotAnError : s32
 
 // Constructor specialization that doesn't trigger reporting
 template <>
-constexpr FORCE_INLINE error_code::error_code(const CellNotAnError& value)
+constexpr FORCE_INLINE error_code::error_code(const CellNotAnError& value) noexcept
 	: value(value)
 {
 }

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -945,7 +945,7 @@ error_code sys_fs_open(ppu_thread& ppu, vm::cptr<char> path, s32 flags, vm::ptr<
 			return not_an_error(CELL_EEXIST);
 		}
 
-		return {error, path};
+		return {lv2_fs_object::get_mp(vpath) == &g_mp_sys_dev_hdd1 ? sys_fs.warning : sys_fs.error, error, path};
 	}
 
 	if (const u32 id = idm::import<lv2_fs_object, lv2_file>([&ppath = ppath, &file = file, mode, flags, &real = real, &type = type]() -> std::shared_ptr<lv2_file>
@@ -1246,7 +1246,7 @@ error_code sys_fs_opendir(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u32> fd)
 		{
 			if (ext.empty())
 			{
-				return {CELL_ENOENT, path};
+				return {mp == &g_mp_sys_dev_hdd1 ? sys_fs.warning : sys_fs.error, CELL_ENOENT, path};
 			}
 
 			break;
@@ -1435,7 +1435,7 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 				break;
 			}
 
-			return {CELL_ENOENT, path};
+			return {mp == &g_mp_sys_dev_hdd1 ? sys_fs.warning : sys_fs.error, CELL_ENOENT, path};
 		}
 		default:
 		{
@@ -1563,8 +1563,14 @@ error_code sys_fs_mkdir(ppu_thread& ppu, vm::cptr<char> path, s32 mode)
 	{
 		switch (auto error = fs::g_tls_error)
 		{
-		case fs::error::noent: return {CELL_ENOENT, path};
-		case fs::error::exist: return {CELL_EEXIST, path};
+		case fs::error::noent:
+		{
+			return {mp == &g_mp_sys_dev_hdd1 ? sys_fs.warning : sys_fs.error, CELL_ENOENT, path};
+		}
+		case fs::error::exist:
+		{
+			return {sys_fs.warning, CELL_EEXIST, path};
+		}
 		default: sys_fs.error("sys_fs_mkdir(): unknown error %s", error);
 		}
 
@@ -1737,7 +1743,10 @@ error_code sys_fs_unlink(ppu_thread& ppu, vm::cptr<char> path)
 	{
 		switch (auto error = fs::g_tls_error)
 		{
-		case fs::error::noent: return {CELL_ENOENT, path};
+		case fs::error::noent:
+		{
+			return {mp == &g_mp_sys_dev_hdd1 ? sys_fs.warning : sys_fs.error, CELL_ENOENT, path};
+		}
 		default: sys_fs.error("sys_fs_unlink(): unknown error %s", error);
 		}
 
@@ -2690,7 +2699,10 @@ error_code sys_fs_truncate(ppu_thread& ppu, vm::cptr<char> path, u64 size)
 	{
 		switch (auto error = fs::g_tls_error)
 		{
-		case fs::error::noent: return {CELL_ENOENT, path};
+		case fs::error::noent:
+		{
+			return {mp == &g_mp_sys_dev_hdd1 ? sys_fs.warning : sys_fs.error, CELL_ENOENT, path};
+		}
 		default: sys_fs.error("sys_fs_truncate(): unknown error %s", error);
 		}
 
@@ -2890,7 +2902,10 @@ error_code sys_fs_utime(ppu_thread& ppu, vm::cptr<char> path, vm::cptr<CellFsUti
 	{
 		switch (auto error = fs::g_tls_error)
 		{
-		case fs::error::noent: return {CELL_ENOENT, path};
+		case fs::error::noent:
+		{
+			return {mp == &g_mp_sys_dev_hdd1 ? sys_fs.warning : sys_fs.error, CELL_ENOENT, path};
+		}
 		default: sys_fs.error("sys_fs_utime(): unknown error %s", error);
 		}
 


### PR DESCRIPTION
* Allow silencing pending errors manually for ignored errors.
* Allow setting error as warning level so HDD1 errors would be logged as warnings.
* Prevent double error reports in the same syscall/function.

Implements https://github.com/RPCS3/rpcs3/issues/12667