### PR TITLE
Qt: Fix file explorer call when opening file paths with double slashes

### DIFF
--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -397,17 +397,18 @@ namespace gui
 
 		void open_dir(const std::string& spath)
 		{
-			const QString path = qstr(spath);
+			QString path = qstr(spath);
 
 			if (fs::is_file(spath))
 			{
 				// open directory and select file
 				// https://stackoverflow.com/questions/3490336/how-to-reveal-in-finder-or-show-in-explorer-with-qt
 #ifdef _WIN32
-				const QString cleaned_path = QDir::toNativeSeparators(path);
-				gui_log.notice("gui::utils::open_dir: About to open file path '%s' (original: '%s')", cleaned_path.toStdString(), spath);
+				// Remove double slashes and convert to native separators. Double slashes don't seem to work with the explorer call.
+				path.replace(QRegularExpression("[\\\\|/]+"), QDir::separator());
+				gui_log.notice("gui::utils::open_dir: About to open file path '%s' (original: '%s')", path.toStdString(), spath);
 
-				if (!QProcess::startDetached("explorer.exe", {"/select,", cleaned_path}))
+				if (!QProcess::startDetached("explorer.exe", {"/select,", path}))
 				{
 					gui_log.error("gui::utils::open_dir: Failed to start explorer process");
 				}

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -385,11 +385,7 @@ bool update_manager::handle_rpcs3(const QByteArray& data, bool auto_accept)
 	// Get executable path
 	const std::string exe_dir = rpcs3::utils::get_exe_dir();
 	const std::string orig_path = exe_dir + "rpcs3.exe";
-
-	std::wstring wchar_orig_path;
-	const auto tmp_size = MultiByteToWideChar(CP_UTF8, 0, orig_path.c_str(), -1, nullptr, 0);
-	wchar_orig_path.resize(tmp_size);
-	MultiByteToWideChar(CP_UTF8, 0, orig_path.c_str(), -1, wchar_orig_path.data(), tmp_size);
+	const std::wstring wchar_orig_path = utf8_to_wchar(orig_path);
 
 	char temp_path[PATH_MAX];
 
@@ -417,7 +413,7 @@ bool update_manager::handle_rpcs3(const QByteArray& data, bool auto_accept)
 	ISzAlloc allocImp;
 	ISzAlloc allocTempImp;
 
-	CFileInStream archiveStream;
+	CFileInStream archiveStream{};
 	CLookToRead2 lookStream;
 	CSzArEx db;
 	SRes res;


### PR DESCRIPTION
I found out that opening paths with double slashes doesn't work with the explorer.exe /select call:

`explorer.exe '/select,"D:\dev\rpcs3\bin\dev_flash\vsh\module\\vsh.self"'` <- Opens default location (e.g. Desktop or Documents).
`explorer.exe '/select,"D:\dev\rpcs3\bin\dev_flash\vsh\module\vsh.self"'` <- opens `D:\dev\rpcs3\bin\dev_flash\vsh\module` with `vsh.self` selected.

Also use utf8_to_wchar util call in updater.