### PR TITLE
PRX: Implement multi-referenced library management

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -789,7 +789,7 @@ static auto ppu_load_exports(ppu_linkage_info* link, u32 exports_start, u32 expo
 
 			if (flink.export_addr)
 			{
-				ppu_loader.error("Already linked function '%s' in module '%s'", ppu_get_function_name(module_name, fnid), module_name);
+				ppu_loader.notice("Already linked function '%s' in module '%s'", ppu_get_function_name(module_name, fnid), module_name);
 			}
 			//else
 			{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -63,17 +63,17 @@ struct sys_prx_segment_info_t
 
 struct sys_prx_module_info_t
 {
-	be_t<u64> size;
-	char name[30];
-	char version[2];
-	be_t<u32> modattribute;
-	be_t<u32> start_entry;
-	be_t<u32> stop_entry;
-	be_t<u32> all_segments_num;
-	vm::bptr<char> filename;
-	be_t<u32> filename_size;
-	vm::bptr<sys_prx_segment_info_t> segments;
-	be_t<u32> segments_num;
+	be_t<u64> size; // 0
+	char name[30]; // 8
+	char version[2]; // 0x26
+	be_t<u32> modattribute; // 0x28
+	be_t<u32> start_entry; // 0x2c
+	be_t<u32> stop_entry; // 0x30
+	be_t<u32> all_segments_num; // 0x34
+	vm::bptr<char> filename; // 0x38
+	be_t<u32> filename_size; // 0x3c
+	vm::bptr<sys_prx_segment_info_t> segments; // 0x40 
+	be_t<u32> segments_num; // 0x44
 };
 
 struct sys_prx_module_info_option_t
@@ -188,14 +188,18 @@ struct lv2_prx final : lv2_obj, ppu_module
 	vm::ptr<s32(u64 callback, u64 argc, vm::ptr<void, u64> argv)> epilogue = vm::null;
 	vm::ptr<s32()> exit = vm::null;
 
-	char module_info_name[28];
-	u8 module_info_version[2];
-	be_t<u16> module_info_attributes;
+	char module_info_name[28]{};
+	u8 module_info_version[2]{};
+	be_t<u16> module_info_attributes{};
 
 	u32 exports_start = umax;
 	u32 exports_end = 0;
 
+	std::basic_string<bool> m_loaded_flags;
+
 	void load_exports(); // (Re)load exports
+	void restore_exports(); // For savestates
+	void unload_exports();
 
 	lv2_prx() noexcept = default;
 	lv2_prx(utils::serial&) {}

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -396,7 +396,7 @@ error_code sys_timer_sleep(ppu_thread& ppu, u32 sleep_time)
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_timer.warning("sys_timer_sleep(sleep_time=%d)", sleep_time);
+	sys_timer.trace("sys_timer_sleep(sleep_time=%d)", sleep_time);
 
 	return sys_timer_usleep(ppu, sleep_time * u64{1000000});
 }

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -42,7 +42,7 @@ SERIALIZATION_VER(lv2_sync, 3,                                  1)
 SERIALIZATION_VER(lv2_vm, 4,                                    1)
 SERIALIZATION_VER(lv2_net, 5,                                   1)
 SERIALIZATION_VER(lv2_fs, 6,                                    1)
-SERIALIZATION_VER(lv2_prx_overlay, 7,                           1, 2/*PRX dynamic exports*/)
+SERIALIZATION_VER(lv2_prx_overlay, 7,                           1, 2/*PRX dynamic exports*/, 3/*Conditionally Loaded Local Exports*/)
 SERIALIZATION_VER(lv2_memory, 8,                                1)
 SERIALIZATION_VER(lv2_config, 9,                                1)
 
@@ -57,7 +57,7 @@ namespace np
 }
 
 #ifdef _MSC_VER
-// Compiler bug, lambda function body does seem to inherit used namespace atleast for function decleration 
+// Compiler bug, lambda function body does seem to inherit used namespace atleast for function declaration 
 SERIALIZATION_VER(rsx, 10)
 SERIALIZATION_VER(sceNp, 11)
 #endif

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -466,7 +466,7 @@ void kernel_explorer::update()
 				break;
 			}
 
-			const QString text = qstr(fmt::format("PRX 0x%08x: '%s'", id, prx.name));
+			const QString text = qstr(fmt::format("PRX 0x%08x: '%s', attr=0x%x, lib=%s", id, prx.name, prx.module_info_attributes, prx.module_info_name));
 			QTreeWidgetItem* prx_tree = add_solid_node(node, text, text);
 			display_program_segments(prx_tree, prx);
 			break;


### PR DESCRIPTION
* I made a hw test that uses its own SPRX to reference it multiple times and show results, I tracked where the function is actually loaded and the possible error codes, which surprisingly were non-existent on real hw. It seems it allows one to reference a library multiple times, the addresses of the first reference are the ones used. It does this on a per-library basis, so if a PRX exports multiple it does it individually and keeps track of what's actually used. stop() in the case of being unused does nothing.

Hardware test: https://github.com/elad335/myps3tests/commit/3c4d4e68bb7e4690f145f88bfff0ee4aaf192704

Allowing [Asdivine Hearts](https://forums.rpcs3.net/thread-179705.html) and [Revenant Saga](https://forums.rpcs3.net/thread-195514.html) to no longer be loadable.

![image](https://user-images.githubusercontent.com/18193363/209437283-0710c765-51da-44a3-b1dc-c17cb71f4706.png)

Fixes https://github.com/RPCS3/rpcs3/issues/6365
Fixes #13011 