### PR TITLE
rsx: Minor memory optimizations

### DIFF
--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -138,6 +138,17 @@ namespace rsx
 			_data[_size++] = val;
 		}
 
+		template <typename... Args>
+		void emplace_back(Args&&... args)
+		{
+			if (_size >= _capacity)
+			{
+				reserve(_capacity + 16);
+			}
+
+			std::construct_at(&_data[_size++], std::forward<Args&&>(args)...);
+		}
+
 		Ty pop_back()
 		{
 			return _data[--_size];

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -835,7 +835,9 @@ void GLGSRender::load_program_env()
 			auto mapping = m_transform_constants_buffer->alloc_from_heap(static_cast<u32>(transform_constants_size), m_uniform_buffer_offset_align);
 			auto buf = static_cast<u8*>(mapping.first);
 
-			const std::vector<u16>& constant_ids = (transform_constants_size == 8192) ? std::vector<u16>{} : m_vertex_prog->constant_ids;
+			const auto constant_ids = (transform_constants_size == 8192)
+				? std::span<const u16>{}
+				: std::span<const u16>(m_vertex_prog->constant_ids);
 			fill_vertex_program_constants_data(buf, constant_ids);
 
 			m_transform_constants_buffer->bind_range(GL_VERTEX_CONSTANT_BUFFERS_BIND_SLOT, mapping.second, static_cast<u32>(transform_constants_size));

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1077,7 +1077,7 @@ namespace rsx
 	* Fill buffer with vertex program constants.
 	* Buffer must be at least 512 float4 wide.
 	*/
-	void thread::fill_vertex_program_constants_data(void* buffer, const std::vector<u16>& reloc_table)
+	void thread::fill_vertex_program_constants_data(void* buffer, const std::span<const u16>& reloc_table)
 	{
 		if (!reloc_table.empty()) [[ likely ]]
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -493,7 +493,7 @@ namespace rsx
 		* Fill buffer with vertex program constants.
 		* Relocation table allows to do a partial fill with only selected registers.
 		*/
-		void fill_vertex_program_constants_data(void* buffer, const std::vector<u16>& reloc_table);
+		void fill_vertex_program_constants_data(void* buffer, const std::span<const u16>& reloc_table);
 
 		/**
 		 * Fill buffer with fragment rasterization state.

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -160,7 +160,7 @@ namespace rsx
 	protected:
 
 		std::array<push_buffer_vertex_info, 16> vertex_push_buffers;
-		std::vector<u32> element_push_buffer;
+		rsx::simple_array<u32> element_push_buffer;
 
 		s32 m_skip_frame_ctr = 0;
 		bool skip_current_frame = false;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2081,8 +2081,11 @@ void VKGSRender::load_program_env()
 			auto mem = m_transform_constants_ring_info.alloc<1>(utils::align(transform_constants_size, alignment));
 			auto buf = m_transform_constants_ring_info.map(mem, transform_constants_size);
 
-			const std::vector<u16>& constant_ids = (transform_constants_size == 8192) ? std::vector<u16>{} : m_vertex_prog->constant_ids;
+			const auto constant_ids = (transform_constants_size == 8192)
+				? std::span<const u16>{}
+				: std::span<const u16>(m_vertex_prog->constant_ids);
 			fill_vertex_program_constants_data(buf, constant_ids);
+
 			m_transform_constants_ring_info.unmap();
 			m_vertex_constants_buffer_info = { m_transform_constants_ring_info.heap->value, mem, transform_constants_size };
 		}

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -275,8 +275,7 @@ namespace vk
 	{
 		m_push_type_mask |= (1ull << type);
 		m_buffer_view_pool.push_back(buffer_view);
-		m_pending_writes.push_back(
-		{
+		m_pending_writes.emplace_back(
 			VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,    // sType
 			nullptr,                                   // pNext
 			m_handle,                                  // dstSet
@@ -287,15 +286,14 @@ namespace vk
 			nullptr,                                   // pImageInfo
 			nullptr,                                   // pBufferInfo
 			&m_buffer_view_pool.back()                 // pTexelBufferView
-		});
+		);
 	}
 
 	void descriptor_set::push(const VkDescriptorBufferInfo& buffer_info, VkDescriptorType type, u32 binding)
 	{
 		m_push_type_mask |= (1ull << type);
 		m_buffer_info_pool.push_back(buffer_info);
-		m_pending_writes.push_back(
-		{
+		m_pending_writes.emplace_back(
 			VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,    // sType
 			nullptr,                                   // pNext
 			m_handle,                                  // dstSet
@@ -306,15 +304,14 @@ namespace vk
 			nullptr,                                   // pImageInfo
 			&m_buffer_info_pool.back(),                // pBufferInfo
 			nullptr                                    // pTexelBufferView
-		});
+		);
 	}
 
 	void descriptor_set::push(const VkDescriptorImageInfo& image_info, VkDescriptorType type, u32 binding)
 	{
 		m_push_type_mask |= (1ull << type);
 		m_image_info_pool.push_back(image_info);
-		m_pending_writes.push_back(
-		{
+		m_pending_writes.emplace_back(
 			VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,    // sType
 			nullptr,                                   // pNext
 			m_handle,                                  // dstSet
@@ -325,7 +322,7 @@ namespace vk
 			&m_image_info_pool.back(),                 // pImageInfo
 			nullptr,                                   // pBufferInfo
 			nullptr                                    // pTexelBufferView
-		});
+		);
 	}
 
 	void descriptor_set::push(const VkDescriptorImageInfo* image_info, u32 count, VkDescriptorType type, u32 binding)

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -82,7 +82,39 @@ namespace vk
 		rsx::simple_array<VkDescriptorBufferInfo> m_buffer_info_pool;
 		rsx::simple_array<VkDescriptorImageInfo> m_image_info_pool;
 
-		rsx::simple_array<VkWriteDescriptorSet> m_pending_writes;
+#ifdef __clang__
+		// Clang (pre 16.x) does not support LWG 2089, std::construct_at for POD types
+		struct WriteDescriptorSetT : public VkWriteDescriptorSet
+		{
+			WriteDescriptorSetT(
+				VkStructureType                  sType,
+				const void*                      pNext,
+				VkDescriptorSet                  dstSet,
+				uint32_t                         dstBinding,
+				uint32_t                         dstArrayElement,
+				uint32_t                         descriptorCount,
+				VkDescriptorType                 descriptorType,
+				const VkDescriptorImageInfo*     pImageInfo,
+				const VkDescriptorBufferInfo*    pBufferInfo,
+				const VkBufferView*              pTexelBufferView)
+			{
+				this->sType = sType,
+				this->pNext = pNext,
+				this->dstSet = dstSet,
+				this->dstBinding = dstBinding,
+				this->dstArrayElement = dstArrayElement,
+				this->descriptorCount = descriptorCount,
+				this->descriptorType = descriptorType,
+				this->pImageInfo = pImageInfo,
+				this->pBufferInfo = pBufferInfo,
+				this->pTexelBufferView = pTexelBufferView;
+			}
+		};
+#else
+		using WriteDescriptorSetT = VkWriteDescriptorSet;
+#endif
+
+		rsx::simple_array<WriteDescriptorSetT> m_pending_writes;
 		rsx::simple_array<VkCopyDescriptorSet> m_pending_copies;
 	};
 


### PR DESCRIPTION
Avoid unnecessary copies on the hot path. Profiling identified millions of memory copies every frame in msvc-compiled builds that actually add up enough to hurt performance with draw-call-heavy titles. A modest 3-10% uplift is observed in "infamous" which regularly issues 10-20k draw calls per frame.