### PR TITLE
llvm: update code to new API

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -1304,7 +1304,7 @@ std::string jit_compiler::cpu(const std::string& _cpu)
 
 	if (m_cpu.empty())
 	{
-		m_cpu = llvm::sys::getHostCPUName().operator std::string();
+		m_cpu = llvm::sys::getHostCPUName().str();
 
 		if (m_cpu == "sandybridge" ||
 			m_cpu == "ivybridge" ||

--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -299,7 +299,7 @@ llvm::Constant* cpu_translator::make_const_vector<v128>(v128 v, llvm::Type* t, u
 {
 	if (const auto ct = llvm::dyn_cast<llvm::IntegerType>(t); ct && ct->getBitWidth() == 128)
 	{
-		return llvm::ConstantInt::get(t, llvm::APInt(128, llvm::makeArrayRef(reinterpret_cast<const u64*>(v._bytes), 2)));
+		return llvm::ConstantInt::get(t, llvm::APInt(128, llvm::ArrayRef(reinterpret_cast<const u64*>(v._bytes), 2)));
 	}
 
 	ensure(t->isVectorTy());
@@ -309,27 +309,27 @@ llvm::Constant* cpu_translator::make_const_vector<v128>(v128 v, llvm::Type* t, u
 
 	if (sct->isIntegerTy(8))
 	{
-		return llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u8*>(v._bytes), 16));
+		return llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u8*>(v._bytes), 16));
 	}
 	if (sct->isIntegerTy(16))
 	{
-		return llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u16*>(v._bytes), 8));
+		return llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u16*>(v._bytes), 8));
 	}
 	if (sct->isIntegerTy(32))
 	{
-		return llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u32*>(v._bytes), 4));
+		return llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u32*>(v._bytes), 4));
 	}
 	if (sct->isIntegerTy(64))
 	{
-		return llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u64*>(v._bytes), 2));
+		return llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u64*>(v._bytes), 2));
 	}
 	if (sct->isFloatTy())
 	{
-		return llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const f32*>(v._bytes), 4));
+		return llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const f32*>(v._bytes), 4));
 	}
 	if (sct->isDoubleTy())
 	{
-		return llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const f64*>(v._bytes), 2));
+		return llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const f64*>(v._bytes), 2));
 	}
 
 	fmt::throw_exception("[line %u] No supported constant type", _line);

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3429,7 +3429,7 @@ public:
 
 			if (cv || llvm::isa<llvm::ConstantAggregateZero>(c))
 			{
-				result.value = llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u8*>(&mask), 16));
+				result.value = llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u8*>(&mask), 16));
 				result.value = m_ir->CreateZExt(result.value, get_type<u32[16]>());
 				result.value = m_ir->CreateShuffleVector(data0, zeros, result.value);
 				return result;
@@ -3472,7 +3472,7 @@ public:
 
 			if (cv || llvm::isa<llvm::ConstantAggregateZero>(c))
 			{
-				result.value = llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u8*>(&mask), 16));
+				result.value = llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u8*>(&mask), 16));
 				result.value = m_ir->CreateZExt(result.value, get_type<u32[16]>());
 				result.value = m_ir->CreateShuffleVector(data0, data1, result.value);
 				return result;
@@ -3512,7 +3512,7 @@ public:
 
 			if (cv || llvm::isa<llvm::ConstantAggregateZero>(c))
 			{
-				result.value = llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u8*>(&mask), 16));
+				result.value = llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u8*>(&mask), 16));
 				result.value = m_ir->CreateZExt(result.value, get_type<u32[16]>());
 				result.value = m_ir->CreateShuffleVector(data0, data1, result.value);
 				return result;
@@ -3530,7 +3530,7 @@ public:
 		u8 mask16[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
 		// insert the second source operand into the same vector as the first source operand and expand to 256 bit width
-		shuffle.value = llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u8*>(&mask32), 32));
+		shuffle.value = llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u8*>(&mask32), 32));
 		shuffle.value = m_ir->CreateZExt(shuffle.value, get_type<u32[32]>());
 		intermediate.value = m_ir->CreateShuffleVector(data0, data1, shuffle.value);
 
