### PR TITLE
Misc and minor improvements of syscalls used by VSH

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -425,7 +425,7 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	BIND_SYSC(_sys_game_watchdog_clear),                     //374 (0x176)
 	NULL_FUNC(sys_game_set_system_sw_version),              //375 (0x177)  ROOT
 	BIND_SYSC(_sys_game_get_system_sw_version),              //376 (0x178)  ROOT
-	NULL_FUNC(sys_sm_set_shop_mode),                        //377 (0x179)  ROOT
+	BIND_SYSC(sys_sm_set_shop_mode),                        //377 (0x179)  ROOT
 	BIND_SYSC(sys_sm_get_ext_event2),                       //378 (0x17A)  ROOT
 	BIND_SYSC(sys_sm_shutdown),                             //379 (0x17B)  ROOT
 	BIND_SYSC(sys_sm_get_params),                           //380 (0x17C)  DBG

--- a/rpcs3/Emu/Cell/lv2/sys_sm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_sm.cpp
@@ -84,6 +84,13 @@ error_code sys_sm_shutdown(ppu_thread& ppu, u16 op, vm::ptr<void> param, u64 siz
 	return CELL_OK;
 }
 
+error_code sys_sm_set_shop_mode(s32 mode)
+{
+	sys_sm.todo("sys_sm_set_shop_mode(mode=0x%x)", mode);
+
+	return CELL_OK;
+}
+
 error_code sys_sm_control_led(u8 led, u8 action)
 {
 	sys_sm.todo("sys_sm_control_led(led=0x%x, action=0x%x)", led, action);

--- a/rpcs3/Emu/Cell/lv2/sys_sm.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sm.h
@@ -8,6 +8,7 @@
 error_code sys_sm_get_ext_event2(vm::ptr<u64> a1, vm::ptr<u64> a2, vm::ptr<u64> a3, u64 a4);
 error_code sys_sm_shutdown(ppu_thread& ppu, u16 op, vm::ptr<void> param, u64 size);
 error_code sys_sm_get_params(vm::ptr<u8> a, vm::ptr<u8> b, vm::ptr<u32> c, vm::ptr<u64> d);
+error_code sys_sm_set_shop_mode(s32 mode);
 error_code sys_sm_control_led(u8 led, u8 action);
 error_code sys_sm_ring_buzzer(u64 packet, u64 a1, u64 a2);
 constexpr auto sys_sm_ring_buzzer2 = sys_sm_ring_buzzer;

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -126,14 +126,14 @@ error_code sys_ss_access_control_engine(u64 pkg_id, u64 a2, u64 a3)
 
 error_code sys_ss_get_console_id(vm::ptr<u8> buf)
 {
-	sys_ss.trace("sys_ss_get_console_id(buf=*0x%x)", buf);
+	sys_ss.notice("sys_ss_get_console_id(buf=*0x%x)", buf);
 
 	return sys_ss_appliance_info_manager(0x19003, buf);
 }
 
 error_code sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid)
 {
-	sys_ss.trace("sys_ss_get_open_psid(psid=*0x%x)", psid);
+	sys_ss.notice("sys_ss_get_open_psid(psid=*0x%x)", psid);
 
 	psid->high = g_cfg.sys.console_psid_high;
 	psid->low = g_cfg.sys.console_psid_low;

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -124,19 +124,16 @@ error_code sys_ss_access_control_engine(u64 pkg_id, u64 a2, u64 a3)
 	return CELL_OK;
 }
 
-s32 sys_ss_get_console_id(vm::ptr<u8> buf)
+error_code sys_ss_get_console_id(vm::ptr<u8> buf)
 {
-	sys_ss.todo("sys_ss_get_console_id(buf=*0x%x)", buf);
+	sys_ss.trace("sys_ss_get_console_id(buf=*0x%x)", buf);
 
-	// TODO: Return some actual IDPS?
-	*buf = 0;
-
-	return CELL_OK;
+	return sys_ss_appliance_info_manager(0x19003, buf);
 }
 
-s32 sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid)
+error_code sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid)
 {
-	sys_ss.warning("sys_ss_get_open_psid(psid=*0x%x)", psid);
+	sys_ss.trace("sys_ss_get_open_psid(psid=*0x%x)", psid);
 
 	psid->high = g_cfg.sys.console_psid_high;
 	psid->low = g_cfg.sys.console_psid_low;
@@ -146,7 +143,7 @@ s32 sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid)
 
 error_code sys_ss_appliance_info_manager(u32 code, vm::ptr<u8> buffer)
 {
-	sys_ss.warning("sys_ss_appliance_info_manager(code=0x%x, buffer=*0x%x)", code, buffer);
+	sys_ss.notice("sys_ss_appliance_info_manager(code=0x%x, buffer=*0x%x)", code, buffer);
 
 	if (!buffer)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_ss.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.h
@@ -20,8 +20,8 @@ struct CellSsOpenPSID
 
 error_code sys_ss_random_number_generator(u64 pkg_id, vm::ptr<void> buf, u64 size);
 error_code sys_ss_access_control_engine(u64 pkg_id, u64 a2, u64 a3);
-s32 sys_ss_get_console_id(vm::ptr<u8> buf);
-s32 sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid);
+error_code sys_ss_get_console_id(vm::ptr<u8> buf);
+error_code sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid);
 error_code sys_ss_appliance_info_manager(u32 code, vm::ptr<u8> buffer);
 error_code sys_ss_get_cache_of_product_mode(vm::ptr<u8> ptr);
 error_code sys_ss_secure_rtc(u64 cmd, u64 a2, u64 a3, u64 a4);


### PR DESCRIPTION
Mainly implemented sys_ss_get_console_id(), and added sys_sm_set_shop_mode(), which is used not only by SHOP firmware but also by GEX firmware.