### PR TITLE
Fix test binary install location on Linux

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -218,5 +218,5 @@ if(UNIX AND NOT APPLE)
     install(DIRECTORY ../bin/git
         DESTINATION ${CMAKE_INSTALL_DATADIR}/rpcs3)
     install(DIRECTORY ../bin/test
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/rpcs3)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/rpcs3)
 endif()


### PR DESCRIPTION
These test binary files are architecture dependent. And it should be installed in /usr/lib or /usr/lib64, not /usr/share.