### PR TITLE
CI: switch FreeBSD to Clang/libc++ 15

### DIFF
--- a/.ci/build-freebsd.sh
+++ b/.ci/build-freebsd.sh
@@ -7,11 +7,12 @@ git submodule -q update --init --depth 1 $(awk '/path/ && !/llvm/ { print $3 }' 
 
 # Prefer newer Clang than in base system (see also .ci/install-freebsd.sh)
 # libc++ isn't in llvm* packages, so download manually
-fetch https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-13.0.1-rc1.tar.gz
-tar xf llvm*.tar.gz
-export CC=clang13 CXX=clang++13
+fetch https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/llvm-project-15.0.6.src.tar.xz
+tar xf llvm*.tar.xz
+export CC=clang15 CXX=clang++15
 cmake -B libcxx_build -G Ninja -S llvm*/libcxx \
       -DLLVM_CCACHE_BUILD=ON \
+      -DLIBCXX_INCLUDE_BENCHMARKS=OFF \
       -DCMAKE_INSTALL_PREFIX:PATH=libcxx_prefix
 cmake --build libcxx_build
 cmake --install libcxx_build

--- a/.ci/install-freebsd.sh
+++ b/.ci/install-freebsd.sh
@@ -9,7 +9,7 @@ export ASSUME_ALWAYS_YES=true
 pkg info # debug
 
 # Prefer newer Clang than in base system (see also .ci/build-freebsd.sh)
-pkg install llvm13
+pkg install llvm15
 
 # Mandatory dependencies (qt5-dbus and qt5-gui are pulled via qt5-widgets)
 pkg install git ccache cmake ninja qt5-qmake qt5-buildtools qt5-widgets qt5-concurrent qt5-multimedia qt5-svg glew openal-soft ffmpeg


### PR DESCRIPTION
After https://github.com/freebsd/freebsd-ports/commit/855947ebf7e738232a8bbf6d47cc56f2896f276f [Qt5 itself](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=266007) brings LLVM 15 as a dependency, so avoid having to install more than one llvm package.