### PR TITLE
use new LLVM API in SPURecompiler

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9930,8 +9930,8 @@ public:
 			m_ir->SetInsertPoint(done);
 
 			const auto ad64 = m_ir->CreateZExt(ad32, get_type<u64>());
-			const auto pptr = m_ir->CreateGEP(m_function_table->getValueType(), m_function_table, {m_ir->getInt64(0), m_ir->CreateLShr(ad64, 2, "", true)});
-			tail_chunk({m_dispatch->getFunctionType(), m_ir->CreateLoad(pptr->getType()->getPointerElementType(), pptr)});
+			const auto pptr = dyn_cast<llvm::GetElementPtrInst>(m_ir->CreateGEP(m_function_table->getValueType(), m_function_table, {m_ir->getInt64(0), m_ir->CreateLShr(ad64, 2, "", true)}));
+			tail_chunk({m_dispatch->getFunctionType(), m_ir->CreateLoad(pptr->getResultElementType(), pptr)});
 			m_ir->SetInsertPoint(fail);
 		}
 


### PR DESCRIPTION
My PR #13500 had a bug. Sorry, I didn't notice because I didn't test with "SPU Block Size" Mega. The fix in #13533 uses the deprecated LLVM API. I fixed it to use the new LLVM API.