### PR TITLE
cellVdec: fix pitch of RGBA/ARGB images

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -1298,7 +1298,7 @@ error_code cellVdecGetPictureExt(ppu_thread& ppu, u32 handle, vm::cptr<CellVdecP
 		u8* in_data[4] = { frame->data[0], frame->data[1], frame->data[2], alpha_plane.get() };
 		int in_line[4] = { frame->linesize[0], frame->linesize[1], frame->linesize[2], w * 1 };
 		u8* out_data[4] = { outBuff.get_ptr() };
-		int out_line[4] = { w * 4 }; // RGBA32 or ARGB32
+		int out_line[4] = { static_cast<int>(utils::align(w * 4u, 128)) }; // RGBA32 or ARGB32
 
 		if (!alpha_plane)
 		{
@@ -1310,19 +1310,13 @@ error_code cellVdecGetPictureExt(ppu_thread& ppu, u32 handle, vm::cptr<CellVdecP
 			{
 				fmt::throw_exception("cellVdecGetPictureExt: av_image_fill_linesizes failed (handle=0x%x, seq_id=%d, cmd_id=%d, ret=0x%x): %s", handle, frame.seq_id, frame.cmd_id, ret, utils::av_error_to_string(ret));
 			}
+
+			// TODO:
+			// It's possible that we need to align the pitch to 128 here as well.
+			// But I'd wait for a game with broken images before tackling this.
 		}
 
 		sws_scale(vdec->sws, in_data, in_line, 0, h, out_data, out_line);
-
-		//const u32 buf_size = utils::align(av_image_get_buffer_size(vdec->ctx->pix_fmt, vdec->ctx->width, vdec->ctx->height, 1), 128);
-
-		//// TODO: zero padding bytes
-
-		//int err = av_image_copy_to_buffer(outBuff.get_ptr(), buf_size, frame->data, frame->linesize, vdec->ctx->pix_fmt, frame->width, frame->height, 1);
-		//if (err < 0)
-		//{
-		//	cellVdec.fatal("cellVdecGetPictureExt: av_image_copy_to_buffer failed (handle=0x%x, seq_id=%d, cmd_id=%d, err=0x%x='%s')", handle, frame.seq_id, frame.cmd_id, err, utils::av_error_to_string(err));
-		//}
 	}
 
 	return CELL_OK;


### PR DESCRIPTION
Aligns cellVdecGetPicture outBuffer pitch to 128.
The buffer itself is aligned to 128, so this seems like the correct alignment.
I tried with other alignments, but in all other cases the image looked crooked.

~~Additionally, I re-use existing alpha caches if possible.~~

Before:
![image](https://user-images.githubusercontent.com/23019877/219871687-b7b86012-40b5-4c75-9c33-274f5aa70de4.png)

After:
![image](https://user-images.githubusercontent.com/23019877/219871441-71db21fd-16dd-4dc3-a903-a4e7e995a0b9.png)

fixes #11751