### PR TITLE
sys_usbd: fix usb handler deinitialization

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -352,14 +352,14 @@ usb_handler_thread::~usb_handler_thread()
 	open_pipes.clear();
 	usb_devices.clear();
 
-	if (ctx)
-		libusb_exit(ctx);
-
 	for (u32 index = 0; index < MAX_SYS_USBD_TRANSFERS; index++)
 	{
 		if (transfers[index].transfer)
 			libusb_free_transfer(transfers[index].transfer);
 	}
+
+	if (ctx)
+		libusb_exit(ctx);
 }
 
 void usb_handler_thread::operator()()


### PR DESCRIPTION
Fixes exception on emulation stop when using usb passthrough.
libusb was deinitialized before usb device was unreferenced.

Fixes #12329