### PR TITLE
Game management improvements

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -858,6 +858,12 @@ bool package_reader::extract_data(atomic_t<double>& sync)
 					else
 					{
 						pkg_log.notice("Created file %s", path);
+
+						if (name == "USRDIR/EBOOT.BIN" && entry.file_size > 4)
+						{
+							// Expose the creation of a bootable file
+							m_bootable_file_path = path;
+						}
 					}
 				}
 				else

--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -312,6 +312,11 @@ public:
 	bool extract_data(atomic_t<double>& sync);
 	psf::registry get_psf() const { return m_psf; }
 
+	std::string try_get_bootable_file_path_if_created_new() const
+	{
+		return m_bootable_file_path;
+	}
+
 private:
 	bool read_header();
 	bool read_metadata();
@@ -334,4 +339,7 @@ private:
 	PKGHeader m_header{};
 	PKGMetaData m_metadata{};
 	psf::registry m_psf{};
+
+	// Expose bootable file installed (if installed such)
+	std::string m_bootable_file_path;
 };

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -422,9 +422,9 @@ void Emulator::Init(bool add_only)
 	make_path_verbose(fs::get_config_dir() + "sounds/");
 	make_path_verbose(patch_engine::get_patches_path());
 
-	if (const std::string games_common = fs::get_config_dir() + "/games"; make_path_verbose(games_common))
+	if (const std::string games_common = fs::get_config_dir() + "/games/"; make_path_verbose(games_common))
 	{
-		fs::write_file(user_path + "/Disc Games Can Be Put Here For Automatic Detection.txt", fs::create + fs::excl + fs::write, ""s);
+		fs::write_file(games_common + "/Disc Games Can Be Put Here For Automatic Detection.txt", fs::create + fs::excl + fs::write, ""s);
 	}
 
 	if (add_only)

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -1133,7 +1133,20 @@ int main(int argc, char** argv)
 	}
 	else if (const QStringList args = parser.positionalArguments(); !args.isEmpty() && !is_updating && !parser.isSet(arg_installfw) && !parser.isSet(arg_installpkg))
 	{
-		sys_log.notice("Booting application from command line: %s", ::at32(args, 0).toStdString());
+		std::string spath = sstr(::at32(args, 0));
+
+		if (spath.starts_with("%RPCS3_VFS%"))
+		{
+			sys_log.notice("Booting application from command line using VFS path: %s", spath.substr(("%RPCS3_VFS%"sv).size()));
+		}
+		else if (spath.starts_with("%RPCS3_GAMEID%"))
+		{
+			sys_log.notice("Booting application from command line using GAMEID: %s", spath.substr(("%RPCS3_GAMEID%"sv).size()));
+		}
+		else
+		{
+			sys_log.notice("Booting application from command line: %s", spath);
+		}
 
 		// Propagate command line arguments
 		std::vector<std::string> rpcs3_argv;
@@ -1163,7 +1176,7 @@ int main(int argc, char** argv)
 		}
 
 		// Postpone startup to main event loop
