### PR TITLE
overlays/osk: improvements

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -10,6 +10,7 @@
 #include "cellSysutil.h"
 #include "cellOskDialog.h"
 #include "cellMsgDialog.h"
+#include "cellImeJp.h"
 
 #include "util/init_mutex.hpp"
 
@@ -855,8 +856,6 @@ error_code cellOskDialogAddSupportLanguage(u32 supportLanguage)
 {
 	cellOskDialog.warning("cellOskDialogAddSupportLanguage(supportLanguage=0x%x)", supportLanguage);
 
-	// TODO: error checks
-
 	g_fxo->get<osk_info>().supported_languages = supportLanguage;
 
 	return CELL_OK;
@@ -865,8 +864,6 @@ error_code cellOskDialogAddSupportLanguage(u32 supportLanguage)
 error_code cellOskDialogSetLayoutMode(s32 layoutMode)
 {
 	cellOskDialog.warning("cellOskDialogSetLayoutMode(layoutMode=0x%x)", layoutMode);
-
-	// TODO: error checks
 
 	auto& osk = g_fxo->get<osk_info>();
 	osk.layout_mode = layoutMode;
@@ -953,14 +950,32 @@ error_code cellOskDialogExtRegisterKeyboardEventHookCallbackEx(u16 hookEventMode
 error_code cellOskDialogExtAddJapaneseOptionDictionary(vm::cpptr<char> filePath)
 {
 	cellOskDialog.todo("cellOskDialogExtAddJapaneseOptionDictionary(filePath=**0x%0x)", filePath);
+
+	std::vector<std::string> paths;
+
+	if (filePath)
+	{
+		for (u32 i = 0; i < 4; i++)
+		{
+			if (!filePath[i])
+			{
+				break;
+			}
+
+			std::array<char, CELL_IMEJP_DIC_PATH_MAXLENGTH + 1> path{};
+			std::memcpy(path.data(), filePath[i].get_ptr(), CELL_IMEJP_DIC_PATH_MAXLENGTH);
+			paths.push_back(path.data());
+		}
+	}
+
+	cellOskDialog.todo("cellOskDialogExtAddJapaneseOptionDictionary: got %d dictionaries:\n%s", paths.size(), fmt::merge(paths, "\n"));
+
 	return CELL_OK;
 }
 
 error_code cellOskDialogExtEnableClipboard()
 {
 	cellOskDialog.todo("cellOskDialogExtEnableClipboard()");
-
-	// TODO: error checks
 
 	g_fxo->get<osk_info>().clipboard_enabled = true;
 
@@ -986,9 +1001,37 @@ error_code cellOskDialogExtSendFinishMessage(u32 /*CellOskDialogFinishReason*/ f
 	return CELL_OK;
 }
 
-error_code cellOskDialogExtAddOptionDictionary(vm::cptr<CellOskDialogImeDictionaryInfo> dictionaryInfo)
+error_code cellOskDialogExtAddOptionDictionary(vm::cpptr<CellOskDialogImeDictionaryInfo> dictionaryInfo)
 {
 	cellOskDialog.todo("cellOskDialogExtAddOptionDictionary(dictionaryInfo=*0x%x)", dictionaryInfo);
+
+	if (!dictionaryInfo)
+	{
+		return CELL_OSKDIALOG_ERROR_PARAM;
+	}
+
+	std::vector<std::pair<u32, std::string>> paths; // language and path
+
+	for (u32 i = 0; i < 10; i++)
+	{
+		if (!dictionaryInfo[i] || !dictionaryInfo[i]->dictionaryPath)
+		{
+			break;
+		}
+
+		std::array<char, CELL_IMEJP_DIC_PATH_MAXLENGTH + 1> path{};
+		std::memcpy(path.data(), dictionaryInfo[i]->dictionaryPath.get_ptr(), CELL_IMEJP_DIC_PATH_MAXLENGTH);
+		paths.push_back({ dictionaryInfo[i]->targetLanguage, path.data() });
+	}
+
+	std::vector<std::string> msgs;
+	for (const auto& entry : paths)
+	{
+		msgs.push_back(fmt::format("languages=0x%x, path='%s'", entry.first, entry.second));
+	}
+
+	cellOskDialog.todo("cellOskDialogExtAddOptionDictionary: got %d dictionaries:\n%s", msgs.size(), fmt::merge(msgs, "\n"));
+
 	return CELL_OK;
 }
 
@@ -1010,8 +1053,6 @@ error_code cellOskDialogExtInputDeviceLock()
 {
 	cellOskDialog.warning("cellOskDialogExtInputDeviceLock()");
 
-	// TODO: error checks
-
 	g_fxo->get<osk_info>().lock_ext_input = true;
 
 	if (const auto osk = _get_osk_dialog(false))
@@ -1025,8 +1066,6 @@ error_code cellOskDialogExtInputDeviceLock()
 error_code cellOskDialogExtInputDeviceUnlock()
 {
 	cellOskDialog.warning("cellOskDialogExtInputDeviceUnlock()");
-
-	// TODO: error checks
 
 	g_fxo->get<osk_info>().lock_ext_input = false;
 
@@ -1098,8 +1137,6 @@ error_code cellOskDialogExtSetPointerEnable(b8 enable)
 {
 	cellOskDialog.warning("cellOskDialogExtSetPointerEnable(enable=%d)", enable);
 
-	// TODO: error checks
-
 	g_fxo->get<osk_info>().pointer_enabled = enable;
 	g_osk_pointer_enabled = enable;
 
@@ -1109,8 +1146,6 @@ error_code cellOskDialogExtSetPointerEnable(b8 enable)
 error_code cellOskDialogExtUpdatePointerDisplayPos(vm::cptr<CellOskDialogPoint> pos)
 {
 	cellOskDialog.warning("cellOskDialogExtUpdatePointerDisplayPos(pos=0x%x, posX=%f, posY=%f)", pos->x, pos->y);
-
-	// TODO: error checks
 
 	if (pos)
 	{
@@ -1126,8 +1161,6 @@ error_code cellOskDialogExtEnableHalfByteKana()
 {
 	cellOskDialog.todo("cellOskDialogExtEnableHalfByteKana()");
 
-	// TODO: error checks
-
 	g_fxo->get<osk_info>().half_byte_kana_enabled = true;
 
 	// TODO: use new value in osk
@@ -1138,8 +1171,6 @@ error_code cellOskDialogExtEnableHalfByteKana()
 error_code cellOskDialogExtDisableHalfByteKana()
 {
 	cellOskDialog.todo("cellOskDialogExtDisableHalfByteKana()");
-
-	// TODO: error checks
 
 	g_fxo->get<osk_info>().half_byte_kana_enabled = false;
 

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -65,10 +65,10 @@ struct osk_info
 	atomic_t<bool> use_separate_windows = false;
 
 	atomic_t<bool> lock_ext_input = false;
-	atomic_t<u32> device_mask = 0; // 0 means all devices can influence the OSK
-	atomic_t<u32> key_layout = CELL_OSKDIALOG_10KEY_PANEL;
-	atomic_t<CellOskDialogInitialKeyLayout> initial_key_layout = CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_SYSTEM;
-	atomic_t<CellOskDialogInputDevice> initial_input_device = CELL_OSKDIALOG_INPUT_DEVICE_PAD;
+	atomic_t<u32> device_mask = 0; // OSK ignores input from the specified devices. 0 means all devices can influence the OSK
+	atomic_t<u32> key_layout_options = CELL_OSKDIALOG_10KEY_PANEL;
+	atomic_t<CellOskDialogInitialKeyLayout> initial_key_layout = CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_SYSTEM; // TODO: use
+	atomic_t<CellOskDialogInputDevice> initial_input_device = CELL_OSKDIALOG_INPUT_DEVICE_PAD; // OSK at first only receives input from the initial device
 
 	atomic_t<bool> clipboard_enabled = false; // For copy and paste
 	atomic_t<bool> half_byte_kana_enabled = false;
@@ -102,7 +102,7 @@ struct osk_info
 		use_separate_windows = false;
 		lock_ext_input = false;
 		device_mask = 0;
-		key_layout = CELL_OSKDIALOG_10KEY_PANEL;
+		key_layout_options = CELL_OSKDIALOG_10KEY_PANEL;
 		initial_key_layout = CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_SYSTEM;
 		initial_input_device = CELL_OSKDIALOG_INPUT_DEVICE_PAD;
 		clipboard_enabled = false;
@@ -797,14 +797,17 @@ error_code cellOskDialogSetInitialKeyLayout(u32 initialKeyLayout)
 {
 	cellOskDialog.todo("cellOskDialogSetInitialKeyLayout(initialKeyLayout=%d)", initialKeyLayout);
 
-	if (initialKeyLayout > (CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_10KEY | CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_FULLKEY))
+	if (initialKeyLayout > CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_FULLKEY)
 	{
 		return CELL_OSKDIALOG_ERROR_PARAM;
 	}
 
-	g_fxo->get<osk_info>().initial_key_layout = static_cast<CellOskDialogInitialKeyLayout>(initialKeyLayout);
+	auto& osk = g_fxo->get<osk_info>();
 
-	// TODO: use initial_key_layout
+	if (osk.key_layout_options & initialKeyLayout)
+	{
+		osk.initial_key_layout = static_cast<CellOskDialogInitialKeyLayout>(initialKeyLayout);
+	}
 
 	return CELL_OK;
 }
@@ -827,9 +830,7 @@ error_code cellOskDialogSetKeyLayoutOption(u32 option)
 		return CELL_OSKDIALOG_ERROR_PARAM;
 	}
 
-	g_fxo->get<osk_info>().key_layout = option;
-
-	// TODO: use key_layout
+	g_fxo->get<osk_info>().key_layout_options = option;
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -51,6 +51,10 @@ void fmt_class_string<CellOskDialogContinuousMode>::format(std::string& out, u64
 	});
 }
 
+atomic_t<bool> g_osk_pointer_enabled = false;
+atomic_t<f32> g_osk_pointer_x = 0.0f;
+atomic_t<f32> g_osk_pointer_y = 0.0f;
+
 OskDialogBase::~OskDialogBase()
 {
 }
@@ -535,6 +539,11 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 	Emu.BlockingCallFromMainThread([=, &info]()
 	{
+		// Make sure to always have the latest pointer params
+		g_osk_pointer_enabled = info.pointer_enabled.load();
+		g_osk_pointer_x = info.pointer_pos.x;
+		g_osk_pointer_y = info.pointer_pos.y;
+
 		osk->Create({
 			.title = get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE),
 			.message = message,
@@ -802,7 +811,7 @@ error_code cellOskDialogSetInitialInputDevice(u32 inputDevice)
 
 error_code cellOskDialogSetInitialKeyLayout(u32 initialKeyLayout)
 {
-	cellOskDialog.todo("cellOskDialogSetInitialKeyLayout(initialKeyLayout=%d)", initialKeyLayout);
+	cellOskDialog.warning("cellOskDialogSetInitialKeyLayout(initialKeyLayout=%d)", initialKeyLayout);
 
 	if (initialKeyLayout > CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_FULLKEY)
 	{
@@ -830,7 +839,7 @@ error_code cellOskDialogDisableDimmer()
 
 error_code cellOskDialogSetKeyLayoutOption(u32 option)
 {
-	cellOskDialog.todo("cellOskDialogSetKeyLayoutOption(option=0x%x)", option);
+	cellOskDialog.warning("cellOskDialogSetKeyLayoutOption(option=0x%x)", option);
 
 	if (option == 0 || option > 3) // CELL_OSKDIALOG_10KEY_PANEL OR CELL_OSKDIALOG_FULLKEY_PANEL
 	{
@@ -844,7 +853,7 @@ error_code cellOskDialogSetKeyLayoutOption(u32 option)
 
 error_code cellOskDialogAddSupportLanguage(u32 supportLanguage)
 {
-	cellOskDialog.todo("cellOskDialogAddSupportLanguage(supportLanguage=0x%x)", supportLanguage);
+	cellOskDialog.warning("cellOskDialogAddSupportLanguage(supportLanguage=0x%x)", supportLanguage);
 
 	// TODO: error checks
 
@@ -855,7 +864,7 @@ error_code cellOskDialogAddSupportLanguage(u32 supportLanguage)
 
 error_code cellOskDialogSetLayoutMode(s32 layoutMode)
 {
-	cellOskDialog.todo("cellOskDialogSetLayoutMode(layoutMode=0x%x)", layoutMode);
+	cellOskDialog.warning("cellOskDialogSetLayoutMode(layoutMode=0x%x)", layoutMode);
 
 	// TODO: error checks
 
@@ -985,7 +994,7 @@ error_code cellOskDialogExtAddOptionDictionary(vm::cptr<CellOskDialogImeDictiona
 
 error_code cellOskDialogExtSetInitialScale(f32 initialScale)
 {
-	cellOskDialog.todo("cellOskDialogExtSetInitialScale(initialScale=%f)", initialScale);
+	cellOskDialog.warning("cellOskDialogExtSetInitialScale(initialScale=%f)", initialScale);
 
 	if (initialScale < CELL_OSKDIALOG_SCALE_MIN || initialScale > CELL_OSKDIALOG_SCALE_MAX)
 	{
@@ -1087,29 +1096,28 @@ error_code cellOskDialogExtUpdateInputText()
 
 error_code cellOskDialogExtSetPointerEnable(b8 enable)
 {
-	cellOskDialog.todo("cellOskDialogExtSetPointerEnable(enable=%d)", enable);
+	cellOskDialog.warning("cellOskDialogExtSetPointerEnable(enable=%d)", enable);
 
 	// TODO: error checks
 
 	g_fxo->get<osk_info>().pointer_enabled = enable;
-
-	// TODO: Show/hide pointer at the specified position in the OSK overlay.
+	g_osk_pointer_enabled = enable;
 
 	return CELL_OK;
 }
 
 error_code cellOskDialogExtUpdatePointerDisplayPos(vm::cptr<CellOskDialogPoint> pos)
 {
-	cellOskDialog.todo("cellOskDialogExtUpdatePointerDisplayPos(pos=0x%x, posX=%f, posY=%f)", pos->x, pos->y);
+	cellOskDialog.warning("cellOskDialogExtUpdatePointerDisplayPos(pos=0x%x, posX=%f, posY=%f)", pos->x, pos->y);
 
 	// TODO: error checks
 
 	if (pos)
 	{
 		g_fxo->get<osk_info>().pointer_pos = *pos;
+		g_osk_pointer_x = pos->x;
+		g_osk_pointer_y = pos->y;
 	}
-
-	// TODO: Update pointer position in the OSK overlay.
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -546,6 +546,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 			.first_view_panel = firstViewPanel,
 			.x_align = info.x_align,
 			.y_align = info.y_align,
+			.initial_scale = info.initial_scale,
 			.base_color = info.base_color.load(),
 			.dimmer_enabled = info.dimmer_enabled.load(),
 			.intercept_input = false
@@ -992,8 +993,6 @@ error_code cellOskDialogExtSetInitialScale(f32 initialScale)
 	}
 
 	g_fxo->get<osk_info>().initial_scale = initialScale;
-
-	// TODO: implement overlay scaling
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -531,7 +531,19 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 	Emu.BlockingCallFromMainThread([=, &info]()
 	{
-		osk->Create(get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE), message, osk->osk_text, maxLength, prohibitFlgs, allowOskPanelFlg, firstViewPanel, info.base_color.load(), info.dimmer_enabled.load(), false);
+		osk->Create({
+			.title = get_localized_string(localized_string_id::CELL_OSK_DIALOG_TITLE),
+			.message = message,
+			.init_text = osk->osk_text,
+			.charlimit = maxLength,
+			.prohibit_flags = prohibitFlgs,
+			.panel_flag = allowOskPanelFlg,
+			.support_language = info.supported_languages,
+			.first_view_panel = firstViewPanel,
+			.base_color = info.base_color.load(),
+			.dimmer_enabled = info.dimmer_enabled.load(),
+			.intercept_input = false
+		});
 	});
 
 	if (info.osk_continuous_mode == CELL_OSKDIALOG_CONTINUOUS_MODE_HIDE)
@@ -775,7 +787,7 @@ error_code cellOskDialogSetInitialInputDevice(u32 inputDevice)
 
 	g_fxo->get<osk_info>().initial_input_device = static_cast<CellOskDialogInputDevice>(inputDevice);
 
-	// TODO: use value
+	// TODO: use initial_input_device
 	// TODO: Signal CELL_SYSUTIL_OSKDIALOG_INPUT_DEVICE_CHANGED if the input device changed (probably only when the dialog is already open)
 
 	return CELL_OK;
@@ -792,7 +804,7 @@ error_code cellOskDialogSetInitialKeyLayout(u32 initialKeyLayout)
 
 	g_fxo->get<osk_info>().initial_key_layout = static_cast<CellOskDialogInitialKeyLayout>(initialKeyLayout);
 
-	// TODO: use value
+	// TODO: use initial_key_layout
 
 	return CELL_OK;
 }
@@ -817,7 +829,7 @@ error_code cellOskDialogSetKeyLayoutOption(u32 option)
 
 	g_fxo->get<osk_info>().key_layout = option;
 
-	// TODO: use value
+	// TODO: use key_layout
 
 	return CELL_OK;
 }
@@ -829,19 +841,6 @@ error_code cellOskDialogAddSupportLanguage(u32 supportLanguage)
 	// TODO: error checks
 
 	g_fxo->get<osk_info>().supported_languages = supportLanguage;
-
-	// TODO: disable extra languages unless they were enabled here
-	// Extra languages are:
-	// CELL_OSKDIALOG_PANELMODE_POLISH
-	// CELL_OSKDIALOG_PANELMODE_KOREAN
-	// CELL_OSKDIALOG_PANELMODE_TURKEY
-	// CELL_OSKDIALOG_PANELMODE_TRADITIONAL_CHINESE
-	// CELL_OSKDIALOG_PANELMODE_SIMPLIFIED_CHINESE
-	// CELL_OSKDIALOG_PANELMODE_PORTUGUESE_BRAZIL
-	// CELL_OSKDIALOG_PANELMODE_DANISH
-	// CELL_OSKDIALOG_PANELMODE_SWEDISH
-	// CELL_OSKDIALOG_PANELMODE_NORWEGIAN
-	// CELL_OSKDIALOG_PANELMODE_FINNISH
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -2,6 +2,8 @@
 
 #include "util/types.hpp"
 #include "util/atomic.hpp"
+#include "util/init_mutex.hpp"
+#include "Utilities/mutex.h"
 #include "Emu/Memory/vm_ptr.h"
 #include <string>
 #include <functional>
@@ -242,6 +244,20 @@ using cellOskDialogConfirmWordFilterCallback = int(vm::ptr<u16> pConfirmString, 
 using cellOskDialogHardwareKeyboardEventHookCallback = class b8(vm::ptr<CellOskDialogKeyMessage> keyMessage, vm::ptr<u32> action, vm::ptr<void> pActionInfo);
 using cellOskDialogForceFinishCallback = class b8();
 
+struct osk_window_layout
+{
+	u32 layout_mode = CELL_OSKDIALOG_LAYOUTMODE_X_ALIGN_LEFT | CELL_OSKDIALOG_LAYOUTMODE_Y_ALIGN_TOP;
+	u32 x_align = CELL_OSKDIALOG_LAYOUTMODE_X_ALIGN_LEFT;
+	u32 y_align = CELL_OSKDIALOG_LAYOUTMODE_Y_ALIGN_TOP;
+	f32 x_offset = 0.0f;
+	f32 y_offset = 0.0f;
+
+	std::string to_string() const
+	{
+		return fmt::format("{ layout_mode=0x%x, x_align=0x%x, y_align=0x%x, x_offset=%.2f, y_offset=%.2f }", layout_mode, x_align, y_align, x_offset, y_offset);
+	}
+};
+
 enum class OskDialogState
 {
 	Unloaded,
@@ -287,7 +303,7 @@ public:
 	// Set status to CELL_OSKDIALOG_CLOSE_CONFIRM or CELL_OSKDIALOG_CLOSE_CANCEL for user input.
 	// Set status to -1 if closed by the game or system.
 	virtual void Close(s32 status) = 0;
-	virtual ~OskDialogBase();
+	virtual ~OskDialogBase() {};
 
 	std::function<void(s32 status)> on_osk_close;
 	std::function<void(CellOskDialogKeyMessage key_message)> on_osk_key_input_entered;
@@ -300,4 +316,56 @@ public:
 
 	atomic_t<CellOskDialogInputFieldResult> osk_input_result{ CellOskDialogInputFieldResult::CELL_OSKDIALOG_INPUT_FIELD_RESULT_OK };
 	char16_t osk_text[CELL_OSKDIALOG_STRING_SIZE]{};
+};
+
+struct osk_info
+{
+	std::shared_ptr<OskDialogBase> dlg;
+
+	std::array<char16_t, CELL_OSKDIALOG_STRING_SIZE> valid_text{};
+	shared_mutex text_mtx;
+
+	atomic_t<bool> use_separate_windows = false;
+
+	atomic_t<bool> lock_ext_input = false;
+	atomic_t<u32> device_mask = 0; // OSK ignores input from the specified devices. 0 means all devices can influence the OSK
+	atomic_t<u32> input_field_window_width = 0;
+	atomic_t<f32> input_field_background_transparency = 0.0f;
+	osk_window_layout input_field_layout_info{};
+	osk_window_layout input_panel_layout_info{};
+	atomic_t<u32> key_layout_options = CELL_OSKDIALOG_10KEY_PANEL;
+	atomic_t<CellOskDialogInitialKeyLayout> initial_key_layout = CELL_OSKDIALOG_INITIAL_PANEL_LAYOUT_SYSTEM; // TODO: use
+	atomic_t<CellOskDialogInputDevice> initial_input_device = CELL_OSKDIALOG_INPUT_DEVICE_PAD; // OSK at first only receives input from the initial device
+
+	atomic_t<bool> clipboard_enabled = false; // For copy and paste
+	atomic_t<bool> half_byte_kana_enabled = false;
+	atomic_t<u32> supported_languages = 0; // Used to enable non-default languages in the OSK
+
+	atomic_t<bool> dimmer_enabled = true;
+	atomic_t<OskDialogBase::color> base_color = OskDialogBase::color{ 0.2f, 0.2f, 0.2f, 1.0f };
+
+	atomic_t<bool> pointer_enabled = false;
+	atomic_t<f32> pointer_x = 0.0f;
+	atomic_t<f32> pointer_y = 0.0f;
+	atomic_t<f32> initial_scale = 1.0f;
+
+	osk_window_layout layout = {};
+
+	atomic_t<CellOskDialogContinuousMode> osk_continuous_mode = CELL_OSKDIALOG_CONTINUOUS_MODE_NONE;
+	atomic_t<u32> last_dialog_state = CELL_SYSUTIL_OSKDIALOG_UNLOADED; // Used for continuous seperate window dialog
+
+	atomic_t<vm::ptr<cellOskDialogConfirmWordFilterCallback>> osk_confirm_callback{};
+	atomic_t<vm::ptr<cellOskDialogForceFinishCallback>> osk_force_finish_callback{};
+	atomic_t<vm::ptr<cellOskDialogHardwareKeyboardEventHookCallback>> osk_hardware_keyboard_event_hook_callback{};
+	atomic_t<u16> hook_event_mode{0};
+
+	stx::init_mutex init;
+
+	void reset();
+
+	// Align horizontally
+	static u32 get_aligned_x(u32 layout_mode);
+
+	// Align vertically
+	static u32 get_aligned_y(u32 layout_mode);
 };

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -271,6 +271,8 @@ public:
 		u32 panel_flag = 0;
 		u32 support_language = 0;
 		u32 first_view_panel = 0;
+		u32 x_align = 0;
+		u32 y_align = 0;
 		color base_color{};
 		bool dimmer_enabled = false;
 		bool intercept_input = false;

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -261,7 +261,22 @@ public:
 		f32 a = 1.0f;
 	};
 
-	virtual void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled, bool intercept_input) = 0;
+	struct osk_params
+	{
+		std::string title;
+		std::u16string message;
+		char16_t* init_text = nullptr;
+		u32 charlimit = 0;
+		u32 prohibit_flags = 0;
+		u32 panel_flag = 0;
+		u32 support_language = 0;
+		u32 first_view_panel = 0;
+		color base_color{};
+		bool dimmer_enabled = false;
+		bool intercept_input = false;
+	};
+
+	virtual void Create(const osk_params& params) = 0;
 
 	// Closes the dialog.
 	// Set status to CELL_OSKDIALOG_CLOSE_CONFIRM or CELL_OSKDIALOG_CLOSE_CANCEL for user input.

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -273,6 +273,8 @@ public:
 		u32 first_view_panel = 0;
 		u32 x_align = 0;
 		u32 y_align = 0;
+		f32 x_offset = 0.0f;
+		f32 y_offset = 0.0f;
 		f32 initial_scale = 1.0f;
 		color base_color{};
 		bool dimmer_enabled = false;

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.h
@@ -273,6 +273,7 @@ public:
 		u32 first_view_panel = 0;
 		u32 x_align = 0;
 		u32 y_align = 0;
+		f32 initial_scale = 1.0f;
 		color base_color{};
 		bool dimmer_enabled = false;
 		bool intercept_input = false;

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -263,7 +263,7 @@ namespace rsx
 
 		struct image_button : public image_view
 		{
-			const u16 text_horizontal_offset = 25;
+			u16 text_horizontal_offset = 25;
 			u16 m_text_offset_x = 0;
 			s16 m_text_offset_y = 0;
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_cursor.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_cursor.cpp
@@ -56,6 +56,11 @@ namespace rsx
 			return m_visible;
 		}
 
+		bool cursor_item::visible() const
+		{
+			return m_visible;
+		}
+
 		compiled_resource cursor_item::get_compiled()
 		{
 			if (!m_visible)

--- a/rpcs3/Emu/RSX/Overlays/overlay_cursor.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_cursor.h
@@ -23,6 +23,7 @@ namespace rsx
 			bool set_color(color4f color);
 
 			bool update_visibility(u64 time);
+			bool visible() const;
 
 			compiled_resource get_compiled();
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
@@ -45,12 +45,12 @@ namespace rsx
 
 						if (convert_ratio > 1.0f)
 						{
-							const u16 new_padding = (target_height - target_height / convert_ratio) / 2;
+							const u16 new_padding = static_cast<u16>(target_height - target_height / convert_ratio) / 2;
 							image->set_padding(image->padding_left, image->padding_right, new_padding + image->padding_top, new_padding + image->padding_bottom);
 						}
 						else if (convert_ratio < 1.0f)
 						{
-							const u16 new_padding = (target_width - target_width * convert_ratio) / 2;
+							const u16 new_padding = static_cast<u16>(target_width - target_width * convert_ratio) / 2;
 							image->set_padding(image->padding_left + new_padding, image->padding_right + new_padding, image->padding_top, image->padding_bottom);
 						}
 					}
@@ -329,7 +329,7 @@ namespace rsx
 					if (new_entry.type != media_list_dialog::media_type::invalid)
 					{
 						new_entry.parent = &current_entry;
-						new_entry.index = current_entry.children.size();
+						new_entry.index = ::narrow<u32>(current_entry.children.size());
 						current_entry.children.emplace_back(std::move(new_entry));
 					}
 				}

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -7,10 +7,6 @@
 
 LOG_CHANNEL(osk, "OSK");
 
-extern atomic_t<bool> g_osk_pointer_enabled;
-extern atomic_t<f32> g_osk_pointer_x;
-extern atomic_t<f32> g_osk_pointer_y;
-
 namespace rsx
 {
 	namespace overlays
@@ -937,14 +933,16 @@ namespace rsx
 				m_update = true;
 			}
 
-			if (g_osk_pointer_enabled != m_pointer.visible())
+			osk_info& info = g_fxo->get<osk_info>();
+
+			if (const bool pointer_enabled = info.pointer_enabled; pointer_enabled != m_pointer.visible())
 			{
-				m_pointer.set_expiration(g_osk_pointer_enabled ? u64{umax} : 0);
+				m_pointer.set_expiration(pointer_enabled ? u64{umax} : 0);
 				m_pointer.update_visibility(get_system_time());
 				m_update = true;
 			}
 
-			if (m_pointer.visible() && m_pointer.set_position(static_cast<u16>(g_osk_pointer_x), static_cast<u16>(g_osk_pointer_y)))
+			if (m_pointer.visible() && m_pointer.set_position(static_cast<u16>(info.pointer_x), static_cast<u16>(info.pointer_y)))
 			{
 				m_update = true;
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -7,6 +7,10 @@
 
 LOG_CHANNEL(osk, "OSK");
 
+extern atomic_t<bool> g_osk_pointer_enabled;
+extern atomic_t<f32> g_osk_pointer_x;
+extern atomic_t<f32> g_osk_pointer_y;
+
 namespace rsx
 {
 	namespace overlays
@@ -303,6 +307,8 @@ namespace rsx
 					elem.set_font(fnt->get_name().data(), get_scaled(fnt->get_size_pt()));
 				}
 			};
+
+			m_pointer.set_color(color4f{ 1.f, 1.f, 1.f, 1.f });
 
 			m_background.set_size(virtual_width, virtual_height);
 
@@ -876,6 +882,18 @@ namespace rsx
 				fade_animation.update(rsx::get_current_renderer()->vblank_count);
 				m_update = true;
 			}
+
+			if (g_osk_pointer_enabled != m_pointer.visible())
+			{
+				m_pointer.set_expiration(g_osk_pointer_enabled ? u64{umax} : 0);
+				m_pointer.update_visibility(get_system_time());
+				m_update = true;
+			}
+
+			if (m_pointer.visible() && m_pointer.set_position(static_cast<u16>(g_osk_pointer_x), static_cast<u16>(g_osk_pointer_y)))
+			{
+				m_update = true;
+			}
 		}
 
 		compiled_resource osk_dialog::get_compiled()
@@ -995,6 +1013,7 @@ namespace rsx
 					}
 				}
 
+				m_cached_resource.add(m_pointer.get_compiled());
 				m_reset_pulse = false;
 				m_update = false;
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -89,8 +89,8 @@ namespace rsx
 
 			num_rows = panel.num_rows;
 			num_columns = panel.num_columns;
-			cell_size_x = panel.cell_size_x;
-			cell_size_y = panel.cell_size_y;
+			cell_size_x = get_scaled(panel.cell_size_x);
+			cell_size_y = get_scaled(panel.cell_size_y);
 
 			update_layout();
 
@@ -99,7 +99,7 @@ namespace rsx
 			m_grid.resize(cell_count);
 			num_shift_layers_by_charset.clear();
 
-			const position2u grid_origin = { m_frame.x, m_frame.y + 30u + m_preview.h };
+			const position2u grid_origin(m_frame.x, m_frame.y + m_title.h + m_preview.h);
 
 			const u32 old_index = (selected_y * num_columns) + selected_x;
 
@@ -215,14 +215,15 @@ namespace rsx
 
 		void osk_dialog::update_layout()
 		{
-			const u16 preview_height = (flags & CELL_OSKDIALOG_NO_RETURN) ? 40 : 90;
+			const u16 title_height = get_scaled(30);
+			const u16 preview_height = get_scaled((flags & CELL_OSKDIALOG_NO_RETURN) ? 40 : 90);
 
 			// Place elements with absolute positioning
-			constexpr u16 margin = 100;
-			constexpr u16 button_margin = 30;
-			constexpr u16 button_height = 30;
-			const u16 frame_w = static_cast<u16>(num_columns * cell_size_x);
-			const u16 frame_h = static_cast<u16>(num_rows * cell_size_y) + 30 + preview_height;
+			const u16 margin = get_scaled(100);
+			const u16 button_margin = get_scaled(30);
+			const u16 button_height = get_scaled(30);
+			const u16 frame_w = num_columns * cell_size_x;
+			const u16 frame_h = num_rows * cell_size_y + title_height + preview_height;
 			u16 frame_x = 0;
 			u16 frame_y = 0;
 
@@ -258,51 +259,61 @@ namespace rsx
 			m_frame.set_size(frame_w, frame_h);
 
 			m_title.set_pos(frame_x, frame_y);
-			m_title.set_size(frame_w, 30);
-			m_title.set_padding(15, 0, 5, 0);
+			m_title.set_size(frame_w, title_height);
+			m_title.set_padding(get_scaled(15), 0, get_scaled(5), 0);
 
-			m_preview.set_pos(frame_x, frame_y + 30);
+			m_preview.set_pos(frame_x, frame_y + title_height);
 			m_preview.set_size(frame_w, preview_height);
-			m_preview.set_padding(15, 0, 10, 0);
+			m_preview.set_padding(get_scaled(15), 0, get_scaled(10), 0);
 
 			m_btn_cancel.set_pos(frame_x, frame_y + frame_h + button_margin);
-			m_btn_cancel.set_size(140, button_height);
+			m_btn_cancel.set_size(get_scaled(140), button_height);
 			m_btn_cancel.set_text(localized_string_id::RSX_OVERLAYS_OSK_DIALOG_CANCEL);
-			m_btn_cancel.set_text_vertical_adjust(5);
+			m_btn_cancel.set_text_vertical_adjust(get_scaled(5));
 
-			m_btn_space.set_pos(frame_x + 100, frame_y + frame_h + button_margin);
-			m_btn_space.set_size(100, button_height);
+			m_btn_space.set_pos(frame_x + get_scaled(100), frame_y + frame_h + button_margin);
+			m_btn_space.set_size(get_scaled(100), button_height);
 			m_btn_space.set_text(localized_string_id::RSX_OVERLAYS_OSK_DIALOG_SPACE);
-			m_btn_space.set_text_vertical_adjust(5);
+			m_btn_space.set_text_vertical_adjust(get_scaled(5));
 
-			m_btn_delete.set_pos(frame_x + 200, frame_y + frame_h + button_margin);
-			m_btn_delete.set_size(100, button_height);
+			m_btn_delete.set_pos(frame_x + get_scaled(200), frame_y + frame_h + button_margin);
+			m_btn_delete.set_size(get_scaled(100), button_height);
 			m_btn_delete.set_text(localized_string_id::RSX_OVERLAYS_OSK_DIALOG_BACKSPACE);
-			m_btn_delete.set_text_vertical_adjust(5);
+			m_btn_delete.set_text_vertical_adjust(get_scaled(5));
 
-			m_btn_shift.set_pos(frame_x + 320, frame_y + frame_h + button_margin);
-			m_btn_shift.set_size(80, button_height);
+			m_btn_shift.set_pos(frame_x + get_scaled(320), frame_y + frame_h + button_margin);
+			m_btn_shift.set_size(get_scaled(80), button_height);
 			m_btn_shift.set_text(localized_string_id::RSX_OVERLAYS_OSK_DIALOG_SHIFT);
-			m_btn_shift.set_text_vertical_adjust(5);
+			m_btn_shift.set_text_vertical_adjust(get_scaled(5));
 
-			m_btn_accept.set_pos(frame_x + 400, frame_y + frame_h + button_margin);
-			m_btn_accept.set_size(100, button_height);
+			m_btn_accept.set_pos(frame_x + get_scaled(400), frame_y + frame_h + button_margin);
+			m_btn_accept.set_size(get_scaled(100), button_height);
 			m_btn_accept.set_text(localized_string_id::RSX_OVERLAYS_OSK_DIALOG_ACCEPT);
-			m_btn_accept.set_text_vertical_adjust(5);
+			m_btn_accept.set_text_vertical_adjust(get_scaled(5));
 
 			m_update = true;
 		}
 
 		void osk_dialog::initialize_layout(const std::u32string& title, const std::u32string& initial_text)
 		{
+			const auto scale_font = [this](overlay_element& elem)
+			{
+				if (const font* fnt = elem.get_font())
+				{
+					elem.set_font(fnt->get_name().data(), get_scaled(fnt->get_size_pt()));
+				}
+			};
+
 			m_background.set_size(virtual_width, virtual_height);
 
 			m_title.set_unicode_text(title);
 			m_title.back_color.a = 0.7f; // Uses the dimmed color of the frame background
+			scale_font(m_title);
 
 			m_preview.password_mode = m_password_mode;
 			m_preview.set_placeholder(get_placeholder());
 			m_preview.set_unicode_text(initial_text);
+			scale_font(m_preview);
 
 			if (m_preview.value.empty())
 			{
@@ -314,6 +325,18 @@ namespace rsx
 				m_preview.caret_position = m_preview.value.length();
 				m_preview.fore_color.a = 1.f;
 			}
+
+			scale_font(m_btn_shift);
+			scale_font(m_btn_accept);
+			scale_font(m_btn_space);
+			scale_font(m_btn_delete);
+			scale_font(m_btn_cancel);
+
+			m_btn_shift.text_horizontal_offset = get_scaled(m_btn_shift.text_horizontal_offset);
+			m_btn_accept.text_horizontal_offset = get_scaled(m_btn_accept.text_horizontal_offset);
+			m_btn_space.text_horizontal_offset = get_scaled(m_btn_space.text_horizontal_offset);
+			m_btn_delete.text_horizontal_offset = get_scaled(m_btn_delete.text_horizontal_offset);
+			m_btn_cancel.text_horizontal_offset = get_scaled(m_btn_cancel.text_horizontal_offset);
 
 			m_btn_shift.set_image_resource(resource_config::standard_image_resource::select);
 			m_btn_accept.set_image_resource(resource_config::standard_image_resource::start);
@@ -364,11 +387,11 @@ namespace rsx
 
 		std::pair<u32, u32> osk_dialog::get_cell_geometry(u32 index)
 		{
-			const auto index_limit = (num_columns * num_rows) - 1;
+			const u32 grid_size = num_columns * num_rows;
 			u32 start_index = index;
 			u32 count = 0;
 
-			while (start_index > index_limit && start_index >= num_columns)
+			while (start_index >= grid_size && start_index >= num_columns)
 			{
 				// Try one row above
 				start_index -= num_columns;
@@ -383,8 +406,8 @@ namespace rsx
 			// Find last cell
 			while (true)
 			{
-				const auto current_index = (start_index + count);
-				ensure(current_index <= index_limit);
+				const u32 current_index = (start_index + count);
+				ensure(current_index < grid_size);
 				++count;
 
 				if (m_grid[current_index].flags & border_flags::right)
@@ -424,7 +447,7 @@ namespace rsx
 			if (!pad_input_enabled || ignore_input_events)
 				return;
 
-			const auto index_limit = (num_columns * num_rows) - 1;
+			const u32 grid_size = num_columns * num_rows;
 
 			const auto on_accept = [this]()
 			{
@@ -479,7 +502,7 @@ namespace rsx
 					const auto current = get_cell_geometry(current_index);
 					current_index = current.first + current.second;
 
-					if (current_index > index_limit)
+					if (current_index >= grid_size)
 					{
 						break;
 					}
@@ -525,7 +548,7 @@ namespace rsx
 				while (true)
 				{
 					current_index += num_columns;
-					if (current_index > index_limit)
+					if (current_index >= grid_size)
 					{
 						break;
 					}
@@ -885,7 +908,16 @@ namespace rsx
 
 				label label;
 				label.back_color = { 0.f, 0.f, 0.f, 0.f };
-				label.set_padding(0, 0, 10, 0);
+				label.set_padding(0, 0, get_scaled(10), 0);
+
+				const auto scale_font = [this](overlay_element& elem)
+				{
+					if (const font* fnt = elem.get_font())
+					{
+						elem.set_font(fnt->get_name().data(), get_scaled(fnt->get_size_pt()));
+					}
+				};
+				scale_font(label);
 
 				if (m_reset_pulse)
 				{
@@ -983,6 +1015,7 @@ namespace rsx
 			char_limit = params.charlimit;
 			m_x_align = params.x_align;
 			m_y_align = params.y_align;
+			m_scaling = params.initial_scale;
 			m_frame.back_color.r = params.base_color.r;
 			m_frame.back_color.g = params.base_color.g;
 			m_frame.back_color.b = params.base_color.b;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -223,41 +223,42 @@ namespace rsx
 			const u16 preview_height = get_scaled((flags & CELL_OSKDIALOG_NO_RETURN) ? 40 : 90);
 
 			// Place elements with absolute positioning
-			const u16 margin = get_scaled(100);
 			const u16 button_margin = get_scaled(30);
 			const u16 button_height = get_scaled(30);
 			const u16 frame_w = num_columns * cell_size_x;
 			const u16 frame_h = num_rows * cell_size_y + title_height + preview_height;
-			u16 frame_x = 0;
-			u16 frame_y = 0;
+			f32 origin_x = 0.0f;
+			f32 origin_y = 0.0f;
 
 			switch (m_x_align)
 			{
-			case CELL_OSKDIALOG_LAYOUTMODE_X_ALIGN_LEFT:
-				frame_x = margin;
-				break;
 			case CELL_OSKDIALOG_LAYOUTMODE_X_ALIGN_RIGHT:
-				frame_x = virtual_width - (frame_w + margin);
+				origin_x = virtual_width;
 				break;
 			case CELL_OSKDIALOG_LAYOUTMODE_X_ALIGN_CENTER:
+				origin_x = static_cast<f32>(virtual_width - frame_w) / 2.0f;
+				break;
+			case CELL_OSKDIALOG_LAYOUTMODE_X_ALIGN_LEFT:
 			default:
-				frame_x = (virtual_width - frame_w) / 2;
 				break;
 			}
 
 			switch (m_y_align)
 			{
-			case CELL_OSKDIALOG_LAYOUTMODE_Y_ALIGN_TOP:
-				frame_y = margin;
-				break;
 			case CELL_OSKDIALOG_LAYOUTMODE_Y_ALIGN_BOTTOM:
-				frame_y = virtual_height - (frame_h + button_height + button_margin + margin);
+				origin_y = virtual_height;
 				break;
 			case CELL_OSKDIALOG_LAYOUTMODE_Y_ALIGN_CENTER:
+				origin_y = static_cast<f32>(virtual_height - frame_h) / 2.0f;
+				break;
+			case CELL_OSKDIALOG_LAYOUTMODE_Y_ALIGN_TOP:
 			default:
-				frame_y = (virtual_height - (frame_h + button_height + button_margin)) / 2;
 				break;
 			}
+
+			constexpr f32 margin = 50.0f; // Let's add a minimal margin on all sides
+			const u16 frame_x = static_cast<u16>(std::clamp<f32>(origin_x + m_x_offset, margin, static_cast<f32>(virtual_width - frame_w) - margin));
+			const u16 frame_y = static_cast<u16>(std::clamp<f32>(origin_y + m_y_offset, margin, static_cast<f32>(virtual_height - (frame_h + button_height + button_margin)) - margin));
 
 			m_frame.set_pos(frame_x, frame_y);
 			m_frame.set_size(frame_w, frame_h);
@@ -1034,6 +1035,8 @@ namespace rsx
 			char_limit = params.charlimit;
 			m_x_align = params.x_align;
 			m_y_align = params.y_align;
+			m_x_offset = params.x_offset;
+			m_y_offset = params.y_offset;
 			m_scaling = params.initial_scale;
 			m_frame.back_color.r = params.base_color.r;
 			m_frame.back_color.g = params.base_color.g;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -2,6 +2,7 @@
 
 #include "overlays.h"
 #include "overlay_edit_text.hpp"
+#include "overlay_cursor.h"
 #include "overlay_osk_panel.h"
 #include "Emu/Cell/Modules/cellOskDialog.h"
 
@@ -50,6 +51,9 @@ namespace rsx
 			image_button m_btn_shift;
 			image_button m_btn_space;
 			image_button m_btn_delete;
+
+			// Pointer
+			cursor_item m_pointer{};
 
 			// Grid
 			u16 cell_size_x = 0;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -38,6 +38,8 @@ namespace rsx
 			};
 
 			// Base UI
+			u32 m_x_align = 0;
+			u32 m_y_align = 0;
 			overlay_element m_frame;
 			overlay_element m_background;
 			label m_title;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -40,6 +40,7 @@ namespace rsx
 			// Base UI
 			u32 m_x_align = 0;
 			u32 m_y_align = 0;
+			f32 m_scaling = 1.0f;
 			overlay_element m_frame;
 			overlay_element m_background;
 			label m_title;
@@ -51,10 +52,10 @@ namespace rsx
 			image_button m_btn_delete;
 
 			// Grid
-			u32 cell_size_x = 0;
-			u32 cell_size_y = 0;
-			u32 num_columns = 0;
-			u32 num_rows = 0;
+			u16 cell_size_x = 0;
+			u16 cell_size_y = 0;
+			u16 num_columns = 0;
+			u16 num_rows = 0;
 			std::vector<u32> num_shift_layers_by_charset;
 			u32 selected_x = 0;
 			u32 selected_y = 0;
@@ -113,6 +114,12 @@ namespace rsx
 			std::u32string get_placeholder() const;
 
 			std::pair<u32, u32> get_cell_geometry(u32 index);
+
+			template <typename T>
+			u16 get_scaled(T val)
+			{
+				return static_cast<u16>(static_cast<f32>(val) * m_scaling);
+			}
 
 			compiled_resource get_compiled() override;
 		};

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -41,6 +41,8 @@ namespace rsx
 			// Base UI
 			u32 m_x_align = 0;
 			u32 m_y_align = 0;
+			f32 m_x_offset = 0.0f;
+			f32 m_y_offset = 0.0f;
 			f32 m_scaling = 1.0f;
 			overlay_element m_frame;
 			overlay_element m_background;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -57,6 +57,10 @@ namespace rsx
 			// Pointer
 			cursor_item m_pointer{};
 
+			// Analog movement
+			u16 m_x_pos = 0;
+			u16 m_y_pos = 0;
+
 			// Grid
 			u16 cell_size_x = 0;
 			u16 cell_size_y = 0;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -82,7 +82,7 @@ namespace rsx
 			osk_dialog();
 			~osk_dialog() override = default;
 
-			void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled, bool intercept_input) override;
+			void Create(const osk_params& params) override;
 			void Close(s32 status) override;
 
 			void initialize_layout(const std::u32string& title, const std::u32string& initial_text);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk_panel.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk_panel.h
@@ -35,10 +35,10 @@ namespace rsx
 			const color4f special2_bg = { 0.83f, 0.81f, 0.57f, 1.f };
 
 			u32 osk_panel_mode = 0;
-			u32 num_rows = 0;
-			u32 num_columns = 0;
-			u32 cell_size_x = 0;
-			u32 cell_size_y = 0;
+			u16 num_rows = 0;
+			u16 num_columns = 0;
+			u16 cell_size_x = 0;
+			u16 cell_size_y = 0;
 
 			std::vector<grid_entry_ctor> layout;
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -49,11 +49,10 @@ namespace rsx
 		{
 			m_interactive = true;
 
-			const u64 ms_interval = 200;
 			std::array<steady_clock::time_point, CELL_PAD_MAX_PORT_NUM> timestamp;
 			timestamp.fill(steady_clock::now());
 
-			const u64 ms_threshold = 500;
+			constexpr u64 ms_threshold = 500;
 			std::array<steady_clock::time_point, CELL_PAD_MAX_PORT_NUM> initial_timestamp;
 			initial_timestamp.fill(steady_clock::now());
 
@@ -98,7 +97,7 @@ namespace rsx
 					{
 						if (last_auto_repeat_button[pad_index] == button_id
 						    && m_input_timer.GetMsSince(initial_timestamp[pad_index]) > ms_threshold
-						    && m_input_timer.GetMsSince(timestamp[pad_index]) > ms_interval)
+						    && m_input_timer.GetMsSince(timestamp[pad_index]) > m_auto_repeat_ms_interval)
 						{
 							// The auto-repeat button was pressed for at least the given threshold in ms and will trigger at an interval.
 							timestamp[pad_index] = steady_clock::now();

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -91,11 +91,17 @@ namespace rsx
 
 		protected:
 			Timer m_input_timer;
+			static constexpr u64 m_auto_repeat_ms_interval_default = 200;
+			u64 m_auto_repeat_ms_interval = m_auto_repeat_ms_interval_default;
 			std::set<u8> m_auto_repeat_buttons = {
 				pad_button::dpad_up,
 				pad_button::dpad_down,
 				pad_button::dpad_left,
 				pad_button::dpad_right,
+				pad_button::rs_up,
+				pad_button::rs_down,
+				pad_button::rs_left,
+				pad_button::rs_right,
 				pad_button::ls_up,
 				pad_button::ls_down,
 				pad_button::ls_left,

--- a/rpcs3/rpcs3qt/osk_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.cpp
@@ -22,7 +22,7 @@ osk_dialog_frame::~osk_dialog_frame()
 	}
 }
 
-void osk_dialog_frame::Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 /*first_view_panel*/, color /*base_color*/, bool /*dimmer_enabled*/, bool /*intercept_input*/)
+void osk_dialog_frame::Create(const osk_params& params)
 {
 	state = OskDialogState::Open;
 
@@ -38,14 +38,14 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 	m_dialog->setModal(true);
 
 	// Title
-	m_dialog->setWindowTitle(qstr(title));
+	m_dialog->setWindowTitle(qstr(params.title));
 
 	// Message
-	QLabel* message_label = new QLabel(QString::fromStdU16String(message));
+	QLabel* message_label = new QLabel(QString::fromStdU16String(params.message));
 
 	// Text Input Counter
-	const QString input_text = QString::fromStdU16String(std::u16string(init_text));
-	QLabel* input_count_label = new QLabel(QString("%1/%2").arg(input_text.length()).arg(charlimit));
+	const QString input_text = QString::fromStdU16String(std::u16string(params.init_text));
+	QLabel* input_count_label = new QLabel(QString("%1/%2").arg(input_text.length()).arg(params.charlimit));
 
 	// Button Layout
 	QDialogButtonBox* button_box = new QDialogButtonBox(QDialogButtonBox::Ok);
@@ -55,25 +55,25 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 	inputLayout->setAlignment(Qt::AlignHCenter);
 
 	// Text Input
-	if (prohibit_flags & CELL_OSKDIALOG_NO_RETURN)
+	if (params.prohibit_flags & CELL_OSKDIALOG_NO_RETURN)
 	{
 		QLineEdit* input = new QLineEdit(m_dialog);
 		input->setFixedWidth(lineEditWidth());
-		input->setMaxLength(charlimit);
+		input->setMaxLength(params.charlimit);
 		input->setText(input_text);
 		input->setFocus();
 
-		if (panel_flag & CELL_OSKDIALOG_PANELMODE_PASSWORD)
+		if (params.panel_flag & CELL_OSKDIALOG_PANELMODE_PASSWORD)
 		{
 			input->setEchoMode(QLineEdit::Password); // Let's assume that games only use the password mode with single-line edit fields
 		}
 
-		if (prohibit_flags & CELL_OSKDIALOG_NO_SPACE)
+		if (params.prohibit_flags & CELL_OSKDIALOG_NO_SPACE)
 		{
 			input->setValidator(new QRegularExpressionValidator(QRegularExpression("^\\S*$"), this));
 		}
 
-		connect(input, &QLineEdit::textChanged, input_count_label, [input_count_label, charlimit, this](const QString& text)
+		connect(input, &QLineEdit::textChanged, input_count_label, [input_count_label, charlimit = params.charlimit, this](const QString& text)
 		{
 			input_count_label->setText(QString("%1/%2").arg(text.length()).arg(charlimit));
 			SetOskText(text);
@@ -106,7 +106,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 			const int cursor_pos_old = cursor_pos_new + m_text_old.length() - text.length();
 
 			// Reset to old state if character limit was reached
-			if (m_text_old.length() >= static_cast<int>(charlimit) && text.length() > static_cast<int>(charlimit))
+			if (m_text_old.length() >= static_cast<int>(params.charlimit) && text.length() > static_cast<int>(params.charlimit))
 			{
 				input->blockSignals(true);
 				input->setPlainText(m_text_old);
@@ -119,7 +119,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 			int cursor_pos = cursor.position();
 
 			// Clear text of spaces if necessary
-			if (prohibit_flags & CELL_OSKDIALOG_NO_SPACE)
+			if (params.prohibit_flags & CELL_OSKDIALOG_NO_SPACE)
 			{
 				int trim_len = text.length();
 				text.remove(QRegularExpression("\\s+"));
@@ -128,7 +128,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 			}
 
 			// Crop if more than one character was pasted and the character limit was exceeded
-			text.chop(text.length() - charlimit);
+			text.chop(text.length() - params.charlimit);
 
 			// Set new text and block signals to prevent infinite loop
 			input->blockSignals(true);
@@ -139,7 +139,7 @@ void osk_dialog_frame::Create(const std::string& title, const std::u16string& me
 
 			m_text_old = text;
 
-			input_count_label->setText(QString("%1/%2").arg(text.length()).arg(charlimit));
+			input_count_label->setText(QString("%1/%2").arg(text.length()).arg(params.charlimit));
 			SetOskText(text);
 			// if (on_osk_key_input_entered) on_osk_key_input_entered({}); // Not applicable
 		});

--- a/rpcs3/rpcs3qt/osk_dialog_frame.h
+++ b/rpcs3/rpcs3qt/osk_dialog_frame.h
@@ -16,7 +16,7 @@ class osk_dialog_frame : public QObject, public OskDialogBase
 public:
 	osk_dialog_frame() = default;
 	~osk_dialog_frame();
-	void Create(const std::string& title, const std::u16string& message, char16_t* init_text, u32 charlimit, u32 prohibit_flags, u32 panel_flag, u32 first_view_panel, color base_color, bool dimmer_enabled, bool intercept_input) override;
+	void Create(const osk_params& params) override;
 	void Close(s32 status) override;
 
 private:


### PR DESCRIPTION
- Some languages/panels in the osk need to be activated by the developer. They are not available otherwise.
So let's check if they were pre-configured and only add the panels if they are supported.
- Improve the error checks and logic of the initial key layout. Layouts are only supported if they were allowed as kay layout option first.
- Try to position and scale the osk based on the game's parameters
- Add a rudimentary osk pointer/mousecursor based on cell parameters. The game will toggle it and also set its position live.
- Parse paths in IME dictionary functions
- Improve cellOskDialogSetSeparateWindowOption. This will allow us to parametrize the "Separate Window" version of the OSK
- Add analog movement with right stick if CELL_OSKDIALOG_NO_INPUT_ANALOG is unset