### PR TITLE
Patches: Virtual move/remove/create game files patches

### DIFF
--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -52,7 +52,14 @@ enum class patch_type
 	bef32,
 	bef64,
 	utf8, // Text of string (not null-terminated automatically)
+	move_file, // Move file
+	hide_file, // Hide file
 };
+
+static constexpr bool patch_type_uses_hex_offset(patch_type type)
+{
+	return type >= patch_type::alloc && type <= patch_type::utf8;
+}
 
 enum class patch_configurable_type
 {
@@ -69,6 +76,7 @@ public:
 	{
 		patch_type type = patch_type::load;
 		u32 offset = 0;
+		std::string original_offset{}; // Used for specifying paths
 		std::string original_value{}; // Used for import consistency (avoid rounding etc.)
 		union
 		{


### PR DESCRIPTION
Two new patch types, "move_file" and "hide_file":

**"hide_file":**
Specify the PS3 path of the file to mark as non-existant in offset field, the value field is unused. This can be used to "remove" cutscenes for example without needing to make any modification to game files. When specifying an already non-existant file this will prevent its creation further on. (ENOENT error code)

**"move_file":**
Specify the PS3 path of the file to "move" in offset field, and the destination path in value field. The original PS3 path does not have to exist for this operation to work. This can be used to install configurable mods and texture packs without modifying the original game files. 

Do note that this can also be used on directories and PS3 partitions.
You do not have to specify "/dev_" at the start of path.

Examples:
- [ hide_file, /dev_hdd0/game/SERIAL/USRDIR/Video.mp4, "" ] # Mark the video as non-existant
- [ hide_file, hdd0/game/SERIAL/USRDIR/Video.mp4, "" ] # Same
- [ move_file, /dev_hdd0/game/SERIAL/USRDIR/Textures.tex, /dev_usbd/SERIAL/Textures.tex ] # Replace 'Textures.tex' with another file at /dev_usbd