@@ -3541,22 +3541,27 @@ public:
 		intermediate.value = m_ir->CreateCall(get_intrinsic(llvm::Intrinsic::x86_avx512_permvar_qi_256), {intermediate.value, shuffleindex.value});
 
 		// convert the 256 bit vector back to 128 bits
-		result.value = llvm::ConstantDataVector::get(m_context, llvm::makeArrayRef(reinterpret_cast<const u8*>(&mask16), 16));
+		result.value = llvm::ConstantDataVector::get(m_context, llvm::ArrayRef(reinterpret_cast<const u8*>(&mask16), 16));
 		result.value = m_ir->CreateZExt(result.value, get_type<u32[16]>());
 		result.value = m_ir->CreateShuffleVector(intermediate.value, zeroes32, result.value);
 		return result;
 	}
 
+	template <typename T>
 	llvm::Value* load_const(llvm::GlobalVariable* g, llvm::Value* i)
 	{
+#ifdef OLDLLVM
 		return m_ir->CreateLoad(m_ir->CreateGEP(g, {m_ir->getInt64(0), m_ir->CreateZExtOrTrunc(i, get_type<u64>())}));
+#else
+		return m_ir->CreateLoad(get_type<T>(), m_ir->CreateGEP(g->getValueType(), g, {m_ir->getInt64(0), m_ir->CreateZExtOrTrunc(i, get_type<u64>())}));
+#endif
 	}
 
 	template <typename T, typename I>
 	value_t<T> load_const(llvm::GlobalVariable* g, I i)
 	{
 		value_t<T> result;
-		result.value = load_const(g, i.eval(m_ir));
+		result.value = load_const<T>(g, i.eval(m_ir));
 		return result;
 	}
 
@@ -3635,7 +3640,7 @@ public:
 				if (cv || llvm::isa<llvm::ConstantAggregateZero>(c))
 				{
 					llvm::Value* r = nullptr;
-					r = llvm::ConstantDataVector::get(ir->getContext(), llvm::makeArrayRef(reinterpret_cast<const u8*>(&mask), 16));
+					r = llvm::ConstantDataVector::get(ir->getContext(), llvm::ArrayRef(reinterpret_cast<const u8*>(&mask), 16));
 					r = ir->CreateZExt(r, llvm_value_t<u32[16]>::get_type(ir->getContext()));
 					r = ir->CreateShuffleVector(args[0], zeros, r);
 					return r;

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3550,11 +3550,7 @@ public:
 	template <typename T>
 	llvm::Value* load_const(llvm::GlobalVariable* g, llvm::Value* i)
 	{
-#ifdef OLDLLVM
-		return m_ir->CreateLoad(m_ir->CreateGEP(g, {m_ir->getInt64(0), m_ir->CreateZExtOrTrunc(i, get_type<u64>())}));
-#else
 		return m_ir->CreateLoad(get_type<T>(), m_ir->CreateGEP(g->getValueType(), g, {m_ir->getInt64(0), m_ir->CreateZExtOrTrunc(i, get_type<u64>())}));
-#endif
 	}
 
 	template <typename T, typename I>

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -42,7 +42,9 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Object/ObjectFile.h"
+#if LLVM_VERSION_MAJOR < 17
 #include "llvm/ADT/Triple.h"
+#endif
 #include "llvm/IR/Verifier.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -3975,7 +3977,7 @@ static void ppu_initialize2(jit_compiler& jit, const ppu_module& module_part, co
 		{
 			const auto f = cast<Function>(_module->getOrInsertFunction(func.name, _func).getCallee());
 			f->setCallingConv(CallingConv::GHC);
-			f->addAttribute(2, Attribute::NoAlias);
+			f->addParamAttr(1, llvm::Attribute::NoAlias);
 			f->addFnAttr(Attribute::NoUnwind);
 		}
 	}

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1,3 +1,4 @@
+#include <bit>
 #ifdef LLVM_AVAILABLE
 
 #include "Emu/system_config.h"
