### PR TITLE
Road to Qt6: move progress indication to own handler

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -672,6 +672,7 @@
     <ClCompile Include="rpcs3qt\patch_manager_dialog.cpp" />
     <ClCompile Include="rpcs3qt\pkg_install_dialog.cpp" />
     <ClCompile Include="rpcs3qt\persistent_settings.cpp" />
+    <ClCompile Include="rpcs3qt\progress_indicator.cpp" />
     <ClCompile Include="rpcs3qt\qt_camera_error_handler.cpp" />
     <ClCompile Include="rpcs3qt\qt_camera_handler.cpp" />
     <ClCompile Include="rpcs3qt\qt_music_error_handler.cpp" />
@@ -1236,6 +1237,7 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWIN32_LEAN_AND_MEAN -DHAVE_VULKAN -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -DQT_MULTIMEDIA_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_SVG_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\SoundTouch\soundtouch\include" "-I.\..\3rdparty\cubeb\extra" "-I.\..\3rdparty\cubeb\cubeb\include" "-I.\..\3rdparty\flatbuffers\include" "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent" "-I$(QTDIR)\include\QtMultimedia" "-I$(QTDIR)\include\QtMultimediaWidgets" "-I$(QTDIR)\include\QtSvg"</Command>
     </CustomBuild>
     <ClInclude Include="rpcs3qt\pad_device_info.h" />
+    <ClInclude Include="rpcs3qt\progress_indicator.h" />
     <ClInclude Include="rpcs3qt\qt_camera_handler.h" />
     <ClInclude Include="rpcs3qt\qt_music_handler.h" />
     <CustomBuild Include="rpcs3qt\qt_music_error_handler.h">

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -148,6 +148,9 @@
     <Filter Include="Gui\shortcuts">
       <UniqueIdentifier>{1b83df2f-bb74-4bc9-87f1-ab2f3889bcc9}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Gui\progress">
+      <UniqueIdentifier>{d60be100-0d7e-4076-a24a-d413d0e91532}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -921,6 +924,9 @@
     <ClCompile Include="QTGeneratedFiles\Release\moc_shortcut_dialog.cpp">
       <Filter>Generated Files\Release</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\progress_indicator.cpp">
+      <Filter>Gui\progress</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">
@@ -1090,6 +1096,9 @@
     </ClInclude>
     <ClInclude Include="QTGeneratedFiles\ui_shortcut_dialog.h">
       <Filter>Generated Files</Filter>
+    </ClInclude>
+    <ClInclude Include="rpcs3qt\progress_indicator.h">
+      <Filter>Gui\progress</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SRC_FILES
     persistent_settings.cpp
     pkg_install_dialog.cpp
     progress_dialog.cpp
+    progress_indicator.cpp
     qt_camera_error_handler.cpp
     qt_camera_handler.cpp
     qt_camera_video_surface.cpp

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "shortcut_handler.h"
+#include "progress_indicator.h"
 #include "util/types.hpp"
 #include "util/atomic.hpp"
 #include "util/media_utils.h"
@@ -10,11 +11,6 @@
 #include <QWindow>
 #include <QPaintEvent>
 #include <QTimer>
-
-#ifdef _WIN32
-#include <QWinTaskbarProgress>
-#include <QWinTaskbarButton>
-#endif
 
 #include <memory>
 #include <vector>
@@ -27,14 +23,7 @@ class gs_frame : public QWindow, public GSFrameBase
 
 private:
 	// taskbar progress
-	int m_gauge_max = 100;
-#ifdef _WIN32
-	QWinTaskbarButton* m_tb_button = nullptr;
-	QWinTaskbarProgress* m_tb_progress = nullptr;
-#elif HAVE_QTDBUS
-	int m_progress_value = 0;
-	void UpdateProgress(int progress, bool progress_visible);
-#endif
+	std::unique_ptr<progress_indicator> m_progress_indicator;
 
 	QRect m_initial_geometry;
 

--- a/rpcs3/rpcs3qt/msg_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.cpp
@@ -5,13 +5,6 @@
 #include <QPushButton>
 #include <QFormLayout>
 
-#ifdef _WIN32
-#include <QWinTHumbnailToolbutton>
-#elif HAVE_QTDBUS
-#include <QtDBus/QDBusMessage>
-#include <QtDBus/QDBusConnection>
-#endif
-
 constexpr auto qstr = QString::fromStdString;
 
 void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
