### PR TITLE
Qt: Disable some network settings in global config. Re-enable RPCN in global config.

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1783,7 +1783,7 @@ const std::string& fs::get_config_dir()
 		if (GetEnvironmentVariable(L"RPCS3_CONFIG_DIR", buf, size) - 1 >= size - 1 &&
 			GetModuleFileName(nullptr, buf, size) - 1 >= size - 1)
 		{
-			MessageBoxA(nullptr, fmt::format("GetModuleFileName() failed: error %u.", GetLastError()).c_str(), "fs::get_config_dir()", MB_ICONERROR);
+			MessageBoxA(nullptr, fmt::format("GetModuleFileName() failed: error: %s", fmt::win_error{GetLastError(), nullptr}).c_str(), "fs::get_config_dir()", MB_ICONERROR);
 			return dir; // empty
 		}
 
@@ -1868,7 +1868,7 @@ const std::string& fs::get_temp_dir()
 		wchar_t buf[MAX_PATH + 2]{};
 		if (GetTempPathW(MAX_PATH + 1, buf) - 1 > MAX_PATH)
 		{
-			MessageBoxA(nullptr, fmt::format("GetTempPath() failed: error %u.", GetLastError()).c_str(), "fs::get_temp_dir()", MB_ICONERROR);
+			MessageBoxA(nullptr, fmt::format("GetTempPath() failed: error: %s", fmt::win_error{GetLastError(), nullptr}).c_str(), "fs::get_temp_dir()", MB_ICONERROR);
 			return dir; // empty
 		}
 

--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -79,6 +79,17 @@ std::string fmt::win_error_to_string(unsigned long error, void* module_handle)
 
 	return message;
 }
+
+std::string fmt::win_error_to_string(const fmt::win_error& error)
+{
+	return fmt::win_error_to_string(error.error, error.module_handle);
+}
+
+template <>
+void fmt_class_string<fmt::win_error>::format(std::string& out, u64 arg)
+{
+	fmt::append(out, "%s", fmt::win_error_to_string(get_object(arg)));
+}
 #endif
 
 template <>

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -10,8 +10,15 @@ namespace fmt
 	static std::string format(const CharT(&)[N], const Args&...);
 
 #ifdef _WIN32
+	struct win_error
+	{
+		unsigned long error{};
+		void* module_handle{};
+	};
+
 	// Get a string for a windows error (DWORD). Optionally a module HANDLE can be passed.
 	std::string win_error_to_string(unsigned long error, void* module_handle = nullptr);
+	std::string win_error_to_string(const win_error& error);
 #endif
 }
 

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2710,7 +2710,7 @@ void thread_ctrl::detect_cpu_layout()
 		if (!GetLogicalProcessorInformationEx(relationship,
 			reinterpret_cast<SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *>(buffer.data()), &buffer_size))
 		{
-			sig_log.error("GetLogicalProcessorInformationEx failed (size=%u, error=%u)", buffer_size, GetLastError());
+			sig_log.error("GetLogicalProcessorInformationEx failed (size=%u, error=%s)", buffer_size, fmt::win_error{GetLastError(), nullptr});
 		}
 		else
 		{
@@ -2957,7 +2957,7 @@ void thread_ctrl::set_native_priority(int priority)
 
 	if (!SetThreadPriority(_this_thread, native_priority))
 	{
-		sig_log.error("SetThreadPriority() failed: 0x%x", GetLastError());
+		sig_log.error("SetThreadPriority() failed: %s", fmt::win_error{GetLastError(), nullptr});
 	}
 #else
 	int policy;
@@ -3009,7 +3009,7 @@ void thread_ctrl::set_thread_affinity_mask(u64 mask)
 	HANDLE _this_thread = GetCurrentThread();
 	if (!SetThreadAffinityMask(_this_thread, !mask ? process_affinity_mask : mask))
 	{
-		sig_log.error("Failed to set thread affinity 0x%x: error 0x%x.", mask, GetLastError());
+		sig_log.error("Failed to set thread affinity 0x%x: error: %s", mask, fmt::win_error{GetLastError(), nullptr});
 	}
 #elif __APPLE__
 	// Supports only one core

--- a/rpcs3/Emu/RSX/VK/VKDMA.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDMA.cpp
@@ -290,7 +290,7 @@ namespace vk
 		MEMORY_BASIC_INFORMATION mem_info;
 		if (!::VirtualQuery(vm::get_super_ptr<const void>(base_address), &mem_info, sizeof(mem_info)))
 		{
-			rsx_log.error("VirtualQuery failed! LastError=0x%x", GetLastError());
+			rsx_log.error("VirtualQuery failed! LastError=%s", fmt::win_error{GetLastError(), nullptr});
 			return false;
 		}
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -503,7 +503,7 @@ int main(int argc, char** argv)
 	WSADATA wsa_data{};
 	if (const int res = WSAStartup(MAKEWORD(2, 2), &wsa_data); res != 0)
 	{
-		report_fatal_error(fmt::format("WSAStartup failed (error=%s)", fmt::win_error_to_string(res, nullptr)));
+		report_fatal_error(fmt::format("WSAStartup failed (error=%s)", fmt::win_error{static_cast<unsigned long>(res), nullptr}));
 	}
 #endif
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1322,29 +1322,34 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	m_emu_settings->EnhanceLineEdit(ui->edit_bind, emu_settings_type::BindAddress);
 	SubscribeTooltip(ui->gb_edit_bind, tooltips.settings.bind);
+	ui->gb_edit_bind->setEnabled(!!game);
 
 	m_emu_settings->EnhanceLineEdit(ui->edit_swaps, emu_settings_type::IpSwapList);
 	SubscribeTooltip(ui->gb_edit_swaps, tooltips.settings.dns_swap);
+	ui->gb_edit_swaps->setEnabled(!!game);
 
 	m_emu_settings->EnhanceCheckBox(ui->enable_upnp, emu_settings_type::EnableUpnp);
 	SubscribeTooltip(ui->enable_upnp, tooltips.settings.enable_upnp);
 
 	// Comboboxes
 
+	connect(ui->netStatusBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index)
+	{
+		if (index < 0) return;
+		const auto [text, value] = get_data(ui->netStatusBox, index);
+		ui->gb_edit_dns->setEnabled(static_cast<np_internet_status>(value) != np_internet_status::disabled);
+		ui->enable_upnp->setEnabled(static_cast<np_internet_status>(value) != np_internet_status::disabled);
+	});
 	m_emu_settings->EnhanceComboBox(ui->netStatusBox, emu_settings_type::InternetStatus);
 	SubscribeTooltip(ui->gb_netStatusBox, tooltips.settings.net_status);
 
