### PR TITLE
rsx: More regression fixes

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -289,10 +289,10 @@ namespace glsl
 
 		"vec4 fetch_attribute(const in attribute_desc desc, const in int vertex_id, usamplerBuffer input_stream)\n"
 		"{\n"
-		"	const int elem_size_table[] = { 2, 4, 2, 1, 2, 4, 1 };\n"
-		"	const float scaling_table[] = { 32767.5, 1., 1., 255., 1., 32767., 1. };\n"
-		"	const int elem_size = elem_size_table[desc.type - 1];\n"
-		"	const vec4 scale = scaling_table[desc.type - 1].xxxx;\n\n"
+		"	const int elem_size_table[] = { 0, 2, 4, 2, 1, 2, 4, 1 };\n"
+		"	const float scaling_table[] = { 1., 32767.5, 1., 1., 255., 1., 32767., 1. };\n"
+		"	const int elem_size = elem_size_table[desc.type];\n"
+		"	const vec4 scale = scaling_table[desc.type].xxxx;\n\n"
 
 		"	uvec4 tmp, result = uvec4(0u);\n"
 		"	vec4 ret;\n"

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -2461,7 +2461,7 @@ namespace rsx
 			state_signals[NV4097_SET_ALPHA_FUNC] = rsx::fragment_state_dirty;
 			state_signals[NV4097_SET_ALPHA_REF] = rsx::fragment_state_dirty;
 			state_signals[NV4097_SET_ALPHA_TEST_ENABLE] = rsx::fragment_state_dirty;
-			state_signals[NV4097_SET_ANTI_ALIASING_CONTROL] = rsx::fragment_state_dirty;
+			state_signals[NV4097_SET_ANTI_ALIASING_CONTROL] = rsx::fragment_state_dirty | rsx::pipeline_config_dirty;
 			state_signals[NV4097_SET_SHADER_PACKER] = rsx::fragment_state_dirty;
 			state_signals[NV4097_SET_SHADER_WINDOW] = rsx::fragment_state_dirty;
 			state_signals[NV4097_SET_FOG_MODE] = rsx::fragment_state_dirty;
@@ -2525,7 +2525,6 @@ namespace rsx
 			state_signals[NV4097_SET_BLEND_ENABLE_MRT] = rsx::pipeline_config_dirty;
 			state_signals[NV4097_SET_STENCIL_FUNC] = rsx::pipeline_config_dirty;
 			state_signals[NV4097_SET_BACK_STENCIL_FUNC] = rsx::pipeline_config_dirty;
-			state_signals[NV4097_SET_ANTI_ALIASING_CONTROL] = rsx::pipeline_config_dirty;
 			state_signals[NV4097_SET_RESTART_INDEX_ENABLE] = rsx::pipeline_config_dirty;
 		}
 


### PR DESCRIPTION
- Allow vertex fetch on uninitialized attribute channels
- Do not override state signal for MSAA control flags

Fixes https://github.com/RPCS3/rpcs3/issues/13237
Fixes https://github.com/RPCS3/rpcs3/issues/13239