@@ -60,15 +53,7 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 	{
 		l_AddGauge(m_gauge1, m_text1);
 
-#ifdef _WIN32
-		m_tb_button = new QWinTaskbarButton();
-		m_tb_progress = m_tb_button->progress();
-		m_tb_progress->setRange(0, 100);
-		m_tb_progress->setVisible(true);
-#elif HAVE_QTDBUS
-		UpdateProgress(0, true);
-		m_progress_value = 0;
-#endif
+		m_progress_indicator = std::make_unique<progress_indicator>(0, 100);
 	}
 
 	if (type.progress_bar_count >= 2)
@@ -153,10 +138,8 @@ void msg_dialog_frame::Create(const std::string& msg, const std::string& title)
 	m_dialog->layout()->setSizeConstraint(QLayout::SetFixedSize);
 	m_dialog->show();
 
-#ifdef _WIN32
 	// if we do this before, the QWinTaskbarProgress won't show
-	if (m_tb_button) m_tb_button->setWindow(m_dialog->windowHandle());
-#endif
+	if (m_progress_indicator) m_progress_indicator->show(m_dialog->windowHandle());
 }
 
 void msg_dialog_frame::Close(bool success)
@@ -170,20 +153,6 @@ void msg_dialog_frame::Close(bool success)
 
 msg_dialog_frame::~msg_dialog_frame()
 {
-#ifdef _WIN32
-	// QWinTaskbarProgress::hide() will crash if the application is already about to close, even if the object is not null.
-	if (m_tb_progress && !QCoreApplication::closingDown())
-	{
-		m_tb_progress->hide();
-	}
-	if (m_tb_button)
-	{
-		m_tb_button->deleteLater();
-	}
-#elif HAVE_QTDBUS
-	UpdateProgress(0, false);
-#endif
-
 	if (m_dialog)
 	{
 		m_dialog->deleteLater();
@@ -243,14 +212,10 @@ void msg_dialog_frame::ProgressBarReset(u32 index)
 
 	if (index == taskbar_index + 0u)
 	{
-#ifdef _WIN32
-		if (m_tb_progress)
+		if (m_progress_indicator)
 		{
-			m_tb_progress->reset();
+			m_progress_indicator->reset();
 		}
-#elif HAVE_QTDBUS
-		UpdateProgress(0, false);
-#endif
 	}
 }
 
@@ -278,15 +243,10 @@ void msg_dialog_frame::ProgressBarInc(u32 index, u32 delta)
 
 	if (index == taskbar_index + 0u || taskbar_index == -1)
 	{
-#ifdef _WIN32
-		if (m_tb_progress)
+		if (m_progress_indicator)
 		{
-			m_tb_progress->setValue(std::min(m_tb_progress->value() + static_cast<int>(delta), m_tb_progress->maximum()));
+			m_progress_indicator->set_value(m_progress_indicator->value() + static_cast<int>(delta));
 		}
-#elif HAVE_QTDBUS
-		m_progress_value = std::min(m_progress_value + static_cast<int>(delta), m_gauge_max);
-		UpdateProgress(m_progress_value, true);
-#endif
 	}
 }
 
@@ -314,15 +274,10 @@ void msg_dialog_frame::ProgressBarSetValue(u32 index, u32 value)
 
 	if (index == taskbar_index + 0u || taskbar_index == -1)
 	{
-#ifdef _WIN32
-		if (m_tb_progress)
+		if (m_progress_indicator)
 		{
-			m_tb_progress->setValue(std::min(static_cast<int>(value), m_tb_progress->maximum()));
+			m_progress_indicator->set_value(static_cast<int>(value));
 		}
-#elif HAVE_QTDBUS
-		m_progress_value = std::min(static_cast<int>(value), m_gauge_max);
-		UpdateProgress(m_progress_value, true);
-#endif
 	}
 }
 
@@ -361,26 +316,8 @@ void msg_dialog_frame::ProgressBarSetLimit(u32 index, u32 limit)
 		set_taskbar_limit = true;
 	}
 
-#ifdef _WIN32
-	if (set_taskbar_limit && m_tb_progress)
+	if (set_taskbar_limit && m_progress_indicator)
 	{
-		m_tb_progress->setMaximum(m_gauge_max);
+		m_progress_indicator->set_range(0, m_gauge_max);
 	}
-#endif
 }
