### PR TITLE
Fix for Windows ENOTCONN on connecting socket

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/sys_net_helpers.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/sys_net_helpers.h
@@ -18,7 +18,8 @@
 #include "Emu/Cell/lv2/sys_net.h"
 
 int get_native_error();
-sys_net_error get_last_error(bool is_blocking, int native_error = 0);
+sys_net_error convert_error(bool is_blocking, int native_error, bool is_connecting = false);
+sys_net_error get_last_error(bool is_blocking, bool is_connecting = false);
 sys_net_sockaddr native_addr_to_sys_net_addr(const ::sockaddr_storage& native_addr);
 ::sockaddr_in sys_net_addr_to_native_addr(const sys_net_sockaddr& sn_addr);
 bool is_ip_public_address(const ::sockaddr_in& addr);


### PR DESCRIPTION
Fixes Windows returns ENOTCONN when using recvfrom/sendto on connecting socket instead of the expected EAGAIN.