### PR TITLE
cellFsReaddir: Fix termination sequence / Fix savestate crash on load

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -242,6 +242,8 @@ public:
 		g_to_awake.clear();
 	}
 
+	static void make_scheduler_ready();
+
 	static ppu_thread_status ppu_state(ppu_thread* ppu, bool lock_idm = true, bool lock_lv2 = true);
 
 	static inline void append(cpu_thread* const thread)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2249,7 +2249,7 @@ void Emulator::FinalizeRunRequest()
 
 	idm::select<named_thread<spu_thread>>(on_select);
 
-	lv2_obj::awake_all();
+	lv2_obj::make_scheduler_ready();
 
 	m_state.compare_and_swap_test(system_state::starting, system_state::running);
 }


### PR DESCRIPTION
* Turns out cellFsReaddir is always writing data even when it goes out of entries: on HDD1: it copies bytes of the last entry, on HDD0: it copies bytes of the last entry, but also sets the first 3 bytes to 0. Th game was expecting this and looped until it got a zero, but the zero never came.
Game code:
![image](https://user-images.githubusercontent.com/18193363/224483029-e0d5f2b8-fd56-4b69-9dcb-4f26f998428e.png)
Testcase: https://github.com/elad335/myps3tests/commit/8f311ccdecc3186a8cc5b82335baa1fb13e29262

* Fix deadlock when loading savestate when there is a PPU executing deallocation syscall under IDM mutex such as sys_vm_unmap before GUI thread had completed FinalizeRunRequest(), which caused the PPU to wait for RSX, RSX to wait for GUI thread (to update emulation state), GUI thread for PPU to release IDM lock. Fixes savestating after reaching new gameplay with Far Cry Classic. This happened because the PPU started execution too early, it is a regression from a time which lv2_obj::schedule_all has been unconditionally called nin lv2_obj::sleep.

Fixes #5968, possibly making this game playable.

![image](https://user-images.githubusercontent.com/18193363/224483614-7fca2739-389a-4f93-8e4e-955e42b751ba.png)

