### PR TITLE
VFS: Fix mounting non-existant paths

### DIFF
--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -71,6 +71,8 @@ bool vfs::mount(std::string_view vpath, std::string_view path, bool is_dir)
 		{
 			// Mounting completed; fixup for directories due to resolve_path messing with trailing /
 			list.back()->path = Emu.GetCallbacks().resolve_path(path);
+			if (list.back()->path.empty())
+				list.back()->path = std::string(path); // Fallback when resolving failed
 			if (is_dir && !list.back()->path.ends_with('/'))
 				list.back()->path += '/';
 			if (!is_dir && list.back()->path.ends_with('/'))

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -327,7 +327,15 @@ EmuCallbacks main_application::CreateCallbacks()
 
 	callbacks.resolve_path = [](std::string_view sv)
 	{
-		return QFileInfo(QString::fromUtf8(sv.data(), static_cast<int>(sv.size()))).canonicalFilePath().toStdString();
+		const std::string result = QFileInfo(QString::fromUtf8(sv.data(), static_cast<int>(sv.size()))).canonicalFilePath().toStdString();
+
+		if (result.empty())
+		{
+			// May fail if path does not exist
+			std::clog << fmt::format("main_application: resolve_path(): Failed to resolve path \'%s\'\n", sv);
+		}
+
+		return result;
 	};
 
 	return callbacks;

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -328,15 +328,8 @@ EmuCallbacks main_application::CreateCallbacks()
 
 	callbacks.resolve_path = [](std::string_view sv)
 	{
-		const std::string result = QFileInfo(QString::fromUtf8(sv.data(), static_cast<int>(sv.size()))).canonicalFilePath().toStdString();
-
-		if (result.empty())
-		{
-			// May fail if path does not exist
-			std::clog << fmt::format("main_application: resolve_path(): Failed to resolve path \'%s\'\n", sv);
-		}
-
-		return result;
+		// May result in an empty string if path does not exist
+		return QFileInfo(QString::fromUtf8(sv.data(), static_cast<int>(sv.size()))).canonicalFilePath().toStdString();
 	};
 
 	return callbacks;

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -37,6 +37,7 @@
 #include <QFileInfo> // This shouldn't be outside rpcs3qt...
 #include <QImageReader> // This shouldn't be outside rpcs3qt...
 #include <thread>
+#include <iostream>
 
 LOG_CHANNEL(sys_log, "SYS");
 

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -37,7 +37,6 @@
 #include <QFileInfo> // This shouldn't be outside rpcs3qt...
 #include <QImageReader> // This shouldn't be outside rpcs3qt...
 #include <thread>
-#include <iostream>
 
 LOG_CHANNEL(sys_log, "SYS");
 


### PR DESCRIPTION
resolve_path is just a simplification of path compariosns I added in the past for savestates. It is not  
 required to succeed, nor should VFS care whether the file path exists or not.