### PR TITLE
CLI: add game-screen parameter, save last game window screen in no-gui mode

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -277,6 +277,7 @@ constexpr auto arg_commit_db    = "get-commit-db";
 // Arguments that can be used with a gui application
 constexpr auto arg_no_gui       = "no-gui";
 constexpr auto arg_fullscreen   = "fullscreen"; // only useful with no-gui
+constexpr auto arg_gs_screen    = "game-screen";
 constexpr auto arg_high_dpi     = "hidpi";
 constexpr auto arg_rounding     = "dpi-rounding";
 constexpr auto arg_styles       = "styles";
@@ -629,6 +630,8 @@ int main(int argc, char** argv)
 	parser.addOption(QCommandLineOption(arg_headless, "Run RPCS3 in headless mode."));
 	parser.addOption(QCommandLineOption(arg_no_gui, "Run RPCS3 without its GUI."));
 	parser.addOption(QCommandLineOption(arg_fullscreen, "Run games in fullscreen mode. Only used when no-gui is set."));
+	const QCommandLineOption screen_option(arg_gs_screen, "Forces the emulator to use the specified screen for the game window.", "index", "");
+	parser.addOption(screen_option);
 	parser.addOption(QCommandLineOption(arg_high_dpi, "Enables Qt High Dpi Scaling.", "enabled", "1"));
 	parser.addOption(QCommandLineOption(arg_rounding, "Sets the Qt::HighDpiScaleFactorRoundingPolicy for values like 150% zoom.", "rounding", "4"));
 	parser.addOption(QCommandLineOption(arg_styles, "Lists the available styles."));
@@ -954,6 +957,18 @@ int main(int argc, char** argv)
 			}
 
 			gui_app->SetStartGamesFullscreen(true);
+		}
+
+		if (parser.isSet(arg_gs_screen))
+		{
+			const int game_screen_index = parser.value(arg_gs_screen).toInt();
+
+			if (game_screen_index < 0)
+			{
+				report_fatal_error(fmt::format("The option '%s' can only be used with numbers >= 0 (you used %d)", arg_gs_screen, game_screen_index));
+			}
+
+			gui_app->SetGameScreenIndex(game_screen_index);
 		}
 
 		if (!gui_app->Init())

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -5,8 +5,8 @@
 #include <QOpenGLContext>
 #include <QOffscreenSurface>
 
-gl_gs_frame::gl_gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings)
-	: gs_frame(screen, geometry, appIcon, std::move(gui_settings))
+gl_gs_frame::gl_gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings, bool force_fullscreen)
+	: gs_frame(screen, geometry, appIcon, std::move(gui_settings), force_fullscreen)
 {
 	setSurfaceType(QSurface::OpenGLSurface);
 

--- a/rpcs3/rpcs3qt/gl_gs_frame.h
+++ b/rpcs3/rpcs3qt/gl_gs_frame.h
@@ -18,7 +18,7 @@ private:
 	GLContext *m_primary_context = nullptr;
 
 public:
-	explicit gl_gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings);
+	explicit gl_gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings, bool force_fullscreen);
 
 	draw_context_t make_context() override;
 	void set_current(draw_context_t ctx) override;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -50,7 +50,6 @@ extern atomic_t<bool> g_user_asked_for_recording;
 extern atomic_t<bool> g_user_asked_for_screenshot;
 extern atomic_t<bool> g_user_asked_for_frame_capture;
 extern atomic_t<bool> g_disable_frame_limit;
-extern atomic_t<bool> g_start_games_fullscreen;
 extern atomic_t<recording_mode> g_recording_mode;
 
 atomic_t<bool> g_game_window_focused = false;
@@ -62,10 +61,11 @@ bool is_input_allowed()
 
 constexpr auto qstr = QString::fromStdString;
 
-gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings)
+gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings, bool force_fullscreen)
 	: QWindow()
 	, m_initial_geometry(geometry)
 	, m_gui_settings(std::move(gui_settings))
