### PR TITLE
macOS: Set LSApplicationCategoryType to games

### DIFF
--- a/rpcs3/rpcs3.plist.in
+++ b/rpcs3/rpcs3.plist.in
@@ -26,6 +26,8 @@
 	<string>Licensed under GPLv2</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>11.6</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype This makes it show up in the macOS Launchpad Games folder