### PR TITLE
sys_fs: sys_fs_get_mount_info(): Made g_mp_sys_dev_root always reported as mounted

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -3058,12 +3058,9 @@ error_code sys_fs_get_mount_info_size(ppu_thread&, vm::ptr<u64> len)
 				}
 			}
 		}
-		else
+		else if (mp == &g_mp_sys_dev_root || !vfs::get(mp->root).empty())
 		{
-			if (!vfs::get(mp->root).empty())
-			{
-				count++;
-			}
+			count++;
 		}
 	}
 
@@ -3114,7 +3111,7 @@ error_code sys_fs_get_mount_info(ppu_thread&, vm::ptr<CellFsMountInfo> info, u64
 				}
 			}
 		}
-		else if (!vfs::get(mp->root).empty())
+		else if (mp == &g_mp_sys_dev_root || !vfs::get(mp->root).empty())
 		{
 			if (mp == &g_mp_sys_dev_root || mp == &g_mp_sys_dev_flash)
 			{


### PR DESCRIPTION
Although RPCS3 VFS doesn't really mount g_mp_sys_dev_root (path: "/"), it should always be deemed mounted in sys_fs_get_mount_info().
Reference:
https://www.psdevwiki.com/ps3/Talk:Files_on_the_PS3
and what sys_fs_get_mount_info() reported before PR #12917.