+	, m_start_games_fullscreen(force_fullscreen)
 {
 	m_disable_mouse = m_gui_settings->GetValue(gui::gs_disableMouse).toBool();
 	m_disable_kb_hotkeys = m_gui_settings->GetValue(gui::gs_disableKbHotkeys).toBool();
@@ -611,7 +611,7 @@ void gs_frame::show()
 	Emu.CallFromMainThread([this]()
 	{
 		QWindow::show();
-		if (g_cfg.misc.start_fullscreen || g_start_games_fullscreen)
+		if (g_cfg.misc.start_fullscreen || m_start_games_fullscreen)
 		{
 			setVisibility(FullScreen);
 		}

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -146,6 +146,22 @@ gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon,
 gs_frame::~gs_frame()
 {
 	g_user_asked_for_screenshot = false;
+
+	// Save active screen to gui settings
+	const QScreen* current_screen = screen();
+	const QList<QScreen*> screens = QGuiApplication::screens();
+	int screen_index = 0;
+
+	for (int i = 0; i < screens.count(); i++)
+	{
+		if (current_screen == ::at32(screens, i))
+		{
+			screen_index = i;
+			break;
+		}
+	}
+
+	m_gui_settings->SetValue(gui::gs_screen, screen_index);
 }
 
 void gs_frame::paintEvent(QPaintEvent *event)

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -43,11 +43,12 @@ private:
 	bool m_hide_mouse_after_idletime = false;
 	u32 m_hide_mouse_idletime = 2000; // ms
 	bool m_flip_showed_frame = false;
+	bool m_start_games_fullscreen = false;
 
 	std::shared_ptr<utils::video_encoder> m_video_encoder{};
 
 public:
-	explicit gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings);
+	explicit gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon, std::shared_ptr<gui_settings> gui_settings, bool force_fullscreen);
 	~gs_frame();
 
 	draw_context_t make_context() override;

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -288,10 +288,37 @@ std::unique_ptr<gs_frame> gui_application::get_gs_frame()
 		}
 	}
 
-	const auto screen = m_main_window ? m_main_window->screen() : primaryScreen();
-	const auto base_geometry  = m_main_window ? m_main_window->frameGeometry() : primaryScreen()->geometry();
-	const auto frame_geometry = gui::utils::create_centered_window_geometry(screen, base_geometry, w, h);
-	const auto app_icon = m_main_window ? m_main_window->GetAppIcon() : gui::utils::get_app_icon_from_path(Emu.GetBoot(), Emu.GetTitleID());
+	QScreen* screen = nullptr;
+	QRect base_geometry{};
+
+	if (m_game_screen_index >= 0)
+	{
+		const QList<QScreen*> available_screens = screens();
+
+		if (m_game_screen_index < available_screens.count())
+		{
+			screen = ::at32(available_screens, m_game_screen_index);
+
+			if (screen)
+			{
+				base_geometry = screen->geometry();
+			}
+		}
+
+		if (!screen)
+		{
+			gui_log.error("The selected game screen with index %d is not available (available screens: %d)", m_game_screen_index, available_screens.count());
+		}
+	}
+
+	if (!screen)
+	{
+		screen = m_main_window ? m_main_window->screen() : primaryScreen();
+		base_geometry = m_main_window ? m_main_window->frameGeometry() : primaryScreen()->geometry();
+	}
+
+	const QRect frame_geometry = gui::utils::create_centered_window_geometry(screen, base_geometry, w, h);
+	const QIcon app_icon = m_main_window ? m_main_window->GetAppIcon() : gui::utils::get_app_icon_from_path(Emu.GetBoot(), Emu.GetTitleID());
 
 	gs_frame* frame = nullptr;
 

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -291,13 +291,23 @@ std::unique_ptr<gs_frame> gui_application::get_gs_frame()
 	QScreen* screen = nullptr;
 	QRect base_geometry{};
 
