### PR TITLE
rsx: Improve surface<->texture cache communication

### DIFF
--- a/Utilities/stack_trace.h
+++ b/Utilities/stack_trace.h
@@ -4,17 +4,43 @@
 
 namespace utils
 {
+	namespace stack_trace
+	{
+		// Printing utilities
+
+		template <typename T>
+		concept Logger = requires (T& t, const std::string& msg)
+		{
+			{ t.print(msg) };
+		};
+
+		struct print_to_log
+		{
+			logs::channel& log;
+
+		public:
+			print_to_log(logs::channel& chan)
+				: log(chan)
+			{}
+
+			void print(const std::string& s)
+			{
+				log.error("%s", s);
+			}
+		};
+	}
+
 	std::vector<void*> get_backtrace(int max_depth = 255);
 	std::vector<std::string> get_backtrace_symbols(const std::vector<void*>& stack);
 
-	FORCE_INLINE void print_trace(logs::channel& logger, int max_depth = 255)
+	FORCE_INLINE void print_trace(stack_trace::Logger auto& logger, int max_depth = 255)
 	{
 		const auto trace = get_backtrace(max_depth);
 		const auto lines = get_backtrace_symbols(trace);
 
 		for (const auto& line : lines)
 		{
-			logger.error("%s", line);
+			logger.print(line);
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -722,6 +722,30 @@ namespace rsx
 			release();
 		}
 
+		void on_swap_out()
+		{
+			if (is_locked())
+			{
+				on_unlock();
+			}
+			else
+			{
+				release();
+			}
+		}
+
+		void on_swap_in(bool lock)
+		{
+			if (!is_locked() && lock)
+			{
+				on_lock();
+			}
+			else
+			{
+				add_ref();
+			}
+		}
+
 		bool is_locked() const
 		{
 			return texture_cache_metadata.locked;

--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -392,6 +392,9 @@ namespace rsx
 			ensure(native_pitch);
 			ensure(rsx_pitch);
 
+			// Clear metadata
+			reset();
+
 			base_addr = address;
 
 			const u32 size_x = (native_pitch > 8)? (native_pitch - 8) : 0u;
@@ -744,6 +747,19 @@ namespace rsx
 			{
 				add_ref();
 			}
+		}
+
+		void on_clone_from(const render_target_descriptor* ref)
+		{
+			if (ref->is_locked() && !is_locked())
+			{
+				// Propagate locked state only.
+				texture_cache_metadata = ref->texture_cache_metadata;
+			}
+
+			rsx_pitch = ref->get_rsx_pitch();
+			last_use_tag = ref->last_use_tag;
+			raster_type = ref->raster_type;     // Can't actually cut up swizzled data
 		}
 
 		bool is_locked() const

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -583,6 +583,7 @@ namespace rsx
 			}
 
 			data.flushed = true;
+			update_cache_tag();
 		}
 
 

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1324,6 +1324,26 @@ namespace rsx
 			return (get_protection() == utils::protection::no);
 		}
 
+		bool is_synchronized() const
+		{
+			return synchronized;
+		}
+
+		bool is_flushed() const
+		{
+			return flushed;
+		}
+
+		bool should_flush() const
+		{
+			if (context == rsx::texture_upload_context::framebuffer_storage)
+			{
+				const auto surface = derived()->get_render_target();
+				return surface->has_flushable_data();
+			}
+
+			return true;
+		}
 
 	private:
 		/**
@@ -1359,14 +1379,14 @@ namespace rsx
 				{
 					// Locked memory. We have to take ownership of the object in the surface cache as well
 					auto surface = derived()->get_render_target();
-					surface->add_ref();
+					surface->on_lock();
 				}
 				else if (old_prot == utils::protection::no && prot != utils::protection::no)
 				{
 					// Release the surface, the cache can remove it if needed
 					ensure(prot == utils::protection::rw);
 					auto surface = derived()->get_render_target();
-					surface->release();
+					surface->on_unlock();
 				}
 			}
 		}

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1375,17 +1375,17 @@ namespace rsx
 			if (context == rsx::texture_upload_context::framebuffer_storage && !Emu.IsStopped())
 			{
 				// Lock, unlock
+				auto surface = derived()->get_render_target();
+
 				if (prot == utils::protection::no && old_prot != utils::protection::no)
 				{
 					// Locked memory. We have to take ownership of the object in the surface cache as well
-					auto surface = derived()->get_render_target();
 					surface->on_lock();
 				}
 				else if (old_prot == utils::protection::no && prot != utils::protection::no)
 				{
 					// Release the surface, the cache can remove it if needed
 					ensure(prot == utils::protection::rw);
-					auto surface = derived()->get_render_target();
 					surface->on_unlock();
 				}
 			}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.cpp
@@ -322,10 +322,15 @@ void GLGSRender::init_buffers(rsx::framebuffer_creation_context context, bool /*
 				!!g_cfg.video.write_color_buffers;
 
 			if (lock &&
+#ifdef TEXTURE_CACHE_DEBUG
 				!m_gl_texture_cache.is_protected(
 					base_addr,
 					surface->get_memory_range(),
-					rsx::texture_upload_context::framebuffer_storage))
+					rsx::texture_upload_context::framebuffer_storage)
+#else
+				!surface->is_locked()
+#endif
+				)
 			{
 				lock = false;
 			}

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -47,7 +47,7 @@ namespace rsx
 
 namespace gl
 {
-	class render_target : public viewable_image, public rsx::ref_counted, public rsx::render_target_descriptor<texture*>
+	class render_target : public viewable_image, public rsx::render_target_descriptor<texture*>
 	{
 		void clear_memory(gl::command_context& cmd);
 		void load_memory(gl::command_context& cmd);
@@ -79,11 +79,6 @@ namespace gl
 		bool is_depth_surface() const override
 		{
 			return !!(aspect() & gl::image_aspect::depth);
-		}
-
-		void release_ref(texture* t) const override
-		{
-			static_cast<gl::render_target*>(t)->release();
 		}
 
 		viewable_image* get_surface(rsx::surface_access /*access_type*/) override
