### PR TITLE
cellMic: fallback to lower channel count and sampling rate if requested is not supported

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -656,7 +656,7 @@ error_code cellMicOpenRaw(s32 dev_num, s32 sampleRate, s32 maxChannels)
 	return cellMicOpenEx(dev_num, sampleRate, maxChannels, sampleRate, 0x80, CELLMIC_SIGTYPE_RAW);
 }
 
-u8 cellMicIsOpen(s32 dev_num)
+s32 cellMicIsOpen(s32 dev_num)
 {
 	cellMic.trace("cellMicIsOpen(dev_num=%d)", dev_num);
 
@@ -1121,6 +1121,22 @@ error_code cellMicReadDsp(s32 dev_num, vm::ptr<void> data, s32 max_bytes)
 error_code cellMicReset(s32 dev_num)
 {
 	cellMic.todo("cellMicReset(dev_num=%d)", dev_num);
+
+	auto& mic_thr = g_fxo->get<mic_thread>();
+	const std::lock_guard lock(mic_thr.mutex);
+	if (!mic_thr.init)
+		return CELL_MICIN_ERROR_NOT_INIT;
+
+	if (!mic_thr.check_device(dev_num))
+		return CELL_MICIN_ERROR_DEVICE_NOT_FOUND;
+
+	microphone_device& device = ::at32(mic_thr.mic_list, dev_num);
+
+	if (!device.is_opened())
+		return CELL_MICIN_ERROR_NOT_OPEN;
+
+	// TODO
+
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -1269,7 +1269,7 @@ error_code cellMicGetType(s32 dev_num, vm::ptr<s32> ptr_type)
 		return CELL_MICIN_ERROR_NOT_INIT;
 
 	// TODO: get proper type (log message is trace because of massive spam)
-	*ptr_type = CELLMIC_TYPE_BLUETOOTH;
+	*ptr_type = CELLMIC_TYPE_USBAUDIO; // Needed for Guitar Hero: Warriors of Rock (BLUS30487)
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -661,7 +661,7 @@ error_code cellMicEnd()
 
 error_code cellMicOpenEx(s32 dev_num, s32 rawSampleRate, s32 rawChannel, s32 DSPSampleRate, s32 bufferSizeMS, u8 signalType)
 {
-	cellMic.trace("cellMicOpenEx(dev_num=%d, rawSampleRate=%d, rawChannel=%d, DSPSampleRate=%d, bufferSizeMS=%d, signalType=0x%x)",
+	cellMic.notice("cellMicOpenEx(dev_num=%d, rawSampleRate=%d, rawChannel=%d, DSPSampleRate=%d, bufferSizeMS=%d, signalType=0x%x)",
 		dev_num, rawSampleRate, rawChannel, DSPSampleRate, bufferSizeMS, signalType);
 
 	auto& mic_thr = g_fxo->get<mic_thread>();
@@ -714,7 +714,9 @@ s32 cellMicIsOpen(s32 dev_num)
 
 s32 cellMicIsAttached(s32 dev_num)
 {
-	cellMic.notice("cellMicIsAttached(dev_num=%d)", dev_num);
+	cellMic.trace("cellMicIsAttached(dev_num=%d)", dev_num);
+
+	// TODO
 	return 1;
 }
 
@@ -922,7 +924,7 @@ error_code cellMicSetSignalAttr(s32 dev_num, CellMicSignalAttr sig_attrib, vm::p
 
 error_code cellMicGetSignalState(s32 dev_num, CellMicSignalState sig_state, vm::ptr<void> value)
 {
-	cellMic.todo("cellMicGetSignalState(dev_num=%d, sig_state=%d, value=*0x%x)", dev_num, +sig_state, value);
+	cellMic.trace("cellMicGetSignalState(dev_num=%d, sig_state=%d, value=*0x%x)", dev_num, +sig_state, value);
 
 	if (!value)
 		return CELL_MICIN_ERROR_PARAM;

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -287,15 +287,21 @@ error_code microphone_device::open_microphone(const u8 type, const u32 dsp_r, co
 			num_channels = 2;
 		}
 		break;
-	case microphone_handler::rocksmith: num_channels = 1; break;
+	case microphone_handler::rocksmith:
+		num_channels = 1;
+		break;
 	case microphone_handler::null:
-	default: ensure(false); break;
+	default:
+		ensure(false);
+		break;
 	}
 
 	ALCenum num_al_channels;
 	switch (num_channels)
 	{
-	case 1: num_al_channels = AL_FORMAT_MONO16; break;
+	case 1:
+		num_al_channels = AL_FORMAT_MONO16;
+		break;
 	case 2:
 		// If we're using SingStar each device needs to be mono
 		if (device_type == microphone_handler::singstar)


### PR DESCRIPTION
- Fallback to 4,2,1 channels by default if requested channels are not supported
- Fallback to 48000, 32000, 24000, 16000, 12000, 8000 samplingrate if not supported
- Change channel count of cellMicOpen to 1 (I hope I saw that correctly)
- Add some error checks to cellMicReset
- Ensure that singstar devices have 1, respective 2 channels
- Change device type back to USB

Should fix the 0 channel error seen in the comment #11266