### PR TITLE
Fix C00 boot from external HG games

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -546,6 +546,12 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 				continue;
 			}
 
+			// Don't use the C00 subdirectory in our game list
+			if (game_dir.ends_with("/C00") || game_dir.ends_with("\\C00"))
+			{
+				game_dir = game_dir.substr(0, game_dir.size() - 4);
+			}
+
 			const bool has_sfo = fs::is_file(game_dir + "/PARAM.SFO");
 
 			if (!has_sfo && fs::is_file(game_dir + "/PS3_DISC.SFB"))


### PR DESCRIPTION
- Fixes mounting of game path and path in games.yml if m_sfo_dir ends with C00
- Fixes argv[0] if m_sfo_dir ends with C00 (USRDIR was cropped to DIR)
- Removes /USRDIR/../ from C00 sfo paths

fixes #13383