-
-#ifdef HAVE_QTDBUS
-void msg_dialog_frame::UpdateProgress(int progress, bool progress_visible)
-{
-	QDBusMessage message = QDBusMessage::createSignal(
-		QStringLiteral("/"),
-		QStringLiteral("com.canonical.Unity.LauncherEntry"),
-		QStringLiteral("Update"));
-	QVariantMap properties;
-	// Progress takes a value from 0.0 to 0.1
-	properties.insert(QStringLiteral("progress"), 1. * progress / m_gauge_max);
-	properties.insert(QStringLiteral("progress-visible"), progress_visible);
-	message << QStringLiteral("application://rpcs3.desktop") << properties;
-	QDBusConnection::sessionBus().send(message);
-}
-#endif

--- a/rpcs3/rpcs3qt/msg_dialog_frame.h
+++ b/rpcs3/rpcs3qt/msg_dialog_frame.h
@@ -2,14 +2,10 @@
 
 #include "util/types.hpp"
 #include "Emu/Cell/Modules/cellMsgDialog.h"
+#include "progress_indicator.h"
 
 #include <QProgressBar>
 #include <QLabel>
-
-#ifdef _WIN32
-#include <QWinTaskbarProgress>
-#include <QWinTaskbarButton>
-#endif
 
 #include <string>
 
@@ -20,12 +16,6 @@ class msg_dialog_frame : public QObject, public MsgDialogBase
 	Q_OBJECT
 
 private:
-#ifdef _WIN32
-	QWinTaskbarButton* m_tb_button = nullptr;
-	QWinTaskbarProgress* m_tb_progress = nullptr;
-#elif HAVE_QTDBUS
-	int m_progress_value = 0;
-#endif
 	custom_dialog* m_dialog = nullptr;
 	QLabel* m_text = nullptr;
 	QLabel* m_text1 = nullptr;
@@ -34,6 +24,7 @@ private:
 	QProgressBar* m_gauge2 = nullptr;
 
 	int m_gauge_max = 0;
+	std::unique_ptr<progress_indicator> m_progress_indicator;
 
 public:
 	msg_dialog_frame() = default;
@@ -46,8 +37,4 @@ public:
 	void ProgressBarInc(u32 progressBarIndex, u32 delta) override;
 	void ProgressBarSetValue(u32 progressBarIndex, u32 value) override;
 	void ProgressBarSetLimit(u32 index, u32 limit) override;
-#ifdef HAVE_QTDBUS
-private:
-	void UpdateProgress(int progress, bool progress_visible);
-#endif
 };

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -3,13 +3,6 @@
 #include <QApplication>
 #include <QLabel>
 
-#ifdef _WIN32
-#include <QWinTHumbnailToolbutton>
-#elif HAVE_QTDBUS
-#include <QtDBus/QDBusMessage>
-#include <QtDBus/QDBusConnection>
-#endif
-
 progress_dialog::progress_dialog(const QString& windowTitle, const QString& labelText, const QString& cancelButtonText, int minimum, int maximum, bool delete_on_close, QWidget* parent, Qt::WindowFlags flags)
 	: QProgressDialog(labelText, cancelButtonText, minimum, maximum, parent, flags)
 {
@@ -23,55 +16,26 @@ progress_dialog::progress_dialog(const QString& windowTitle, const QString& labe
 		connect(this, &QProgressDialog::canceled, this, &QProgressDialog::deleteLater);
 	}
 
-#ifdef _WIN32
 	// Try to find a window handle first
 	QWindow* handle = windowHandle();
 
 	for (QWidget* ancestor = this; !handle && ancestor;)
 	{
-		if (ancestor = static_cast<QWidget*>(ancestor->parent()))
-		{
-			handle = ancestor->windowHandle();
-		}
+		ancestor = static_cast<QWidget*>(ancestor->parent());
+		if (ancestor) handle = ancestor->windowHandle();
 	}
 
-	m_tb_button = std::make_unique<QWinTaskbarButton>();
-	m_tb_button->setWindow(handle);
-	m_tb_progress = m_tb_button->progress();
-	m_tb_progress->setRange(minimum, maximum);
-	m_tb_progress->show();
-#elif HAVE_QTDBUS
-	UpdateProgress(0, true);
-#endif
+	m_progress_indicator = std::make_unique<progress_indicator>(minimum, maximum);
+	m_progress_indicator->show(handle);
 }
 
 progress_dialog::~progress_dialog()
 {
-#ifdef _WIN32
-	// QWinTaskbarProgress::hide() will crash if the application is already about to close, even if the object is not null.
-	if (!QCoreApplication::closingDown())
-	{
-		m_tb_progress->hide();
-	}
-#elif HAVE_QTDBUS
-	QDBusMessage message = QDBusMessage::createSignal(
-		QStringLiteral("/"),
-		QStringLiteral("com.canonical.Unity.LauncherEntry"),
-		QStringLiteral("Update"));
-	QVariantMap properties;
-	properties.insert(QStringLiteral("urgent"), false);
-	properties.insert(QStringLiteral("progress"), 0);
-	properties.insert(QStringLiteral("progress-visible"), false);
-	message << QStringLiteral("application://rpcs3.desktop") << properties;
-	QDBusConnection::sessionBus().send(message);
-#endif
 }
 
 void progress_dialog::SetRange(int min, int max)
 {
-#ifdef _WIN32
-	m_tb_progress->setRange(min, max);
-#endif
+	m_progress_indicator->set_range(min, max);
 
 	QProgressDialog::setRange(min, max);
 }
