### PR TITLE
Fix Visual Studio 17.5.0 compilation

### DIFF
--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -181,10 +181,13 @@ namespace atomic_wait
 		}
 	} any_value;
 
-	template <typename X, typename T = decltype(std::declval<X>().observe())>
+	template <typename X>
+	using payload_type = decltype(std::declval<X>().observe());
+
+	template <typename X, typename T = payload_type<X>>
 	constexpr u128 default_mask = sizeof(T) <= 8 ? u128{u64{umax} >> ((64 - sizeof(T) * 8) & 63)} : u128(-1);
 
-	template <typename X, typename T = decltype(std::declval<X>().observe())>
+	template <typename X, typename T = payload_type<X>>
 	constexpr u128 get_value(X&, T value = T{}, ...)
 	{
 		static_assert((sizeof(T) & (sizeof(T) - 1)) == 0);
@@ -199,13 +202,13 @@ namespace atomic_wait
 		u128 old;
 		u128 mask;
 
-		template <typename X, typename T = decltype(std::declval<X>().observe())>
+		template <typename X, typename T = payload_type<X>>
 		constexpr void set_value(X& a, T value = T{})
 		{
 			old = get_value(a, value);
 		}
 
-		template <typename X, typename T = decltype(std::declval<X>().observe())>
+		template <typename X, typename T = payload_type<X>>
 		constexpr void set_mask(T value)
 		{
 			static_assert((sizeof(T) & (sizeof(T) - 1)) == 0);
@@ -213,7 +216,7 @@ namespace atomic_wait
 			mask = std::bit_cast<get_uint_t<sizeof(T)>, T>(value);
 		}
 
-		template <typename X, typename T = decltype(std::declval<X>().observe())>
+		template <typename X, typename T = payload_type<X>>
 		constexpr void set_mask()
 		{
 			mask = default_mask<X>;

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -1,8 +1,5 @@
 #include "stdafx.h"
 #include "media_utils.h"
-#include "logs.hpp"
-#include "Utilities/StrUtil.h"
-#include "Emu/Cell/Modules/cellSearch.h"
 #include "Emu/System.h"
 
 #include <random>

--- a/rpcs3/util/media_utils.h
+++ b/rpcs3/util/media_utils.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <unordered_map>
-#include <atomic>
-#include <deque>
-#include <mutex>
-#include <thread>
 #include "Utilities/StrUtil.h"
 #include "Utilities/Thread.h"
 #include "util/video_provider.h"
 #include "Emu/Cell/Modules/cellMusic.h"
+
+#include <unordered_map>
+#include <deque>
+#include <mutex>
+#include <thread>
 
 namespace utils
 {


### PR DESCRIPTION
For some reason there's an internal compiler error related to atomic wait.
I could work around this issue when I commented `mask = default_mask<X>;`.
So after playing around a bit I had the suspicion that the VS parser can't handle some of the templatization.
Giving the decltype its own alias seems to fix this issue (and makes the code a bit more readable anyway in my opinion).