### PR TITLE
perfoverlay: fix minimal graph min/max calculation

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -746,52 +746,47 @@ namespace rsx
 				return;
 			}
 
+			m_min = max_v<f32>;
 			m_max = 0.0f;
 			m_avg = 0.0f;
 			m_1p = 0.0f;
 
-			if (m_show_min_max || m_show_1p_avg)
+			std::vector<f32> valid_datapoints;
+
+			// Make sure min/max reflects the data being displayed, not the entire datapoints vector
+			for (usz i = m_datapoints.size() - m_datapoint_count; i < m_datapoints.size(); i++)
 			{
-				m_min = max_v<f32>;
+				const f32& dp = m_datapoints[i];
 
-				std::vector<f32> valid_datapoints;
+				if (dp < 0) continue; // Skip initial negative values. They don't count.
 
-				// Make sure min/max reflects the data being displayed, not the entire datapoints vector
-				for (usz i = m_datapoints.size() - m_datapoint_count; i < m_datapoints.size(); i++)
+				m_min = std::min(m_min, dp);
+				m_max = std::max(m_max, dp);
+				m_avg += dp;
+
+				if (m_show_1p_avg)
 				{
-					const f32& dp = m_datapoints[i];
-
-					if (dp < 0) continue; // Skip initial negative values. They don't count.
-
-					m_min = std::min(m_min, dp);
-					m_max = std::max(m_max, dp);
-					m_avg += dp;
-
 					valid_datapoints.push_back(dp);
 				}
-
-				// Sanitize min value
-				m_min = std::min(m_min, m_max);
-
-				if (m_show_1p_avg && !valid_datapoints.empty())
-				{
-					// Sort datapoints (we are only interested in the lowest/highest 1%)
-					const usz i_1p = valid_datapoints.size() / 100;
-					const usz n_1p = i_1p + 1;
-
-					if (m_1p_sort_high)
-						std::nth_element(valid_datapoints.begin(), valid_datapoints.begin() + i_1p, valid_datapoints.end(), std::greater<f32>());
-					else
-						std::nth_element(valid_datapoints.begin(), valid_datapoints.begin() + i_1p, valid_datapoints.end());
-
-					// Calculate statistics
-					m_avg /= valid_datapoints.size();
-					m_1p = std::accumulate(valid_datapoints.begin(), valid_datapoints.begin() + n_1p, 0.0f) / static_cast<float>(n_1p);
-				}
 			}
-			else
+
+			// Sanitize min value
+			m_min = std::min(m_min, m_max);
+
+			if (m_show_1p_avg && !valid_datapoints.empty())
 			{
-				m_min = 0.0f;
+				// Sort datapoints (we are only interested in the lowest/highest 1%)
+				const usz i_1p = valid_datapoints.size() / 100;
+				const usz n_1p = i_1p + 1;
+
+				if (m_1p_sort_high)
+					std::nth_element(valid_datapoints.begin(), valid_datapoints.begin() + i_1p, valid_datapoints.end(), std::greater<f32>());
+				else
+					std::nth_element(valid_datapoints.begin(), valid_datapoints.begin() + i_1p, valid_datapoints.end());
+
+				// Calculate statistics
+				m_avg /= valid_datapoints.size();
+				m_1p = std::accumulate(valid_datapoints.begin(), valid_datapoints.begin() + n_1p, 0.0f) / static_cast<float>(n_1p);
 			}
 		}
 

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -325,7 +325,8 @@ void pad_thread::operator()()
 
 		// Update variables
 		const bool needs_reset = pad::g_reset && pad::g_reset.exchange(false);
-		mode_changed |= pad_mode != pad_mode.exchange(g_cfg.io.pad_mode.get());
+		const pad_handler_mode new_pad_mode = g_cfg.io.pad_mode.get();
+		mode_changed |= new_pad_mode != pad_mode.exchange(new_pad_mode);
 
 		// Reset pad handlers if necessary
 		if (needs_reset || mode_changed)


### PR DESCRIPTION
- Fix dynamic pad handler mode reset
- Fix minimal graph detail level in performance graphs. Min and max graph values were never calculated.
This led to the following bug:

![image](https://user-images.githubusercontent.com/23019877/214957727-93dbb70e-745f-4483-9824-08a41169db7b.png)
