### PR TITLE
Trophy manager: add more context menu actions

### DIFF
--- a/rpcs3/rpcs3qt/trophy_manager_dialog.h
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.h
@@ -75,10 +75,11 @@ private Q_SLOTS:
 	void ResizeGameIcons();
 	void ResizeTrophyIcons();
 	void ApplyFilter();
-	void ShowContextMenu(const QPoint& pos);
+	void ShowTrophyTableContextMenu(const QPoint& pos);
+	void ShowGameTableContextMenu(const QPoint& pos);
 
 private:
-	/** Loads a trophy folder. 
+	/** Loads a trophy folder.
 	Returns true if successful.  Does not attempt to install if failure occurs, like sceNpTrophy.
 	*/
 	bool LoadTrophyFolderToDB(const std::string& trop_name);


### PR DESCRIPTION
- Adds "Copy Info" submenu to trophy list in trophy manager. You can copy name+description, name or description.
- Adds additional context menu to game list in trophy manager.
- Adds "Open Trophy Directory" entry to game list in trophy manager (same as the one in the trophy list).
- Adds "Copy Name" entry to game list in trophy manager.

![image](https://user-images.githubusercontent.com/23019877/205769308-bfea432b-8a86-494d-a457-ffc4413c8ab4.png)
![image](https://user-images.githubusercontent.com/23019877/205769162-f30cfe87-a2b8-4075-9f05-f81d97f05d43.png)

fixes #13018