-		Emu.CallFromMainThread([path = sstr(QFileInfo(::at32(args, 0)).absoluteFilePath()), rpcs3_argv = std::move(rpcs3_argv), config_path = std::move(config_path)]() mutable
+		Emu.CallFromMainThread([path = spath.starts_with("%RPCS3_") ? spath : sstr(QFileInfo(::at32(args, 0)).absoluteFilePath()), rpcs3_argv = std::move(rpcs3_argv), config_path = std::move(config_path)]() mutable
 		{
 			Emu.argv = std::move(rpcs3_argv);
 			Emu.SetForceBoot(true);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1021,7 +1021,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		const std::string target_cli_args = fmt::format("--no-gui \"%s\"", gameinfo->info.path);
 		const std::string target_icon_dir = fmt::format("%sIcons/game_icons/%s/", fs::get_config_dir(), gameinfo->info.serial);
 
-		if (gui::utils::create_shortcut(gameinfo->info.name, target_cli_args, gameinfo->info.name, gameinfo->info.icon_path, target_icon_dir, is_desktop_shortcut))
+		if (gui::utils::create_shortcut(gameinfo->info.name, target_cli_args, gameinfo->info.name, gameinfo->info.icon_path, target_icon_dir, is_desktop_shortcut ? gui::utils::shortcut_location::desktop : gui::utils::shortcut_location::rpcs3_shortcuts))
 		{
 			game_list_log.success("Created %s shortcut for %s", is_desktop_shortcut ? "desktop" : "application menu", sstr(qstr(gameinfo->info.name).simplified()));
 			QMessageBox::information(this, tr("Success!"), tr("Successfully created a shortcut."));

--- a/rpcs3/rpcs3qt/shortcut_utils.cpp
+++ b/rpcs3/rpcs3qt/shortcut_utils.cpp
@@ -66,7 +66,7 @@ namespace gui::utils
 	    [[maybe_unused]] const std::string& description,
 	    [[maybe_unused]] const std::string& src_icon_path,
 	    [[maybe_unused]] const std::string& target_icon_dir,
-	    bool is_desktop_shortcut)
+	    shortcut_location location)
 	{
 		if (name.empty())
 		{
@@ -84,14 +84,21 @@ namespace gui::utils
 
 		std::string link_path;
 
-		if (is_desktop_shortcut)
+		if (location == shortcut_location::desktop)
 		{
 			link_path = QStandardPaths::writableLocation(QStandardPaths::StandardLocation::DesktopLocation).toStdString();
 		}
-		else
+		else if (location == shortcut_location::applications)
 		{
 			link_path = QStandardPaths::writableLocation(QStandardPaths::StandardLocation::ApplicationsLocation).toStdString();
 		}
+#ifdef _WIN32
+		else if (location == shortcut_location::rpcs3_shortcuts)
+		{
+			link_path = fs::get_config_dir() + "/games/shortcuts/";
+			fs::create_dir(link_path);
+		}
+#endif
 
 		if (!fs::is_dir(link_path))
 		{
@@ -99,7 +106,7 @@ namespace gui::utils
 			return false;
 		}
 
-		if (!is_desktop_shortcut)
+		if (location == shortcut_location::applications)
 		{
 			link_path += "/RPCS3";
 
@@ -197,7 +204,7 @@ namespace gui::utils
 		res = pPersistFile->Save(w_link_file.c_str(), TRUE);
 		if (FAILED(res))
 		{
-			if (is_desktop_shortcut)
+			if (location == shortcut_location::desktop)
 			{
 				return cleanup(false, fmt::format("Saving file to desktop failed (%s)", str_error(res)));
 			}
@@ -348,7 +355,7 @@ namespace gui::utils
 		}
 		shortcut_file.close();
 
-		if (is_desktop_shortcut)
+		if (location == shortcut_location::desktop)
 		{
 			if (chmod(link_path.c_str(), S_IRWXU) != 0) // enables user to execute file
 			{

--- a/rpcs3/rpcs3qt/shortcut_utils.h
+++ b/rpcs3/rpcs3qt/shortcut_utils.h
@@ -2,10 +2,19 @@
 
 namespace gui::utils
 {
+	enum shortcut_location
+	{
+		desktop,
+		applications,
+#ifdef _WIN32
+		rpcs3_shortcuts,
+#endif
+	};
+
 	bool create_shortcut(const std::string& name,
 	                     const std::string& target_cli_args,
 	                     const std::string& description,
 	                     const std::string& src_icon_path,
 	                     const std::string& target_icon_dir,
-	                     bool is_desktop_shortcut);
+	                     shortcut_location shortcut_location);
 }


### PR DESCRIPTION
* Add an option to create a desktop and start menu shortcut when installing PKG of a bootable game.
* Make game shortcuts not using hardcoded file paths but instead use game serial in order to resolve the boot path. So it works even if the disc game directory has been moved. This is done using the feature detailed below.
* Add CLI support for booting games using PS3 filesystem paths and TITLE ID. 
    - Boot by TITLE_ID example: `rpcs3.exe --no-gui "%RPCS3_GAMEID%:BCES01584"`
    - Boot using PS3 filesystem example: `rpcs3.exe --no-gui "%RPCS3_VFS%:dev_hdd0/game/NPUB30695/USRDIR/EBOOT.BIN"`
* Windows only: Create the directory RPCS3/game/shortcuts/ where shortcuts are created when installing PKGs regardless of user consent. Allows simulating a game library without even opening RPCS3 UI. Also allows searching games by title and booting it from the file explorer.
* Savestates: fix Emulator::m_dir state on savestate load.
* Fixed the creation of "RPCS3/games/Disc Games Can Be Put Here For Automatic Detection.txt" file.