### PR TITLE
Add missing spinning icon from resources

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
@@ -98,6 +98,7 @@ namespace rsx
 			texture_resource_files.emplace_back("R2.png");
 			texture_resource_files.emplace_back("save.png");
 			texture_resource_files.emplace_back("new.png");
+			texture_resource_files.emplace_back("spinner-24.png");
 		}
 
 		void resource_config::load_files()


### PR DESCRIPTION
Affected linux build as the icon wasn't copied to config dir.