### PR TITLE
sys_fs: Implemented sys_fs_newfs() for VSH to format /dev_hdd1

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -192,6 +192,7 @@ public:
 	static std::string_view get_device_path(std::string_view filename);
 	static lv2_fs_mount_point* get_mp(std::string_view filename);
 	static std::string get_vfs(std::string_view filename);
+	static std::string device_name_to_path(std::string_view device_name);
 	static u64 get_mount_count();
 	static bool vfs_unmount(std::string_view vpath, bool no_error = false);
 


### PR DESCRIPTION
I observed that the VSH wants to format /dev_hdd1 during the process of firmware update check (no matter whether a valid update file is found or not), so I implemented sys_fs_newfs() for it to format /dev_hdd1.