### PR TITLE
overlays/osk: fix y offset direction

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -379,7 +379,7 @@ namespace rsx
 				const auto get_y = [](const osk_window_layout& layout, const u16& height) -> f32
 				{
 					constexpr f32 origin_y = virtual_height / 2.0f;
-					const f32 y = origin_y + layout.y_offset;
+					const f32 y = origin_y - layout.y_offset; // Negative because we increase y towards the bottom and cellOsk increases y towards the top.
 
 					switch (layout.y_align)
 					{

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -30,8 +30,8 @@ namespace rsx
 			u32 uid = umax;
 			u32 type_index = umax;
 
-			static const u16 virtual_width = 1280;
-			static const u16 virtual_height = 720;
+			static constexpr u16 virtual_width = 1280;
+			static constexpr u16 virtual_height = 720;
 
 			u32 min_refresh_duration_us = 16600;
 			atomic_t<bool> visible = false;


### PR DESCRIPTION
cellOskDialog does increase y to the top of the screen.
Our overlays increase it to the bottom.
I forgot to fix the offset addition 🤦