### PR TITLE
Qt: Improved the shown path in overlay message "Recording stopped"

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -353,7 +353,19 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 				gui_log.warning("The video provider could not release the image sink. A sink with higher priority must have been set.");
 			}
 
-			rsx::overlays::queue_message(tr("Recording stopped: %0").arg(QString::fromStdString(m_video_encoder->path())).toStdString());
+			// Play a sound
+			if (const std::string sound_path = fs::get_config_dir() + "sounds/snd_recording.wav"; fs::is_file(sound_path))
+			{
+				QSound::play(qstr(sound_path));
+			}
+			else
+			{
+				QApplication::beep();
+			}
+
+			ensure(m_video_encoder->path().starts_with(fs::get_config_dir()));
+			const std::string shortpath = m_video_encoder->path().substr(fs::get_config_dir().size() - 1); // -1 for /
+			rsx::overlays::queue_message(tr("Recording saved: %0").arg(QString::fromStdString(shortpath)).toStdString());
 		}
 		else
 		{
@@ -927,7 +939,7 @@ void gs_frame::take_screenshot(std::vector<u8> data, const u32 sshot_width, cons
 				}
 			});
 
-			ensure(filename.find(fs::get_config_dir()) != filename.npos);
+			ensure(filename.starts_with(fs::get_config_dir()));
 			const std::string shortpath = filename.substr(fs::get_config_dir().size() - 1); // -1 for /
 			rsx::overlays::queue_message(tr("Screenshot saved: %0").arg(QString::fromStdString(shortpath)).toStdString());
 


### PR DESCRIPTION
In #12894, the shown path in the overlay message "Recording stopped: " is too long to be fully shown in some cases due to a long absolute path.
This fix is inspired by the implementation of the overlay message "Screenshot saved: ", which shows a relative path instead.

Comparison
Before this PR:
![before](https://user-images.githubusercontent.com/17809637/206625391-92d24866-39dc-43f4-af34-84427699985c.png)
After this PR:
![after](https://user-images.githubusercontent.com/17809637/206625442-1bb803fc-b0e8-4d9f-8aaa-1e55b9aff5e8.png)
