### PR TITLE
Qt: fix size watcher cancellation on soft refresh

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -139,7 +139,7 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 	connect(&m_refresh_watcher, &QFutureWatcher<void>::finished, this, &game_list_frame::OnRefreshFinished);
 	connect(&m_refresh_watcher, &QFutureWatcher<void>::canceled, this, [this]()
 	{
-		gui::utils::stop_future_watcher(m_size_watcher, true);
+		gui::utils::stop_future_watcher(m_size_watcher, true, m_size_watcher_cancel);
 		gui::utils::stop_future_watcher(m_repaint_watcher, true);
 
 		m_path_list.clear();
@@ -436,7 +436,10 @@ std::string game_list_frame::GetDataDirBySerial(const std::string& serial)
 
 void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 {
-	gui::utils::stop_future_watcher(m_size_watcher, true);
+	if (from_drive)
+	{
+		gui::utils::stop_future_watcher(m_size_watcher, true, m_size_watcher_cancel);
+	}
 	gui::utils::stop_future_watcher(m_repaint_watcher, true);
 	gui::utils::stop_future_watcher(m_refresh_watcher, from_drive);
 
@@ -714,7 +717,7 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 
 void game_list_frame::OnRefreshFinished()
 {
-	gui::utils::stop_future_watcher(m_size_watcher, true);
+	gui::utils::stop_future_watcher(m_size_watcher, true, m_size_watcher_cancel);
 	gui::utils::stop_future_watcher(m_repaint_watcher, true);
 
 	for (auto&& g : m_games.pop_all())

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2982,6 +2982,10 @@ void main_window::keyPressEvent(QKeyEvent *keyEvent)
 	{
 		ui->toolbar_fullscreen->trigger();
 	}
+	else if ((keyEvent->modifiers() & Qt::ControlModifier) && keyEvent->key() == Qt::Key_F5)
+	{
+		m_game_list_frame->Refresh(true);
+	}
 }
 
 void main_window::mouseDoubleClickEvent(QMouseEvent *event)


### PR DESCRIPTION
- Do not cancel size watcher on soft refresh
- Set the cancel flag manually since the canceled signal seems to be very unreliable (I managed to trigger it rarely)
- Add Ctrl+F5 for hard refresh