### PR TITLE
SPU LLVM: Minor SUMB AVX-512 path optimization

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -7709,7 +7709,7 @@ public:
 
 			const auto ax = vdbpsadbw(a, zeroes, 0);
 			const auto bx = vdbpsadbw(b, zeroes, 0);
-			set_vr(op.rt, shuffle2(ax, bx, 0, 8, 2, 10, 4, 12, 6, 14));
+			set_vr(op.rt, shuffle2(ax, bx, 0, 9, 2, 11, 4, 13, 6, 15));
 			return;
 		}
 


### PR DESCRIPTION
- Tweak shuffle to allow LLVM to emit a cheap blend instruction instead of the expensive VPERMI2W instruction
- Also avoids the need to load a constant from memory for the VPERMI2W indices 