### PR TITLE
vk: Improve memory integrity

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.h
@@ -6,9 +6,7 @@ namespace vk
 	VkSampler null_sampler();
 	image_view* null_image_view(const command_buffer& cmd, VkImageViewType type);
 	image* get_typeless_helper(VkFormat format, rsx::format_class format_class, u32 requested_width, u32 requested_height);
-
-	buffer* get_scratch_buffer(u32 queue_family, u64 min_required_size);
-	buffer* get_scratch_buffer(const command_buffer& cmd, u64 min_required_size);
+	buffer* get_scratch_buffer(const command_buffer& cmd, u64 min_required_size, bool zero_memory = false);
 
 	void clear_scratch_resources();
 }


### PR DESCRIPTION
- Zero scratch vram allocations unless we're reusing a resource.
- Introduce some extra barriers in copy_image_typeless. Without these some fast paths had back-to-back CmdCopyImageToBuffer and CmdCopyBufferToImage on the same scratch resource with 0 activity in between, causing garbage to get transferred in the second call and corrupting GPU memory.

Fixes https://github.com/RPCS3/rpcs3/issues/11328