### PR TITLE
Update MoltenVK to 1.2.2 (VK 1.3.239)

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -42,6 +42,7 @@ export LD_LIBRARY_PATH="$BREW_X64_PATH/lib"
 git submodule update --init --recursive --depth 1
 
 # 3rdparty fixes
+ln -s "$VULKAN_SDK/lib/libMoltenVK.dylib" "$VULKAN_SDK/lib/libvulkan.dylib"
 sed -i '' "s/extern const double NSAppKitVersionNumber;/const double NSAppKitVersionNumber = 1343;/g" 3rdparty/hidapi/hidapi/mac/hid.c
 
 mkdir build && cd build || exit 1

--- a/3rdparty/MoltenVK/CMakeLists.txt
+++ b/3rdparty/MoltenVK/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(moltenvk
 	GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-	GIT_TAG a307b24
+	GIT_TAG fb581e4
 	BUILD_IN_SOURCE 1
 	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK
 	CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK/fetchDependencies" --macos


### PR DESCRIPTION
New release for MoltenVK with the following changelog: 

```Fix Metal validation error caused by CAMetalDrawable released before  MTLCommandBuffer is finished using it.
Fix memory leak of MVKFences and MVKSemaphores when a swapchain image is acquired more than it is presented.
Fix issue where fragment shader was not run when no render attachment is available.
Ensure Vulkan public symbols are not stripped from the library when statically linked to an app that calls all Vulkan functions dynamically.
Per Vulkan 1.2 spec, support calling vkGetInstanceProcAddr() with a null instance, when vkGetInstanceProcAddr itself is the function name.
Update VkPhysicalDeviceLimits members maxClipDistances and maxCombinedClipAndCullDistances to more accurate values.
Update VkPhysicalDeviceLimits::maxDrawIndexedIndexValue to acknowledge automatic primitive restart.
Update copyright notices to year 2023.
Update to latest SPIRV-Cross:
MSL: Add support for writable images in iOS Tier2 argument buffers.
MSL: Fix potentially uninitialized warnings.```
