### PR TITLE
cellMsgDialog: fix use-after-free

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -166,7 +166,7 @@ error_code open_msg_dialog(bool is_blocking, u32 type, vm::cptr<char> msgString,
 
 		const auto notify = std::make_shared<atomic_t<bool>>(false);
 
-		const auto res = manager->create<rsx::overlays::message_dialog>()->show(is_blocking, msgString.get_ptr(), _type, [callback, userData, &return_code, is_blocking, &notify](s32 status)
+		const auto res = manager->create<rsx::overlays::message_dialog>()->show(is_blocking, msgString.get_ptr(), _type, [callback, userData, &return_code, is_blocking, notify](s32 status)
 		{
 			if (is_blocking && return_code)
 			{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1097,7 +1097,7 @@ void spu_thread::dump_regs(std::string& ret) const
 			if (!printed_error)
 			{
 				// Shortand formatting
-				fmt::append(ret, "08x", i3);
+				fmt::append(ret, "%08x", i3);
 			}
 		}
 		else

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
@@ -166,7 +166,7 @@ namespace rsx
 
 			overlayman.attach_thread_input(
 				uid, "Home menu",
-				[&notify]() { *notify = true; notify->notify_one(); }
+				[notify]() { *notify = true; notify->notify_one(); }
 			);
 
 			if (g_cfg.misc.pause_during_home_menu)

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -302,14 +302,14 @@ namespace rsx
 					{
 						overlayman.attach_thread_input(
 							uid, "Message dialog",
-							[&notify]() { *notify = true; notify->notify_one(); }
+							[notify]() { *notify = true; notify->notify_one(); }
 						);
 					}
 					else
 					{
 						overlayman.attach_thread_input(
 							uid, "Message dialog",
-							[&notify]() { *notify = true; notify->notify_one(); },
+							[notify]() { *notify = true; notify->notify_one(); },
 							nullptr,
 							[&]()
 							{

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -1625,7 +1625,7 @@ namespace rsx
 
 			overlayman.attach_thread_input(
 				uid, "OSK",
-				[&notify]() { *notify = true; notify->notify_one(); }
+				[notify]() { *notify = true; notify->notify_one(); }
 			);
 
 			while (!Emu.IsStopped() && !*notify)

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
@@ -244,7 +244,7 @@ namespace rsx
 
 			overlayman.attach_thread_input(
 				uid, "User list dialog",
-				[&notify]() { *notify = true; notify->notify_one(); }
+				[notify]() { *notify = true; notify->notify_one(); }
 			);
 
 			while (!Emu.IsStopped() && !*notify)


### PR DESCRIPTION
A race condition could have led the local copy of notify be accessed after destruction.