### PR TITLE
Road to Qt6: preparations

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -63,7 +63,7 @@ void MouseHandlerBase::save(utils::serial& ar)
 
 error_code cellMouseInit(u32 max_connect)
 {
-	sys_io.warning("cellMouseInit(max_connect=%d)", max_connect);
+	sys_io.notice("cellMouseInit(max_connect=%d)", max_connect);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -259,7 +259,7 @@ error_code cellMouseGetData(u32 port_no, vm::ptr<CellMouseData> data)
 
 error_code cellMouseGetDataList(u32 port_no, vm::ptr<CellMouseDataList> data)
 {
-	sys_io.warning("cellMouseGetDataList(port_no=%d, data=0x%x)", port_no, data);
+	sys_io.notice("cellMouseGetDataList(port_no=%d, data=0x%x)", port_no, data);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -406,7 +406,7 @@ error_code cellMouseGetTabletDataList(u32 port_no, vm::ptr<CellMouseTabletDataLi
 
 error_code cellMouseGetRawData(u32 port_no, vm::ptr<CellMouseRawData> data)
 {
-	sys_io.warning("cellMouseGetRawData(port_no=%d, data=*0x%x)", port_no, data);
+	sys_io.notice("cellMouseGetRawData(port_no=%d, data=*0x%x)", port_no, data);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMap>
+#include <vector>
 
 // Node location
 using cfg_location = std::vector<const char*>;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -22,7 +22,6 @@
 #include <QMessageBox>
 #include <QPainter>
 #include <QScreen>
-#include <QSound>
 
 #include <string>
 #include <thread>
@@ -465,7 +464,7 @@ void gs_frame::toggle_recording()
 		// Play a sound
 		if (const std::string sound_path = fs::get_config_dir() + "sounds/snd_recording.wav"; fs::is_file(sound_path))
 		{
-			QSound::play(qstr(sound_path));
+			Emu.GetCallbacks().play_sound(sound_path);
 		}
 		else
 		{
@@ -1006,7 +1005,7 @@ void gs_frame::take_screenshot(std::vector<u8> data, const u32 sshot_width, cons
 			{
 				if (const std::string sound_path = fs::get_config_dir() + "sounds/snd_screenshot.wav"; fs::is_file(sound_path))
 				{
-					QSound::play(qstr(sound_path));
+					Emu.GetCallbacks().play_sound(sound_path);
 				}
 				else
 				{

--- a/rpcs3/rpcs3qt/log_viewer.cpp
+++ b/rpcs3/rpcs3qt/log_viewer.cpp
@@ -3,9 +3,9 @@
 #include "log_viewer.h"
 #include "gui_settings.h"
 #include "syntax_highlighter.h"
-#include "find_dialog.h"
 #include "config_checker.h"
 
+#include <QActionGroup>
 #include <QApplication>
 #include <QMenu>
 #include <QFile>

--- a/rpcs3/rpcs3qt/log_viewer.h
+++ b/rpcs3/rpcs3qt/log_viewer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "find_dialog.h"
+
 #include <QPlainTextEdit>
 #include <QDropEvent>
 
@@ -8,7 +10,6 @@
 
 class LogHighlighter;
 class gui_settings;
-class find_dialog;
 
 class log_viewer : public QWidget
 {

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -288,7 +288,9 @@ void patch_manager_dialog::populate_tree()
 						const QString q_description = QString::fromStdString(description);
 						QString visible_description = q_description;
 
-						const auto match_criteria = QList<QPair<int, QVariant>>() << QPair(description_role, q_description) << QPair(persistance_role, true);
+						const QList<QPair<int, QVariant>> match_criteria = QList<QPair<int, QVariant>>()
+							<< QPair<int, QVariant>(description_role, q_description)
+							<< QPair<int, QVariant>(persistance_role, true);
 
 						// Add counter to leafs if the name already exists due to different hashes of the same game (PPU, SPU, PRX, OVL)
 						if (const auto matches = gui::utils::find_children_by_data(serial_level_item, match_criteria, false); matches.count() > 0)
@@ -322,7 +324,8 @@ void patch_manager_dialog::populate_tree()
 		}
 	}
 
-	const auto match_criteria = QList<QPair<int, QVariant>>() << QPair(persistance_role, true);
+	const QList<QPair<int, QVariant>> match_criteria = QList<QPair<int, QVariant>>()
+		<< QPair<int, QVariant>(persistance_role, true);
 
 	for (int i = ui->patch_tree->topLevelItemCount() - 1; i >= 0; i--)
 	{

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -606,7 +606,7 @@ bool update_manager::handle_rpcs3(const QByteArray& data, bool auto_accept)
 		update_log.error("Failed to create new AppImage file: %s (%s)", replace_path, fs::g_tls_error);
 		return false;
 	}
-	if (new_appimage.write(data.data(), data.size()) != data.size() + 0u)
+	if (new_appimage.write(data.data(), data.size()) != data.size() + 0ull)
 	{
 		update_log.error("Failed to write new AppImage file: %s", replace_path);
 		return false;

--- a/rpcs3/util/cpu_stats.hpp
+++ b/rpcs3/util/cpu_stats.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "util/types.hpp"
+#include <vector>
 
 #ifdef _WIN32
 #include <pdh.h>
 #include <pdhmsg.h>
-#elif __linux__
-#include <vector>
 #endif
 
 namespace utils


### PR DESCRIPTION
This PR just takes some bloat out of the Qt6 PR.

- Fixes some miscellaneous includes and warnings
- Decreases some log levels in cellMouse
- Use the emulator's play_sound callback instead of QSound.
This way we only have a single place that handles in-game emulator sounds.