### PR TITLE
logs.cpp: Steer the ship before hitting the rocks

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -497,7 +497,7 @@ int main(int argc, char** argv)
 		fs::device_stat stats{};
 		if (!fs::statfs(fs::get_cache_dir(), stats) || stats.avail_free < 128 * 1024 * 1024)
 		{
-			report_fatal_error(fmt::format("Not enough free space (%f KB)", stats.avail_free / 1000000.));
+			std::fprintf(stderr, "Not enough free space for logs (%f KB)", stats.avail_free / 1000000.);
 		}
 
 		// Limit log size to ~25% of free space

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -533,7 +533,7 @@ bool logs::file_writer::flush(u64 bufv)
 	const u64 read_pos = m_out;
 	const u64 out_index = read_pos % s_log_size;
 	const u64 pushed = (bufv / s_log_size) % s_log_size;
-	const u64 end = std::min<u64>(out_index > pushed ? read_pos - out_index + pushed : (read_pos + s_log_size) & ~(s_log_size - 1), m_max_size);
+	const u64 end = std::min<u64>(out_index >= pushed ? read_pos - out_index + pushed : (read_pos + s_log_size) & ~(s_log_size - 1), m_max_size);
 
 	if (end > read_pos)
 	{

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -533,7 +533,7 @@ bool logs::file_writer::flush(u64 bufv)
 	const u64 read_pos = m_out;
 	const u64 out_index = read_pos % s_log_size;
 	const u64 pushed = (bufv / s_log_size) % s_log_size;
-	const u64 end = std::min<u64>(out_index < pushed ? read_pos - out_index + pushed : (read_pos + s_log_size) & ~(s_log_size - 1), m_max_size);
+	const u64 end = std::min<u64>(out_index > pushed ? read_pos - out_index + pushed : (read_pos + s_log_size) & ~(s_log_size - 1), m_max_size);
 
 	if (end > read_pos)
 	{

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -533,7 +533,7 @@ bool logs::file_writer::flush(u64 bufv)
 	const u64 read_pos = m_out;
 	const u64 out_index = read_pos % s_log_size;
 	const u64 pushed = (bufv / s_log_size) % s_log_size;
-	const u64 end = std::min<u64>(out_index >= pushed ? read_pos - out_index + pushed : (read_pos + s_log_size) & ~(s_log_size - 1), m_max_size);
+	const u64 end = std::min<u64>(out_index <= pushed ? read_pos - out_index + pushed : (read_pos + s_log_size) & ~(s_log_size - 1), m_max_size);
 
 	if (end > read_pos)
 	{
@@ -590,7 +590,7 @@ void logs::file_writer::log(const char* text, usz size)
 			const u64 v1 = (v / s_log_size) % s_log_size;
 			const u64 v2 = v % s_log_size;
 
-			if (v1 + v2 + size > (out < v1 ? out + s_log_size - 1 : out)) [[unlikely]]
+			if (v1 + v2 + size > (out <= v1 ? out + s_log_size - 1 : out)) [[unlikely]]
 			{
 				return nullptr;
 			}

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -590,7 +590,7 @@ void logs::file_writer::log(const char* text, usz size)
 			const u64 v1 = (v / s_log_size) % s_log_size;
 			const u64 v2 = v % s_log_size;
 
-			if (v1 + v2 + size > (out < v1 ? out + s_log_size : out)) [[unlikely]]
+			if (v1 + v2 + size > (out < v1 ? out + s_log_size - 1 : out)) [[unlikely]]
 			{
 				return nullptr;
 			}

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -644,7 +644,7 @@ void logs::file_writer::log(const char* text, usz size)
 
 void logs::file_writer::sync()
 {
-	if (!m_fptr || (!m_fout && !m_fout2))
+	if (!m_fptr)
 	{
 		return;
 	}

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -533,7 +533,7 @@ bool logs::file_writer::flush(u64 bufv)
 	const u64 read_pos = m_out;
 	const u64 out_index = read_pos % s_log_size;
 	const u64 pushed = (bufv / s_log_size) % s_log_size;
-	const u64 end = std::min<u64>(out_index <= pushed ? read_pos - out_index + pushed : (read_pos + s_log_size) & ~(s_log_size - 1), m_max_size);
+	const u64 end = std::min<u64>(out_index <= pushed ? read_pos - out_index + pushed : ((read_pos + s_log_size) & ~(s_log_size - 1)), m_max_size);
 
 	if (end > read_pos)
 	{
@@ -590,7 +590,7 @@ void logs::file_writer::log(const char* text, usz size)
 			const u64 v1 = (v / s_log_size) % s_log_size;
 			const u64 v2 = v % s_log_size;
 
-			if (v1 + v2 + size > (out <= v1 ? out + s_log_size - 1 : out)) [[unlikely]]
+			if (v1 + v2 + size >= (out <= v1 ? out + s_log_size : out)) [[unlikely]]
 			{
 				return nullptr;
 			}

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -650,7 +650,7 @@ void logs::file_writer::sync()
 	}
 
 	// Wait for the writer thread
-	while ((m_out % s_log_size) * s_log_size < m_buf)
+	while ((m_out % s_log_size) * s_log_size != m_buf % (s_log_size * s_log_size))
 	{
 		if (m_out >= m_max_size)
 		{


### PR DESCRIPTION
Attempts to address #12994 
Also don't crash RPCS3  on startup if there is not enough space for logs, disable logging in this case.