### PR TITLE
vk: Improve hardware detection for M1

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -633,7 +633,7 @@ namespace vk
 					else
 					{
 						// Ampere GPUs don't like the direct transfer hack above
-						stretch_image_typeless_safe(src, dst, typeless, src_rect, dst_rect, VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_ASPECT_DEPTH_BIT);
+						stretch_image_typeless_safe(src, dst, typeless, src_rect, dst_rect, VK_IMAGE_ASPECT_DEPTH_BIT);
 					}
 					break;
 				}
@@ -641,12 +641,21 @@ namespace vk
 				{
 					auto typeless = vk::get_typeless_helper(VK_FORMAT_R32_SFLOAT, RSX_FORMAT_CLASS_COLOR, typeless_w, typeless_h);
 					change_image_layout(cmd, typeless, VK_IMAGE_LAYOUT_GENERAL);
-					stretch_image_typeless_unsafe(src, dst, typeless, src_rect, dst_rect, VK_IMAGE_ASPECT_DEPTH_BIT);
+
+					if (use_unsafe_transport)
+					{
+						stretch_image_typeless_unsafe(src, dst, typeless, src_rect, dst_rect, VK_IMAGE_ASPECT_DEPTH_BIT);
+					}
+					else
+					{
+						stretch_image_typeless_safe(src, dst, typeless, src_rect, dst_rect, VK_IMAGE_ASPECT_DEPTH_BIT);
+					}
 					break;
 				}
 				case VK_FORMAT_D24_UNORM_S8_UINT:
 				{
 					const VkImageAspectFlags depth_stencil = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+
 					if (use_unsafe_transport)
 					{
 						auto typeless = vk::get_typeless_helper(VK_FORMAT_B8G8R8A8_UNORM, RSX_FORMAT_CLASS_COLOR, typeless_w, typeless_h);

--- a/rpcs3/Emu/RSX/VK/vkutils/chip_class.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/chip_class.cpp
@@ -82,6 +82,11 @@ namespace vk
 			return s_AMD_family_tree.find(device_id);
 		}
 
+		if (vendor_id == 0x106B)
+		{
+			return chip_class::MVK_apple;
+		}
+
 		return chip_class::unknown;
 	}
 


### PR DESCRIPTION
1. Fix detection of apple GPUs. I'm only using the vendor ID here for detection as we assume all apple-made GPUs to behave the same way at this time.
2. Don't unconditionally assume free DEPTH<->COLOR conversions for D16F emulation.

Fixes https://github.com/RPCS3/rpcs3/issues/13590