### PR TITLE
sys_lwmutex/mutex: Fix race on lock timeout

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.h
@@ -152,21 +152,15 @@ struct lv2_lwmutex final : lv2_obj
 	template <typename T>
 	T* reown(bool unlock2 = false)
 	{
-		T* res{};
-		T* restore_next{};
+		T* res = nullptr;
 
 		lv2_control.fetch_op([&](control_data_t& data)
 		{
-			if (res)
-			{
-				res->next_cpu = restore_next;
-				res = nullptr;
-			}
+			res = nullptr;
 
 			if (auto sq = static_cast<T*>(data.sq))
 			{
-				restore_next = sq->next_cpu;
-				res = schedule<T>(data.sq, protocol);
+				res = schedule<T>(data.sq, protocol, false);
 
 				if (sq == data.sq)
 				{
@@ -181,6 +175,12 @@ struct lv2_lwmutex final : lv2_obj
 				return true;
 			}
 		});
+
+		if (res && cpu_flag::again - res->state)
+		{
+			// Detach manually (fetch_op can fail, so avoid side-effects on the first node in this case)
+			res->next_cpu = nullptr;
+		}
 
 		return res;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -245,12 +245,38 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 
 				std::lock_guard lock(mutex->mutex);
 
-				if (!mutex->unqueue(mutex->control.raw().sq, &ppu))
+				bool success = false;
+
+				mutex->control.fetch_op([&](lv2_mutex::control_data_t& data)
 				{
-					break;
+					success = false;
+
+					ppu_thread* sq = static_cast<ppu_thread*>(data.sq);
+
+					const bool retval = &ppu == sq;
+
+					if (!mutex->unqueue<false>(sq, &ppu))
+					{
+						return false;
+					}
+
+					success = true;
+
+					if (!retval)
+					{
+						return false;
+					}
+
+					data.sq = sq;
+					return true;
+				});
+
+				if (success)
+				{
+					ppu.next_cpu = nullptr;
+					ppu.gpr[3] = CELL_ETIMEDOUT;
 				}
 
-				ppu.gpr[3] = CELL_ETIMEDOUT;
 				break;
 			}
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -107,7 +107,7 @@ public:
 	}
 
 	// Find and remove the object from the linked list
-	template <typename T>
+	template <bool ModifyNode = true, typename T>
 	static T* unqueue(T*& first, T* object, T* T::* mem_ptr = &T::next_cpu)
 	{
 		auto it = +first;
@@ -115,7 +115,12 @@ public:
 		if (it == object)
 		{
 			atomic_storage<T*>::release(first, it->*mem_ptr);
-			atomic_storage<T*>::release(it->*mem_ptr, nullptr);
+
+			if (ModifyNode)
+			{
+				atomic_storage<T*>::release(it->*mem_ptr, nullptr);
+			}
+
 			return it;
 		}
 
@@ -126,7 +131,12 @@ public:
 			if (next == object)
 			{
 				atomic_storage<T*>::release(it->*mem_ptr, next->*mem_ptr);
-				atomic_storage<T*>::release(next->*mem_ptr, nullptr);
+
+				if (ModifyNode)
+				{
+					atomic_storage<T*>::release(next->*mem_ptr, nullptr);
+				}
+
 				return next;
 			}
 
@@ -138,7 +148,7 @@ public:
 
 	// Remove an object from the linked set according to the protocol
 	template <typename E, typename T>
-	static E* schedule(T& first, u32 protocol)
+	static E* schedule(T& first, u32 protocol, bool modify_node = true)
 	{
 		auto it = static_cast<E*>(first);
 
@@ -162,7 +172,7 @@ public:
 					continue;
 				}
 
-				if (it && cpu_flag::again - it->state)
+				if (cpu_flag::again - it->state)
 				{
 					atomic_storage<T>::release(*parent_found, nullptr);
 				}
@@ -200,7 +210,11 @@ public:
 		if (cpu_flag::again - found->state)
 		{
 			atomic_storage<T>::release(*parent_found, found->next_cpu);
-			atomic_storage<T>::release(found->next_cpu, nullptr);
+
+			if (modify_node)
+			{
+				atomic_storage<T>::release(found->next_cpu, nullptr);
+			}
 		}
 
 		return found;


### PR DESCRIPTION
Fix a race condition causing possible discard of waiter PPU which just registered while another timed-out.