### PR TITLE
3rd Party: Update MoltenVK to 1.2.3 (Vulkan SDK 1.3.243)

### DIFF
--- a/3rdparty/MoltenVK/CMakeLists.txt
+++ b/3rdparty/MoltenVK/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(moltenvk
 	GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-	GIT_TAG fb581e4
+	GIT_TAG db8512a
 	BUILD_IN_SOURCE 1
 	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK
 	CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK/fetchDependencies" --macos


### PR DESCRIPTION
Update MoltenVK to [version 1.2.3](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.3)

Changelog: 

- Add support for extensions:
  - `VK_EXT_external_memory_host`
  - `VK_EXT_pipeline_creation_cache_control`
  - `VK_EXT_shader_atomic_float`
  - `VK_EXT_surface_maintenance1`
  - `VK_EXT_swapchain_maintenance1`
- Fix crash when `VkCommandBufferInheritanceInfo::renderPass` is `VK_NULL_HANDLE` during dynamic rendering.
- Do not clear attachments when dynamic rendering is resumed.
- Allow ending dynamic rendering to trigger next multiview pass if needed.
- Fix premature caching of occlusion query results during tessellation rendering.
- `vkCmdCopyQueryPoolResults()`: Fix loss of queries when query count is not a multiple of GPU threadgroup execution width.
- Disable occlusion recording while clearing attachments or render area.
- Fix issue where extension `VK_KHR_fragment_shader_barycentric` was sometimes incorrectly disabled due to a Metal driver bug.
- Detect when size of surface has changed under the covers.
- Change rounding of surface size provided by Metal from truncation to rounding-with-half-to-even.
- Queue submissions retain wait semaphores until `MTLCommandBuffer` finishes.
- Use a different visibility buffer for each `MTLCommandBuffer` in a queue submit.
- Work around problems with using explicit LoD with arrayed depth images on Apple Silicon.
- Fix issue when `VkPipelineVertexInputDivisorStateCreateInfoEXT::vertexBindingDivisorCount` doesn't match `VkPipelineVertexInputStateCreateInfo::vertexBindingDescriptionCount`.
- Support Apple Silicon pixel formats on a MoltenVK x86_64 build that is running on Apple Silicon using Rosetta2.
- Reduce memory footprint of MSL source code retained in pipeline cache.
- Add `MVKConfiguration::shaderSourceCompressionAlgorithm` and env var `MVK_CONFIG_SHADER_COMPRESSION_ALGORITHM` to support compressing MSL shader source code held in a pipeline cache.
- Add `MVKShaderCompilationPerformance::mslCompress` and `mslDecompress` to allow performance of MSL compression to be tracked and queried.
- Add support for logging performance stats accumulated in a VkDevice, when it is destroyed.
- Change `MVKConfiguration::logActivityPerformanceInline` boolean to `activityPerformanceLoggingStyle` enumeration value.
- Add `MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE` environment variable and build setting to set `MVKConfiguration::activityPerformanceLoggingStyle` value.
- Expand `MVK_CONFIG_TRACE_VULKAN_CALLS` to log thread ID only if requested.
- Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version 37.
- Update dependency libraries to match Vulkan SDK 1.3.243.
- Update to latest SPIRV-Cross:
  - MSL: Add support for `OpAtomicFAddEXT` atomic add on float types
  - MSL: Add a workaround for broken level() arguments.
  - MSL: Deduplicate function constants.
