### PR TITLE
sys_fs & VFS: Misc bug fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -192,7 +192,7 @@ public:
 	static std::string_view get_device_path(std::string_view filename);
 	static lv2_fs_mount_point* get_mp(std::string_view filename, std::string* vfs_path = nullptr);
 	static std::string device_name_to_path(std::string_view device_name);
-	static bool vfs_unmount(std::string_view vpath, bool no_error = false);
+	static bool vfs_unmount(std::string_view vpath);
 
 	static std::array<char, 0x420> get_name(std::string_view filename)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -285,7 +285,9 @@ usb_handler_thread::usb_handler_thread()
 
 	for (int i = 0; i < 8; i++) // Add VFS USB mass storage devices (/dev_usbXXX) to the USB device list
 	{
-		usb_devices.push_back(std::make_shared<usb_device_vfs>(g_cfg_vfs.get_device(g_cfg_vfs.dev_usb, fmt::format("/dev_usb%03d", i)), get_new_location()));
+		const auto usb_info = g_cfg_vfs.get_device(g_cfg_vfs.dev_usb, fmt::format("/dev_usb%03d", i));
+		if (fs::is_dir(usb_info.path))
+			usb_devices.push_back(std::make_shared<usb_device_vfs>(usb_info, get_new_location()));
 	}
 
 	if (!found_skylander)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -298,7 +298,8 @@ void Emulator::Init(bool add_only)
 			continue;
 		}
 
-		vfs::mount(key, usb_info.path);
+		if (fs::is_dir(usb_info.path))
+			vfs::mount(key, usb_info.path);
 
 		if (key == "/dev_usb000"sv)
 		{


### PR DESCRIPTION
1. Do not mount dev_usbXXX if its path is not properly specified since this can cause confusion to some games that detect and determine which USB flash drive to use.
2. Allow dev_usbXXX to be mounted, unmounted, and formatted(newfs) by the corresponding sys_fs syscalls as some games do format the attached USB flash drives in some cases.
3. Improve the permission check for the three syscalls mentioned above: PS3 root permission is required in order to perform actions on devices other than dev_usbXXX.
4. Add read-only flag check to sys_fs_newfs() to prevent devices with this flag from being formatted.
5. Implement CELL_FS_PATH path-as-device support.