### PR TITLE
rsx/overlays: Unified overlay input

### DIFF
--- a/Utilities/lockless.h
+++ b/Utilities/lockless.h
@@ -359,6 +359,14 @@ public:
 		return result;
 	}
 
+	// Withdraw the list in reverse order (LIFO/FILO)
+	lf_queue_slice<T> pop_all_reversed()
+	{
+		lf_queue_slice<T> result;
+		result.m_head = m_head.exchange(nullptr);
+		return result;
+	}
+
 	// Apply func(data) to each element, return the total length
 	template <typename F>
 	usz apply(F func)

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -456,6 +456,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/Overlays/overlay_edit_text.cpp
     RSX/Overlays/overlay_fonts.cpp
     RSX/Overlays/overlay_list_view.cpp
+    RSX/Overlays/overlay_manager.cpp
     RSX/Overlays/overlay_media_list_dialog.cpp
     RSX/Overlays/overlay_message.cpp
     RSX/Overlays/overlay_message_dialog.cpp

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -5,6 +5,8 @@
 #include "Emu/Cell/lv2/sys_sync.h"
 #include "Emu/Cell/timers.hpp"
 #include "Emu/Io/interception.h"
+
+#include "Emu/RSX/Overlays/overlay_manager.h"
 #include "Emu/RSX/Overlays/overlay_message_dialog.h"
 
 #include "cellSysutil.h"

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -4,8 +4,10 @@
 #include "Emu/Cell/PPUModule.h"
 #include "Emu/Io/interception.h"
 #include "Emu/Io/Keyboard.h"
-#include "Emu/RSX/Overlays/overlay_osk.h"
 #include "Emu/IdManager.h"
+
+#include "Emu/RSX/Overlays/overlay_manager.h"
+#include "Emu/RSX/Overlays/overlay_osk.h"
 
 #include "cellSysutil.h"
 #include "cellOskDialog.h"

--- a/rpcs3/Emu/Cell/Modules/cellUserInfo.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellUserInfo.cpp
@@ -4,6 +4,8 @@
 #include "Emu/VFS.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUModule.h"
+
+#include "Emu/RSX/Overlays/overlay_manager.h"
 #include "Emu/RSX/Overlays/overlay_user_list_dialog.h"
 
 #include "cellUserInfo.h"

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "GLGSRender.h"
 #include "Emu/Cell/Modules/cellVideoOut.h"
+#include "Emu/RSX/Overlays/overlay_manager.h"
 #include "util/video_provider.h"
 
 LOG_CHANNEL(screenshot_log, "SCREENSHOT");

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
@@ -170,19 +170,8 @@ namespace rsx
 			auto& overlayman = g_fxo->get<display_manager>();
 
 			overlayman.attach_thread_input(
-				uid,                         // Target
-				[](s32 error)               // What to do with the result
-				{
-					if (error && error != selection_code::canceled)
-					{
-						rsx_log.error("Home menu dialog input loop exited with error code=%d", error);
-					}
-				},
-				[&notify]()                  // What to do before starting the loop
-				{
-					*notify = true;
-					notify->notify_one();
-				}
+				uid,
+				[&notify]() { *notify = true; notify->notify_one(); }
 			);
 
 			if (g_cfg.misc.pause_during_home_menu)

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
@@ -165,7 +165,7 @@ namespace rsx
 			auto& overlayman = g_fxo->get<display_manager>();
 
 			overlayman.attach_thread_input(
-				uid,
+				uid, "Home menu",
 				[&notify]() { *notify = true; notify->notify_one(); }
 			);
 

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
@@ -150,11 +150,6 @@ namespace rsx
 			return result;
 		}
 
