### PR TITLE
Invert the DJ Hero Turntable crossfader axis bind.

### DIFF
--- a/rpcs3/Emu/Io/Turntable.cpp
+++ b/rpcs3/Emu/Io/Turntable.cpp
@@ -248,16 +248,17 @@ void usb_device_turntable::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpo
 		switch (stick.m_offset)
 		{
 			case CELL_PAD_BTN_OFFSET_ANALOG_LEFT_Y:
-				buf[6] = ~(stick.m_value) + 0x01; // Right Turntable
-				// Some pad handlers like MMJoystick are centered at 0x81 instead of 0x80
-				// which leaves the turntable stuck at 0x7F instead of 0x80, causing auto-scrolling menus
-				// so force 0x7F to 0x80.
-				if (buf[6] == 0x7F)
-					buf[6] = 0x80;
+				buf[6] = 255 - stick.m_value; // Right Turntable
+				// DJ Hero requires turntables to be centered at 128.
+				// If this axis ends up centered at 127, force it to 128.
+				if (buf[6] == 127)
+				{
+					buf[6] = 128;
+				}
 				break;
 			case CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_Y:
-				buf[21] = (stick.m_value & 0x3F) << 2; // Crossfader, lower 6 bits
-				buf[22] = (stick.m_value & 0xC0) >> 6; // Crossfader, upper 2 bits
+				buf[21] = ((255 - stick.m_value) & 0x3F) << 2; // Crossfader, lower 6 bits
+				buf[22] = ((255 - stick.m_value) & 0xC0) >> 6; // Crossfader, upper 2 bits
 				break;
 			case CELL_PAD_BTN_OFFSET_ANALOG_RIGHT_X:
 				buf[19] = (stick.m_value & 0x3F) << 2; // Effects Dial, lower 6 bits


### PR DESCRIPTION
Back when I submitted turntable emulation in #9965, I set the crossfader bind such that Crossfade Left was Y Up and Crossfade Right was Y Down, intending to imitate the binds of an Xbox 360 turntable.

Turns out I messed up. On Xbox 360 turntables, Crossfade Left is Y Down, Crossfade Right is Y Up.
This PR flips the crossfader bind to match the real turntable's inputs.

This will flip the crossfader for all emulated turntable users until they rebind, but I'm familiar with the DJ Hero community and I think it's worth a one-time change for accuracy.

Also fix turntable/left stick input overflow while I'm here.