### PR TITLE
Fix OpenGl overlay colors

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/OverlayRenderFS.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/OverlayRenderFS.glsl
@@ -138,7 +138,11 @@ void main()
 		ocol = texture(fs1, vec3(tc0.x, fract(tc0.y), trunc(tc0.y))).rrrr * diff_color;
 		break;
 	case SAMPLER_MODE_TEXTURE2D:
+#ifdef VULKAN
 		ocol = sample_image(fs0, tc0, blur_intensity).bgra * diff_color;
+#else
+		ocol = sample_image(fs0, tc0, blur_intensity).rgba * diff_color;
+#endif
 		break;
 	}
 }


### PR DESCRIPTION
I'm sure this is utterly wrong, but it fixes the OpenGl overlay colors:

![image](https://user-images.githubusercontent.com/23019877/217084402-81bd5df6-f74b-4314-b2e4-cfa3371b8660.png)

fixes #13365