-		struct home_menu_dialog_thread
-		{
-			static constexpr auto thread_name = "Home Menu Thread"sv;
-		};
-
 		error_code home_menu_dialog::show(std::function<void(s32 status)> on_close)
 		{
 			visible = false;

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "shader_loading_dialog_native.h"
+#include "../overlay_manager.h"
 #include "../overlay_message_dialog.h"
 #include "../../GSRender.h"
 #include "Emu/Cell/ErrorCodes.h"

--- a/rpcs3/Emu/RSX/Overlays/overlay_cursor.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_cursor.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 #include "overlay_cursor.h"
+#include "overlay_manager.h"
+
 #include "Emu/RSX/RSXThread.h"
 
 namespace rsx

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -151,6 +151,7 @@ namespace rsx
 
 		void display_manager::attach_thread_input(
 			u32 uid,
+			const std::string_view& name,
 			std::function<void()> on_input_loop_enter,
 			std::function<void(s32)> on_input_loop_exit,
 			std::function<s32()> input_loop_override)
@@ -158,6 +159,7 @@ namespace rsx
 			if (auto iface = std::dynamic_pointer_cast<user_interface>(get(uid)))
 			{
 				m_input_token_stack.push(
+					name,
 					std::move(iface),
 					on_input_loop_enter,
 					on_input_loop_exit,
@@ -209,7 +211,7 @@ namespace rsx
 					}
 					else if (result && result != user_interface::selection_code::canceled)
 					{
-						rsx_log.error("Input loop exited with error code=%d", result);
+						rsx_log.error("%s exited with error code=%d", input_context.name, result);
 					}
 				}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -1,0 +1,157 @@
+#include "stdafx.h"
+#include "overlay_manager.h"
+
+namespace rsx
+{
+	namespace overlays
+	{
+		void display_manager::lock()
+		{
+			m_list_mutex.lock_shared();
+		}
+
+		void display_manager::unlock()
+		{
+			m_list_mutex.unlock_shared();
+
+			if (!m_uids_to_remove.empty() || !m_type_ids_to_remove.empty())
+			{
+				std::lock_guard lock(m_list_mutex);
+				cleanup_internal();
+			}
+		}
+
+		std::shared_ptr<overlay> display_manager::get(u32 uid)
+		{
+			reader_lock lock(m_list_mutex);
+
+			for (const auto& iface : m_iface_list)
+			{
+				if (iface->uid == uid)
+					return iface;
+			}
+
+			return {};
+		}
+
+		void display_manager::remove(u32 uid)
+		{
+			if (m_list_mutex.try_lock())
+			{
+				remove_uid(uid);
+				m_list_mutex.unlock();
+			}
+			else
+			{
+				m_uids_to_remove.push_back(uid);
+			}
+		}
+
+		void display_manager::dispose(const std::vector<u32>& uids)
+		{
+			std::lock_guard lock(m_list_mutex);
+
+			if (!m_uids_to_remove.empty() || !m_type_ids_to_remove.empty())
+			{
+				cleanup_internal();
+			}
+
+			m_dirty_list.erase
+			(
+				std::remove_if(m_dirty_list.begin(), m_dirty_list.end(), [&uids](std::shared_ptr<overlay>& e)
+				{
+					return std::find(uids.begin(), uids.end(), e->uid) != uids.end();
+				}),
+				m_dirty_list.end());
+		}
+
+		bool display_manager::remove_type(u32 type_id)
+		{
+			bool found = false;
+			for (auto It = m_iface_list.begin(); It != m_iface_list.end();)
+			{
+				if (It->get()->type_index == type_id)
+				{
+					on_overlay_removed(*It);
+					m_dirty_list.push_back(std::move(*It));
+					It = m_iface_list.erase(It);
+					found = true;
+				}
+				else
+				{
+					++It;
+				}
+			}
+
+			return found;
+		}
+
+		bool display_manager::remove_uid(u32 uid)
+		{
+			for (auto It = m_iface_list.begin(); It != m_iface_list.end(); It++)
+			{
+				const auto e = It->get();
+				if (e->uid == uid)
+				{
+					on_overlay_removed(*It);
+					m_dirty_list.push_back(std::move(*It));
+					m_iface_list.erase(It);
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		void display_manager::cleanup_internal()
+		{
+			for (const auto& uid : m_uids_to_remove)
+			{
+				remove_uid(uid);
+			}
+
+			for (const auto& type_id : m_type_ids_to_remove)
+			{
+				remove_type(type_id);
+			}
+
+			m_uids_to_remove.clear();
+			m_type_ids_to_remove.clear();
+		}
+
+		void display_manager::on_overlay_activated(const std::shared_ptr<overlay>& item)
+		{
+			if (auto iface = std::dynamic_pointer_cast<user_interface>(item))
+			{
+				std::lock_guard lock(m_input_thread_lock);
+				m_input_token_stack.emplace_front(std::move(iface));
+			}
+		}
+
+		void display_manager::on_overlay_removed(const std::shared_ptr<overlay>& item)
+		{
+			if (!dynamic_cast<user_interface*>(item.get()))
+			{
+				// Not instance of UI, ignore
+				return;
+			}
+
+			std::lock_guard lock(m_input_thread_lock);
+			for (auto& entry : m_input_token_stack)
+			{
+				if (entry.target->uid == item->uid)
+				{
+					// Release
+					entry.target = {};
+					break;
+				}
+			}
+
+			// The top must never be an empty ref. Pop all empties.
+			while (!m_input_token_stack.front().target && m_input_token_stack.size())
+			{
+				m_input_token_stack.pop_front();
+			}
+		}
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -189,7 +189,7 @@ namespace rsx
 			}
 
 			// The top must never be an empty ref. Pop all empties.
-			while (!m_input_token_stack.front().target && m_input_token_stack.size())
+			while (!m_input_token_stack.empty() && !m_input_token_stack.front().target)
 			{
 				m_input_token_stack.pop_front();
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "overlay_manager.h"
 #include "Emu/System.h"
+#include <util/asm.hpp>
 
 namespace rsx
 {
@@ -15,7 +16,7 @@ namespace rsx
 				*m_input_thread = thread_state::aborting;
 				while (*m_input_thread <= thread_state::aborting)
 				{
-					_mm_pause();
+					utils::pause();
 				}
 			}
 		}

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -7,7 +7,7 @@ namespace rsx
 {
 	namespace overlays
 	{
-		display_manager::display_manager(int)
+		display_manager::display_manager(int) noexcept
 		{
 			m_input_thread = std::make_shared<named_thread<overlay_input_thread>>();
 			(*m_input_thread)([this]()

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -181,6 +181,8 @@ namespace rsx
 
 			lf_queue<input_thread_context_t> m_input_token_stack;
 			atomic_t<bool> m_input_thread_abort = false;
+			atomic_t<bool> m_input_thread_interrupted = false;
+			shared_mutex m_input_stack_guard;
 
 			std::shared_ptr<named_thread<overlay_input_thread>> m_input_thread;
 			void input_thread_loop();

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -39,8 +39,7 @@ namespace rsx
 
 		public:
 			// Disable default construction to make it conditionally available in g_fxo
-			explicit display_manager(int) noexcept
-			{}
+			explicit display_manager(int) noexcept;
 
 			~display_manager();
 
@@ -176,8 +175,7 @@ namespace rsx
 				std::function<s32()> input_loop_override = nullptr;
 			};
 
-			std::deque<input_thread_context_t> m_input_token_stack;
-			shared_mutex m_input_thread_lock;
+			lf_queue<input_thread_context_t> m_input_token_stack;
 			atomic_t<bool> m_input_thread_abort = false;
 
 			std::shared_ptr<named_thread<overlay_input_thread>> m_input_thread;

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -170,13 +170,30 @@ namespace rsx
 
 			struct input_thread_context_t
 			{
+				// Ctor
+				input_thread_context_t(
+					const std::string_view& name,
+					std::shared_ptr<user_interface> iface,
+					std::function<void()> on_input_loop_enter,
+					std::function<void(s32)> on_input_loop_exit,
+					std::function<s32()> input_loop_override)
+					: name(name)
+					, target(iface)
+					, input_loop_prologue(on_input_loop_enter)
+					, input_loop_epilogue(on_input_loop_exit)
+					, input_loop_override(input_loop_override)
+					, prologue_completed(false)
+				{}
+
+				// Attributes
 				std::string_view name;
 				std::shared_ptr<user_interface> target;
-				std::function<void()> input_loop_prologue = nullptr;
-				std::function<void(s32)> input_loop_epilogue = nullptr;
-				std::function<s32()> input_loop_override = nullptr;
+				std::function<void()> input_loop_prologue;
+				std::function<void(s32)> input_loop_epilogue;
+				std::function<s32()> input_loop_override;
 
-				bool prologue_completed = false;
+				// Runtime stats
+				bool prologue_completed;
 			};
 
 			lf_queue<input_thread_context_t> m_input_token_stack;

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -157,6 +157,7 @@ namespace rsx
 			// Enable input thread attach to the specified interface
 			void attach_thread_input(
 				u32 uid,                                                 // The input target
+				const std::string_view& name,                            // The name of the target
 				std::function<void()> on_input_loop_enter = nullptr,     // [optional] What to do before running the input routine
 				std::function<void(s32)> on_input_loop_exit = nullptr,   // [optional] What to do with the result if any
 				std::function<s32()> input_loop_override = nullptr);     // [optional] What to do during the input loop. By default calls user_interface::run_input_loop
@@ -169,6 +170,7 @@ namespace rsx
 
 			struct input_thread_context_t
 			{
+				std::string_view name;
 				std::shared_ptr<user_interface> target;
 				std::function<void()> input_loop_prologue = nullptr;
 				std::function<void(s32)> input_loop_epilogue = nullptr;

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -175,6 +175,8 @@ namespace rsx
 				std::function<void()> input_loop_prologue = nullptr;
 				std::function<void(s32)> input_loop_epilogue = nullptr;
 				std::function<s32()> input_loop_override = nullptr;
+
+				bool prologue_completed = false;
 			};
 
 			lf_queue<input_thread_context_t> m_input_token_stack;

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include "overlays.h"
+
+#include "Emu/IdManager.h"
+#include "Utilities/mutex.h"
+#include "Utilities/Timer.h"
+
+#include <deque>
+#include <set>
+
+namespace rsx
+{
+	namespace overlays
+	{
+		struct overlay;
+
+		class display_manager
+		{
+		private:
+			atomic_t<u32> m_uid_ctr = 0;
+			std::vector<std::shared_ptr<overlay>> m_iface_list;
+			std::vector<std::shared_ptr<overlay>> m_dirty_list;
+
+			shared_mutex m_list_mutex;
+			std::vector<u32> m_uids_to_remove;
+			std::vector<u32> m_type_ids_to_remove;
+
+			bool remove_type(u32 type_id);
+
+			bool remove_uid(u32 uid);
+
+			void cleanup_internal();
+
+			void on_overlay_activated(const std::shared_ptr<overlay>& item);
+
+			void on_overlay_removed(const std::shared_ptr<overlay>& item);
+
+		public:
+			// Disable default construction to make it conditionally available in g_fxo
+			explicit display_manager(int) noexcept
+			{}
+
+			// Adds an object to the internal list. Optionally removes other objects of the same type.
+			// Original handle loses ownership but a usable pointer is returned
+			template <typename T>
+			std::shared_ptr<T> add(std::shared_ptr<T>& entry, bool remove_existing = true)
+			{
+				std::lock_guard lock(m_list_mutex);
+
+				entry->uid = m_uid_ctr.fetch_add(1);
+				entry->type_index = id_manager::typeinfo::get_index<T>();
+
+				if (remove_existing)
+				{
+					for (auto It = m_iface_list.begin(); It != m_iface_list.end(); It++)
+					{
+						if (It->get()->type_index == entry->type_index)
+						{
+							// Replace
+							m_dirty_list.push_back(std::move(*It));
+							*It = std::move(entry);
+							return std::static_pointer_cast<T>(*It);
+						}
+					}
+				}
+
+				m_iface_list.push_back(std::move(entry));
+				on_overlay_activated(m_iface_list.back());
+				return std::static_pointer_cast<T>(m_iface_list.back());
+			}
+
+			// Allocates object and adds to internal list. Returns pointer to created object
+			template <typename T, typename ...Args>
+			std::shared_ptr<T> create(Args&&... args)
+			{
+				auto object = std::make_shared<T>(std::forward<Args>(args)...);
+				return add(object);
+			}
+
+			// Removes item from list if it matches the uid
+			void remove(u32 uid);
+
+			// Removes all objects of this type from the list
+			template <typename T>
+			void remove()
+			{
+				const auto type_id = id_manager::typeinfo::get_index<T>();
+				if (m_list_mutex.try_lock())
+				{
+					remove_type(type_id);
+					m_list_mutex.unlock();
+				}
+				else
+				{
+					m_type_ids_to_remove.push_back(type_id);
+				}
+			}
+
+			// True if any visible elements to draw exist
+			bool has_visible() const
+			{
+				return !m_iface_list.empty();
+			}
+
+			// True if any elements have been deleted but their resources may not have been cleaned up
+			bool has_dirty() const
+			{
+				return !m_dirty_list.empty();
+			}
+
+			// Returns current list for reading. Caller must ensure synchronization by first locking the list
+			const std::vector<std::shared_ptr<overlay>>& get_views() const
+			{
+				return m_iface_list;
+			}
+
+			// Returns current list of removed objects not yet deallocated for reading.
+			// Caller must ensure synchronization by first locking the list
+			const std::vector<std::shared_ptr<overlay>>& get_dirty() const
+			{
+				return m_dirty_list;
+			}
+
+			// Deallocate object. Object must first be removed via the remove() functions
+			void dispose(const std::vector<u32>& uids);
+
+			// Returns pointer to the object matching the given uid
+			std::shared_ptr<overlay> get(u32 uid);
+
+			// Returns pointer to the first object matching the given type
+			template <typename T>
+			std::shared_ptr<T> get()
+			{
+				reader_lock lock(m_list_mutex);
+
+				const auto type_id = id_manager::typeinfo::get_index<T>();
+				for (const auto& iface : m_iface_list)
+				{
+					if (iface->type_index == type_id)
+					{
+						return std::static_pointer_cast<T>(iface);
+					}
+				}
+
+				return {};
+			}
+
+			// Lock for read-only access (BasicLockable)
+			void lock();
+
+			// Release read-only lock (BasicLockable). May perform internal cleanup before returning
+			void unlock();
+
+		private:
+			struct overlay_input_thread
+			{
+				static constexpr auto thread_name = "Overlay Input Thread"sv;
+			};
+
+			struct input_thread_access_token
+			{
+				std::shared_ptr<user_interface> target;
+			};
+
+			std::deque<input_thread_access_token> m_input_token_stack;
+			shared_mutex m_input_thread_lock;
+		};
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -158,8 +158,9 @@ namespace rsx
 			// Enable input thread attach to the specified interface
 			void attach_thread_input(
 				u32 uid,                                                 // The input target
+				std::function<void()> on_input_loop_enter = nullptr,     // [optional] What to do before running the input routine
 				std::function<void(s32)> on_input_loop_exit = nullptr,   // [optional] What to do with the result if any
-				std::function<void()> on_input_loop_enter = nullptr);    // [optional] What to do before running the input routine
+				std::function<s32()> input_loop_override = nullptr);     // [optional] What to do during the input loop. By default calls user_interface::run_input_loop
 
 		private:
 			struct overlay_input_thread
@@ -172,6 +173,7 @@ namespace rsx
 				std::shared_ptr<user_interface> target;
 				std::function<void()> input_loop_prologue = nullptr;
 				std::function<void(s32)> input_loop_epilogue = nullptr;
+				std::function<s32()> input_loop_override = nullptr;
 			};
 
 			std::deque<input_thread_context_t> m_input_token_stack;

--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
@@ -1,10 +1,12 @@
 #include "stdafx.h"
+#include "overlays.h"
+#include "overlay_manager.h"
 #include "overlay_media_list_dialog.h"
+
+#include "Emu/Cell/Modules/cellMusic.h"
+#include "Emu/VFS.h"
 #include "Utilities/StrUtil.h"
 #include "Utilities/Thread.h"
-#include "overlays.h"
-#include "Emu/VFS.h"
-#include "Emu/Cell/Modules/cellMusic.h"
 
 namespace rsx
 {

--- a/rpcs3/Emu/RSX/Overlays/overlay_message.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "overlays.h"
+#include "overlay_manager.h"
+
 #include <deque>
 
 namespace rsx

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -196,11 +196,6 @@ namespace rsx
 			user_interface::close(use_callback, stop_pad_interception);
 		}
 
-		struct msg_dialog_thread
-		{
-			static constexpr auto thread_name = "MsgDialog Thread"sv;
-		};
-
 		void message_dialog::update()
 		{
 			if (fade_animation.active)

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -284,6 +284,8 @@ namespace rsx
 						}
 						return error;
 					}
+
+					g_last_user_response = return_code;
 				}
 				else
 				{

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -303,14 +303,14 @@ namespace rsx
 					if (interactive)
 					{
 						overlayman.attach_thread_input(
-							uid,
+							uid, "Message dialog",
 							[&notify]() { *notify = true; notify->notify_one(); }
 						);
 					}
 					else
 					{
 						overlayman.attach_thread_input(
-							uid,
+							uid, "Message dialog",
 							[&notify]() { *notify = true; notify->notify_one(); },
 							nullptr,
 							[&]()

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -1624,7 +1624,7 @@ namespace rsx
 			auto& overlayman = g_fxo->get<display_manager>();
 
 			overlayman.attach_thread_input(
-				uid,
+				uid, "OSK",
 				[&notify]() { *notify = true; notify->notify_one(); }
 			);
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -1321,11 +1321,6 @@ namespace rsx
 			return m_cached_resource;
 		}
 
-		struct osk_dialog_thread
-		{
-			static constexpr auto thread_name = "OSK Thread"sv;
-		};
-
 		void osk_dialog::Create(const osk_params& params)
 		{
 			state = OskDialogState::Open;

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -1630,18 +1630,7 @@ namespace rsx
 
 			overlayman.attach_thread_input(
 				uid,
-				[](s32 error)
-				{
-					if (error && error != selection_code::canceled)
-					{
-						rsx_log.error("Osk input loop exited with error code=%d", error);
-					}
-				},
-				[&notify]()
-				{
-					*notify = true;
-					notify->notify_one();
-				}
+				[&notify]() { *notify = true; notify->notify_one(); }
 			);
 
 			while (!Emu.IsStopped() && !*notify)

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "overlay_manager.h"
 #include "overlay_perf_metrics.h"
 #include "Emu/RSX/RSXThread.h"
 #include "Emu/Cell/SPUThread.h"

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
@@ -249,18 +249,7 @@ namespace rsx
 
 			overlayman.attach_thread_input(
 				uid,
-				[](s32 error)
-				{
-					if (error && error != selection_code::canceled)
-					{
-						rsx_log.error("User list dialog input loop exited with error code=%d", error);
-					}
-				},
-				[&notify]()
-				{
-					*notify = true;
-					notify->notify_one();
-				}
+				[&notify]() { *notify = true; notify->notify_one(); }
 			);
 
 			while (!Emu.IsStopped() && !*notify)

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
@@ -176,11 +176,6 @@ namespace rsx
 			return result;
 		}
 
-		struct user_list_dialog_thread
-		{
-			static constexpr auto thread_name = "UserList Thread"sv;
-		};
-
 		error_code user_list_dialog::show(const std::string& title, u32 focused, const std::vector<u32>& user_ids, bool enable_overlay, std::function<void(s32 status)> on_close)
 		{
 			visible = false;

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "overlay_manager.h"
 #include "overlay_user_list_dialog.h"
 #include "Emu/vfs_config.h"
 #include "Emu/system_utils.hpp"
@@ -243,33 +244,26 @@ namespace rsx
 			this->on_close = std::move(on_close);
 			visible = true;
 
-			auto& list_thread = g_fxo->get<named_thread<user_list_dialog_thread>>();
-
 			const auto notify = std::make_shared<atomic_t<bool>>(false);
+			auto& overlayman = g_fxo->get<display_manager>();
 
-			list_thread([&, notify]()
-			{
-				const u64 tbit = alloc_thread_bit();
-				g_thread_bit = tbit;
-
-				*notify = true;
-				notify->notify_one();
-
-				auto ref = g_fxo->get<display_manager>().get(uid);
-
-				if (const auto error = run_input_loop())
+			overlayman.attach_thread_input(
+				uid,
+				[](s32 error)
 				{
-					if (error != selection_code::canceled)
+					if (error && error != selection_code::canceled)
 					{
 						rsx_log.error("User list dialog input loop exited with error code=%d", error);
 					}
+				},
+				[&notify]()
+				{
+					*notify = true;
+					notify->notify_one();
 				}
+			);
 
-				thread_bits &= ~tbit;
-				thread_bits.notify_all();
-			});
-
-			while (list_thread < thread_state::errored && !*notify)
+			while (!Emu.IsStopped() && !*notify)
 			{
 				notify->wait(false, atomic_wait_timeout{1'000'000});
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
@@ -243,7 +243,7 @@ namespace rsx
 			auto& overlayman = g_fxo->get<display_manager>();
 
 			overlayman.attach_thread_input(
-				uid,
+				uid, "User list dialog",
 				[&notify]() { *notify = true; notify->notify_one(); }
 			);
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -122,7 +122,7 @@ namespace rsx
 				last_button_state[pad_index][button_id] = pressed;
 			};
 
-			while (!m_stop_input_loop)
+			while (!m_stop_input_loop && !m_input_loop_interrupted)
 			{
 				if (Emu.IsStopped())
 				{
@@ -363,7 +363,9 @@ namespace rsx
 
 			m_interactive = false;
 
-			return 0;
+			return (m_input_loop_interrupted && !m_stop_input_loop)
+				? selection_code::interrupted
+				: selection_code::ok;
 		}
 
 		void user_interface::close(bool use_callback, bool stop_pad_interception)

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -46,7 +46,7 @@ namespace rsx
 		// Singleton instance declaration
 		fontmgr* fontmgr::m_instance = nullptr;
 
-		s32 user_interface::run_input_loop()
+		s32 user_interface::run_input_loop(std::function<bool()> check_state)
 		{
 			user_interface::thread_bits_allocator thread_bits_alloc(this);
 
@@ -122,8 +122,14 @@ namespace rsx
 				last_button_state[pad_index][button_id] = pressed;
 			};
 
-			while (!m_stop_input_loop && !m_input_loop_interrupted)
+			while (!m_stop_input_loop)
 			{
+				if (check_state && !check_state())
+				{
+					// Interrupted externally.
+					break;
+				}
+
 				if (Emu.IsStopped())
 				{
 					return selection_code::canceled;
@@ -361,9 +367,7 @@ namespace rsx
 				input::SetIntercepted(false);
 			}
 
-			m_interactive = false;
-
-			return (m_input_loop_interrupted && !m_stop_input_loop)
+			return !m_stop_input_loop
 				? selection_code::interrupted
 				: selection_code::ok;
 		}

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "overlays.h"
+#include "overlay_manager.h"
 #include "overlay_message_dialog.h"
 #include "Input/pad_thread.h"
 #include "Emu/Io/interception.h"
@@ -47,6 +48,8 @@ namespace rsx
 
 		s32 user_interface::run_input_loop()
 		{
+			user_interface::thread_bits_allocator thread_bits_alloc(this);
+
 			m_interactive = true;
 
 			std::array<steady_clock::time_point, CELL_PAD_MAX_PORT_NUM> timestamp;

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -84,9 +84,11 @@ namespace rsx
 			// Move this somewhere to avoid duplication
 			enum selection_code
 			{
+				ok = 0,
 				new_save = -1,
 				canceled = -2,
-				error = -3
+				error = -3,
+				interrupted = -4
 			};
 
 		protected:
@@ -113,6 +115,7 @@ namespace rsx
 			bool m_start_pad_interception = true;
 			atomic_t<bool> m_stop_pad_interception = false;
 			atomic_t<bool> m_input_thread_detached = false;
+			atomic_t<bool> m_input_loop_interrupted = false;
 			atomic_t<u64> thread_bits = 0;
 			bool m_keyboard_input_enabled = false; // Allow keyboard input
 			bool m_keyboard_pad_handler_active = true; // Initialized as true to prevent keyboard input until proven otherwise.
@@ -149,6 +152,8 @@ namespace rsx
 
 			bool is_detached() const { return m_input_thread_detached; }
 			void detach_input() { m_input_thread_detached.store(true); }
+			void on_input_interrupted() { m_input_loop_interrupted.store(true); }
+			void on_input_resumed() { m_input_loop_interrupted.store(false); }
 
 			void update() override {}
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -115,7 +115,6 @@ namespace rsx
 			bool m_start_pad_interception = true;
 			atomic_t<bool> m_stop_pad_interception = false;
 			atomic_t<bool> m_input_thread_detached = false;
-			atomic_t<bool> m_input_loop_interrupted = false;
 			atomic_t<u64> thread_bits = 0;
 			bool m_keyboard_input_enabled = false; // Allow keyboard input
 			bool m_keyboard_pad_handler_active = true; // Initialized as true to prevent keyboard input until proven otherwise.
@@ -152,8 +151,6 @@ namespace rsx
 
 			bool is_detached() const { return m_input_thread_detached; }
 			void detach_input() { m_input_thread_detached.store(true); }
-			void on_input_interrupted() { m_input_loop_interrupted.store(true); }
-			void on_input_resumed() { m_input_loop_interrupted.store(false); }
 
 			void update() override {}
 
@@ -164,7 +161,7 @@ namespace rsx
 
 			virtual void close(bool use_callback, bool stop_pad_interception);
 
-			s32 run_input_loop();
+			s32 run_input_loop(std::function<bool()> check_state = nullptr);
 		};
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -112,6 +112,7 @@ namespace rsx
 			atomic_t<bool> m_interactive = false;
 			bool m_start_pad_interception = true;
 			atomic_t<bool> m_stop_pad_interception = false;
+			atomic_t<bool> m_input_thread_detached = false;
 			atomic_t<u64> thread_bits = 0;
 			bool m_keyboard_input_enabled = false; // Allow keyboard input
 			bool m_keyboard_pad_handler_active = true; // Initialized as true to prevent keyboard input until proven otherwise.
@@ -145,6 +146,9 @@ namespace rsx
 			};
 		public:
 			s32 return_code = 0; // CELL_OK
+
+			bool is_detached() const { return m_input_thread_detached; }
+			void detach_input() { m_input_thread_detached.store(true); }
 
 			void update() override {}
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -123,6 +123,26 @@ namespace rsx
 
 			std::function<void(s32 status)> on_close = nullptr;
 
+			class thread_bits_allocator
+			{
+			public:
+				thread_bits_allocator(user_interface* parent)
+					: m_parent(parent)
+				{
+					m_thread_bit = m_parent->alloc_thread_bit();
+					g_thread_bit = m_thread_bit;
+				}
+
+				~thread_bits_allocator()
+				{
+					m_parent->thread_bits &= ~m_thread_bit;
+					m_parent->thread_bits.notify_all();
+				}
+
+			private:
+				user_interface* m_parent;
+				u64 m_thread_bit;
+			};
 		public:
 			s32 return_code = 0; // CELL_OK
 
@@ -136,237 +156,6 @@ namespace rsx
 			virtual void close(bool use_callback, bool stop_pad_interception);
 
 			s32 run_input_loop();
-		};
-
-		class display_manager
-		{
-		private:
-			atomic_t<u32> m_uid_ctr = 0;
-			std::vector<std::shared_ptr<overlay>> m_iface_list;
-			std::vector<std::shared_ptr<overlay>> m_dirty_list;
-
-			shared_mutex m_list_mutex;
-			std::vector<u32> m_uids_to_remove;
-			std::vector<u32> m_type_ids_to_remove;
-
-			bool remove_type(u32 type_id)
-			{
-				bool found = false;
-				for (auto It = m_iface_list.begin(); It != m_iface_list.end();)
-				{
-					if (It->get()->type_index == type_id)
-					{
-						m_dirty_list.push_back(std::move(*It));
-						It = m_iface_list.erase(It);
-						found = true;
-					}
-					else
-					{
-						++It;
-					}
-				}
-
-				return found;
-			}
-
-			bool remove_uid(u32 uid)
-			{
-				for (auto It = m_iface_list.begin(); It != m_iface_list.end(); It++)
-				{
-					const auto e = It->get();
-					if (e->uid == uid)
-					{
-						m_dirty_list.push_back(std::move(*It));
-						m_iface_list.erase(It);
-						return true;
-					}
-				}
-
-				return false;
-			}
-
-			void cleanup_internal()
-			{
-				for (const auto &uid : m_uids_to_remove)
-				{
-					remove_uid(uid);
-				}
-
-				for (const auto &type_id : m_type_ids_to_remove)
-				{
-					remove_type(type_id);
-				}
-
-				m_uids_to_remove.clear();
-				m_type_ids_to_remove.clear();
-			}
-
-		public:
-			// Disable default construction to make it conditionally available in g_fxo
-			explicit display_manager(int) noexcept
-			{
-			}
-
-			// Adds an object to the internal list. Optionally removes other objects of the same type.
-			// Original handle loses ownership but a usable pointer is returned
-			template <typename T>
-			std::shared_ptr<T> add(std::shared_ptr<T>& entry, bool remove_existing = true)
-			{
-				std::lock_guard lock(m_list_mutex);
-
-				entry->uid = m_uid_ctr.fetch_add(1);
-				entry->type_index = id_manager::typeinfo::get_index<T>();
-
-				if (remove_existing)
-				{
-					for (auto It = m_iface_list.begin(); It != m_iface_list.end(); It++)
-					{
-						if (It->get()->type_index == entry->type_index)
-						{
-							// Replace
-							m_dirty_list.push_back(std::move(*It));
-							*It = std::move(entry);
-							return std::static_pointer_cast<T>(*It);
-						}
-					}
-				}
-
-				m_iface_list.push_back(std::move(entry));
-				return std::static_pointer_cast<T>(m_iface_list.back());
-			}
-
-			// Allocates object and adds to internal list. Returns pointer to created object
-			template <typename T, typename ...Args>
-			std::shared_ptr<T> create(Args&&... args)
-			{
-				auto object = std::make_shared<T>(std::forward<Args>(args)...);
-				return add(object);
-			}
-
-			// Removes item from list if it matches the uid
-			void remove(u32 uid)
-			{
-				if (m_list_mutex.try_lock())
-				{
-					remove_uid(uid);
-					m_list_mutex.unlock();
-				}
-				else
-				{
-					m_uids_to_remove.push_back(uid);
-				}
-			}
-
-			// Removes all objects of this type from the list
-			template <typename T>
-			void remove()
-			{
-				const auto type_id = id_manager::typeinfo::get_index<T>();
-				if (m_list_mutex.try_lock())
-				{
-					remove_type(type_id);
-					m_list_mutex.unlock();
-				}
-				else
-				{
-					m_type_ids_to_remove.push_back(type_id);
-				}
-			}
-
-			// True if any visible elements to draw exist
-			bool has_visible() const
-			{
-				return !m_iface_list.empty();
-			}
-
-			// True if any elements have been deleted but their resources may not have been cleaned up
-			bool has_dirty() const
-			{
-				return !m_dirty_list.empty();
-			}
-
-			// Returns current list for reading. Caller must ensure synchronization by first locking the list
-			const std::vector<std::shared_ptr<overlay>>& get_views() const
-			{
-				return m_iface_list;
-			}
-
-			// Returns current list of removed objects not yet deallocated for reading.
-			// Caller must ensure synchronization by first locking the list
-			const std::vector<std::shared_ptr<overlay>>& get_dirty() const
-			{
-				return m_dirty_list;
-			}
-
-			// Deallocate object. Object must first be removed via the remove() functions
-			void dispose(const std::vector<u32>& uids)
-			{
-				std::lock_guard lock(m_list_mutex);
-
-				if (!m_uids_to_remove.empty() || !m_type_ids_to_remove.empty())
-				{
-					cleanup_internal();
-				}
-
-				m_dirty_list.erase
-				(
-					std::remove_if(m_dirty_list.begin(), m_dirty_list.end(), [&uids](std::shared_ptr<overlay>& e)
-					{
-						return std::find(uids.begin(), uids.end(), e->uid) != uids.end();
-					}),
-					m_dirty_list.end()
-				);
-			}
-
-			// Returns pointer to the object matching the given uid
-			std::shared_ptr<overlay> get(u32 uid)
-			{
-				reader_lock lock(m_list_mutex);
-
-				for (const auto& iface : m_iface_list)
-				{
-					if (iface->uid == uid)
-						return iface;
-				}
-
-				return {};
-			}
-
-			// Returns pointer to the first object matching the given type
-			template <typename T>
-			std::shared_ptr<T> get()
-			{
-				reader_lock lock(m_list_mutex);
-
-				const auto type_id = id_manager::typeinfo::get_index<T>();
-				for (const auto& iface : m_iface_list)
-				{
-					if (iface->type_index == type_id)
-					{
-						return std::static_pointer_cast<T>(iface);
-					}
-				}
-
-				return {};
-			}
-
-			// Lock for read-only access (BasicLockable)
-			void lock()
-			{
-				m_list_mutex.lock_shared();
-			}
-
-			// Release read-only lock (BasicLockable). May perform internal cleanup before returning
-			void unlock()
-			{
-				m_list_mutex.unlock_shared();
-
-				if (!m_uids_to_remove.empty() || !m_type_ids_to_remove.empty())
-				{
-					std::lock_guard lock(m_list_mutex);
-					cleanup_internal();
-				}
-			}
 		};
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1,4 +1,7 @@
 #include "stdafx.h"
+#include "../Overlays/overlay_animated_icon.h"
+#include "../Overlays/overlay_dock.h"
+#include "../Overlays/overlay_manager.h"
 #include "../Overlays/overlay_shader_compile_notification.h"
 #include "../Overlays/Shaders/shader_loading_dialog_native.h"
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "../Overlays/overlay_animated_icon.h"
-#include "../Overlays/overlay_dock.h"
 #include "../Overlays/overlay_manager.h"
 #include "../Overlays/overlay_shader_compile_notification.h"
 #include "../Overlays/Shaders/shader_loading_dialog_native.h"

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "VKGSRender.h"
 #include "vkutils/buffer_object.h"
+#include "Emu/RSX/Overlays/overlay_manager.h"
 #include "Emu/RSX/Overlays/overlays.h"
 #include "Emu/Cell/Modules/cellVideoOut.h"
 

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -2,6 +2,7 @@
 #include "system_progress.hpp"
 #include "Emu/Cell/Modules/cellMsgDialog.h"
 #include "Emu/RSX/RSXThread.h"
+#include "Emu/RSX/Overlays/overlay_manager.h"
 #include "Emu/RSX/Overlays/overlay_message_dialog.h"
 #include "Emu/System.h"
 

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="Emu\RSX\Overlays\overlay_animated_icon.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_controls.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_cursor.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\overlay_manager.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_media_list_dialog.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_osk_panel.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_shader_compile_notification.cpp" />
@@ -555,6 +556,7 @@
     <ClInclude Include="Emu\RSX\Overlays\overlay_edit_text.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_list_view.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_loading_icon.hpp" />
+    <ClInclude Include="Emu\RSX\Overlays\overlay_manager.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_media_list_dialog.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_progress_bar.hpp" />
     <ClInclude Include="Emu\RSX\Program\GLSLTypes.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1144,6 +1144,9 @@
     <ClCompile Include="Emu\NP\upnp_config.cpp">
       <Filter>Emu\NP</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\overlay_manager.cpp">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -2295,6 +2298,9 @@
     </ClInclude>
     <ClInclude Include="Emu\RSX\Overlays\HomeMenu\overlay_home_menu_message_box.h">
       <Filter>Emu\GPU\RSX\Overlays\HomeMenu</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\overlay_manager.h">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClInclude>
     <ClInclude Include="Emu\NP\upnp_handler.h">
       <Filter>Emu\NP</Filter>

--- a/rpcs3/rpcs3qt/save_data_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_dialog.cpp
@@ -4,6 +4,7 @@
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
 #include "Emu/Io/interception.h"
+#include "../Emu/RSX/Overlays/overlay_manager.h"
 #include "Emu/RSX/Overlays/overlay_save_dialog.h"
 #include "Emu/Cell/Modules/cellSysutil.h"
 

--- a/rpcs3/rpcs3qt/trophy_notification_helper.cpp
+++ b/rpcs3/rpcs3qt/trophy_notification_helper.cpp
@@ -3,6 +3,8 @@
 
 #include "../Emu/IdManager.h"
 #include "../Emu/System.h"
+
+#include "../Emu/RSX/Overlays/overlay_manager.h"
 #include "../Emu/RSX/Overlays/overlay_trophy_notification.h"
 
 #include "Utilities/File.h"


### PR DESCRIPTION
Instead of having each async dialog spawning its own thread, let's just have the manager handle this. Interfaces are pushed onto a LIFO stack which also inserts some Z-ordering. Multiple open dialogs do not fight for input, the last active dialog retains the input target until it releases it.
The current implementation here is far from complete. As there is no input pre-emption, the currently opened dialog must finish inputs before handing over to the next one. This actually works out ok for what we need, but can be improved upon.

TODOs:
- [x] Input queue pre-emption. New dialogs should pause open ones and take input for themselves.
    - [x] Input loop is re-entrant.
    - [x] ~~Pad intercept state should be a function of the unified handler.~~ Nothing needs this right now.
- [x] ~~Explicit Z-pinning (e.g top-most or bottom-most pin)~~ This requires a different stack implementation. Maybe later.