### PR TITLE
[WIP] Reimplement vm::ref to replace vm::ptr

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellL10n.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellL10n.cpp
@@ -1256,7 +1256,7 @@ s32 UTF8toBIG5()
 
 s32 UTF16stoUTF8s(vm::cptr<u16> utf16, vm::ref<s32> utf16_len, vm::ptr<u8> utf8, vm::ref<s32> utf8_len)
 {
-	cellL10n.error("UTF16stoUTF8s(utf16=*0x%x, utf16_len=*0x%x, utf8=*0x%x, utf8_len=*0x%x)", utf16, utf16_len.addr(), utf8, utf8_len.addr());
+	cellL10n.error("UTF16stoUTF8s(utf16=*0x%x, utf16_len=*0x%x, utf8=*0x%x, utf8_len=*0x%x)", utf16, utf16_len, utf8, utf8_len);
 
 	const u32 max_len = utf8_len; utf8_len = 0;
 

--- a/rpcs3/Emu/Cell/Modules/cellSync.h
+++ b/rpcs3/Emu/Cell/Modules/cellSync.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Emu/Memory/vm_ptr.h"
+#include "Emu/Memory/vm_ref.h"
 
 #include "Utilities/BitField.h"
 

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -10,9 +10,6 @@ struct ppu_func_opd_t;
 
 namespace vm
 {
-	template <typename T, typename AT>
-	class _ref_base;
-
 	// Enables comparison between comparable types of pointers
 	template<typename T1, typename T2>
 	concept PtrComparable = requires (T1* t1, T2* t2) { t1 == t2; };
@@ -79,27 +76,6 @@ namespace vm
 		_ptr_base<ET, u32> ptr(MT T2::*const mptr, u32 index) const
 		{
 			return vm::cast(vm::cast(m_addr) + offset32(mptr) + u32{sizeof(ET)} * index);
-		}
-
-		// Get vm reference to a struct member
-		template <typename MT, typename T2> requires PtrComparable<T, T2> && (!std::is_void_v<T>)
-		_ref_base<MT, u32> ref(MT T2::*const mptr) const
-		{
-			return vm::cast(vm::cast(m_addr) + offset32(mptr));
-		}
-
-		// Get vm reference to a struct member with array subscription
-		template <typename MT, typename T2, typename ET = std::remove_extent_t<MT>> requires PtrComparable<T, T2> && (!std::is_void_v<T>)
-		_ref_base<ET, u32> ref(MT T2::*const mptr, u32 index) const
-		{
-			return vm::cast(vm::cast(m_addr) + offset32(mptr) + u32{sizeof(ET)} * index);
-		}
-
-		// Get vm reference
-		template <bool = false> requires (!std::is_void_v<T>)
-		_ref_base<T, u32> ref() const
-		{
-			return vm::cast(m_addr);
 		}
 
 		T* get_ptr() const

--- a/rpcs3/Emu/Memory/vm_ref.h
+++ b/rpcs3/Emu/Memory/vm_ref.h
@@ -2,6 +2,7 @@
 
 #include <type_traits>
 #include "vm.h"
+#include "vm_ptr.h"
 
 #include "util/to_endian.hpp"
 
@@ -12,12 +13,18 @@
 
 namespace vm
 {
-	template <typename T, typename AT>
-	class _ptr_base;
+	template <typename T>
+	concept Ref = requires (T& ref)
+	{
+		ref.addr();
+		ref.aligned();
+		ref.rebind(vm::addr_t{});
+	};
 
 	template <typename T, typename AT>
-	class _ref_base
+	class _ref_base_base
 	{
+	protected:
 		AT m_addr;
 
 		static_assert(!std::is_pointer<T>::value, "vm::_ref_base<> error: invalid type (pointer)");
@@ -29,155 +36,732 @@ namespace vm
 		using type = T;
 		using addr_type = std::remove_cv_t<AT>;
 
-		_ref_base(const _ref_base&) = default;
+		_ref_base_base(const _ref_base_base&) = default;
 
-		_ref_base(vm::addr_t addr)
+		_ref_base_base(vm::addr_t addr)
 			: m_addr(addr)
 		{
 		}
+
+		template <typename T2, typename AT2> requires (std::is_constructible_v<const volatile T*, const volatile T2*>)
+		_ref_base_base(const _ref_base_base<T2, AT2>& other)
+			: m_addr(vm::cast(other))
+		{
+		}
+
+		_ref_base_base& operator =(const _ref_base_base&) = delete;
+
+		template <typename T2, typename AT2>
+		_ref_base_base& operator =(const _ref_base_base<T2, AT2>&) = delete; // TODO: verify
 
 		addr_type addr() const
 		{
 			return m_addr;
 		}
 
-		T& get_ref() const
+		// Test address for arbitrary alignment: (addr & (align - 1)) == 0
+		bool aligned(u32 align = alignof(T)) const
 		{
-			return *static_cast<T*>(vm::base(vm::cast(m_addr)));
+			return (m_addr & (align - 1)) == 0u;
 		}
 
-		// convert to vm pointer
-		vm::_ptr_base<T, u32> ptr() const
+		// Get type size
+		static constexpr u32 size()
 		{
-			return vm::cast(m_addr);
+			return sizeof(T);
+		}
+
+		// Get type alignment
+		static constexpr u32 align()
+		{
+			return alignof(T);
+		}
+
+		// Overwrite reference
+		void rebind(vm::addr_t addr)
+		{
+			m_addr = addr;
+		}
+
+		template <typename T2, typename AT2> requires (std::is_assignable_v<const volatile T*, const volatile T2*>)
+		void rebind(const _ref_base_base<T2, AT2>& rhs)
+		{
+			m_addr = vm::cast(rhs.addr());
+		}
+	};
+
+	template <typename T, typename AT>
+	class _ref_base : public _ref_base_base<T, AT>
+	{
+	public:
+		using _ref_base_base<T, AT>::_ref_base_base;
+
+		_ref_base& operator =(const _ref_base&) = delete;
+
+		std::common_type_t<T> operator =(const std::common_type_t<T>& right) const requires (!std::is_const_v<T>)
+		{
+			write_to_ptr<T>(vm::g_base_addr, vm::cast(this->m_addr), right);
+			return right;
+		}
+
+		void assign(const std::common_type_t<T>& value) const requires (!std::is_const_v<T>)
+		{
+			write_to_ptr<T>(vm::g_base_addr, vm::cast(this->m_addr), value);
 		}
 
 		operator std::common_type_t<T>() const
 		{
-			return get_ref();
+			return read_from_ptr<T>(vm::g_base_addr, vm::cast(this->m_addr));
 		}
 
-		operator T&() const
+		std::common_type_t<T> value() const
 		{
-			return get_ref();
+			return read_from_ptr<T>(vm::g_base_addr, vm::cast(this->m_addr));
 		}
 
-		T& operator =(const _ref_base& right)
+		SAFE_BUFFERS(std::pair<bool, std::decay_t<T>>) try_read() const
 		{
-			return get_ref() = right.get_ref();
+			alignas(T) std::byte buf[sizeof(T)]{};
+			const bool ok = vm::try_access(vm::cast(this->m_addr), buf, sizeof(T), false);
+			return {ok, std::bit_cast<std::decay_t>(buf)};
 		}
 
-		T& operator =(const std::common_type_t<T>& right) const
+		bool try_read(std::decay_t<T>& out) const
 		{
-			return get_ref() = right;
+			return vm::try_access(vm::cast(this->m_addr), std::addressof(out), sizeof(T), false);
 		}
 
-		decltype(auto) operator ++(int) const
+		bool try_write(const std::common_type_t<T>& _in) const requires (!std::is_const_v<T>)
 		{
-			return get_ref()++;
+			T value = _in;
+			return vm::try_access(vm::cast(this->m_addr), std::addressof(value), sizeof(T), true);
 		}
 
-		decltype(auto) operator ++() const
+		bool try_write(std::decay_t<T>& value) const requires (!std::is_const_v<T>)
 		{
-			return ++get_ref();
+			return vm::try_access(vm::cast(this->m_addr), std::addressof(value), sizeof(T), true);
 		}
 
-		decltype(auto) operator --(int) const
+		// Get vm reference to a struct member
+		template <typename MT, typename T2> requires PtrComparable<T, T2>
+		_ref_base<stx::copy_cv_t<T, MT>, u32> ref(MT T2::*const mptr) const
 		{
-			return get_ref()--;
+			return vm::cast(vm::cast(this->m_addr) + offset32(mptr));
 		}
 
-		decltype(auto) operator --() const
+		// Get vm reference to a struct member with array subscription
+		template <typename MT, typename T2, typename ET = std::remove_extent_t<MT>> requires PtrComparable<T, T2>
+		_ref_base<stx::copy_cv_t<T, ET>, u32> ref(MT T2::*const mptr, u32 index) const
 		{
-			return --get_ref();
+			return vm::cast(vm::cast(this->m_addr) + offset32(mptr) + u32{sizeof(ET)} * index);
 		}
 
-		template<typename T2>
-		decltype(auto) operator +=(const T2& right)
+		auto operator ++(int) const requires (!std::is_const_v<T>)
 		{
-			return get_ref() += right;
+			auto x = this->value();
+			auto r = x++;
+			*this = x;
+			return r;
 		}
 
-		template<typename T2>
-		decltype(auto) operator -=(const T2& right)
+		auto operator ++() const requires (!std::is_const_v<T>)
 		{
-			return get_ref() -= right;
+			auto x = ++this->value();
+			*this = x;
+			return x;
 		}
 
-		template<typename T2>
-		decltype(auto) operator *=(const T2& right)
+		auto operator --(int) const requires (!std::is_const_v<T>)
 		{
-			return get_ref() *= right;
+			auto x = this->value();
+			auto r = x--;
+			*this = x;
+			return r;
 		}
 
-		template<typename T2>
-		decltype(auto) operator /=(const T2& right)
+		auto operator --() const requires (!std::is_const_v<T>)
 		{
-			return get_ref() /= right;
+			auto x = --this->value();
+			*this = x;
+			return x;
 		}
 
-		template<typename T2>
-		decltype(auto) operator %=(const T2& right)
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator +=(const T2& right) const
 		{
-			return get_ref() %= right;
+			auto x = this->value();
+			auto r = x += right;
+			*this = x;
+			return r;
 		}
 
-		template<typename T2>
-		decltype(auto) operator &=(const T2& right)
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator -=(const T2& right) const
 		{
-			return get_ref() &= right;
+			auto x = this->value();
+			auto r = x -= right;
+			*this = x;
+			return r;
 		}
 
-		template<typename T2>
-		decltype(auto) operator |=(const T2& right)
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator *=(const T2& right) const
 		{
-			return get_ref() |= right;
+			auto x = this->value();
+			auto r = x *= right;
+			*this = x;
+			return r;
 		}
 
-		template<typename T2>
-		decltype(auto) operator ^=(const T2& right)
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator /=(const T2& right) const
 		{
-			return get_ref() ^= right;
+			auto x = this->value();
+			auto r = x /= right;
+			*this = x;
+			return r;
 		}
 
-		template<typename T2>
-		decltype(auto) operator <<=(const T2& right)
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator %=(const T2& right) const
 		{
-			return get_ref() <<= right;
+			auto x = this->value();
+			auto r = x %= right;
+			*this = x;
+			return r;
 		}
 
-		template<typename T2>
-		decltype(auto) operator >>=(const T2& right)
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator &=(const T2& right) const
 		{
-			return get_ref() >>= right;
+			auto x = this->value();
+			auto r = x &= right;
+			*this = x;
+			return r;
+		}
+
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator |=(const T2& right) const
+		{
+			auto x = this->value();
+			auto r = x |= right;
+			*this = x;
+			return r;
+		}
+
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator ^=(const T2& right) const
+		{
+			auto x = this->value();
+			auto r = x ^= right;
+			*this = x;
+			return r;
+		}
+
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator <<=(const T2& right) const
+		{
+			auto x = this->value();
+			auto r = x <<= right;
+			*this = x;
+			return r;
+		}
+
+		template <typename T2> requires (!std::is_const_v<T>)
+		auto operator >>=(const T2& right) const
+		{
+			auto x = this->value();
+			auto r = x >>= right;
+			*this = x;
+			return r;
+		}
+	};
+
+	template <typename T, typename AT>
+	class _ref_base<T[], AT> : public _ref_base_base<T[], AT>
+	{
+	public:
+		using _ref_base_base<T, AT>::_ref_base_base;
+
+		_ref_base& operator =(const _ref_base&) = delete;
+
+		_ref_base<T, AT> operator [](u32 index) const
+		{
+			return _ref_base<T, AT>(vm::cast(this->m_addr + sizeof(T) * index));
+		}
+	};
+
+	template <typename T, typename AT, std::size_t N>
+	class _ref_base<T[N], AT> : public _ref_base_base<T[N], AT>
+	{
+	public:
+		using _ref_base_base<T, AT>::_ref_base_base;
+
+		_ref_base& operator =(const _ref_base&) = delete;
+
+		_ref_base<T, AT> operator [](u32 index) const
+		{
+			return _ref_base<T, AT>(vm::cast(this->m_addr + sizeof(T) * index));
+		}
+	};
+
+	template <typename T, typename AT, std::size_t Align>
+	class _ref_base<atomic_t<T, Align>, AT> : public _ref_base_base<atomic_t<T, Align>, AT>
+	{
+		// See atomic.hpp atomic_t
+		using type = typename std::remove_cv<T>::type;
+
+		type& raw() const
+		{
+			return reinterpret_cast<type&>(g_base_addr[vm::cast(this->m_addr)]);
+		}
+
+		// Disable overaligned atomics
+		static_assert(Align == sizeof(T));
+
+	public:
+		using _ref_base_base<atomic_t<T, Align>, AT>::_ref_base_base;
+
+		_ref_base& operator =(const _ref_base&) = delete;
+
+		// See atomic.hpp atomic_t
+		type compare_and_swap(const type& cmp, const type& exch) const requires (!std::is_const_v<T>)
+		{
+			ensure(this->aligned());
+			type old = cmp;
+			atomic_storage<type>::compare_exchange(raw(), old, exch);
+			return old;
+		}
+
+		// See atomic.hpp atomic_t
+		bool compare_and_swap_test(const type& cmp, const type& exch) const requires (!std::is_const_v<T>)
+		{
+			ensure(this->aligned());
+			type old = cmp;
+			return atomic_storage<type>::compare_exchange(raw(), old, exch);
+		}
+
+		// See atomic.hpp atomic_t
+		bool compare_exchange(type& cmp_and_old, const type& exch) const requires (!std::is_const_v<T>)
+		{
+			ensure(this->aligned());
+			return atomic_storage<type>::compare_exchange(raw(), cmp_and_old, exch);
+		}
+
+		// See atomic.hpp atomic_t
+		template <typename F, typename RT = std::invoke_result_t<F, T&>> requires (!std::is_const_v<T>)
+		std::conditional_t<std::is_void_v<RT>, type, std::pair<type, RT>> fetch_op(F func) const
+		{
+			ensure(this->aligned());
+			type _new, old = atomic_storage<type>::load(raw());
+
+			while (true)
+			{
+				_new = old;
+
+				if constexpr (std::is_void_v<RT>)
+				{
+					std::invoke(func, _new);
+
+					if (atomic_storage<type>::compare_exchange(raw(), old, _new)) [[likely]]
+					{
+						return old;
+					}
+				}
+				else
+				{
+					RT ret = std::invoke(func, _new);
+
+					if (!ret || atomic_storage<type>::compare_exchange(raw(), old, _new)) [[likely]]
+					{
+						return {old, std::move(ret)};
+					}
+				}
+			}
+		}
+
+		// See atomic.hpp atomic_t
+		template <typename F, typename RT = std::invoke_result_t<F, T&>> requires (!std::is_const_v<T>)
+		RT atomic_op(F func) const
+		{
+			ensure(this->aligned());
+			type _new, old = atomic_storage<type>::load(raw());
+
+			while (true)
+			{
+				_new = old;
+
+				if constexpr (std::is_void_v<RT>)
+				{
+					std::invoke(func, _new);
+
+					if (atomic_storage<type>::compare_exchange(raw(), old, _new)) [[likely]]
+					{
+						return;
+					}
+				}
+				else
+				{
+					RT result = std::invoke(func, _new);
+
+					if (atomic_storage<type>::compare_exchange(raw(), old, _new)) [[likely]]
+					{
+						return result;
+					}
+				}
+			}
+		}
+
+		// See atomic.hpp atomic_t
+		type load() const
+		{
+			ensure(this->aligned());
+			return atomic_storage<type>::load(raw());
+		}
+
+		// See atomic.hpp atomic_t
+		operator std::common_type_t<T>() const
+		{
+			return load();
+		}
+
+		// See atomic.hpp atomic_t
+		type observe() const
+		{
+			ensure(this->aligned());
+			return atomic_storage<type>::observe(raw());
+		}
+
+		// See atomic.hpp atomic_t
+		void store(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			ensure(this->aligned());
+			atomic_storage<type>::store(raw(), rhs);
+		}
+
+		// See atomic.hpp atomic_t
+		type operator =(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			store(rhs);
+			return rhs;
+		}
+
+		// See atomic.hpp atomic_t
+		void release(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			ensure(this->aligned());
+			atomic_storage<type>::release(raw(), rhs);
+		}
+
+		// See atomic.hpp atomic_t
+		type exchange(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			ensure(this->aligned());
+			return atomic_storage<type>::exchange(raw(), rhs);
+		}
+
+		// See atomic.hpp atomic_t
+		auto fetch_add(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return fetch_op([&](T& v)
+			{
+				v += rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto add_fetch(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				v += rhs;
+				return v;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator +=(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				return v += rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto fetch_sub(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return fetch_op([&](T& v)
+			{
+				v -= rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto sub_fetch(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				v -= rhs;
+				return v;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator -=(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				return v -= rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto fetch_and(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return fetch_op([&](T& v)
+			{
+				v &= rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto and_fetch(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				v &= rhs;
+				return v;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator &=(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				return v &= rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto fetch_or(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return fetch_op([&](T& v)
+			{
+				v |= rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto or_fetch(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				v |= rhs;
+				return v;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator |=(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				return v |= rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto fetch_xor(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return fetch_op([&](T& v)
+			{
+				v ^= rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto xor_fetch(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				v ^= rhs;
+				return v;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator ^=(const type& rhs) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([&](T& v)
+			{
+				return v ^= rhs;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator ++() const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([](T& v)
+			{
+				return ++v;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator --() const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([](T& v)
+			{
+				return --v;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator ++(int) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([](T& v)
+			{
+				return v++;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		auto operator --(int) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([](T& v)
+			{
+				return v--;
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		bool try_dec(std::common_type_t<T> greater_than) const requires (!std::is_const_v<T>)
+		{
+			ensure(this->aligned());
+			type _new, old = atomic_storage<type>::load(raw());
+
+			while (true)
+			{
+				_new = old;
+
+				if (!(_new > greater_than))
+				{
+					return false;
+				}
+
+				_new -= 1;
+
+				if (atomic_storage<type>::compare_exchange(raw(), old, _new)) [[likely]]
+				{
+					return true;
+				}
+			}
+		}
+
+		// See atomic.hpp atomic_t
+		bool try_inc(std::common_type_t<T> less_than) const requires (!std::is_const_v<T>)
+		{
+			ensure(this->aligned());
+			type _new, old = atomic_storage<type>::load(raw());
+
+			while (true)
+			{
+				_new = old;
+
+				if (!(_new < less_than))
+				{
+					return false;
+				}
+
+				_new += 1;
+
+				if (atomic_storage<type>::compare_exchange(raw(), old, _new)) [[likely]]
+				{
+					return true;
+				}
+			}
+		}
+
+		// See atomic.hpp atomic_t
+		bool bit_test_set(uint bit) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([](type& v)
+			{
+				const auto old = v;
+				const auto bit = type(1) << (sizeof(T) * 8 - 1);
+				v |= bit;
+				return !!(old & bit);
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		bool bit_test_reset(uint bit) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([](type& v)
+			{
+				const auto old = v;
+				const auto bit = type(1) << (sizeof(T) * 8 - 1);
+				v &= ~bit;
+				return !!(old & bit);
+			});
+		}
+
+		// See atomic.hpp atomic_t
+		bool bit_test_invert(uint bit) const requires (!std::is_const_v<T>)
+		{
+			return atomic_op([](type& v)
+			{
+				const auto old = v;
+				const auto bit = type(1) << (sizeof(T) * 8 - 1);
+				v ^= bit;
+				return !!(old & bit);
+			});
 		}
 	};
 
 	// Native endianness reference to LE data
-	template<typename T, typename AT = u32> using refl = _ref_base<to_le_t<T>, AT>;
+	template <typename T, typename AT = u32>
+	using refl = _ref_base<to_le_t<T>, AT>;
 
 	// Native endianness reference to BE data
-	template<typename T, typename AT = u32> using refb = _ref_base<to_be_t<T>, AT>;
+	template <typename T, typename AT = u32>
+	using refb = _ref_base<to_be_t<T>, AT>;
 
 	// BE reference to LE data
-	template<typename T, typename AT = u32> using brefl = _ref_base<to_le_t<T>, to_be_t<AT>>;
+	template <typename T, typename AT = u32>
+	using brefl = _ref_base<to_le_t<T>, to_be_t<AT>>;
 
 	// BE reference to BE data
-	template<typename T, typename AT = u32> using brefb = _ref_base<to_be_t<T>, to_be_t<AT>>;
+	template <typename T, typename AT = u32>
+	using brefb = _ref_base<to_be_t<T>, to_be_t<AT>>;
 
 	// LE reference to LE data
-	template<typename T, typename AT = u32> using lrefl = _ref_base<to_le_t<T>, to_le_t<AT>>;
+	template <typename T, typename AT = u32>
+	using lrefl = _ref_base<to_le_t<T>, to_le_t<AT>>;
 
 	// LE reference to BE data
-	template<typename T, typename AT = u32> using lrefb = _ref_base<to_be_t<T>, to_le_t<AT>>;
+	template <typename T, typename AT = u32>
+	using lrefb = _ref_base<to_be_t<T>, to_le_t<AT>>;
 
 	inline namespace ps3_
 	{
-		// default reference for PS3 HLE functions (Native endianness reference to BE data)
-		template<typename T, typename AT = u32> using ref = refb<T, AT>;
+		// Default reference for PS3 HLE functions (Native endianness reference to BE data)
+		template <typename T, typename AT = u32>
+		using ref = refb<T, AT>;
 
-		// default reference for PS3 HLE structures (BE reference to BE data)
-		template<typename T, typename AT = u32> using bref = brefb<T, AT>;
+		// Default reference for PS3 HLE structures (BE reference to BE data)
+		template <typename T, typename AT = u32>
+		using bref = brefb<T, AT>;
+
+		// Atomic specialization (native endianness reference to atomic BE data)
+		template <typename T, typename AT = u32>
+		using atomic_ref = _ref_base<atomic_t<to_be_t<T>>, AT>;
+
+		// Atomic specialization for structures (BE reference to atomic BE data)
+		template <typename T, typename AT = u32>
+		using atomic_bref = _ref_base<atomic_t<to_be_t<T>>, to_be_t<AT>>;
 	}
 }
 
@@ -192,9 +776,30 @@ struct to_se<vm::_ref_base<T, AT>, Se>
 	using type = vm::_ref_base<T, typename to_se<AT, Se>::type>;
 };
 
-// Forbid formatting
+// Format address
 template<typename T, typename AT>
 struct fmt_unveil<vm::_ref_base<T, AT>, void>
 {
-	static_assert(!sizeof(T), "vm::_ref_base<>: ambiguous format argument");
+	using type = vm::_ref_base<T, u32>; // Use only T, ignoring AT
+
+	static inline auto get(const vm::_ref_base<T, AT>& arg)
+	{
+		return fmt_unveil<AT>::get(arg.addr());
+	}
+};
+
+template <typename T>
+struct fmt_class_string<vm::_ref_base<T, u32>, void> : fmt_class_string<vm::_ptr_base<const void, u32>, void>
+{
+	// TODO
+};
+
+template <>
+struct fmt_class_string<vm::_ref_base<char, u32>, void> : fmt_class_string<vm::_ptr_base<const char, u32>, void>
+{
+};
+
+template <>
+struct fmt_class_string<vm::_ref_base<const char, u32>, void> : fmt_class_string<vm::_ptr_base<const char, u32>, void>
+{
 };

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -1254,7 +1254,6 @@ protected:
 	alignas(Align) type m_data;
 
 public:
-	static constexpr usz align = Align;
 	ENABLE_BITWISE_SERIALIZATION;
 
 	atomic_t() noexcept = default;
@@ -1800,8 +1799,6 @@ class atomic_t<bool, Align> : private atomic_t<uchar, Align>
 	using base = atomic_t<uchar, Align>;
 
 public:
-	static constexpr usz align = Align;
-
 	atomic_t() noexcept = default;
 
 	atomic_t(const atomic_t&) = delete;

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1171,6 +1171,18 @@ concept PtrSame = (is_same_ptr<X, Y>());
 
 namespace stx
 {
+	template <typename T, typename U>
+	class copy_cv
+	{
+		using C = std::conditional_t<std::is_const<T>::value, std::add_const_t<U>, U>;
+		using V = std::conditional_t<std::is_volatile<T>::value, std::add_volatile_t<C>, C>;
+	public:
+		using type = V;
+	};
+
+	template <typename T, typename U>
+	using copy_cv_t = typename copy_cv<T,U>::type;
+
 	template <typename T>
 	struct exact_t
 	{
@@ -1252,13 +1264,13 @@ public:
 	}
 
 	template <typename MT, typename T2> requires (std::is_convertible_v<const volatile T*, const volatile T2*>) && PtrSame<T, T2>
-	aref<MT, U> ref(MT T2::*const mptr) const
+	aref<stx::copy_cv_t<T, MT>, U> ref(MT T2::*const mptr) const
 	{
 		return aref<MT, U>(aref_tag, m_ptr + offset32(mptr) / sizeof(U));
 	}
 
 	template <typename MT, typename T2, typename ET = std::remove_extent_t<MT>> requires (std::is_convertible_v<const volatile T*, const volatile T2*>) && PtrSame<T, T2>
-	aref<ET, U> ref(MT T2::*const mptr, usz index) const
+	aref<stx::copy_cv_t<T, ET>, U> ref(MT T2::*const mptr, usz index) const
 	{
 		return aref<ET, U>(aref_tag, m_ptr + offset32(mptr) / sizeof(U) + sizeof(ET) / sizeof(U) * index);
 	}

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1186,7 +1186,7 @@ namespace stx
 
 // Read object of type T from raw pointer, array, string, vector, or any contiguous container
 template <typename T, typename U>
-constexpr T read_from_ptr(U&& array, usz pos = 0)
+constexpr SAFE_BUFFERS(T) read_from_ptr(U&& array, usz pos = 0)
 {
 	// TODO: ensure array element types are trivial
 	static_assert(sizeof(T) % sizeof(array[0]) == 0);
@@ -1199,7 +1199,7 @@ constexpr T read_from_ptr(U&& array, usz pos = 0)
 }
 
 template <typename T, typename U>
-constexpr void write_to_ptr(U&& array, usz pos, const T& value)
+constexpr SAFE_BUFFERS(void) write_to_ptr(U&& array, usz pos, const T& value)
 {
 	static_assert(sizeof(T) % sizeof(array[0]) == 0);
 	if (!std::is_constant_evaluated())
@@ -1209,13 +1209,9 @@ constexpr void write_to_ptr(U&& array, usz pos, const T& value)
 }
 
 template <typename T, typename U>
-constexpr void write_to_ptr(U&& array, const T& value)
+constexpr SAFE_BUFFERS(void) write_to_ptr(U&& array, const T& value)
 {
-	static_assert(sizeof(T) % sizeof(array[0]) == 0);
-	if (!std::is_constant_evaluated())
-		std::memcpy(&array[0], &value, sizeof(value));
-	else
-		ensure(!"Unimplemented");
+	return write_to_ptr<T>(std::forward<U>(array), 0, value);
 }
 
 constexpr struct aref_tag_t{} aref_tag{};


### PR DESCRIPTION
I recently discovered a problem with unaligned memory access of objects stored in PS3 memory. It usually works as intended due to both PS3 and x86 PC intrinsically permitting unaligned reads/writes of 8 bytes and lower, but in fact it's a UB in C++ and it's pure luck it works without problems. One possible solution is to use memcpy instead of creating a native pointer or reference which may be unaligned. This may lead to the deprecation of uncontrollable memory access via native pointers, as they leak deeply into other APIs and may cause various problems, notably having to do the similar workaround in file reads/writes.