@@ -80,45 +44,14 @@ void progress_dialog::SetValue(int progress)
 {
 	const int value = std::clamp(progress, minimum(), maximum());
 
-#ifdef _WIN32
-	m_tb_progress->setValue(value);
-#elif HAVE_QTDBUS
-	UpdateProgress(value, true);
-#endif
+	m_progress_indicator->set_value(value);
 
 	QProgressDialog::setValue(value);
 }
 
 void progress_dialog::SignalFailure() const
 {
-#ifdef _WIN32
-	m_tb_progress->stop();
-#elif HAVE_QTDBUS
-	QDBusMessage message = QDBusMessage::createSignal(
-		QStringLiteral("/"),
-		QStringLiteral("com.canonical.Unity.LauncherEntry"),
-		QStringLiteral("Update"));
-	QVariantMap properties;
-	properties.insert(QStringLiteral("urgent"), true);
-	message << QStringLiteral("application://rpcs3.desktop") << properties;
-	QDBusConnection::sessionBus().send(message);
-#endif
+	m_progress_indicator->signal_failure();
 
 	QApplication::beep();
 }
-
-#ifdef HAVE_QTDBUS
-void progress_dialog::UpdateProgress(int progress, bool progress_visible)
-{
-	QDBusMessage message = QDBusMessage::createSignal(
-		QStringLiteral("/"),
-		QStringLiteral("com.canonical.Unity.LauncherEntry"),
-		QStringLiteral("Update"));
-	QVariantMap properties;
-	// Progress takes a value from 0.0 to 0.1
-	properties.insert(QStringLiteral("progress"), 1. * progress / maximum());
-	properties.insert(QStringLiteral("progress-visible"), progress_visible);
-	message << QStringLiteral("application://rpcs3.desktop") << properties;
-	QDBusConnection::sessionBus().send(message);
-}
-#endif

--- a/rpcs3/rpcs3qt/progress_dialog.h
+++ b/rpcs3/rpcs3qt/progress_dialog.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <QProgressDialog>
+#include "progress_indicator.h"
 
-#ifdef _WIN32
-#include <QWinTaskbarProgress>
-#include <QWinTaskbarButton>
-#endif
+#include <QProgressDialog>
 
 class progress_dialog : public QProgressDialog
 {
@@ -17,10 +14,5 @@ public:
 	void SignalFailure() const;
 
 private:
-#ifdef _WIN32
-	std::unique_ptr<QWinTaskbarButton> m_tb_button = nullptr;
-	QWinTaskbarProgress* m_tb_progress = nullptr;
-#elif HAVE_QTDBUS
-	void UpdateProgress(int progress, bool progress_visible);
-#endif
+	std::unique_ptr<progress_indicator> m_progress_indicator;
 };

