### PR TITLE
Unbreak build with Vulkan-Headers >= 1.3.240

### DIFF
--- a/rpcs3/Emu/RSX/VK/VulkanAPI.h
+++ b/rpcs3/Emu/RSX/VK/VulkanAPI.h
@@ -14,7 +14,6 @@
 #endif
 
 #include <vulkan/vulkan.h>
-#include <vulkan/vk_sdk_platform.h>
 
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
Regressed by https://github.com/KhronosGroup/Vulkan-Headers/commit/6f62a95edbfe. From [error log](https://github.com/RPCS3/rpcs3/files/10523789/rpcs3-0.0.26.14614.log)

```c++
In file included from rpcs3/Emu/System.cpp:55:
rpcs3/Emu/RSX/VK/VulkanAPI.h:17:10: fatal error: 'vulkan/vk_sdk_platform.h' file not found
#include <vulkan/vk_sdk_platform.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
```
