### PR TITLE
rsx/overlays: Fix emu close

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -293,7 +293,7 @@ namespace rsx
 					// Clear
 					interrupted_items.clear();
 				}
-				else
+				else if (!m_input_thread_abort)
 				{
 					m_input_token_stack.wait();
 				}

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -20,8 +20,21 @@ namespace rsx
 		{
 			if (m_input_thread)
 			{
+				// This keeps the input thread from looping again
 				m_input_thread_abort.store(true);
 
+				// Wake it if it is asleep
+				const input_thread_context_t wakeup_node =
+				{
+					"stop_node",
+					nullptr,
+					nullptr,
+					nullptr,
+					nullptr
+				};
+				m_input_token_stack.push(wakeup_node);
+
+				// Wait for join
 				*m_input_thread = thread_state::aborting;
 				while (*m_input_thread <= thread_state::aborting)
 				{
@@ -87,7 +100,8 @@ namespace rsx
 				{
 					return std::find(uids.begin(), uids.end(), e->uid) != uids.end();
 				}),
-				m_dirty_list.end());
+				m_dirty_list.end()
+			);
 		}
 
 		bool display_manager::remove_type(u32 type_id)
@@ -197,7 +211,7 @@ namespace rsx
 
 				for (auto&& input_context : m_input_token_stack.pop_all_reversed())
 				{
-					if (input_context.target->is_detached())
+					if (!input_context.target || input_context.target->is_detached())
 					{
 						continue;
 					}


### PR DESCRIPTION
Input thread gets stuck in the lf_queue.wait() routine and never wakes up to exit. Just insert a dummy node to wake it on exit.
Fixes https://github.com/RPCS3/rpcs3/issues/13447