### PR TITLE
Debugger: Fix step over

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1141,10 +1141,10 @@ void debugger_frame::DoStep(bool step_over)
 			{
 				const u32 current_instruction_pc = cpu->get_pc();
 
-				ppu_opcode_t op{};
 				vm::ptr<u32> inst_ptr = vm::cast(current_instruction_pc);
+				be_t<u32> result{};
 
-				if (inst_ptr.try_read(op.opcode) && op.lk == 0)
+				if (inst_ptr.try_read(result) && ppu_opcode_t{+result}.lk == 0)
 				{
 					should_step_over = false;
 				}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1150,7 +1150,7 @@ void debugger_frame::DoStep(bool step_over)
 				if (inst_ptr.try_read(result))
 				{
 					ppu_opcode_t ppu_op{result};
-					const ppu_itype itype = g_ppu_itype.decode(ppu_op.opcode);
+					const ppu_itype::type itype = g_ppu_itype.decode(ppu_op.opcode);
 
 					should_step_over = (itype == ppu_itype::BC || itype == ppu_itype::B || itype == ppu_itype::BCCTR || itype == ppu_itype::BCLR) && ppu_op.lk;
 				}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1137,6 +1137,19 @@ void debugger_frame::DoStep(bool step_over)
 
 		if (const auto _state = +cpu->state; _state & s_pause_flags && _state & cpu_flag::wait && !(_state & cpu_flag::dbg_step))
 		{
+			if (should_step_over && cpu->id_type() == 1)
+			{
+				const u32 current_instruction_pc = cpu->get_pc();
+
+				ppu_opcode_t op{};
+				vm::ptr<u32> inst_ptr = vm::cast(current_instruction_pc);
+
+				if (inst_addr.try_read(op.opcode) && op.lk == 0)
+				{
+					should_step_over = false;
+				}
+			}
+
 			if (should_step_over)
 			{
 				const u32 current_instruction_pc = cpu->get_pc();

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1144,7 +1144,7 @@ void debugger_frame::DoStep(bool step_over)
 				ppu_opcode_t op{};
 				vm::ptr<u32> inst_ptr = vm::cast(current_instruction_pc);
 
-				if (inst_addr.try_read(op.opcode) && op.lk == 0)
+				if (inst_ptr.try_read(op.opcode) && op.lk == 0)
 				{
 					should_step_over = false;
 				}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1146,11 +1146,12 @@ void debugger_frame::DoStep(bool step_over)
 
 				vm::ptr<u32> inst_ptr = vm::cast(current_instruction_pc);
 				be_t<u32> result{};
+
 				if (inst_ptr.try_read(result))
 				{
 					ppu_opcode_t ppu_op{result};
+					const ppu_itype itype = g_ppu_itype.decode(ppu_op.opcode);
 
-					const auto itype = g_ppu_itype.decode(pp.opcode);
 					should_step_over = (itype == ppu_itype::BC || itype == ppu_itype::B || itype == ppu_itype::BCCTR || itype == ppu_itype::BCLR) && ppu_op.lk;
 				}
 			}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1144,7 +1144,7 @@ void debugger_frame::DoStep(bool step_over)
 				vm::ptr<u32> inst_ptr = vm::cast(current_instruction_pc);
 				be_t<u32> result{};
 
-				if (inst_ptr.try_read(result) && ppu_opcode_t{+result}.lk == 0)
+				if (inst_ptr.try_read(result) && !ppu_opcode_t{+result}.lk)
 				{
 					should_step_over = false;
 				}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -15,6 +15,7 @@
 #include "Emu/IdManager.h"
 #include "Emu/RSX/RSXThread.h"
 #include "Emu/RSX/RSXDisAsm.h"
+#include "Emu/Cell/PPUAnalyser.h"
 #include "Emu/Cell/PPUDisAsm.h"
 #include "Emu/Cell/PPUThread.h"
 #include "Emu/Cell/SPUDisAsm.h"


### PR DESCRIPTION
Fix stepping over branches which do not have the link flag. This is of course based on the wrong assumption that all linked branches must return but oh well.