### PR TITLE
pkg install: return correct error if possible

### DIFF
--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -338,9 +338,9 @@ public:
 		started,
 		success,
 		aborted,
-		aborted_cleaned,
+		aborted_dirty,
 		error,
-		error_cleaned
+		error_dirty
 	};
 
 	bool is_valid() const { return m_is_valid; }

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1015,18 +1015,18 @@ void main_window::HandlePackageInstallation(QStringList file_paths)
 			}
 			case package_reader::result::not_started:
 			case package_reader::result::started:
-			case package_reader::result::aborted_cleaned:
+			case package_reader::result::aborted:
 			{
 				gui_log.notice("Aborted installation of %s (title_id=%s, title=%s, version=%s).", sstr(package.path), sstr(package.title_id), sstr(package.title), sstr(package.version));
 				break;
 			}
-			case package_reader::result::error_cleaned:
+			case package_reader::result::error:
 			{
 				gui_log.error("Failed to install %s (title_id=%s, title=%s, version=%s).", sstr(package.path), sstr(package.title_id), sstr(package.title), sstr(package.version));
 				break;
 			}
-			case package_reader::result::aborted:
-			case package_reader::result::error:
+			case package_reader::result::aborted_dirty:
+			case package_reader::result::error_dirty:
 			{
 				gui_log.error("Partially installed %s (title_id=%s, title=%s, version=%s).", sstr(package.path), sstr(package.title_id), sstr(package.title), sstr(package.version));
 				break;
@@ -1142,10 +1142,10 @@ void main_window::HandlePackageInstallation(QStringList file_paths)
 				case package_reader::result::not_started:
 				case package_reader::result::started:
 				case package_reader::result::aborted:
-				case package_reader::result::aborted_cleaned:
+				case package_reader::result::aborted_dirty:
 					break;
 				case package_reader::result::error:
-				case package_reader::result::error_cleaned:
+				case package_reader::result::error_dirty:
 					package = &packages[i];
 					break;
 				}


### PR DESCRIPTION
- Do not use a generic error if the error is already set.
- Abort installation immediately without processing the other packages if an error occured in order to properly determine the failed package.
- Skip workers on error. No real code change here as it was already done internally. But it was confusing to read without the extra check in the loop.

maybe fixes #13472