### PR TITLE
evdev: fix sony guitar hero button assignment

### DIFF
--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -366,14 +366,17 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 		std::string name;
 	} pressed_button{};
 
+	const bool is_xbox_360_controller = padId.find("Xbox 360") != umax;
+	const bool is_sony_controller = !is_xbox_360_controller && padId.find("Sony") != umax;
+
 	for (const auto& [code, name] : button_list)
 	{
 		// Handle annoying useless buttons
 		if (code == NO_BUTTON)
 			continue;
-		if (padId.find("Xbox 360") != umax && code >= BTN_TRIGGER_HAPPY)
+		if (is_xbox_360_controller && code >= BTN_TRIGGER_HAPPY)
 			continue;
-		if (padId.find("Sony") != umax && (code == BTN_TL2 || code == BTN_TR2))
+		if (is_sony_controller && (code == BTN_TL2 || code == BTN_TR2))
 			continue;
 
 		if (!get_blacklist && std::find(m_blacklist.begin(), m_blacklist.end(), name) != m_blacklist.end())

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -368,6 +368,7 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 
 	const bool is_xbox_360_controller = padId.find("Xbox 360") != umax;
 	const bool is_sony_controller = !is_xbox_360_controller && padId.find("Sony") != umax;
+	const bool is_sony_guitar = is_sony_controller && padId.find("Guitar") != umax;
 
 	for (const auto& [code, name] : button_list)
 	{
@@ -376,7 +377,7 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 			continue;
 		if (is_xbox_360_controller && code >= BTN_TRIGGER_HAPPY)
 			continue;
-		if (is_sony_controller && (code == BTN_TL2 || code == BTN_TR2))
+		if (is_sony_controller && !is_sony_guitar && (code == BTN_TL2 || code == BTN_TR2))
 			continue;
 
 		if (!get_blacklist && std::find(m_blacklist.begin(), m_blacklist.end(), name) != m_blacklist.end())


### PR DESCRIPTION
This may fix the assignment of the TR1 and TR2 buttons in the pad settings dialog for Sony Guitars.