### PR TITLE
Fix recvn high cpu usage

### DIFF
--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -496,14 +496,13 @@ namespace rpcn
 			{
 				if (wolfSSL_want_read(read_wssl))
 				{
-					// If we received partially what we want try to wait longer
-					if (n_recv == 0)
-						return recvn_result::recvn_nodata;
-
 					pollfd poll_fd{};
 
 					while ((poll_fd.revents & POLLIN) != POLLIN && (poll_fd.revents & POLLRDNORM) != POLLRDNORM)
 					{
+						if (!connected)
+							return recvn_result::recvn_noconn;
+
 						if (terminate)
 							return recvn_result::recvn_terminate;
 
@@ -523,8 +522,12 @@ namespace rpcn
 						}
 
 						num_timeouts++;
+
 						if (num_timeouts > (RPCN_TIMEOUT / RPCN_TIMEOUT_INTERVAL))
 						{
+							if (n_recv == 0)
+								return recvn_result::recvn_nodata;
+
 							rpcn_log.error("recvn timeout with %d bytes received", n_recv);
 							return recvn_result::recvn_timeout;
 						}
@@ -545,6 +548,12 @@ namespace rpcn
 
 				res = 0;
 			}
+			else
+			{
+				// Reset timeout each time something is received
+				num_timeouts = 0;
+			}
+
 			n_recv += res;
 		}
 


### PR DESCRIPTION
Also improved the logic to ensure the beginning of a packet received near timeout realization would not result in a timeout.

Fixes #13539