### PR TITLE
Package installation fixes

### DIFF
--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -335,6 +335,7 @@ public:
 	enum result
 	{
 		not_started,
+		started,
 		success,
 		aborted,
 		aborted_cleaned,
@@ -344,7 +345,7 @@ public:
 
 	bool is_valid() const { return m_is_valid; }
 	package_error check_target_app_version() const;
-	static bool extract_data(std::deque<package_reader>& readers, std::deque<std::string>& bootable_paths);
+	static package_error extract_data(std::deque<package_reader>& readers, std::deque<std::string>& bootable_paths);
 	psf::registry get_psf() const { return m_psf; }
 	result get_result() const { return m_result; };
 
@@ -359,6 +360,7 @@ private:
 	bool decrypt_data();
 	void archive_seek(s64 new_offset, const fs::seek_mode damode = fs::seek_set);
 	u64 archive_read(void* data_ptr, u64 num_bytes);
+	bool set_install_path();
 	bool fill_data(std::map<std::string, install_entry*>& all_install_entries);
 	std::span<const char> archive_read_block(u64 offset, void* data_ptr, u64 num_bytes);
 	std::span<const char> decrypt(u64 offset, u64 size, const uchar* key, thread_key thread_data_key = {0});

--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -337,26 +337,9 @@ public:
 	static bool extract_data(std::deque<package_reader>& readers, std::deque<std::string>& bootable_paths);
 	psf::registry get_psf() const { return m_psf; }
 
-	int get_progress(int maximum = 100) const
-	{
-		const usz wr = m_written_bytes;
+	int get_progress(int maximum = 100) const;
 
-		return wr >= m_header.data_size ? maximum : ::narrow<int>(wr * maximum / m_header.data_size);
-	}
-
-	void abort_extract()
-	{
-		m_entry_indexer.fetch_op([this](usz& v)
-		{
-			if (v < m_install_entries.size())
-			{
-				v = m_install_entries.size();
-				return true;
-			}
-
-			return false;
-		});
-	}
+	void abort_extract();
 
 private:
 	bool read_header();
@@ -368,7 +351,7 @@ private:
 	bool fill_data(std::map<std::string, install_entry*>& all_install_entries);
 	std::span<const char> archive_read_block(u64 offset, void* data_ptr, u64 num_bytes);
 	std::span<const char> decrypt(u64 offset, u64 size, const uchar* key, thread_key thread_data_key = {0});
-	usz extract_worker(thread_key thread_data_key, std::map<std::string, install_entry*>& all_install_entries);
+	usz extract_worker(thread_key thread_data_key);
 
 	std::deque<install_entry> m_install_entries;
 	std::string m_install_path;

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -92,8 +92,8 @@ namespace rpcs3::utils
 		named_thread worker("PKG Installer", [&]
 		{
 			std::deque<std::string> bootables;
-
-			return package_reader::extract_data(reader, bootables);
+			const package_error error = package_reader::extract_data(reader, bootables);
+			return error == package_error::no_error;
 		});
 
 		// Wait for the completion

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1035,22 +1035,22 @@ void main_window::HandlePackageInstallation(QStringList file_paths)
 
 		m_game_list_frame->Refresh(true);
 
-		pdlg.hide();
+		std::map<std::string, QString> bootable_paths_installed; // -> title id
 
-		if (!cancelled)
+		for (usz index = 0; index < bootable_paths.size(); index++)
 		{
-			std::map<std::string, QString> bootable_paths_installed; // -> title id
-
-			for (usz index = 0; index < bootable_paths.size(); index++)
+			if (bootable_paths[index].empty())
 			{
-				if (bootable_paths[index].empty())
-				{
-					continue;
-				}
-
-				bootable_paths_installed[bootable_paths[index]] = packages[index].title_id;
+				continue;
 			}
 
+			bootable_paths_installed[bootable_paths[index]] = packages[index].title_id;
+		}
+
+		pdlg.hide();
+
+		if (!cancelled || !bootable_paths_installed.empty())
+		{
 			if (bootable_paths_installed.empty())
 			{
 				m_gui_settings->ShowInfoBox(tr("Success!"), tr("Successfully installed software from package(s)!"), gui::ib_pkg_success, this);


### PR DESCRIPTION
- Fix check_target_app_version when installing multiple packages (compromise: no more optimized singular file installs)
- Abort installation if any thread has errors
- Clean directories if fill_path fails
- Only clean the directories of packages that actually had errors
- Additionally clean the directories of packages that were cancelled before they could finish
- Clear boot path in case of error or cancelation
- Propagate result to caller
- Skip success message if the installation was canceled

fixes #13207