-	if (m_game_screen_index >= 0)
+	// Use screen index set by CLI argument
+	int screen_index = m_game_screen_index;
+
+	// In no-gui mode: use last used screen if no CLI index was set
+	if (screen_index < 0 && !m_main_window)
+	{
+		screen_index = m_gui_settings->GetValue(gui::gs_screen).toInt();
+	}
+
+	// Try to find the specified screen
+	if (screen_index >= 0)
 	{
 		const QList<QScreen*> available_screens = screens();
 
-		if (m_game_screen_index < available_screens.count())
+		if (screen_index < available_screens.count())
 		{
-			screen = ::at32(available_screens, m_game_screen_index);
+			screen = ::at32(available_screens, screen_index);
 
 			if (screen)
 			{
@@ -307,10 +317,11 @@ std::unique_ptr<gs_frame> gui_application::get_gs_frame()
 
 		if (!screen)
 		{
-			gui_log.error("The selected game screen with index %d is not available (available screens: %d)", m_game_screen_index, available_screens.count());
+			gui_log.error("The selected game screen with index %d is not available (available screens: %d)", screen_index, available_screens.count());
 		}
 	}
 
+	// Fallback to the screen of the main window. Use the primary screen as last resort.
 	if (!screen)
 	{
 		screen = m_main_window ? m_main_window->screen() : primaryScreen();

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -299,13 +299,13 @@ std::unique_ptr<gs_frame> gui_application::get_gs_frame()
 	{
 	case video_renderer::opengl:
 	{
-		frame = new gl_gs_frame(screen, frame_geometry, app_icon, m_gui_settings);
+		frame = new gl_gs_frame(screen, frame_geometry, app_icon, m_gui_settings, m_start_games_fullscreen);
 		break;
 	}
 	case video_renderer::null:
 	case video_renderer::vulkan:
 	{
-		frame = new gs_frame(screen, frame_geometry, app_icon, m_gui_settings);
+		frame = new gs_frame(screen, frame_geometry, app_icon, m_gui_settings, m_start_games_fullscreen);
 		break;
 	}
 	}

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -44,6 +44,11 @@ public:
 		m_with_cli_boot = with_cli_boot;
 	}
 
+	void SetStartGamesFullscreen(bool start_games_fullscreen = false)
+	{
+		m_start_games_fullscreen = start_games_fullscreen;
+	}
+
 	/** Call this method before calling app.exec */
 	bool Init() override;
 
@@ -82,6 +87,7 @@ private:
 	bool m_show_gui = true;
 	bool m_use_cli_style = false;
 	bool m_with_cli_boot = false;
+	bool m_start_games_fullscreen = false;
 
 private Q_SLOTS:
 	void OnChangeStyleSheetRequest();

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -49,6 +49,11 @@ public:
 		m_start_games_fullscreen = start_games_fullscreen;
 	}
 
+	void SetGameScreenIndex(int screen_index = -1)
+	{
+		m_game_screen_index = screen_index;
+	}
+
 	/** Call this method before calling app.exec */
 	bool Init() override;
 
@@ -88,6 +93,7 @@ private:
 	bool m_use_cli_style = false;
 	bool m_with_cli_boot = false;
 	bool m_start_games_fullscreen = false;
+	int m_game_screen_index = -1;
 
 private Q_SLOTS:
 	void OnChangeStyleSheetRequest();

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -221,6 +221,7 @@ namespace gui
 	const gui_save gs_lockMouseFs       = gui_save(gs_frame, "lockMouseInFullscreen", true);
 	const gui_save gs_resize            = gui_save(gs_frame, "resize",                false);
 	const gui_save gs_resize_manual     = gui_save(gs_frame, "resizeManual",          true);
+	const gui_save gs_screen            = gui_save(gs_frame, "screen",                0);
 	const gui_save gs_width             = gui_save(gs_frame, "width",                 1280);
 	const gui_save gs_height            = gui_save(gs_frame, "height",                720);
 	const gui_save gs_hideMouseIdle     = gui_save(gs_frame, "hideMouseOnIdle",       false);


### PR DESCRIPTION
- Adds the CLI argument "game-screen" which can be used to set a preferred screen for the game window. Use it for example like: `rpcs3.exe --no-gui --game-screen=1`
- Saves the last game window screen and re-uses it in the no-gui mode if no game-screen is set
- Moves the global parameter for the fullscreen mode to member variables of gui_application and gs_frame

fixes #12828