### PR TITLE
UI: Report Game Size On Disk, Make Game Removal An Informed Decision

### DIFF
--- a/rpcs3/Emu/GameInfo.h
+++ b/rpcs3/Emu/GameInfo.h
@@ -20,6 +20,7 @@ struct GameInfo
 	u32 parental_lvl = 0;
 	u32 sound_format = 0;
 	u32 resolution = 0;
+	usz size_on_disk = umax;
 
 	GameInfo()
 	{

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -117,23 +117,22 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 
 	const QFlags<QMessageBox::StandardButton> buttons = icon != QMessageBox::Information ? QMessageBox::Yes | QMessageBox::No : QMessageBox::Ok;
 
-	QMessageBox* mb = new QMessageBox(icon, title, text, buttons, parent, Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint | (always_on_top ? Qt::WindowStaysOnTopHint : Qt::Widget));
-	mb->deleteLater();
-	mb->setTextFormat(Qt::RichText);
+	QMessageBox mb(icon, title, text, buttons, parent, Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint | (always_on_top ? Qt::WindowStaysOnTopHint : Qt::Widget));
+	mb.setTextFormat(Qt::RichText);
 
 	if (has_gui_setting && icon != QMessageBox::Critical)
 	{
-		mb->setCheckBox(new QCheckBox(tr("Don't show again")));
+		mb.setCheckBox(new QCheckBox(tr("Don't show again")));
 	}
 
-	connect(mb, &QMessageBox::finished, [&](int res)
+	connect(&mb, &QMessageBox::finished, [&](int res)
 	{
 		if (result)
 		{
 			*result = res;
 		}
 
-		const auto checkBox = mb->checkBox();
+		const auto checkBox = mb.checkBox();
 
 		if (checkBox && checkBox->isChecked())
 		{
@@ -142,7 +141,7 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 		}
 	});
 
-	mb->exec();
+	mb.exec();
 }
 
 void gui_settings::ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr)

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -33,6 +33,7 @@ namespace gui
 		column_last_play,
 		column_playtime,
 		column_compat,
+		column_dir_size,
 
 		column_count
 	};
@@ -69,6 +70,8 @@ namespace gui
 			return "column_playtime";
 		case column_compat:
 			return "column_compat";
+		case column_dir_size:
+			return "column_dir_size";
 		case column_count:
 			return "";
 		}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -294,13 +294,12 @@ bool main_window::OnMissingFw()
 	const QString message = tr("Commercial games require the firmware (PS3UPDAT.PUP file) to be installed."
 				"\n<br>For information about how to obtain the required firmware read the <a href=\"https://rpcs3.net/quickstart\">quickstart guide</a>.");
 
-	QMessageBox* mb = new QMessageBox(QMessageBox::Question, title, message, QMessageBox::Ok | QMessageBox::Cancel, this, Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint | Qt::WindowStaysOnTopHint);
-	mb->deleteLater();
-	mb->setTextFormat(Qt::RichText);
+	QMessageBox mb(QMessageBox::Question, title, message, QMessageBox::Ok | QMessageBox::Cancel, this, Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint | Qt::WindowStaysOnTopHint);
+	mb.setTextFormat(Qt::RichText);
 
-	mb->button(QMessageBox::Ok)->setText(tr("Locate PS3UPDAT.PUP"));
+	mb.button(QMessageBox::Ok)->setText(tr("Locate PS3UPDAT.PUP"));
 
-	if (mb->exec() == QMessageBox::Ok)
+	if (mb.exec() == QMessageBox::Ok)
 	{
 		InstallPup();
 		return true;

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -589,5 +589,21 @@ namespace gui
 				}
 			}
 		}
+
+		QString format_byte_size(usz size)
+		{
+			usz byte_unit = 0;
+			usz divisor = 1;
+
+			static const QString s_units[]{"B", "KB", "MB", "GB", "TB", "PB"};
+
+			while (byte_unit < std::size(s_units) - 1 && size / divisor >= 1024)
+			{
+				byte_unit++;
+				divisor *= 1024;
+			}
+
+			return QStringLiteral("%0 %1").arg(QString::number((size + 0.) / divisor, 'f', 2)).arg(s_units[byte_unit]);
+		}
 	} // utils
 } // gui

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -124,5 +124,8 @@ namespace gui
 
 		// Sort a QTreeWidget (currently only column 0)
 		void sort_tree(QTreeWidget* tree, Qt::SortOrder sort_order, bool recursive);
+
+		// Convert an arbitrary count of bytes to a readable format using global units (KB, MB...)
+		QString format_byte_size(usz size);
 	} // utils
 } // gui


### PR DESCRIPTION
* Add the "Space On Disk" column in the game grid. This also means you can sort games by their size.
* Report game size and current free space when trying to remove a game to help the user make an informed decision.
![image](https://user-images.githubusercontent.com/18193363/208232810-d138b9fd-e651-4877-ba51-80eca0e9da5a.png)
![image](https://user-images.githubusercontent.com/18193363/208232830-28caf03c-0f0e-4b89-9ec6-0ab6334c7436.png)
