### PR TITLE
fix missing synchronization in progress_dialog_server

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -8,6 +8,8 @@
 #include "Utilities/Timer.h"
 
 #include "../Common/bitfield.hpp"
+#include "../../system_progress.hpp"
+
 
 #include <mutex>
 #include <set>
@@ -141,6 +143,7 @@ namespace rsx
 		class display_manager
 		{
 		private:
+			friend progress_dialog_server;
 			atomic_t<u32> m_uid_ctr = 0;
 			std::vector<std::shared_ptr<overlay>> m_iface_list;
 			std::vector<std::shared_ptr<overlay>> m_dirty_list;

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -80,6 +80,7 @@ void progress_dialog_server::operator()()
 				type.progress_bar_count = 1;
 
 				native_dlg = manager->create<rsx::overlays::progress_dialog>(true);
+				std::lock_guard lock(manager->m_list_mutex);
 				native_dlg->show(false, text0, type, nullptr);
 				native_dlg->progress_bar_set_message(0, "Please wait");
 			}
@@ -161,6 +162,8 @@ void progress_dialog_server::operator()()
 				// Changes detected, send update
 				if (native_dlg)
 				{
+					auto manager  = g_fxo->try_get<rsx::overlays::display_manager>();
+					std::lock_guard lock(manager->m_list_mutex);
 					native_dlg->set_text(text_new);
 					native_dlg->progress_bar_set_message(0, progr);
 					native_dlg->progress_bar_set_value(0, std::floor(value));


### PR DESCRIPTION
I compiled rpcs3 with the address sanitizer. This was one of the bugs that I found.

Excerpt from the error message.
```
[16928] =================================================================
[16928] ==16928==ERROR: AddressSanitizer: heap-use-after-free on address 0x12132397f6a4 at pc 0x000006e6c570 bp 0x00d1715fb0a0 sp 0x00d1715fb0e8
[16928] READ of size 4 at 0x12132397f6a4 thread T70
[16928]     #0 0x6e6c56f in rsx::overlays::font::render_text_ex(float&, float&, char32_t const*, unsigned long long, unsigned short, bool) C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp:311:25
[16928]     #1 0x6e6d90c in rsx::overlays::font::render_text(char32_t const*, unsigned short, bool) C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp:430:11
[16928]     #2 0x29af4e3 in rsx::overlays::overlay_element::render_text(char32_t const*, float, float) C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp:400:43
[16928]     #3 0x29b2db4 in rsx::overlays::overlay_element::get_compiled() C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp:575:23
[16928]     #4 0x612c495 in rsx::overlays::message_dialog::get_compiled() C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp:83:28
[16928]     #5 0x73d453e in vk::ui_overlay_renderer::run(vk::command_buffer&, area_base<unsigned int> const&, vk::framebuffer*, VkRenderPass_T*, vk::data_heap&, rsx::overlays::overlay&) C:/src/rpcs3/rpcs3/Emu/RSX/VK/VKOverlays.cpp:752:27
[16928]     #6 0x3877e3f in VKGSRender::flip(rsx::display_flip_info_t const&) C:/src/rpcs3/rpcs3/Emu/RSX/VK/VKPresent.cpp:764:18
[16928]     #7 0x3517bd4 in VKGSRender::do_local_task(rsx::FIFO::state) C:/src/rpcs3/rpcs3/Emu/RSX/VK/VKGSRender.cpp:1918:4
[16928]     #8 0x1232de7 in rsx::thread::on_task() C:/src/rpcs3/rpcs3/Emu/RSX/RSXThread.cpp:825:4
[16928]     #9 0x12310a2 in rsx::thread::cpu_task() C:/src/rpcs3/rpcs3/Emu/RSX/RSXThread.cpp:720:4
[16928]     #10 0x11ac565 in cpu_thread::operator()() C:/src/rpcs3/rpcs3/Emu/CPU/CPUThread.cpp:607:4
[16928]     #11 0x15ff64a in named_thread<VKGSRender>::entry_point2() C:/src/rpcs3/rpcs3/../Utilities/Thread.h:464:14
[16928]     #12 0x1590456 in named_thread<VKGSRender>::entry_point(thread_base*) C:/src/rpcs3/rpcs3/../Utilities/Thread.h:445:45
[16928]     #13 0x5c92800a  (<unknown module>)
[16928] 
[16928] 0x12132397f6a4 is located 4 bytes inside of 96-byte region [0x12132397f6a0,0x12132397f700)
[16928] freed by thread T1 here:
[16928]     #0 0x7ffa596b23a1 in free (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x1800423a1)
[16928]     #1 0x9894c6 in void std::__1::__libcpp_operator_delete[abi:v15007]<void*>(void*) C:/msys64/clang64/include/c++/v1/new:256:3
[16928]     #2 0x98946a in void std::__1::__do_deallocate_handle_size[abi:v15007]<>(void*, unsigned long long) C:/msys64/clang64/include/c++/v1/new:280:10
[16928]     #3 0x989416 in std::__1::__libcpp_deallocate[abi:v15007](void*, unsigned long long, unsigned long long) C:/msys64/clang64/include/c++/v1/new:296:14
[16928]     #4 0xa5e60c in std::__1::allocator<char32_t>::deallocate[abi:v15007](char32_t*, unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocator.h:128:13
[16928]     #5 0xa5e4b6 in std::__1::allocator_traits<std::__1::allocator<char32_t>>::deallocate[abi:v15007](std::__1::allocator<char32_t>&, char32_t*, unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocator_traits.h:282:13
[16928]     #6 0x240b2ba in std::__1::basic_string<char32_t, std::__1::char_traits<char32_t>, std::__1::allocator<char32_t>>::__move_assign(std::__1::basic_string<char32_t, std::__1::char_traits<char32_t>, std::__1::allocator<char32_t>>&, std::__1::integral_constant<bool, true>) C:/msys64/clang64/include/c++/v1/string:2537:5
[16928]     #7 0x23f343a in std::__1::basic_string<char32_t, std::__1::char_traits<char32_t>, std::__1::allocator<char32_t>>::operator=(std::__1::basic_string<char32_t, std::__1::char_traits<char32_t>, std::__1::allocator<char32_t>>&&) C:/msys64/clang64/include/c++/v1/string:2562:5
[16928]     #8 0x29ae3da in rsx::overlays::overlay_element::set_text(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp:356:15
[16928]     #9 0x612e910 in rsx::overlays::message_dialog::set_text(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp:343:17
[16928]     #10 0x1f9da3d in progress_dialog_server::operator()() C:/src/rpcs3/rpcs3/Emu/system_progress.cpp:164:18
[16928]     #11 0xdd0e3f in named_thread<progress_dialog_server>::entry_point2() C:/src/rpcs3/Utilities/Thread.h:464:14
[16928]     #12 0xd7a266 in named_thread<progress_dialog_server>::entry_point(thread_base*) C:/src/rpcs3/Utilities/Thread.h:445:45
[16928]     #13 0x5c92bf4a  (<unknown module>)
[16928] 
[16928] previously allocated by thread T1 here:
[16928]     #0 0x7ffa596b24c1 in malloc (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x1800424c1)
[16928]     #1 0x7ffa5cc92898 in .weak._Znwy.default.__clang_call_terminate (C:\msys64\clang64\bin\libc++.dll+0x180022898)
[16928]     #2 0x9893b6 in void* std::__1::__libcpp_operator_new[abi:v15007]<unsigned long long>(unsigned long long) C:/msys64/clang64/include/c++/v1/new:246:10
[16928]     #3 0x98930e in std::__1::__libcpp_allocate[abi:v15007](unsigned long long, unsigned long long) C:/msys64/clang64/include/c++/v1/new:272:10
[16928]     #4 0xb0350e in std::__1::allocator<char32_t>::allocate[abi:v15007](unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocator.h:112:38
[16928]     #5 0xb02eab in std::__1::__allocation_result<std::__1::allocator_traits<std::__1::allocator<char32_t>>::pointer> std::__1::__allocate_at_least[abi:v15007]<std::__1::allocator<char32_t>>(std::__1::allocator<char32_t>&, unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocate_at_least.h:54:19
[16928]     #6 0x241f98e in std::__1::basic_string<char32_t, std::__1::char_traits<char32_t>, std::__1::allocator<char32_t>>::__shrink_or_extend(unsigned long long) C:/msys64/clang64/include/c++/v1/string:3437:33
[16928]     #7 0x2416764 in std::__1::basic_string<char32_t, std::__1::char_traits<char32_t>, std::__1::allocator<char32_t>>::reserve(unsigned long long) C:/msys64/clang64/include/c++/v1/string:3403:5
[16928]     #8 0x2413e48 in utf8_to_u32string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_utils.cpp:174:9
[16928]     #9 0x29ae3c1 in rsx::overlays::overlay_element::set_text(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp:356:17
[16928]     #10 0x612e910 in rsx::overlays::message_dialog::set_text(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp:343:17
[16928]     #11 0x1f9da3d in progress_dialog_server::operator()() C:/src/rpcs3/rpcs3/Emu/system_progress.cpp:164:18
[16928]     #12 0xdd0e3f in named_thread<progress_dialog_server>::entry_point2() C:/src/rpcs3/Utilities/Thread.h:464:14
[16928]     #13 0xd7a266 in named_thread<progress_dialog_server>::entry_point(thread_base*) C:/src/rpcs3/Utilities/Thread.h:445:45
[16928]     #14 0x5c92bf4a  (<unknown module>)
[16928] 
```