--- a/rpcs3/rpcs3qt/progress_indicator.cpp
+++ b/rpcs3/rpcs3qt/progress_indicator.cpp
@@ -1,0 +1,123 @@
+#include "progress_indicator.h"
+
+#ifdef _WIN32
+#include <QCoreApplication>
+#include <QWinTaskbarProgress>
+#elif HAVE_QTDBUS
+#include <QtDBus/QDBusMessage>
+#include <QtDBus/QDBusConnection>
+#endif
+
+progress_indicator::progress_indicator(int minimum, int maximum)
+{
+#ifdef _WIN32
+	m_tb_button = std::make_unique<QWinTaskbarButton>();
+	m_tb_button->progress()->setRange(minimum, maximum);
+	m_tb_button->progress()->setVisible(false);
+#else
+	m_minimum = minimum;
+	m_maximum = maximum;
+#if HAVE_QTDBUS
+	update_progress(0, true, false);
+#endif
+#endif
+}
+
+progress_indicator::~progress_indicator()
+{
+#ifdef _WIN32
+	// QWinTaskbarProgress::hide() will crash if the application is already about to close, even if the object is not null.
+	if (!QCoreApplication::closingDown())
+	{
+		m_tb_button->progress()->hide();
+	}
+#elif HAVE_QTDBUS
+	update_progress(0, false, false);
+#endif
+}
+
+void progress_indicator::show(QWindow* window)
+{
+#ifdef _WIN32
+	m_tb_button->setWindow(window);
+	m_tb_button->progress()->show();
+#else
+	Q_UNUSED(window);
+#endif
+}
+
+int progress_indicator::value() const
+{
+#ifdef _WIN32
+	return m_tb_button->progress()->value();
+#else
+	return m_value;
+#endif
+}
+
+void progress_indicator::set_value(int value)
+{
+#ifdef _WIN32
+	m_tb_button->progress()->setValue(std::clamp(value, m_tb_button->progress()->minimum(), m_tb_button->progress()->maximum()));
+#else
+	m_value = std::clamp(value, m_minimum, m_maximum);
+#if HAVE_QTDBUS
+	update_progress(m_value, true, false);
+#endif
+#endif
+}
+
+void progress_indicator::set_range(int minimum, int maximum)
+{
+#ifdef _WIN32
+	m_tb_button->progress()->setRange(minimum, maximum);
+#else
+	m_minimum = minimum;
+	m_maximum = maximum;
+#endif
+}
+
+void progress_indicator::reset()
+{
+#ifdef _WIN32
+	m_tb_button->progress()->reset();
+#else
+	m_value = m_minimum;
+#if HAVE_QTDBUS
+	update_progress(m_value, false, false);
+#endif
+#endif
+}
+
+void progress_indicator::signal_failure()
+{
+#ifdef _WIN32
+	m_tb_button->progress()->stop();
+#elif HAVE_QTDBUS
+	update_progress(0, false, true);
+#endif
+}
+
+#if HAVE_QTDBUS
+void progress_indicator::update_progress(int progress, bool progress_visible, bool urgent)
+{
+	QVariantMap properties;
+	properties.insert(QStringLiteral("urgent"), urgent);
+
+	if (!urgent)
+	{
+		// Progress takes a value from 0.0 to 0.1
+		properties.insert(QStringLiteral("progress"), 1. * progress / m_maximum);
+		properties.insert(QStringLiteral("progress-visible"), progress_visible);
+	}
+
+	QDBusMessage message = QDBusMessage::createSignal(
+		QStringLiteral("/"),
+		QStringLiteral("com.canonical.Unity.LauncherEntry"),
+		QStringLiteral("Update"));
+
+	message << QStringLiteral("application://rpcs3.desktop") << properties;
+
+	QDBusConnection::sessionBus().send(message);
+}
+#endif

--- a/rpcs3/rpcs3qt/progress_indicator.h
+++ b/rpcs3/rpcs3qt/progress_indicator.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QWindow>
+
+#ifdef _WIN32
+#include <QWinTaskbarButton>
+#endif
+
+class progress_indicator
+{
+public:
+	progress_indicator(int minimum, int maximum);
+	~progress_indicator();
+
+	void show(QWindow* window);
+
+	int value() const;
+
+	void set_value(int value);
+	void set_range(int minimum, int maximum);
+	void reset();
+	void signal_failure();
+
+private:
+
+#ifdef _WIN32
+	std::unique_ptr<QWinTaskbarButton> m_tb_button;
+#else
+	int m_value = 0;
+	int m_minimum = 0;
+	int m_maximum = 100;
+#if HAVE_QTDBUS
+	void update_progress(int progress, bool progress_visible, bool urgent);
+#endif
+#endif
+};


### PR DESCRIPTION
- Moves duplicate progress indicator code to separate file
- This will simplify any further changes to the taskbar progress functionality
- In Qt6 we will have to change all this anyway, so this commit will greatly simplify the Qt6 PR 