### PR TITLE
cellVdec: fix au_count race condition

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -334,7 +334,6 @@ struct vdec_context final
 
 				out_queue.clear(); // Flush image queue
 				log_time_base = {};
-				au_count = 0;
 
 				frc_set = 0; // TODO: ???
 				next_pts = 0;


### PR DESCRIPTION
A comment in a forum mentioned a fatal error in Lair that is fixed by LLE libVdec.

Turns out we were decreasing the au_count to 0 when the start_sequence command was executed.
This meant that it could not be decreased to 0 when the already enqueued follow-up decode command was executed.

We should not set it to 0 at all and let the queue work it off instead.