@@ -176,14 +177,14 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 		}
 	}
 
-	m_thread = &*(m_function->arg_begin() + 1);
-	m_base = &*(m_function->arg_begin() + 3);
-	m_exec = &*(m_function->arg_begin() + 0);
-	m_seg0 = &*(m_function->arg_begin() + 2);
+	m_thread = m_function->getArg(1);
+	m_base = m_function->getArg(3);
+	m_exec = m_function->getArg(0);
+	m_seg0 = m_function->getArg(2);
 
-	m_gpr[0] = &*(m_function->arg_begin() + 4);
-	m_gpr[1] = &*(m_function->arg_begin() + 5);
-	m_gpr[2] = &*(m_function->arg_begin() + 6);
+	m_gpr[0] = m_function->getArg(4);
+	m_gpr[1] = m_function->getArg(5);
+	m_gpr[2] = m_function->getArg(6);
 
 	const auto body = BasicBlock::Create(m_context, "__body", m_function);
 
@@ -191,7 +192,13 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 	if (need_check)
 	{
 		// Check status register in the entry block
+#ifdef OLDLLVM
 		const auto vstate = m_ir->CreateLoad(m_ir->CreateStructGEP(m_thread, 1), true);
+#else
+		auto ptr = llvm::dyn_cast<GetElementPtrInst>(m_ir->CreateStructGEP(m_thread_type, m_thread, 1));
+		assert(ptr->getResultElementType() == GetType<u32>());
+		const auto vstate = m_ir->CreateLoad(ptr->getResultElementType(), ptr, true);
+#endif
 		const auto vcheck = BasicBlock::Create(m_context, "__test", m_function);
 		m_ir->CreateCondBr(m_ir->CreateIsNull(vstate), body, vcheck, m_md_likely);
 
@@ -369,7 +376,11 @@ void PPUTranslator::CallFunction(u64 target, Value* indirect)
 
 	if (indirect)
 	{
+#ifdef OLDLLVM
 		m_ir->CreateStore(Trunc(indirect, GetType<u32>()), m_ir->CreateStructGEP(m_thread, static_cast<uint>(&m_cia - m_locals)), true);
+#else
+		m_ir->CreateStore(Trunc(indirect, GetType<u32>()), m_ir->CreateStructGEP(m_thread_type, m_thread, static_cast<uint>(&m_cia - m_locals)), true);
+#endif
 
 		// Try to optimize
 		if (auto inst = dyn_cast_or_null<Instruction>(indirect))
@@ -381,8 +392,13 @@ void PPUTranslator::CallFunction(u64 target, Value* indirect)
 		}
 
 		const auto pos = m_ir->CreateShl(indirect, 1);
+#ifdef OLDLLVM
 		const auto ptr = m_ir->CreateGEP(m_exec, pos);
 		const auto val = m_ir->CreateLoad(m_ir->CreateBitCast(ptr, get_type<u64*>()));
+#else
+		const auto ptr = dyn_cast<GetElementPtrInst>(m_ir->CreateGEP(get_type<u8>(), m_exec, pos));
+		const auto val = m_ir->CreateLoad(get_type<u64>(), m_ir->CreateBitCast(ptr, get_type<u64*>()));
+#endif
 		callee = FunctionCallee(type, m_ir->CreateIntToPtr(m_ir->CreateAnd(val, 0xffff'ffff'ffff), type->getPointerTo()));
 
 		// Load new segment address
@@ -406,7 +422,11 @@ Value* PPUTranslator::RegInit(Value*& local)
 	}
 
 	// (Re)Initialize global, will be written in FlushRegisters
+#ifdef OLDLLVM
 	m_globals[index] = m_ir->CreateStructGEP(m_thread, index);
+#else
+	m_globals[index] = m_ir->CreateStructGEP(m_thread_type, m_thread, index);
+#endif
 
 	return m_globals[index];
 }
@@ -422,7 +442,12 @@ Value* PPUTranslator::RegLoad(Value*& local)
 	}
 
 	// Load from the global value
