### PR TITLE
Game list: Use the latest game icon instead of 1.00's

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -657,6 +657,15 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 				game.bootable     = psf::get_integer(psf, "BOOTABLE", 0);
 				game.attr         = psf::get_integer(psf, "ATTRIBUTE", 0);
 				game.icon_path    = sfo_dir + "/ICON0.PNG";
+
+				if (game.category == "DG")
+				{
+					const std::string latest_icon = rpcs3::utils::get_hdd0_dir() + "/game/" + game.serial + "/ICON0.PNG";
+					if (fs::is_file(latest_icon))
+					{
+						game.icon_path = latest_icon;
+					}
+				}
 			}
 
 			if (m_show_custom_icons)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -660,10 +660,10 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 
 				if (game.category == "DG")
 				{
-					const std::string latest_icon = rpcs3::utils::get_hdd0_dir() + "/game/" + game.serial + "/ICON0.PNG";
+					std::string latest_icon = rpcs3::utils::get_hdd0_dir() + "game/" + game.serial + "/ICON0.PNG";
 					if (fs::is_file(latest_icon))
 					{
-						game.icon_path = latest_icon;
+						game.icon_path = std::move(latest_icon);
 					}
 				}
 			}


### PR DESCRIPTION
Applies to disc games.

Before (using 1.00 icon from /dev_bdvd):
![image](https://user-images.githubusercontent.com/18193363/216698964-9e44629e-b2c0-4685-912d-a2aa41bb7e3d.png)

After (using 1.11 icon from /dev_hdd0):
![image](https://user-images.githubusercontent.com/18193363/216698221-d7f535b2-df3b-481e-b661-091edb914c70.png)
