### PR TITLE
Use uppercase RPCS3 name in the metainfo file

### DIFF
--- a/rpcs3/rpcs3.metainfo.xml
+++ b/rpcs3/rpcs3.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2018 RPCS3-->
 <component type="desktop-application">
-    <id>net.rpcs3.rpcs3</id>
+    <id>net.rpcs3.RPCS3</id>
     <metadata_license>FSFAP</metadata_license>
     <project_license>GPL-2.0-only</project_license>
     <name>RPCS3</name>


### PR DESCRIPTION
We noticed this naming changed through the [Flathub CI/CD](https://github.com/flathub/net.rpcs3.RPCS3/pull/1270).

The change originates from Related to https://github.com/RPCS3/rpcs3/pull/12974.

The ID should be `net.rpcs3.RPCS3` rather than `net.rpcs3.rpcs3`. The `RPCS3` project name is usually written in uppercase, not rpcs3 - except for the GitHub repository. `net.rpcs3.RPCS3` is used by the Flatpak package as such. Both should be valid though.