### PR TITLE
Deprecate HDD0/disc, make RPCS3/games movable

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -414,10 +414,12 @@ void Emulator::Init(bool add_only)
 		{
 			fs::write_file(games_common_dir + "/Disc Games Can Be Put Here For Automatic Detection.txt", fs::create + fs::excl + fs::write, ""s);
 
+#ifdef _WIN32
 			if (std::string rpcs3_shortcuts = games_common_dir + "/shortcuts"; make_path_verbose(rpcs3_shortcuts))
 			{
 				fs::write_file(rpcs3_shortcuts + "/Copyable Shortcuts For Installed Games Would Be Added Here.txt", fs::create + fs::excl + fs::write, ""s);
 			}
+#endif
 		}
 
 		make_path_verbose(dev_hdd0 + "savedata/");

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -413,6 +413,11 @@ void Emulator::Init(bool add_only)
 		if (make_path_verbose(games_common_dir))
 		{
 			fs::write_file(games_common_dir + "/Disc Games Can Be Put Here For Automatic Detection.txt", fs::create + fs::excl + fs::write, ""s);
+
+			if (std::string rpcs3_shortcuts = games_common_dir + "/shortcuts"; make_path_verbose(rpcs3_shortcuts))
+			{
+				fs::write_file(rpcs3_shortcuts + "/Copyable Shortcuts For Installed Games Would Be Added Here.txt", fs::create + fs::excl + fs::write, ""s);
+			}
 		}
 
 		make_path_verbose(dev_hdd0 + "savedata/");

--- a/rpcs3/Emu/vfs_config.h
+++ b/rpcs3/Emu/vfs_config.h
@@ -16,6 +16,7 @@ struct cfg_vfs : cfg::node
 	cfg::string dev_flash2{ this, "/dev_flash2/", "$(EmulatorDir)dev_flash2/" };
 	cfg::string dev_flash3{ this, "/dev_flash3/", "$(EmulatorDir)dev_flash3/" };
 	cfg::string dev_bdvd{ this, "/dev_bdvd/", "$(EmulatorDir)dev_bdvd/" }; // Only mounted in some special cases
+	cfg::string games_dir{ this, "/games/", "$(EmulatorDir)games/" }; // Not mounted
 	cfg::string app_home{ this, "/app_home/" }; // Not mounted
 
 	cfg::device_entry dev_usb{ this, "/dev_usb***/",

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -456,7 +456,7 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 
 		if (Emu.IsStopped())
 		{
-			Emu.AddGamesFromDir(fs::get_config_dir() + "/games");
+			Emu.AddGamesFromDir(g_cfg_vfs.get(g_cfg_vfs.games_dir, rpcs3::utils::get_emu_dir()));
 		}
 
 		const std::string _hdd =  rpcs3::utils::get_hdd0_dir();
@@ -514,7 +514,7 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 		};
 
 		add_dir(_hdd + "game/", false);
-		add_dir(_hdd + "disc/", true);
+		add_dir(_hdd + "disc/", true); // Deprecated
 
 		auto get_games = []() -> YAML::Node
 		{
@@ -564,6 +564,12 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 						if (frag.find_first_of('/') + 1 == 0)
 						{
 							game_list_log.trace("Removed duplicate for %s: %s", pair.first.Scalar(), pair.second.Scalar());
+
+							if (static std::unordered_set<std::string> warn_once_list; warn_once_list.emplace(game_dir).second)
+							{
+								game_list_log.todo("Game at '%s' is using deprecated directory '/dev_hdd0/disc/'.\nConsider moving into '%s'.", game_dir, g_cfg_vfs.get(g_cfg_vfs.games_dir, rpcs3::utils::get_emu_dir()));
+							}
+
 							continue;
 						}
 					}

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -190,6 +190,7 @@ namespace gui
 	const gui_save fs_dev_flash2_list   = gui_save(fs, "dev_flash2_list",   QStringList());
 	const gui_save fs_dev_flash3_list   = gui_save(fs, "dev_flash3_list",   QStringList());
 	const gui_save fs_dev_bdvd_list     = gui_save(fs, "dev_bdvd_list",     QStringList());
+	const gui_save fs_games_list        = gui_save(fs, "games_list",        QStringList());
 	const gui_save fs_dev_usb_list      = gui_save(fs, "dev_usb00X_list",   QStringList()); // Used as a template for all usb paths
 
 	const gui_save l_tty       = gui_save(logger, "TTY",       true);

--- a/rpcs3/rpcs3qt/shortcut_utils.cpp
+++ b/rpcs3/rpcs3qt/shortcut_utils.cpp
@@ -95,7 +95,7 @@ namespace gui::utils
 #ifdef _WIN32
 		else if (location == shortcut_location::rpcs3_shortcuts)
 		{
-			link_path = fs::get_config_dir() + "/games/shortcuts/";
+			link_path = g_cfg_vfs.get(g_cfg_vfs.games_dir, rpcs3::utils::get_emu_dir()) + "/shortcuts/";
 			fs::create_dir(link_path);
 		}
 #endif

--- a/rpcs3/rpcs3qt/shortcut_utils.cpp
+++ b/rpcs3/rpcs3qt/shortcut_utils.cpp
@@ -3,6 +3,7 @@
 #include "qt_utils.h"
 #include "Emu/system_utils.hpp"
 #include "Emu/VFS.h"
+#include "Emu/vfs_config.h"
 #include "Utilities/StrUtil.h"
 
 #ifdef _WIN32

--- a/rpcs3/rpcs3qt/vfs_dialog.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog.cpp
@@ -34,6 +34,7 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> _gui_settings, QWidget* par
 	vfs_dialog_tab* dev_flash3_tab = new vfs_dialog_tab("dev_flash3", gui::fs_dev_flash3_list, &g_cfg_vfs.dev_flash3, m_gui_settings, this);
 	vfs_dialog_tab* dev_bdvd_tab = new vfs_dialog_tab("dev_bdvd", gui::fs_dev_bdvd_list, &g_cfg_vfs.dev_bdvd, m_gui_settings, this);
 	vfs_dialog_usb_tab* dev_usb_tab = new vfs_dialog_usb_tab(&g_cfg_vfs.dev_usb, m_gui_settings, this);
+	vfs_dialog_tab* games_tab = new vfs_dialog_tab("games", gui::fs_games_list, &g_cfg_vfs.games_dir, m_gui_settings, this);
 
 	tabs->addTab(emulator_tab, "$(EmulatorDir)");
 	tabs->addTab(dev_hdd0_tab, "dev_hdd0");
@@ -43,6 +44,7 @@ vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> _gui_settings, QWidget* par
 	tabs->addTab(dev_flash3_tab, "dev_flash3");
 	tabs->addTab(dev_bdvd_tab, "dev_bdvd");
 	tabs->addTab(dev_usb_tab, "dev_usb");
+	tabs->addTab(games_tab, "games");
 
 	// Create buttons
 	QDialogButtonBox* buttons = new QDialogButtonBox(QDialogButtonBox::Close | QDialogButtonBox::Save | QDialogButtonBox::RestoreDefaults);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18193363/213876750-f262b766-5a19-4d67-a61b-8a58e4689c68.png)
![image](https://user-images.githubusercontent.com/18193363/213876879-bfd5287c-6cc0-4952-ab52-5a061be7a537.png)

* Do not create /dev_hdd0/disc anymore, mounting /dev_bdvd inside /dev_hdd0 is wrong and creates a file reflection situation.
![315mXpN](https://user-images.githubusercontent.com/18193363/213877024-76ff303e-b1c0-408e-800c-80866c1be5ac.jpg)

