### PR TITLE
ci: Build a universal2 build

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-brew install -f --overwrite llvm@14 nasm ninja git p7zip create-dmg ccache llvm@14 sdl2 glew cmake
+brew install -f --overwrite llvm@14 nasm ninja git p7zip create-dmg ccache llvm@14 sdl2 glew cmake qt@5 
 #/usr/sbin/softwareupdate --install-rosetta --agree-to-license
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 arch -x86_64 /usr/local/homebrew/bin/brew install -f --overwrite llvm@14 sdl2 glew cmake
@@ -66,6 +66,7 @@ mkdir build && cd build || exit 1
 "$BREW_PATH/bin/ninja"; build_status=$?;
 # time for arm64 build
 cd ..
+export Qt5_DIR="BREW_PATH/opt/qt@5/lib/cmake/Qt5"
 export SDL2_DIR="$BREW_PATH/opt/sdl2/lib/cmake/SDL2"
 
 export LDFLAGS="-L$BREW_PATH/lib -Wl,-rpath,$BREW_X64_PATH/lib"

--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-brew install -f --overwrite llvm@14 nasm ninja git p7zip create-dmg ccache llvm@14 sdl2 glew cmake qt@5 
+brew install -f --overwrite llvm@14 nasm ninja git p7zip create-dmg ccache sdl2 glew cmake qt@5 
 #/usr/sbin/softwareupdate --install-rosetta --agree-to-license
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 arch -x86_64 /usr/local/homebrew/bin/brew install -f --overwrite llvm@14 sdl2 glew cmake

--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -66,7 +66,7 @@ mkdir build && cd build || exit 1
 "$BREW_PATH/bin/ninja"; build_status=$?;
 # time for arm64 build
 cd ..
-export Qt5_DIR="BREW_PATH/opt/qt@5/lib/cmake/Qt5"
+export Qt5_DIR="$BREW_PATH/opt/qt@5/lib/cmake/Qt5"
 export SDL2_DIR="$BREW_PATH/opt/sdl2/lib/cmake/SDL2"
 
 export LDFLAGS="-L$BREW_PATH/lib -Wl,-rpath,$BREW_X64_PATH/lib"

--- a/.ci/deploy-mac.sh
+++ b/.ci/deploy-mac.sh
@@ -14,8 +14,8 @@ echo "AVVER=$AVVER" >> ../.ci/ci-vars.env
 
 cd bin
 mkdir "rpcs3.app/Contents/lib/"
-
-cp "/usr/local/Homebrew/opt/llvm@14/lib/c++/libc++abi.1.0.dylib" "rpcs3.app/Contents/lib/libc++abi.1.dylib"
+BREW_PATH="$(brew --prefix)"
+cp "$BREW_PATH/opt/llvm@14/lib/c++/libc++abi.1.0.dylib" "rpcs3.app/Contents/lib/libc++abi.1.dylib"
 
 rm -rf "rpcs3.app/Contents/Frameworks/QtPdf.framework" \
 "rpcs3.app/Contents/Frameworks/QtQml.framework" \


### PR DESCRIPTION
For macOS, this installs the needed libraries into the arm64 brew prefix This also combines the dependencies into universal2 ones This way it can properly build a universal2 build and distributes it 