### PR TITLE
Qt: Implement config check in Utilities and log viewer

### DIFF
--- a/Utilities/Config.h
+++ b/Utilities/Config.h
@@ -80,7 +80,13 @@ namespace cfg
 		// Convert to string (optional)
 		virtual std::string to_string() const
 		{
-			return{};
+			return {};
+		}
+
+		// Convert default to string (optional)
+		virtual std::string def_to_string() const
+		{
+			return {};
 		}
 
 		// Try to convert from string (optional)
@@ -89,7 +95,7 @@ namespace cfg
 		// Get string list (optional)
 		virtual std::vector<std::string> to_list() const
 		{
-			return{};
+			return {};
 		}
 
 		// Set multiple values. Implementation-specific, optional.
@@ -163,6 +169,11 @@ namespace cfg
 			return m_value ? "true" : "false";
 		}
 
+		std::string def_to_string() const override
+		{
+			return def ? "true" : "false";
+		}
+
 		bool from_string(std::string_view value, bool /*dynamic*/ = false) override
 		{
 			if (value.size() != 4 && value.size() != 5)
@@ -232,6 +243,13 @@ namespace cfg
 			return result; // TODO: ???
 		}
 
+		std::string def_to_string() const override
+		{
+			std::string result;
+			fmt_class_string<T>::format(result, fmt_unveil<T>::get(def));
+			return result; // TODO: ???
+		}
+
 		bool from_string(std::string_view value, bool /*dynamic*/ = false) override
 		{
 			u64 result;
@@ -295,6 +313,11 @@ namespace cfg
 		std::string to_string() const override
 		{
 			return std::to_string(m_value);
+		}
+
+		std::string def_to_string() const override
+		{
+			return std::to_string(def);
 		}
 
 		bool from_string(std::string_view value, bool /*dynamic*/ = false) override
@@ -361,6 +384,11 @@ namespace cfg
 		std::string to_string() const override
 		{
 			return std::to_string(m_value);
+		}
+
+		std::string def_to_string() const override
+		{
+			return std::to_string(def);
 		}
 
 		bool from_string(std::string_view value, bool /*dynamic*/ = false) override
@@ -437,6 +465,11 @@ namespace cfg
 			return std::to_string(m_value);
 		}
 
+		std::string def_to_string() const override
+		{
+			return std::to_string(def);
+		}
+
 		bool from_string(std::string_view value, bool /*dynamic*/ = false) override
 		{
 			u64 result;
@@ -508,6 +541,11 @@ namespace cfg
 			return *m_value.load().get();
 		}
 