@@ -232,6 +227,7 @@ struct gl_render_target_traits
 
 		sink->set_rsx_pitch(ref->get_rsx_pitch());
 		sink->set_old_contents_region(prev, false);
+		sink->texture_cache_metadata = ref->texture_cache_metadata;
 		sink->last_use_tag = ref->last_use_tag;
 		sink->raster_type = ref->raster_type;     // Can't actually cut up swizzled data
 	}
@@ -293,6 +289,7 @@ struct gl_render_target_traits
 		}
 
 		surface->release();
+		surface->reset();
 	}
 
 	static

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -113,6 +113,11 @@ namespace gl
 	{
 		return ensure(dynamic_cast<gl::render_target*>(t));
 	}
+
+	static inline const gl::render_target* as_rtt(const gl::texture* t)
+	{
+		return ensure(dynamic_cast<const gl::render_target*>(t));
+	}
 }
 
 struct gl_render_target_traits

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -215,7 +215,7 @@ struct gl_render_target_traits
 			sink->queue_tag(address);
 		}
 
-		prev.target = sink.get();
+		sink->on_clone_from(ref);
 
 		if (!sink->old_contents.empty())
 		{
@@ -230,11 +230,8 @@ struct gl_render_target_traits
 			}
 		}
 
-		sink->set_rsx_pitch(ref->get_rsx_pitch());
+		prev.target = sink.get();
 		sink->set_old_contents_region(prev, false);
-		sink->texture_cache_metadata = ref->texture_cache_metadata;
-		sink->last_use_tag = ref->last_use_tag;
-		sink->raster_type = ref->raster_type;     // Can't actually cut up swizzled data
 	}
 
 	static
@@ -294,7 +291,6 @@ struct gl_render_target_traits
 		}
 
 		surface->release();
-		surface->reset();
 	}
 
 	static

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -70,12 +70,12 @@ namespace gl
 			if (vram_texture && !managed_texture && get_protection() == utils::protection::no)
 			{
 				// In-place image swap, still locked. Likely a color buffer that got rebound as depth buffer or vice-versa.
-				gl::as_rtt(vram_texture)->release();
+				gl::as_rtt(vram_texture)->on_swap_out();
 
 				if (!managed)
 				{
 					// Incoming is also an external resource, reference it immediately
-					gl::as_rtt(image)->add_ref();
+					gl::as_rtt(image)->on_swap_in(is_locked());
 				}
 			}
 

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -393,7 +393,7 @@ namespace gl
 			return managed_texture.get();
 		}
 
-		gl::render_target* get_render_target()
+		gl::render_target* get_render_target() const
 		{
 			return gl::as_rtt(vram_texture);
 		}

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -383,26 +383,6 @@ namespace gl
 			return format;
 		}
 
-		bool is_flushed() const
-		{
-			return flushed;
-		}
-
-		bool is_synchronized() const
-		{
-			return synchronized;
-		}
-
-		void set_flushed(bool state)
-		{
-			flushed = state;
-		}
-
-		bool is_empty() const
-		{
-			return vram_texture == nullptr;
-		}
-
 		gl::texture_view* get_view(u32 remap_encoding, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap)
 		{
 			return vram_texture->get_view(remap_encoding, remap);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2450,10 +2450,15 @@ void VKGSRender::prepare_rtts(rsx::framebuffer_creation_context context)
 				!!g_cfg.video.write_color_buffers;
 
 			if (lock &&
+#ifdef TEXTURE_CACHE_DEBUG
 				!m_texture_cache.is_protected(
 					base_addr,
 					surface->get_memory_range(),
-					rsx::texture_upload_context::framebuffer_storage))
+					rsx::texture_upload_context::framebuffer_storage)
+#else
+				!surface->is_locked()
+#endif
+				)
 			{
 				lock = false;
 			}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -788,11 +788,6 @@ namespace vk
 		return !!(aspect() & VK_IMAGE_ASPECT_DEPTH_BIT);
 	}
 
