### PR TITLE
Fix inaccuracies pointed out by PVS-Studio

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2351,10 +2351,9 @@ void thread_ctrl::wait_for(u64 usec, [[maybe_unused]] bool alert /* true */)
 	{
 		struct itimerspec timeout;
 		u64 missed;
-		u64 nsec = usec * 1000ull;
 
-		timeout.it_value.tv_nsec = (nsec % 1000000000ull);
-		timeout.it_value.tv_sec = nsec / 1000000000ull;
+		timeout.it_value.tv_nsec = usec * 1'000ull;
+		timeout.it_value.tv_sec = 0;
 		timeout.it_interval.tv_sec = 0;
 		timeout.it_interval.tv_nsec = 0;
 		timerfd_settime(fd_timer, 0, &timeout, NULL);

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -131,7 +131,7 @@ class evdev_joystick_handler final : public PadHandlerBase
 		{ 0x11d               , "0x11d"       },
 		{ 0x11e               , "0x11e"       },
 		{ 0x11f               , "0x11f"       },
-		{ BTN_JOYSTICK        , "Joystick"    },
+		//{ BTN_JOYSTICK        , "Joystick"    }, same as BTN_TRIGGER
 		{ BTN_TRIGGER         , "Trigger"     },
 		{ BTN_THUMB           , "Thumb"       },
 		{ BTN_THUMB2          , "Thumb 2"     },


### PR DESCRIPTION
Fix inaccuracies pointed out in https://pvs-studio.com/en/blog/posts/cpp/1014/.

I didn't touch the m_finfo one as actually https://github.com/RPCS3/rpcs3/blob/cf5346c263111760752cabb94767c07c501207c4/rpcs3/Emu/Cell/SPURecompiler.cpp#L5299 so it can't be null.
So either the m_info nullptr checks after are redundant or implicit insertion into m_functions with [] is an error, I'm unsure.