+		std::string def_to_string() const override
+		{
+			return def;
+		}
+
 		bool from_string(std::string_view value, bool /*dynamic*/ = false) override
 		{
 			m_value = std::string(value);
@@ -541,7 +579,7 @@ namespace cfg
 
 		std::vector<std::string> to_list() const override
 		{
-			return{ m_set.begin(), m_set.end() };
+			return { m_set.begin(), m_set.end() };
 		}
 
 		bool from_list(std::vector<std::string>&& list) override

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1830,7 +1830,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			if (file == all_files.cend() || file->second.size() <= fileSet->fileOffset)
 			{
-				cellSaveData.error("Failed to open file %s%s", dir_path, file_path);
+				cellSaveData.error("Failed to open file %s%s (size=%d, fileOffset=%d)", dir_path, file_path, file->second.size(), fileSet->fileOffset);
 				savedata_result = CELL_SAVEDATA_ERROR_FAILURE;
 				break;
 			}

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -209,6 +209,9 @@
     <ClCompile Include="QTGeneratedFiles\Debug\moc_cheat_manager.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_config_checker.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug\moc_custom_dialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -431,6 +434,9 @@
     <ClCompile Include="QTGeneratedFiles\Release\moc_cheat_manager.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_config_checker.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_custom_dialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -627,6 +633,7 @@
     <ClCompile Include="rpcs3qt\camera_settings_dialog.cpp" />
     <ClCompile Include="rpcs3qt\cheat_manager.cpp" />
     <ClCompile Include="rpcs3qt\config_adapter.cpp" />
+    <ClCompile Include="rpcs3qt\config_checker.cpp" />
     <ClCompile Include="rpcs3qt\curl_handle.cpp" />
     <ClCompile Include="rpcs3qt\custom_dialog.cpp" />
     <ClCompile Include="rpcs3qt\custom_table_widget_item.cpp" />
@@ -960,6 +967,16 @@
     </CustomBuild>
     <ClInclude Include="rpcs3qt\category.h" />
     <ClInclude Include="rpcs3qt\config_adapter.h" />
+    <CustomBuild Include="rpcs3qt\config_checker.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWIN32_LEAN_AND_MEAN -DHAVE_VULKAN -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -DQT_MULTIMEDIA_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_SVG_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\SoundTouch\soundtouch\include" "-I.\..\3rdparty\cubeb\extra" "-I.\..\3rdparty\cubeb\cubeb\include" "-I.\..\3rdparty\flatbuffers\include" "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent" "-I$(QTDIR)\include\QtMultimedia" "-I$(QTDIR)\include\QtMultimediaWidgets" "-I$(QTDIR)\include\QtSvg"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWIN32_LEAN_AND_MEAN -DHAVE_VULKAN -DHAVE_SDL2 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -DQT_MULTIMEDIA_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_SVG_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\SoundTouch\soundtouch\include" "-I.\..\3rdparty\cubeb\extra" "-I.\..\3rdparty\cubeb\cubeb\include" "-I.\..\3rdparty\flatbuffers\include" "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\libsdl-org\SDL\include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent" "-I$(QTDIR)\include\QtMultimedia" "-I$(QTDIR)\include\QtMultimediaWidgets" "-I$(QTDIR)\include\QtSvg"</Command>
+    </CustomBuild>
     <ClInclude Include="rpcs3qt\curl_handle.h" />
     <ClInclude Include="rpcs3qt\custom_dock_widget.h" />
     <CustomBuild Include="rpcs3qt\debugger_list.h">

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -882,6 +882,15 @@
     <ClCompile Include="Input\sdl_pad_handler.cpp">
       <Filter>Io\SDL</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\config_checker.cpp">
+      <Filter>Gui\log</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_config_checker.cpp">
+      <Filter>Generated Files\Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_config_checker.cpp">
+      <Filter>Generated Files\Release</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">
@@ -1305,6 +1314,9 @@
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\pad_motion_settings_dialog.ui">
       <Filter>Form Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\config_checker.h">
+      <Filter>Gui\log</Filter>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRC_FILES
     cg_disasm_window.cpp
     cheat_manager.cpp
     config_adapter.cpp
+    config_checker.cpp
     curl_handle.cpp
     custom_dialog.cpp
     custom_table_widget_item.cpp

--- a/rpcs3/rpcs3qt/config_checker.cpp
+++ b/rpcs3/rpcs3qt/config_checker.cpp
@@ -1,0 +1,213 @@
+#include "stdafx.h"
+#include "config_checker.h"
+#include "Emu/system_config.h"
+
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QMessageBox>
+#include <QTextEdit>
+#include <QVBoxLayout>
+#include <QLabel>
+
+LOG_CHANNEL(gui_log, "GUI");
+
+config_checker::config_checker(QWidget* parent, const QString& path, bool is_log) : QDialog(parent)
+{
+	setObjectName("config_checker");
+	setAttribute(Qt::WA_DeleteOnClose);
+
+	QVBoxLayout* layout = new QVBoxLayout();
+	QLabel* label = new QLabel(this);
+	layout->addWidget(label);
+
+	QString result;
+
+	if (check_config(path, result, is_log))
+	{
+		setWindowTitle(tr("Interesting!"));
+
+		if (result.isEmpty())
+		{
+			label->setText(tr("Found config.\nIt seems to match the default config."));
+		}
+		else
+		{
+			label->setText(tr("Found config.\nSome settings seem to deviate from the default config:"));
+
+			QTextEdit* text_box = new QTextEdit();
+			text_box->setReadOnly(true);
+			text_box->setHtml(result);
+			layout->addWidget(text_box);
+
+			resize(400, 600);
+		}
+	}
+	else
+	{
+		setWindowTitle(tr("Ooops!"));
+		label->setText(result);
+	}
+
+	QDialogButtonBox* box = new QDialogButtonBox(QDialogButtonBox::Close);
+	connect(box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+	layout->addWidget(box);
+
+	setLayout(layout);
+}
+
+bool config_checker::check_config(QString content, QString& result, bool is_log)
+{
+	cfg_root config{};
+
+	if (is_log)
+	{
+		const QString start_token = "SYS: Used configuration:\n";
+		const QString end_token = "\n·";
+
+		int start = content.indexOf(start_token);
+		int end = -1;
+
+		if (start >= 0)
+		{
+			start += start_token.count();
+			end = content.indexOf(end_token, start);
+		}
+
+		if (end < 0)
+		{
+			result = tr("Cannot find any config!");
+			return false;
+		}
+
+		content = content.mid(start, end - start);
+	}
+
+	if (!config.from_string(content.toStdString()))
+	{
+		gui_log.error("log_viewer: Failed to parse config:\n%s", content.toStdString());
+		result = tr("Cannot find any config!");
+		return false;
+	}
+
+	std::function<void(const cfg::_base*, std::string&, int)> print_diff_recursive;
+	print_diff_recursive = [&print_diff_recursive](const cfg::_base* base, std::string& diff, int indentation) -> void
+	{
+		if (!base)
+		{
+			return;
+		}
+
+		const auto indent = [](std::string& str, int indentation)
+		{
+			for (int i = 0; i < indentation * 2; i++)
+			{
+				str += "&nbsp;";
+			}
+		};
+
+		switch (base->get_type())
+		{
+		case cfg::type::node:
+		{
+			if (const auto& node = static_cast<const cfg::node*>(base))
+			{
+				std::string diff_tmp;
+
+				for (const auto& n : node->get_nodes())
+				{
+					print_diff_recursive(n, diff_tmp, indentation + 1);
+				}
+
+				if (!diff_tmp.empty())
+				{
+					indent(diff, indentation);
+
+					if (!base->get_name().empty())
+					{
+						fmt::append(diff, "<b>%s:</b><br>", base->get_name());
+					}
+
+					fmt::append(diff, "%s", diff_tmp);
+				}
+			}
+			break;
+		}
+		case cfg::type::_bool:
+		case cfg::type::_enum:
+		case cfg::type::_int:
+		case cfg::type::uint:
+		case cfg::type::string:
+		{
+			const std::string val = base->to_string();
+			const std::string def = base->def_to_string();
+
+			if (val != def)
+			{
+				indent(diff, indentation);
+
+				if (def.empty())
+				{
+					fmt::append(diff, "%s: <span style=\"color:red;\">%s</span><br>", base->get_name(), val);
+				}
+				else
+				{
+					fmt::append(diff, "%s: <span style=\"color:red;\">%s</span> <span style=\"color:gray;\">default:</span> <span style=\"color:green;\">%s</span><br>", base->get_name(), val, def);
+				}
+			}
+			break;
+		}
+		case cfg::type::set:
+		{
+			if (const auto& node = static_cast<const cfg::set_entry*>(base))
+			{
+				const std::vector<std::string> set_entries = node->to_list();
+
+				if (!set_entries.empty())
+				{
+					indent(diff, indentation);
+					fmt::append(diff, "<b>%s:</b><br>", base->get_name());
+
+					for (const std::string& entry : set_entries)
+					{
+						indent(diff, indentation + 1);
+						fmt::append(diff, "- <span style=\"color:red;\">%s</span><br>", entry);
+					}
+				}
+			}
+			break;
+		}
+		case cfg::type::log:
+		{
+			if (const auto& node = static_cast<const cfg::log_entry*>(base))
+			{
+				const auto& log_entries = node->get_map();
+
+				if (!log_entries.empty())
+				{
+					indent(diff, indentation);
+					fmt::append(diff, "<b>%s:</b><br>", base->get_name());
+
+					for (const auto& entry : log_entries)
+					{
+						indent(diff, indentation + 1);
+						fmt::append(diff, "<span style=\"color:red;\">%s: %s</span><br>", entry.first, entry.second);
+					}
+				}
+			}
+			break;
+		}
+		case cfg::type::map:
+		case cfg::type::device:
+		{
+			// Ignored
+			break;
+		}
+		}
+	};
+
+	std::string diff;
+	print_diff_recursive(&config, diff, 0);
+	result = QString::fromStdString(diff);
+
+	return true;
+}

--- a/rpcs3/rpcs3qt/config_checker.h
+++ b/rpcs3/rpcs3qt/config_checker.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QDialog>
+
+class config_checker : public QDialog
+{
+	Q_OBJECT
+
+public:
+	config_checker(QWidget* parent, const QString& path, bool is_log);
+
+	bool check_config(QString content, QString& result, bool is_log);
+};

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -145,6 +145,7 @@ namespace gui
 	const gui_save fd_ext_mself    = gui_save(main_window, "lastExplorePathExMSELF",  "");
 	const gui_save fd_ext_tar      = gui_save(main_window, "lastExplorePathExTAR",  "");
 	const gui_save fd_insert_disc  = gui_save(main_window, "lastExplorePathDISC", "");
+	const gui_save fd_cfg_check    = gui_save(main_window, "lastExplorePathCfgChk", "");
 
 	const gui_save mw_debugger         = gui_save(main_window, "debuggerVisible",  false);
 	const gui_save mw_logger           = gui_save(main_window, "loggerVisible",    true);

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -268,6 +268,7 @@
      <string>Utilities</string>
     </property>
     <addaction name="actionLog_Viewer"/>
+    <addaction name="toolsCheckConfigAct"/>
     <addaction name="toolsCgDisasmAct"/>
     <addaction name="toolskernel_explorerAct"/>
     <addaction name="toolsmemory_viewerAct"/>
@@ -1231,6 +1232,11 @@
    </property>
    <property name="text">
     <string>Insert Disc</string>
+   </property>
+  </action>
+  <action name="toolsCheckConfigAct">
+   <property name="text">
+    <string>Check Config</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
- Adds a config checker to Utilities -> Check Config
- Adds a config checker to the context menu of the log viewer
- The config checker accepts .log files and .yml files
- The config checker currently only cares for the first found config in a log

![image](https://user-images.githubusercontent.com/23019877/209020939-65d70c38-ded7-4054-8242-72fb4b2e2068.png)