### PR TITLE
[Testers Needed] LV2: Unconditional Timer Synchronization Fix

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -710,7 +710,7 @@ error_code sys_event_port_send(u32 eport_id, u64 data1, u64 data2, u64 data3)
 	{
 		if (lv2_obj::check(port.queue))
 		{
-			const u64 source = port.name ? port.name : (s64{process_getpid()} << 32) | u64{eport_id};
+			const u64 source = port.name ? port.name : (u64{process_getpid() + 0u} << 32) | u64{eport_id};
 
 			return port.queue->send(source, data1, data2, data3);
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -6,6 +6,8 @@
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/PPUThread.h"
 #include "Emu/Cell/timers.hpp"
+
+#include "util/asm.hpp"
 #include "Emu/System.h"
 #include "sys_event.h"
 #include "sys_process.h"
@@ -23,7 +25,7 @@ struct lv2_timer_thread
 	lv2_timer_thread();
 	void operator()();
 
-	SAVESTATE_INIT_POS(46); // Dependency ion LV2 objects (lv2_timer)
+	SAVESTATE_INIT_POS(46); // Dependency on LV2 objects (lv2_timer)
 
 	static constexpr auto thread_name = "Timer Thread"sv;
 };
@@ -46,7 +48,7 @@ void lv2_timer::save(utils::serial& ar)
 	ar(state), lv2_event_queue::save_ptr(ar, port.get()), ar(source, data1, data2, expire, period);
 }
 
-u64 lv2_timer::check()
+u64 lv2_timer::check() noexcept
 {
 	while (thread_ctrl::state() != thread_state::aborting)
 	{
@@ -63,28 +65,7 @@ u64 lv2_timer::check()
 				lv2_obj::notify_all_t notify;
 
 				std::lock_guard lock(mutex);
-
-				if (next = expire; _now < next)
-				{
-					// expire was updated in the middle, don't send an event
-					continue;
-				}
-
-				if (port)
-				{
-					port->send(source, data1, data2, next);
-				}
-
-				if (period)
-				{
-					// Set next expiration time and check again
-					const u64 _next = next + period;
-					expire.release(_next > next ? _next : umax);
-					continue;
-				}
-
-				// Stop after oneshot
-				state.release(SYS_TIMER_STATE_STOP);
+				check_unlocked(_now);
 				break;
 			}
 
@@ -95,6 +76,31 @@ u64 lv2_timer::check()
 	}
 
 	return umax;
+}
+
+void lv2_timer::check_unlocked(u64 _now) noexcept
+{
+	const u64 next = expire;
+
+	if (_now < next || state != SYS_TIMER_STATE_RUN)
+	{
+		return;
+	}
+
+	if (port)
+	{
+		port->send(source, data1, data2, next);
+	}
+
+	if (period)
+	{
+		// Set next expiration time and check again
+		expire.release(utils::add_saturate<u64>(next, period));
+		return;
+	}
+
+	// Stop after oneshot
+	state.release(SYS_TIMER_STATE_STOP);
 }
 
 lv2_timer_thread::lv2_timer_thread()
@@ -133,11 +139,11 @@ void lv2_timer_thread::operator()()
 		{
 			if (lv2_obj::check(timer))
 			{
-				const u64 adviced_sleep_time = timer->check();
+				const u64 advised_sleep_time = timer->check();
 
-				if (sleep_time > adviced_sleep_time)
+				if (sleep_time > advised_sleep_time)
 				{
-					sleep_time = adviced_sleep_time;
+					sleep_time = advised_sleep_time;
 				}
 			}
 		}