+#ifdef OLDLLVM
 	local = m_ir->CreateLoad(m_ir->CreateStructGEP(m_thread, index));
+#else
+	auto ptr = llvm::dyn_cast<llvm::GetElementPtrInst>(m_ir->CreateStructGEP(m_thread_type, m_thread, index));
+	local = m_ir->CreateLoad(ptr->getResultElementType(), ptr);
+#endif
 	return local;
 }
 
@@ -510,7 +535,7 @@ Value* PPUTranslator::Broadcast(Value* value, u32 count)
 {
 	if (const auto cv = dyn_cast<Constant>(value))
 	{
-		return ConstantVector::getSplat({count, false}, cv);
+		return ConstantVector::getSplat(llvm::ElementCount::get(count, false), cv);
 	}
 
 	return m_ir->CreateVectorSplat(count, value);
@@ -589,7 +614,11 @@ void PPUTranslator::UseCondition(MDNode* hint, Value* cond)
 
 llvm::Value* PPUTranslator::GetMemory(llvm::Value* addr, llvm::Type* type)
 {
+#ifdef OLDLLVM
 	return bitcast(m_ir->CreateGEP(m_base, addr), type->getPointerTo());
+#else
+	return bitcast(m_ir->CreateGEP(get_type<u8>(), m_base, addr), type->getPointerTo());
+#endif
 }
 
 Value* PPUTranslator::ReadMemory(Value* addr, Type* type, bool is_be, u32 align)
@@ -600,12 +629,20 @@ Value* PPUTranslator::ReadMemory(Value* addr, Type* type, bool is_be, u32 align)
 	{
 		// Read, byteswap, bitcast
 		const auto int_type = m_ir->getIntNTy(size);
+#ifdef OLDLLVM
 		const auto value = m_ir->CreateAlignedLoad(GetMemory(addr, int_type), llvm::MaybeAlign{align}, true);
+#else
+		const auto value = m_ir->CreateAlignedLoad(int_type, GetMemory(addr, int_type), llvm::MaybeAlign{align}, true);
+#endif
 		return bitcast(Call(int_type, fmt::format("llvm.bswap.i%u", size), value), type);
 	}
 
 	// Read normally
+#ifdef OLDLLVM
 	return m_ir->CreateAlignedLoad(GetMemory(addr, type), llvm::MaybeAlign{align}, true);
+#else
+	return m_ir->CreateAlignedLoad(type, GetMemory(addr, type), llvm::MaybeAlign{align}, true);
+#endif
 }
 
 void PPUTranslator::WriteMemory(Value* addr, Value* value, bool is_be, u32 align)
@@ -1914,7 +1951,11 @@ void PPUTranslator::BC(ppu_opcode_t op)
 
 	if (op.lk)
 	{
+#ifdef OLDLLVM
 		m_ir->CreateStore(GetAddr(+4), m_ir->CreateStructGEP(m_thread, static_cast<uint>(&m_lr - m_locals)));
+#else
+		m_ir->CreateStore(GetAddr(+4), m_ir->CreateStructGEP(m_thread_type, m_thread, static_cast<uint>(&m_lr - m_locals)));
+#endif
 	}
 
 	UseCondition(CheckBranchProbability(op.bo), CheckBranchCondition(op.bo, op.bi));
@@ -1984,7 +2025,11 @@ void PPUTranslator::BCLR(ppu_opcode_t op)
 
 	if (op.lk)
 	{
+#ifdef OLDLLVM
 		m_ir->CreateStore(GetAddr(+4), m_ir->CreateStructGEP(m_thread, static_cast<uint>(&m_lr - m_locals)));
+#else
+		m_ir->CreateStore(GetAddr(+4), m_ir->CreateStructGEP(m_thread_type, m_thread, static_cast<uint>(&m_lr - m_locals)));
+#endif
 	}
 
 	UseCondition(CheckBranchProbability(op.bo), CheckBranchCondition(op.bo, op.bi));
