### PR TITLE
Thread: silence -Wsign-compare on FreeBSD aarch64

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1802,7 +1802,7 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 	const bool is_executing = err & 0x10;
 	const bool is_writing = err & 0x2;
 #elif defined(ARCH_ARM64)
-	const bool is_executing = uptr(info->si_addr) == RIP(context);
+	const bool is_executing = uptr(info->si_addr) == uptr(RIP(context));
 	const u32 insn = is_executing ? 0 : *reinterpret_cast<u32*>(RIP(context));
 	const bool is_writing = (insn & 0xbfff0000) == 0x0c000000
 		|| (insn & 0xbfe00000) == 0x0c800000


### PR DESCRIPTION
Error since #7524 which predates  #11315 but around #11868 [built fine by accident](https://pkg-status.freebsd.org/ampere3/data/latest-per-pkg/rpcs3/0.0.23.14067/130arm64-default.log). From [error log](https://pkg-status.freebsd.org/ampere2/data/main-arm64-default/p65c6f35619ce_s4883f347f6/logs/rpcs3-0.0.26.14568_1.log):
```c++
Utilities/Thread.cpp:1799:48: error: comparison of integers of different signs: 'uptr' (aka 'unsigned long') and '__register_t' (aka 'long') [-Werror,-Wsign-compare]
        const bool is_executing = uptr(info->si_addr) == RIP(context);
                                  ~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~
```
```c++
rpcs3/util/types.hpp
131:using uptr = std::uintptr_t;

/usr/include/machine/_types.h
75:typedef __int64_t       __register_t;
82:typedef __uint64_t      __uintptr_t;

/usr/include/machine/ucontext.h
40:     __register_t    gp_elr;

/usr/include/sys/signal.h
242:    void    *si_addr;               /* faulting instruction */
```

Note, ignore [macOS CI](https://github.com/RPCS3/rpcs3/pull/13257/checks?check_run_id=10754564595):
> [Intel macOS instances are no longer supported!](https://cirrus-ci.org/blog/2022/11/08/sunsetting-intel-macos-instances/)

b0ee533b3216 [built fine on macOS](https://cirrus-ci.com/task/4590749614866432)