### PR TITLE
rsx: Remove incorrect hack

### DIFF
--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -227,17 +227,6 @@ namespace rsx
 			remap_ctl |= lo_word;
 			break;
 		}
-		case CELL_GCM_TEXTURE_B8:
-		{
-			// Low bit in remap control seems to affect whether the A component is forced to 1
-			// Only seen in BLUS31604
-			if (remap_override)
-			{
-				// Set remap lookup for A component to FORCE_ONE
-				remap_ctl = (remap_ctl & ~(3 << 8)) | (1 << 8);
-			}
-			break;
-		}
 		default:
 			break;
 		}


### PR DESCRIPTION
The commit was originally added to restore previously working functionality that was still not understood at the time. It solved the regression but I never went back to figure out if the "fix" was correct after making all the texture encoding discoveries using realhw. Turns out this hack actually breaks tons of games and the original bug was fixed properly years ago.
See notes in the guilty commit: https://github.com/RPCS3/rpcs3/commit/f559c088a1eff7988e71feb7e05dde303c944f10

Fixes https://github.com/RPCS3/rpcs3/issues/8718 and probably a multitude of other alpha-related glitches.