### PR TITLE
evdev_gun: enable libudev on FreeBSD

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -142,7 +142,7 @@ add_subdirectory(SoundTouch EXCLUDE_FROM_ALL)
 # libevdev
 set(LIBEVDEV_TARGET 3rdparty_dummy_lib)
 if(USE_LIBEVDEV)
-	pkg_check_modules(LIBEVDEV libevdev)
+	pkg_check_modules(LIBEVDEV libevdev libudev)
 	if(LIBEVDEV_FOUND)
 		add_library(3rdparty_libevdev INTERFACE)
 		target_compile_definitions(3rdparty_libevdev INTERFACE -DHAVE_LIBEVDEV)

--- a/rpcs3/Input/evdev_gun_handler.cpp
+++ b/rpcs3/Input/evdev_gun_handler.cpp
@@ -7,9 +7,7 @@
 #include "evdev_gun_handler.h"
 #include "util/logs.hpp"
 
-#ifdef __linux__ // Too lazy to make this work for BSD
 #include <libudev.h>
-#endif
 
 #include <libevdev/libevdev.h>
 #include <fcntl.h>
@@ -95,11 +93,9 @@ evdev_gun_handler::~evdev_gun_handler()
 			close(fd);
 		}
 	}
-#ifdef __linux__
 	if (m_udev != nullptr)
 		udev_unref(m_udev);
 	evdev_log.notice("Lightgun: Shutdown udev initialization");
-#endif
 }
 
 int evdev_gun_handler::get_button(u32 gunno, gun_button button) const
@@ -204,7 +200,6 @@ bool evdev_gun_handler::init()
 
 	m_devices.clear();
 
-#ifdef __linux__
 	evdev_log.notice("Lightgun: Begin udev initialization");
 
 	m_udev = udev_new();
@@ -317,7 +312,6 @@ bool evdev_gun_handler::init()
 	{
 		evdev_log.error("Lightgun: Failed udev enumeration");
 	}
-#endif
 
 	m_is_init = true;
 	return true;


### PR DESCRIPTION
On Linux `-ludev` is added implicitly via bundled hidapi but on FreeBSD it needs to be explicit.
https://github.com/RPCS3/rpcs3/blob/3196ada48151e25dc38ab07d9cbd64e08f4f78e8/3rdparty/hidapi/CMakeLists.txt#L15

Note, FreeBSD >= 13 supports [hidraw(4)](https://man.freebsd.org/hidraw/4) but it's not used by hidapi yet.