-	void render_target::release_ref(vk::viewable_image* t) const
-	{
-		static_cast<vk::render_target*>(t)->release();
-	}
-
 	bool render_target::matches_dimensions(u16 _width, u16 _height) const
 	{
 		// Use forward scaling to account for rounding and clamping errors

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -24,7 +24,7 @@ namespace vk
 	void resolve_image(vk::command_buffer& cmd, vk::viewable_image* dst, vk::viewable_image* src);
 	void unresolve_image(vk::command_buffer& cmd, vk::viewable_image* dst, vk::viewable_image* src);
 
-	class render_target : public viewable_image, public rsx::ref_counted, public rsx::render_target_descriptor<vk::viewable_image*>
+	class render_target : public viewable_image, public rsx::render_target_descriptor<vk::viewable_image*>
 	{
 		u64 cyclic_reference_sync_tag = 0;
 		u64 write_barrier_sync_tag = 0;
@@ -64,7 +64,6 @@ namespace vk
 
 		vk::viewable_image* get_surface(rsx::surface_access access_type) override;
 		bool is_depth_surface() const override;
-		void release_ref(vk::viewable_image* t) const override;
 		bool matches_dimensions(u16 _width, u16 _height) const;
 		void reset_surface_counters();
 
@@ -338,6 +337,7 @@ namespace vk
 
 			sink->rsx_pitch = ref->get_rsx_pitch();
 			sink->set_old_contents_region(prev, false);
+			sink->texture_cache_metadata = ref->texture_cache_metadata;
 			sink->last_use_tag = ref->last_use_tag;
 			sink->raster_type = ref->raster_type;     // Can't actually cut up swizzled data
 		}
@@ -411,6 +411,7 @@ namespace vk
 			}
 
 			surface->release();
+			surface->reset();
 		}
 
 		static void notify_surface_persist(const std::unique_ptr<vk::render_target>& /*surface*/)

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -85,6 +85,11 @@ namespace vk
 		return ensure(dynamic_cast<vk::render_target*>(t));
 	}
 
+	static inline const vk::render_target* as_rtt(const vk::image* t)
+	{
+		return ensure(dynamic_cast<const vk::render_target*>(t));
+	}
+
 	struct surface_cache_traits
 	{
 		using surface_storage_type = std::unique_ptr<vk::render_target>;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -325,7 +325,7 @@ namespace vk
 				sink->change_layout(cmd, best_layout);
 			}
 
-			prev.target = sink.get();
+			sink->on_clone_from(ref);
 
 			if (!sink->old_contents.empty())
 			{
@@ -340,11 +340,8 @@ namespace vk
 				}
 			}
 
-			sink->rsx_pitch = ref->get_rsx_pitch();
+			prev.target = sink.get();
 			sink->set_old_contents_region(prev, false);
-			sink->texture_cache_metadata = ref->texture_cache_metadata;
-			sink->last_use_tag = ref->last_use_tag;
-			sink->raster_type = ref->raster_type;     // Can't actually cut up swizzled data
 		}
 
 		static std::unique_ptr<vk::render_target> convert_pitch(
@@ -416,7 +413,6 @@ namespace vk
 			}
 
 			surface->release();
-			surface->reset();
 		}
 
 		static void notify_surface_persist(const std::unique_ptr<vk::render_target>& /*surface*/)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -50,12 +50,12 @@ namespace vk
 			if (vram_texture && !managed_texture && get_protection() == utils::protection::no)
 			{
 				// In-place image swap, still locked. Likely a color buffer that got rebound as depth buffer or vice-versa.
-				vk::as_rtt(vram_texture)->release();
+				vk::as_rtt(vram_texture)->on_swap_out();
 
 				if (!managed)
 				{
 					// Incoming is also an external resource, reference it immediately
-					vk::as_rtt(image)->add_ref();
+					vk::as_rtt(image)->on_swap_in(is_locked());
 				}
 			}
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -163,7 +163,7 @@ namespace vk
 			return managed_texture;
 		}
 
-		vk::render_target* get_render_target()
+		vk::render_target* get_render_target() const
 		{
 			return vk::as_rtt(vram_texture);
 		}

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -345,11 +345,6 @@ namespace vk
 			}
 		}
 
-		bool is_synchronized() const
-		{
-			return synchronized;
-		}
-
 		bool has_compatible_format(vk::image* tex) const
 		{
 			return vram_texture->info.format == tex->info.format;


### PR DESCRIPTION
Currently only tracks protection setting which is important for validating orphaned slices.
While we're at it, let's also use it to speed up redundant flush operations.

Fixes https://github.com/RPCS3/rpcs3/issues/12971