### PR TITLE
FS - Fix booting games from the root of drives

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3091,7 +3091,7 @@ bool Emulator::IsPathInsideDir(std::string_view path, std::string_view dir) cons
 {
 	const std::string dir_path = GetCallbacks().resolve_path(dir);
 
-	return !dir_path.empty() && (GetCallbacks().resolve_path(path) + '/').starts_with(dir_path + '/');
+	return !dir_path.empty() && (GetCallbacks().resolve_path(path) + '/').starts_with((dir_path.back() == '/') ? dir_path : (dir_path + '/'));
 };
 
 const std::string& Emulator::GetFakeCat() const


### PR DESCRIPTION
Fixes #11126
PR #10849 introduced a bug that lead to games being unable to boot from the root of drives be it either when booting from a mounted decrypted ISO or an actual drive.
The directory check fails on these games as their dir_path is already "%DRIVELETTER%:/" with an terminating slash, making them get treated as HDD Games instead.

This is my first PR so please correct me if I did something wrong here.