### PR TITLE
"Automatic" aspect ratio patching

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -59,6 +59,7 @@ void fmt_class_string<patch_type>::format(std::string& out, u64 arg)
 		case patch_type::lef32: return "lef32";
 		case patch_type::lef64: return "lef64";
 		case patch_type::utf8: return "utf8";
+		case patch_type::bef32_aspectratio: return "bef32_aspectratio";
 		}
 
 		return unknown;
@@ -485,6 +486,7 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 	{
 		break;
 	}
+	//case patch_type::bef32_aspectratio:
 	case patch_type::bef32:
 	case patch_type::lef32:
 	case patch_type::bef64:
@@ -938,6 +940,14 @@ static usz apply_modification(std::basic_string<u32>& applied, const patch_engin
 		case patch_type::utf8:
 		{
 			std::memcpy(ptr, p.original_value.data(), p.original_value.size());
+			break;
+		}
+		case patch_type::bef32_aspectratio:
+		{
+			w = m_gui_settings->GetValue(gui::gs_width).toInt();
+			h = m_gui_settings->GetValue(gui::gs_height).toInt();
+			be_t<f32> val = w / h
+			std::memcpy(ptr, &val, sizeof(val));
 			break;
 		}
 		}

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -22,6 +22,8 @@ namespace patch_key
 
 inline static const std::string patch_engine_version = "1.2";
 
+std::shared_ptr<gui_settings> m_gui_settings
+
 enum class patch_type
 {
 	invalid,
@@ -45,6 +47,7 @@ enum class patch_type
 	bef32,
 	bef64,
 	utf8, // Text of string (not null-terminated automatically)
+	bef32_aspectratio,
 };
 
 class patch_engine


### PR DESCRIPTION
Normally when making an aspect ratio patch, it's hardcoded to one aspect ratio, and must be edited if a different one is desired, which not everyone knows how to do;
  1. Divide width by height.
  2. Convert resulting float to hex.
  3. Change the values in the patch.

Even if there are multiple aspect ratio patches, it's not possible to account for every single one.

This PR tries to solve these problems by doing all of that for you. All you have to do is enter your resolution into the window size:
![](https://user-images.githubusercontent.com/3462541/218412910-a1dca68a-5628-461d-a35a-b35636ff3615.png)
and it will automatically calculate the aspect ratio.
Here's an example (1 is only there because I don't know what I'm doing):
```yml
- [ bef32_aspectratio, 0x00000000, 1.0 ]
```

# Problems/shortcomings
I know there's probably a better way to do this, but this is just a proof of concept.
Maybe have a reserved Anchor so you could do something like this:
```yml
- [ bef32, 0x00000000, *aspectratio_bef32 ]
```
* [ ] Doesn't account for window size changes.
  * ***Might* not be possible, even when using the interpreters to avoid recompilation nonsense.**
  * *Might be possible using [PINE](https://github.com/GovanifY/pine).*
* [ ] This won't work if a game uses anything other than a typical `1.777777...` 16:9 float.