@@ -216,9 +222,13 @@ error_code sys_timer_get_information(ppu_thread& ppu, u32 timer_id, vm::ptr<sys_
 	sys_timer.trace("sys_timer_get_information(timer_id=0x%x, info=*0x%x)", timer_id, info);
 
 	sys_timer_information_t _info{};
+	const u64 now = get_guest_system_time();
 
 	const auto timer = idm::check<lv2_obj, lv2_timer>(timer_id, [&](lv2_timer& timer)
 	{
+		std::lock_guard lock(timer.mutex);
+
+		timer.check_unlocked(now);
 		timer.get_information(_info);
 	});
 
@@ -255,6 +265,7 @@ error_code _sys_timer_start(ppu_thread& ppu, u32 timer_id, u64 base_time, u64 pe
 			return CELL_ENOTCONN;
 		}
 
+		timer.check_unlocked(start_time);
 		if (timer.state != SYS_TIMER_STATE_STOP)
 		{
 			return CELL_EBUSY;
@@ -266,9 +277,24 @@ error_code _sys_timer_start(ppu_thread& ppu, u32 timer_id, u64 base_time, u64 pe
 			return CELL_ETIMEDOUT;
 		}
 
-		// sys_timer_start_periodic() will use current time (TODO: is it correct?)
-		const u64 expire = base_time ? base_time : start_time + period;
-		timer.expire = expire > start_time ? expire : umax;
+		const u64 expire = period == 0 ? base_time : // oneshot
+			base_time == 0 ? utils::add_saturate(start_time, period) : // periodic timer with no base (using start time as base)
+			start_time < utils::add_saturate(base_time, period) ? utils::add_saturate(base_time, period) : // periodic with base time over start time
+			[&]() -> u64 // periodic timer base before start time (align to be at least a period over start time)
+			{
+				// Optimized from a loop in LV2:
+				// do
+				// {
+				// 	  base_time += period;
+				// }
+				// while (base_time < start_time);
+
+				const u64 start_time_with_base_time_reminder = utils::add_saturate(start_time - start_time % period, base_time % period);
+
+				return utils::add_saturate(start_time_with_base_time_reminder, start_time_with_base_time_reminder < start_time ? period : 0);
+			}();
+
+		timer.expire = expire;
 		timer.period = period;
 		timer.state  = SYS_TIMER_STATE_RUN;
 		return {};
@@ -300,10 +326,10 @@ error_code sys_timer_stop(ppu_thread& ppu, u32 timer_id)
 
 	sys_timer.trace("sys_timer_stop()");
 
-	const auto timer = idm::check<lv2_obj, lv2_timer>(timer_id, [](lv2_timer& timer)
+	const auto timer = idm::check<lv2_obj, lv2_timer>(timer_id, [now = get_guest_system_time(), notify = lv2_obj::notify_all_t()](lv2_timer& timer)
 	{
 		std::lock_guard lock(timer.mutex);
-
+		timer.check_unlocked(now);
 		timer.state = SYS_TIMER_STATE_STOP;
 	});
 
@@ -339,7 +365,7 @@ error_code sys_timer_connect_event_queue(ppu_thread& ppu, u32 timer_id, u32 queu
 
 		// Connect event queue
 		timer.port   = std::static_pointer_cast<lv2_event_queue>(found->second);
-		timer.source = name ? name : (s64{process_getpid()} << 32) | u64{timer_id};
+		timer.source = name ? name : (u64{process_getpid() + 0u} << 32) | u64{timer_id};
 		timer.data1  = data1;
 		timer.data2  = data2;
 		return {};
@@ -364,10 +390,11 @@ error_code sys_timer_disconnect_event_queue(ppu_thread& ppu, u32 timer_id)
 
 	sys_timer.warning("sys_timer_disconnect_event_queue(timer_id=0x%x)", timer_id);
 
-	const auto timer = idm::check<lv2_obj, lv2_timer>(timer_id, [](lv2_timer& timer) -> CellError
+	const auto timer = idm::check<lv2_obj, lv2_timer>(timer_id, [now = get_guest_system_time(), notify = lv2_obj::notify_all_t()](lv2_timer& timer) -> CellError
 	{
 		std::lock_guard lock(timer.mutex);
 
+		timer.check_unlocked(now);
 		timer.state = SYS_TIMER_STATE_STOP;
 
 		if (!lv2_obj::check(timer.port))

--- a/rpcs3/Emu/Cell/lv2/sys_timer.h
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.h
@@ -36,20 +36,19 @@ struct lv2_timer : lv2_obj
 	atomic_t<u64> expire{0}; // Next expiration time
 	atomic_t<u64> period{0}; // Period (oneshot if 0)
 
-	u64 check();
+	u64 check() noexcept;
+	void check_unlocked(u64 _now) noexcept;
 
 	lv2_timer() noexcept
 		: lv2_obj{1}
 	{
 	}
 
-	void get_information(sys_timer_information_t& info)
+	void get_information(sys_timer_information_t& info) const
 	{
-		reader_lock lock(mutex);
-
 		if (state == SYS_TIMER_STATE_RUN)
 		{
-			info.timer_state = SYS_TIMER_STATE_RUN;
+			info.timer_state = state;
 			info.next_expire = expire;
 			info.period      = period;
 		}

--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -389,6 +389,25 @@ namespace utils
 		return static_cast<T>(value / align + (value > 0 ? T{(value % align) > (align / 2)} : 0 - T{(value % align) < (align / 2)}));
 	}
 
+	template <UnsignedInt T>
+	constexpr T add_saturate(T addend1, T addend2)
+	{
+		return static_cast<T>(~addend1) < addend2 ? T{umax} : static_cast<T>(addend1 + addend2);
+	}
+
+	template <UnsignedInt T>
+	constexpr T sub_saturate(T minuend, T subtrahend)
+	{
+		return minuend < subtrahend ? T{0} : static_cast<T>(minuend - subtrahend);
+	}
+
+
+	template <UnsignedInt T>
+	constexpr T mul_saturate(T factor1, T factor2)
+	{
+		return T{umax} / factor1 < factor2 ? T{umax} : static_cast<T>(factor1 * factor2);
+	}
+
 	// Hack. Pointer cast util to workaround UB. Use with extreme care.
 	template <typename T, typename U>
 	[[nodiscard]] T* bless(U* ptr)


### PR DESCRIPTION
- `sys_timer_start_periodic_absolute` has been broken when specifying time in the past - UINT64_MAX was set to `expire` and the timer never went off.
- There was also a bug regarding the initial `expire` value of `sys_timer_start_periodic_absolute`, it should always be  a time point in the future. If base time is not, than the soonest time point which is a multiple of period plus base time is used.
- Do not send a timer event when it is stopped, this fixes a race when the PPU stops the timer, but suddenly receives an event after it has been stopped.
- Ensure the current timer state is used in syscall by checking the current time. and stopping the timer manully if it has expired. (do not wait for the thread)

Draft because I want some testing to be done for it.
