### PR TITLE
sys_game: Implemented sys_game_get_rtc_status() & Updated sys_game_board_storage_read()

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3350,6 +3350,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only)
 			{ "sys_game_watchdog_clear", reinterpret_cast<u64>(ppu_execute_syscall) },
 			{ "sys_game_get_system_sw_version", reinterpret_cast<u64>(ppu_execute_syscall) },
 			{ "sys_game_board_storage_read", reinterpret_cast<u64>(ppu_execute_syscall) },
+			{ "sys_game_get_rtc_status", reinterpret_cast<u64>(ppu_execute_syscall) },
 			{ "__trap", reinterpret_cast<u64>(&ppu_trap) },
 			{ "__error", reinterpret_cast<u64>(&ppu_error) },
 			{ "__check", reinterpret_cast<u64>(&ppu_check) },

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -420,11 +420,11 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	BIND_SYSC(sys_uart_send),                               //369 (0x171)  ROOT
 	BIND_SYSC(sys_uart_get_params),                         //370 (0x172)  ROOT
 	uns_func,                                               //371 (0x173)  UNS
-	BIND_SYSC(_sys_game_watchdog_start),                     //372 (0x174)
-	BIND_SYSC(_sys_game_watchdog_stop),                      //373 (0x175)
-	BIND_SYSC(_sys_game_watchdog_clear),                     //374 (0x176)
+	BIND_SYSC(_sys_game_watchdog_start),                    //372 (0x174)
+	BIND_SYSC(_sys_game_watchdog_stop),                     //373 (0x175)
+	BIND_SYSC(_sys_game_watchdog_clear),                    //374 (0x176)
 	NULL_FUNC(sys_game_set_system_sw_version),              //375 (0x177)  ROOT
-	BIND_SYSC(_sys_game_get_system_sw_version),              //376 (0x178)  ROOT
+	BIND_SYSC(_sys_game_get_system_sw_version),             //376 (0x178)  ROOT
 	BIND_SYSC(sys_sm_set_shop_mode),                        //377 (0x179)  ROOT
 	BIND_SYSC(sys_sm_get_ext_event2),                       //378 (0x17A)  ROOT
 	BIND_SYSC(sys_sm_shutdown),                             //379 (0x17B)  ROOT
@@ -460,7 +460,7 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	NULL_FUNC(sys_sm_get_fan_policy),                       //409 (0x199)  PM
 	BIND_SYSC(_sys_game_board_storage_read),                //410 (0x19A)
 	NULL_FUNC(sys_game_board_storage_write),                //411 (0x19B)
-	NULL_FUNC(sys_game_get_rtc_status),                     //412 (0x19C)
+	BIND_SYSC(_sys_game_get_rtc_status),                    //412 (0x19C)
 	null_func,//BIND_SYSC(sys_...),                         //413 (0x19D)  ROOT
 	null_func,//BIND_SYSC(sys_...),                         //414 (0x19E)  ROOT
 	null_func,//BIND_SYSC(sys_...),                         //415 (0x19F)  ROOT

--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -3,7 +3,6 @@
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/System.h"
-#include "Emu/system_config.h"
 
 #include "Emu/IdManager.h"
 #include "Utilities/Thread.h"
@@ -163,26 +162,27 @@ error_code _sys_game_board_storage_read(vm::ptr<u8> buffer1, vm::ptr<u8> buffer2
 {
 	sys_game.trace("sys_game_board_storage_read(buffer1=*0x%x, buffer2=*0x%x)", buffer1, buffer2);
 
-	if (!buffer1)
+	if (!buffer1 || !buffer2)
 	{
 		return CELL_EFAULT;
 	}
 
-	be_t<u64> psid[2] = { +g_cfg.sys.console_psid_high, +g_cfg.sys.console_psid_low };
-	u8* psid_bytes = reinterpret_cast<u8*>(psid);
-	u8 response[16] = { 0x01, 0xFC, 0x43, 0x50, 0xA7, 0x9B, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-	for (int i = 0; i < 16; i++)
-	{
-		response[i] ^= psid_bytes[i];
-	}
-	memcpy(buffer1.get_ptr(), response, 16);
+	memset(buffer1.get_ptr(), 0, 16);
+	*buffer2 = 0;
 
-	if (!buffer2)
+	return CELL_OK;
+}
+
+error_code _sys_game_get_rtc_status(vm::ptr<s32> status)
+{
+	sys_game.trace("sys_game_get_rtc_status(status=*0x%x)", status);
+
+	if (!status)
 	{
 		return CELL_EFAULT;
 	}
 
-	*buffer2 = 0x00;
+	*status = 0;
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_game.h
+++ b/rpcs3/Emu/Cell/lv2/sys_game.h
@@ -7,3 +7,4 @@ error_code _sys_game_watchdog_stop();
 error_code _sys_game_watchdog_clear();
 u64 _sys_game_get_system_sw_version();
 error_code _sys_game_board_storage_read(vm::ptr<u8> buffer1, vm::ptr<u8> buffer2);
+error_code _sys_game_get_rtc_status(vm::ptr<s32> status);

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -367,7 +367,7 @@ usb_handler_thread::~usb_handler_thread()
 
 void usb_handler_thread::operator()()
 {
-	timeval lusb_tv{0, 200};
+	timeval lusb_tv{0, 0};
 
 	while (ctx && thread_ctrl::state() != thread_state::aborting)
 	{
@@ -405,7 +405,10 @@ void usb_handler_thread::operator()()
 		}
 
 		// If there is no handled devices usb thread is not actively needed
-		thread_ctrl::wait_for(handled_devices.empty() ? 500'000 : 200);
+		if (handled_devices.empty())
+			thread_ctrl::wait_for(500'000);
+		else
+			std::this_thread::yield();
 	}
 }
 

--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -384,7 +384,7 @@ void usb_device_usio::usio_read(u8 channel, u16 reg, u16 size)
 		case 0x7000:
 		{
 			// Card reader check - 2
-			response.resize(size);
+			// No data returned
 			break;
 		}
 		case 0x1080:
@@ -444,13 +444,12 @@ void usb_device_usio::usio_read(u8 channel, u16 reg, u16 size)
 			case 0x1000:
 			{
 				//ensure(size == 0x1000);
-				response.resize(size);
+				// No data returned
 				break;
 			}
 			default:
 			{
 				usio_log.error("Unhandled read of sram(chip: %d, addr: 0x%04X)", channel - 2, reg);
-				response.resize(size);
 				break;
 			}
 			}
@@ -459,7 +458,6 @@ void usb_device_usio::usio_read(u8 channel, u16 reg, u16 size)
 		default:
 		{
 			usio_log.error("Unhandled read of sram(chip: %d, addr: 0x%04X)", channel - 2, reg);
-			response.resize(size);
 			break;
 		}
 		}
@@ -470,6 +468,8 @@ void usb_device_usio::usio_read(u8 channel, u16 reg, u16 size)
 		// We are not using any firmware since this is emulation.
 		usio_log.warning("Unsupported read operation(channel: 0x%02X, addr: 0x%04X)", channel, reg);
 	}
+
+	response.resize(size); // Always resize the response vector to the given size
 }
 
 void usb_device_usio::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer)


### PR DESCRIPTION
After looking into a number of System 357 games' decompilation, I figured out that the buffer `status` is supposed be set to all 0 by `sys_game_get_rtc_status()` if the RTC is successfully checked (required by Dark Escape 4D).

Also, with more System 357 games being discovered, I figured out that sys_game_board_storage_read() should always give `buffer1` all 0, and players are responsible for setting a correct PSID in the emulator configuration on a game basis in order to play System 357 games.