### PR TITLE
sys_game: Made the LV2 Watchdog restarts the game forcefully

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -6,6 +6,7 @@
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/Cell/Modules/cellGame.h"
 
+#include "Emu/Cell/lv2/sys_game.h"
 #include "Emu/Cell/lv2/sys_process.h"
 #include "cellSysutil.h"
 
@@ -125,6 +126,10 @@ extern s32 sysutil_send_system_cmd(u64 status, u64 param)
 				cellSysutil.error("Tried to enqueue a DRAWING_END callback without a BEGIN callback!");
 				return -1;
 			}
+		}
+		else if (status == CELL_SYSUTIL_REQUEST_EXITGAME)
+		{
+			abort_lv2_watchdog();
 		}
 
 		for (sysutil_cb_manager::registered_cb cb : cbm->callbacks)

--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -69,7 +69,7 @@ struct watchdog_t
 
 				Emu.CallFromMainThread([]()
 				{
-					Emu.Restart();
+					Emu.Restart(false);
 				});
 
 				return;

--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -82,6 +82,15 @@ struct watchdog_t
 	static constexpr auto thread_name = "LV2 Watchdog Thread"sv;
 };
 
+void abort_lv2_watchdog()
+{
+	if (auto thr = g_fxo->try_get<named_thread<watchdog_t>>())
+	{
+		sys_game.notice("Aborting %s...", thr->thread_name);
+		*thr = thread_state::aborting;
+	}
+}
+
 error_code _sys_game_watchdog_start(u32 timeout)
 {
 	sys_game.trace("sys_game_watchdog_start(timeout=%d)", timeout);

--- a/rpcs3/Emu/Cell/lv2/sys_game.h
+++ b/rpcs3/Emu/Cell/lv2/sys_game.h
@@ -1,5 +1,7 @@
 #pragma once
 
+void abort_lv2_watchdog();
+
 error_code _sys_game_watchdog_start(u32 timeout);
 error_code _sys_game_watchdog_stop();
 error_code _sys_game_watchdog_clear();

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2823,13 +2823,16 @@ std::shared_ptr<utils::serial> Emulator::Kill(bool allow_autoexit, bool savestat
 	return to_ar;
 }
 
-game_boot_result Emulator::Restart()
+game_boot_result Emulator::Restart(bool graceful)
 {
 	if (!IsStopped())
 	{
 		auto save_args = std::make_tuple(argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_mode);
 
-		GracefulShutdown(false, false);
+		if (graceful)
+			GracefulShutdown(false, false);
+		else
+			Kill(false);
 
 		std::tie(argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_mode) = std::move(save_args);
 	}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -307,7 +307,7 @@ public:
 	void Resume();
 	void GracefulShutdown(bool allow_autoexit = true, bool async_op = false, bool savestate = false);
 	std::shared_ptr<utils::serial> Kill(bool allow_autoexit = true, bool savestate = false);
-	game_boot_result Restart();
+	game_boot_result Restart(bool graceful = true);
 	bool Quit(bool force_quit);
 	static void CleanUp();
 


### PR DESCRIPTION
Whenever the LV2 Watchdog is triggered, the game should have already been ready to be killed forcefully (and then restarted).