### PR TITLE
[macOS] Fix build errors in media_utils.cpp 

### DIFF
--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -699,7 +699,7 @@ namespace utils
 			AVCodecID used_codec = static_cast<AVCodecID>(m_video_codec_id);
 
 			// Find specified codec first
-			if (AVCodec* encoder = avcodec_find_encoder(used_codec); !!encoder)
+			if (const AVCodec* encoder = avcodec_find_encoder(used_codec); !!encoder)
 			{
 				media_log.success("video_encoder: Found requested video_codec %d = %s", static_cast<int>(used_codec), encoder->name);
 				av_output_format = find_format(encoder);
@@ -724,7 +724,7 @@ namespace utils
 				void* opaque = nullptr;
 				for (const AVCodec* codec = av_codec_iterate(&opaque); !!codec; codec = av_codec_iterate(&opaque))
 				{
-					if (AVCodec* encoder = avcodec_find_encoder(codec->id); !!encoder)
+					if (const AVCodec* encoder = avcodec_find_encoder(codec->id); !!encoder)
 					{
 						media_log.notice("video_encoder: Found video_codec %d = %s", static_cast<int>(used_codec), encoder->name);
 						av_output_format = find_format(encoder);


### PR DESCRIPTION
Changes AVCodec* to a constant rather than a variable in two places. 

Building on macOS for Arm with Xcode 14.1 would fail with the following errors: 

```
/Users/XXXX/Downloads/rpcs3/rpcs3/util/media_utils.cpp:702:17: error: cannot initialize a variable of type 'AVCodec *' with an rvalue of type 'const AVCodec *'
                        if (AVCodec* encoder = avcodec_find_encoder(used_codec); !!encoder)
                                     ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/XXXX/Downloads/rpcs3/rpcs3/util/media_utils.cpp:727:19: error: cannot initialize a variable of type 'AVCodec *' with an rvalue of type 'const AVCodec *'
                                        if (AVCodec* encoder = avcodec_find_encoder(codec->id); !!encoder)
                                                     ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Allows RPCS3 to build on macOS again

Testing: 
1: Build on macOS (Edit: ARM and Intel)
2: Check that recording still works. 

Should be checked by @Megamouse as they wrote the initial code. 