-	connect(ui->netStatusBox, QOverload<int>::of(&QComboBox::currentIndexChanged), [this](int index)
-	{
-		ui->edit_dns->setEnabled(index > 0);
-		ui->enable_upnp->setEnabled(index > 0);
-	});
-	ui->edit_dns->setEnabled(ui->netStatusBox->currentIndex() > 0);
-	ui->enable_upnp->setEnabled(ui->netStatusBox->currentIndex() > 0);
-
 	m_emu_settings->EnhanceComboBox(ui->psnStatusBox, emu_settings_type::PSNStatus);
 	SubscribeTooltip(ui->gb_psnStatusBox, tooltips.settings.psn_status);
-	ui->gb_psnStatusBox->setEnabled(!!game);
+
+	if (!game)
+	{
+		remove_item(ui->psnStatusBox, static_cast<int>(np_psn_status::psn_fake), static_cast<int>(g_cfg.net.psn_status.def));
+	}
 
 	//                _                               _   _______    _
 	//       /\      | |                             | | |__   __|  | |

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -226,10 +226,10 @@ public:
 		// network
 
 		const QString net_status    = tr("If set to Connected, RPCS3 will allow programs to use your internet connection.");
-		const QString psn_status    = tr("Only available in custom configurations.\nIf set to RPCN, RPCS3 will use the RPCN server as PSN connection if the game is supported.\nIf set to Simulated, RPCS3 will try to fake the PSN connection, but any actual attempt at using the PSN functionality may result in errors or crashes.");
+		const QString psn_status    = tr("If set to RPCN, RPCS3 will use the RPCN server as PSN connection if the game is supported.\nIf set to Simulated, RPCS3 will try to fake the PSN connection, but any actual attempt at using the PSN functionality may result in errors or crashes.\nSimulated is only available in custom configurations.");
 		const QString dns           = tr("DNS used to resolve hostnames by applications.");
-		const QString dns_swap      = tr("DNS Swap List.");
-		const QString bind          = tr("Interface IP Address to bind to.");
+		const QString dns_swap      = tr("DNS Swap List.\nOnly available in custom configurations.");
+		const QString bind          = tr("Interface IP Address to bind to.\nOnly available in custom configurations.");
 		const QString enable_upnp   = tr("Enable UPNP.\nThis will automatically forward ports bound on 0.0.0.0 if your router has UPNP enabled.");
 
 		// system

--- a/rpcs3/util/cpu_stats.cpp
+++ b/rpcs3/util/cpu_stats.cpp
@@ -54,9 +54,9 @@ LOG_CHANNEL(perf_log, "PERF");
 namespace utils
 {
 #ifdef _WIN32
-	std::string pdh_error(PDH_STATUS status)
+	fmt::win_error pdh_error(PDH_STATUS status)
 	{
-		return fmt::win_error_to_string(status, LoadLibrary(L"pdh.dll"));
+		return fmt::win_error{static_cast<unsigned long>(status), LoadLibrary(L"pdh.dll")};
 	}
 #endif
 

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -421,7 +421,7 @@ namespace utils
 
 			if (!::VirtualProtect(reinterpret_cast<LPVOID>(addr), block_size, +prot, &old))
 			{
-				fmt::throw_exception("VirtualProtect failed (%p, 0x%x, addr=0x%x, error=%#x)", pointer, size, addr, GetLastError());
+				fmt::throw_exception("VirtualProtect failed (%p, 0x%x, addr=0x%x, error=%s)", pointer, size, addr, fmt::win_error{GetLastError(), nullptr});
 			}
 
 			// Next region


### PR DESCRIPTION
- Re-enable RPCN as global config
- Hide Fake PSN in global config instead
- Hide "IP/Host Switches" and "Bind Address" in global config
- Properly log some win errors