### PR TITLE
CLI: Add fullscreen and pad profile options

### DIFF
--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -28,6 +28,7 @@ LOG_CHANNEL(input_log, "Input");
 LOG_CHANNEL(sys_log, "SYS");
 
 extern bool is_input_allowed();
+extern std::string g_pad_profile_override;
 
 namespace pad
 {
@@ -102,10 +103,16 @@ void pad_thread::Init()
 
 	g_cfg_profile.load();
 
-	std::string active_profile = g_cfg_profile.active_profiles.get_value(pad::g_title_id);
+	std::string active_profile = g_pad_profile_override;
+
 	if (active_profile.empty())
 	{
-		active_profile = g_cfg_profile.active_profiles.get_value(g_cfg_profile.global_key);
+		active_profile = g_cfg_profile.active_profiles.get_value(pad::g_title_id);
+
+		if (active_profile.empty())
+		{
+			active_profile = g_cfg_profile.active_profiles.get_value(g_cfg_profile.global_key);
+		}
 	}
 
 	input_log.notice("Using pad profile: '%s'", active_profile);

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -81,6 +81,8 @@ static atomic_t<bool> s_headless = false;
 static atomic_t<bool> s_no_gui = false;
 static atomic_t<char*> s_argv0;
 
+atomic_t<bool> g_start_games_fullscreen = false;
+
 extern thread_local std::string(*g_tls_log_prefix)();
 extern thread_local std::string_view g_tls_serialize_name;
 
@@ -274,6 +276,7 @@ constexpr auto arg_commit_db    = "get-commit-db";
 
 // Arguments that can be used with a gui application
 constexpr auto arg_no_gui       = "no-gui";
+constexpr auto arg_fullscreen   = "fullscreen"; // only useful with no-gui
 constexpr auto arg_high_dpi     = "hidpi";
 constexpr auto arg_rounding     = "dpi-rounding";
 constexpr auto arg_styles       = "styles";
@@ -624,6 +627,7 @@ int main(int argc, char** argv)
 	const QCommandLineOption version_option = parser.addVersionOption();
 	parser.addOption(QCommandLineOption(arg_headless, "Run RPCS3 in headless mode."));
 	parser.addOption(QCommandLineOption(arg_no_gui, "Run RPCS3 without its GUI."));
+	parser.addOption(QCommandLineOption(arg_fullscreen, "Run games in fullscreen mode. Only used when no-gui is set."));
 	parser.addOption(QCommandLineOption(arg_high_dpi, "Enables Qt High Dpi Scaling.", "enabled", "1"));
 	parser.addOption(QCommandLineOption(arg_rounding, "Sets the Qt::HighDpiScaleFactorRoundingPolicy for values like 150% zoom.", "rounding", "4"));
 	parser.addOption(QCommandLineOption(arg_styles, "Lists the available styles."));
@@ -927,6 +931,12 @@ int main(int argc, char** argv)
 	}
 
 	s_no_gui = parser.isSet(arg_no_gui);
+	g_start_games_fullscreen = parser.isSet(arg_fullscreen);
+
+	if (g_start_games_fullscreen && !s_no_gui)
+	{
+		report_fatal_error(fmt::format("The option '%s' can only be used in combination with '%s'.", arg_fullscreen, arg_no_gui));
+	}
 
 	if (auto gui_app = qobject_cast<gui_application*>(app.data()))
 	{

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -82,6 +82,7 @@ static atomic_t<bool> s_no_gui = false;
 static atomic_t<char*> s_argv0;
 
 atomic_t<bool> g_start_games_fullscreen = false;
+std::string g_pad_profile_override;
 
 extern thread_local std::string(*g_tls_log_prefix)();
 extern thread_local std::string_view g_tls_serialize_name;
@@ -283,6 +284,7 @@ constexpr auto arg_styles       = "styles";
 constexpr auto arg_style        = "style";
 constexpr auto arg_stylesheet   = "stylesheet";
 constexpr auto arg_config       = "config";
+constexpr auto arg_pad_profile  = "pad-profile"; // only useful with no-gui
 constexpr auto arg_q_debug      = "qDebug";
 constexpr auto arg_error        = "error";
 constexpr auto arg_updating     = "updating";
@@ -635,6 +637,8 @@ int main(int argc, char** argv)
 	parser.addOption(QCommandLineOption(arg_stylesheet, "Loads a custom stylesheet.", "path", ""));
 	const QCommandLineOption config_option(arg_config, "Forces the emulator to use this configuration file for CLI-booted game.", "path", "");
 	parser.addOption(config_option);
+	const QCommandLineOption pad_profile_option(arg_pad_profile, "Forces the emulator to use this pad profile file for CLI-booted game.", "name", "");
+	parser.addOption(pad_profile_option);
 	const QCommandLineOption installfw_option(arg_installfw, "Forces the emulator to install this firmware file.", "path", "");
 	parser.addOption(installfw_option);
 	const QCommandLineOption installpkg_option(arg_installpkg, "Forces the emulator to install this pkg file.", "path", "");
@@ -1208,6 +1212,21 @@ int main(int argc, char** argv)
 			if (!fs::is_file(config_path))
 			{
 				report_fatal_error(fmt::format("No config file found: %s", config_path));
+			}
+		}
+
+		if (parser.isSet(arg_pad_profile))
+		{
+			if (!s_no_gui)
+			{
+				report_fatal_error(fmt::format("The option '%s' can only be used in combination with '%s'.", arg_pad_profile, arg_no_gui));
+			}
+
+			g_pad_profile_override = parser.value(pad_profile_option).toStdString();
+
+			if (g_pad_profile_override.empty())
+			{
+				report_fatal_error(fmt::format("Pad profile name is empty"));
 			}
 		}
 

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -50,6 +50,7 @@ extern atomic_t<bool> g_user_asked_for_recording;
 extern atomic_t<bool> g_user_asked_for_screenshot;
 extern atomic_t<bool> g_user_asked_for_frame_capture;
 extern atomic_t<bool> g_disable_frame_limit;
+extern atomic_t<bool> g_start_games_fullscreen;
 extern atomic_t<recording_mode> g_recording_mode;
 
 atomic_t<bool> g_game_window_focused = false;
@@ -610,7 +611,7 @@ void gs_frame::show()
 	Emu.CallFromMainThread([this]()
 	{
 		QWindow::show();
-		if (g_cfg.misc.start_fullscreen)
+		if (g_cfg.misc.start_fullscreen || g_start_games_fullscreen)
 		{
 			setVisibility(FullScreen);
 		}


### PR DESCRIPTION
- Adds convenient "--fullscreen" option to allow to boot games in fullscreen in "--no-gui" mode
- Adds convenient "--pad-profile=<profile>" option to override the pad profile in "--no-gui" mode

 fixes #13276
 fixes #10332