@@ -2047,7 +2092,11 @@ void PPUTranslator::BCCTR(ppu_opcode_t op)
 
 	if (op.lk)
 	{
+#ifdef OLDLLVM
 		m_ir->CreateStore(GetAddr(+4), m_ir->CreateStructGEP(m_thread, static_cast<uint>(&m_lr - m_locals)));
+#else
+		m_ir->CreateStore(GetAddr(+4), m_ir->CreateStructGEP(m_thread_type, m_thread, static_cast<uint>(&m_lr - m_locals)));
+#endif
 	}
 
 	UseCondition(CheckBranchProbability(op.bo | 0x4), CheckBranchCondition(op.bo | 0x4, op.bi));
@@ -2448,7 +2497,11 @@ void PPUTranslator::MFOCRF(ppu_opcode_t op)
 	{
 		// MFOCRF
 
-		const u64 pos = countLeadingZeros<u32>(op.crm, ZB_Width) - 24;
+#if LLVM_VERSION_MAJOR < 17
+		const u64 pos = countLeadingZeros<u32>(op.crm) - 24;
+#else
+		const u64 pos = countl_zero<u32>(op.crm) - 24;
+#endif
 
 		if (pos >= 8 || 0x80u >> pos != op.crm)
 		{
@@ -2459,11 +2512,20 @@ void PPUTranslator::MFOCRF(ppu_opcode_t op)
 	else if (std::none_of(m_cr + 0, m_cr + 32, [](auto* p) { return p; }))
 	{
 		// MFCR (optimized)
+#ifdef OLDLLVM
 		Value* ln0 = m_ir->CreateIntToPtr(m_ir->CreatePtrToInt(m_ir->CreateStructGEP(m_thread, 99), GetType<uptr>()), GetType<u8[16]>()->getPointerTo());
 		Value* ln1 = m_ir->CreateIntToPtr(m_ir->CreatePtrToInt(m_ir->CreateStructGEP(m_thread, 115), GetType<uptr>()), GetType<u8[16]>()->getPointerTo());
 
 		ln0 = m_ir->CreateLoad(ln0);
 		ln1 = m_ir->CreateLoad(ln1);
+
+#else
+		Value* ln0 = m_ir->CreateIntToPtr(m_ir->CreatePtrToInt(m_ir->CreateStructGEP(m_thread_type, m_thread, 99), GetType<uptr>()), GetType<u8[16]>()->getPointerTo());
+		Value* ln1 = m_ir->CreateIntToPtr(m_ir->CreatePtrToInt(m_ir->CreateStructGEP(m_thread_type, m_thread, 115), GetType<uptr>()), GetType<u8[16]>()->getPointerTo());
+
+		ln0 = m_ir->CreateLoad(GetType<u8[16]>(), ln0);
+		ln1 = m_ir->CreateLoad(GetType<u8[16]>(), ln1);
+#endif
 		if (!m_is_be)
 		{
 			ln0 = Shuffle(ln0, nullptr, {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0});
@@ -2724,7 +2786,11 @@ void PPUTranslator::MTOCRF(ppu_opcode_t op)
 	if (op.l11)
 	{
 		// MTOCRF
-		const u64 pos = countLeadingZeros<u32>(op.crm, ZB_Width) - 24;
+#if LLVM_VERSION_MAJOR < 17
+		const u64 pos = countLeadingZeros<u32>(op.crm) - 24;
+#else
+		const u64 pos = countl_zero<u32>(op.crm) - 24;
+#endif
 
 		if (pos >= 8 || 0x80u >> pos != op.crm)
 		{
@@ -2772,9 +2838,19 @@ void PPUTranslator::MTOCRF(ppu_opcode_t op)
 			std::fill_n(m_g_cr + i * 4, 4, nullptr);
 
 			const auto index = m_ir->CreateAnd(m_ir->CreateLShr(value, 28 - i * 4), 15);
+#ifdef OLDLLVM
 			const auto src = m_ir->CreateGEP(m_mtocr_table, {m_ir->getInt32(0), m_ir->CreateShl(index, 2)});
 			const auto dst = bitcast(m_ir->CreateStructGEP(m_thread, static_cast<uint>(m_cr - m_locals) + i * 4), GetType<u8*>());
 			Call(GetType<void>(), "llvm.memcpy.p0i8.p0i8.i32", dst, src, m_ir->getInt32(4), m_ir->getFalse());
+#else
+			const auto src = m_ir->CreateGEP(dyn_cast<GlobalVariable>(m_mtocr_table)->getValueType(), m_mtocr_table, {m_ir->getInt32(0), m_ir->CreateShl(index, 2)});
+			const auto dst = bitcast(m_ir->CreateStructGEP(m_thread_type, m_thread, static_cast<uint>(m_cr - m_locals) + i * 4), GetType<u8*>());
+#if LLVM_VERSION_MAJOR < 15
+			Call(GetType<void>(), "llvm.memcpy.p0i8.p0i8.i32", dst, src, m_ir->getInt32(4), m_ir->getFalse());
+#else
+			Call(GetType<void>(), "llvm.memcpy.p0.p0.i32", dst, src, m_ir->getInt32(4), m_ir->getFalse());
+#endif
+#endif
 		}
 	}
 }
@@ -3993,7 +4069,13 @@ void PPUTranslator::FRES(ppu_opcode_t op)
 	const auto n = m_ir->CreateFCmpUNO(a, a); // test for NaN
 	const auto e = m_ir->CreateAnd(m_ir->CreateLShr(b, 52), 0x7ff); // double exp
 	const auto i = m_ir->CreateAnd(m_ir->CreateLShr(b, 45), 0x7f); // mantissa LUT index
+#ifdef OLDLLVM
 	const auto m = m_ir->CreateShl(ZExt(m_ir->CreateLoad(m_ir->CreateGEP(m_fres_table, {m_ir->getInt64(0), i}))), 29);
+#else
+	const auto ptr = dyn_cast<GetElementPtrInst>(m_ir->CreateGEP(dyn_cast<GlobalVariable>(m_fres_table)->getValueType(), m_fres_table, {m_ir->getInt64(0), i}));
+	assert(ptr->getResultElementType() == get_type<u32>());
+	const auto m = m_ir->CreateShl(ZExt(m_ir->CreateLoad(ptr->getResultElementType(), ptr)), 29);
+#endif
 	const auto c = m_ir->CreateICmpUGE(e, m_ir->getInt64(0x3ff + 0x80)); // test for INF
 	const auto x = m_ir->CreateShl(m_ir->CreateSub(m_ir->getInt64(0x7ff - 2), e), 52);
 	const auto s = m_ir->CreateSelect(c, m_ir->getInt64(0), m_ir->CreateOr(x, m));
@@ -4364,7 +4446,13 @@ void PPUTranslator::FRSQRTE(ppu_opcode_t op)
 	}
 
 	const auto b = m_ir->CreateBitCast(GetFpr(op.frb), GetType<u64>());
+#ifdef OLDLLVM
 	const auto v = m_ir->CreateLoad(m_ir->CreateGEP(m_frsqrte_table, {m_ir->getInt64(0), m_ir->CreateLShr(b, 49)}));
+#else
+	const auto ptr = dyn_cast<GetElementPtrInst>(m_ir->CreateGEP(dyn_cast<GlobalVariable>(m_frsqrte_table)->getValueType(), m_frsqrte_table, {m_ir->getInt64(0), m_ir->CreateLShr(b, 49)}));
+	assert(ptr->getResultElementType() == get_type<u32>());
+	const auto v = m_ir->CreateLoad(ptr->getResultElementType(), ptr);
+#endif
 	const auto result = m_ir->CreateBitCast(m_ir->CreateShl(ZExt(v), 32), GetType<f64>());
 	SetFpr(op.frd, result);
 


### PR DESCRIPTION
I updated the coded to use the new LLVM API, which uses [opaque pointers](https://llvm.org/docs/OpaquePointers.html). I tested it with the bundles LLVM 13 and with newer LLVM versions, with one game.

If you define `OLDLLVM` then it will use the old deprecated API.