### PR TITLE
sys_fs & sys_game: Misc syscalls enhancement

### DIFF
--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -15,7 +15,7 @@ std::u16string utf8_to_utf16(std::string_view src);
 
 // Copy null-terminated string from a std::string or a char array to a char array with truncation
 template <typename D, typename T>
-inline void strcpy_trunc(D& dst, const T& src)
+inline void strcpy_trunc(D&& dst, const T& src)
 {
 	const usz count = std::size(src) >= std::size(dst) ? std::max<usz>(std::size(dst), 1) - 1 : std::size(src);
 	std::memcpy(std::data(dst), std::data(src), count);

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -424,7 +424,7 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	BIND_SYSC(_sys_game_watchdog_start),                    //372 (0x174)
 	BIND_SYSC(_sys_game_watchdog_stop),                     //373 (0x175)
 	BIND_SYSC(_sys_game_watchdog_clear),                    //374 (0x176)
-	NULL_FUNC(sys_game_set_system_sw_version),              //375 (0x177)  ROOT
+	BIND_SYSC(_sys_game_set_system_sw_version),             //375 (0x177)  ROOT
 	BIND_SYSC(_sys_game_get_system_sw_version),             //376 (0x178)  ROOT
 	BIND_SYSC(sys_sm_set_shop_mode),                        //377 (0x179)  ROOT
 	BIND_SYSC(sys_sm_get_ext_event2),                       //378 (0x17A)  ROOT

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -307,7 +307,6 @@ bool lv2_fs_object::vfs_unmount(std::string_view vpath)
 
 lv2_fs_object::lv2_fs_object(utils::serial& ar, bool)
 	: name(ar)
-	, mp(get_mp(name.data()))
 {
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -595,7 +595,7 @@ CHECK_SIZE(lv2_file_c000001a, 0x18);
 
 struct lv2_file_c000001c : lv2_file_op
 {
-	be_t<u32> size; // 0x20
+	be_t<u32> size; // 0x60
 	be_t<u32> _x4;  // 0x10
 	be_t<u32> _x8;  // 0x18 - offset of out_code
 	be_t<u32> name_size;

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -535,15 +535,16 @@ struct lv2_file_c0000006 : lv2_file_op
 
 CHECK_SIZE(lv2_file_c0000006, 0x20);
 
+// sys_fs_fcntl: cellFsArcadeHddSerialNumber
 struct lv2_file_c0000007 : lv2_file_op
 {
 	be_t<u32> out_code;
-	vm::bcptr<char> name;
-	be_t<u32> name_size; // 0x14
-	vm::bptr<char> unk1;
-	be_t<u32> unk1_size; //0x41
-	vm::bptr<char> unk2;
-	be_t<u32> unk2_size; //0x21
+	vm::bcptr<char> device;
+	be_t<u32> device_size;  // 0x14
+	vm::bptr<char> model;
+	be_t<u32> model_size; // 0x29
+	vm::bptr<char> serial;
+	be_t<u32> serial_size; // 0x15
 };
 
 CHECK_SIZE(lv2_file_c0000007, 0x1c);

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -173,12 +173,11 @@ struct lv2_fs_object
 	const std::array<char, 0x420> name;
 
 	// Mount Point
-	const std::add_pointer_t<lv2_fs_mount_point> mp;
+	lv2_fs_mount_point* const mp = get_mp(name.data());
 
 protected:
-	lv2_fs_object(lv2_fs_mount_point* mp, std::string_view filename)
+	lv2_fs_object(std::string_view filename)
 		: name(get_name(filename))
-		, mp(mp)
 	{
 	}
 
@@ -235,7 +234,7 @@ struct lv2_file final : lv2_fs_object
 	} restore_data{};
 
 	lv2_file(std::string_view filename, fs::file&& file, s32 mode, s32 flags, const std::string& real_path, lv2_file_type type = {})
-		: lv2_fs_object(lv2_fs_object::get_mp(filename), filename)
+		: lv2_fs_object(filename)
 		, file(std::move(file))
 		, mode(mode)
 		, flags(flags)
@@ -245,7 +244,7 @@ struct lv2_file final : lv2_fs_object
 	}
 
 	lv2_file(const lv2_file& host, fs::file&& file, s32 mode, s32 flags, const std::string& real_path, lv2_file_type type = {})
-		: lv2_fs_object(host.mp, host.name.data())
+		: lv2_fs_object(host.name.data())
 		, file(std::move(file))
 		, mode(mode)
 		, flags(flags)
@@ -309,7 +308,7 @@ struct lv2_dir final : lv2_fs_object
 	atomic_t<u64> pos{0};
 
 	lv2_dir(std::string_view filename, std::vector<fs::dir_entry>&& entries)
-		: lv2_fs_object(lv2_fs_object::get_mp(filename), filename)
+		: lv2_fs_object(filename)
 		, entries(std::move(entries))
 	{
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -189,9 +189,8 @@ public:
 
 	lv2_fs_object& operator=(const lv2_fs_object&) = delete;
 
-	static std::string_view get_device_path(std::string_view filename);
+	static std::string_view get_device_root(std::string_view filename);
 	static lv2_fs_mount_point* get_mp(std::string_view filename, std::string* vfs_path = nullptr);
-	static std::string device_name_to_path(std::string_view device_name);
 	static bool vfs_unmount(std::string_view vpath);
 
 	static std::array<char, 0x420> get_name(std::string_view filename)

--- a/rpcs3/Emu/Cell/lv2/sys_game.h
+++ b/rpcs3/Emu/Cell/lv2/sys_game.h
@@ -5,6 +5,7 @@ void abort_lv2_watchdog();
 error_code _sys_game_watchdog_start(u32 timeout);
 error_code _sys_game_watchdog_stop();
 error_code _sys_game_watchdog_clear();
+error_code _sys_game_set_system_sw_version(u64 version);
 u64 _sys_game_get_system_sw_version();
 error_code _sys_game_board_storage_read(vm::ptr<u8> buffer, vm::ptr<u8> status);
 error_code _sys_game_board_storage_write(vm::ptr<u8> buffer, vm::ptr<u8> status);

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -288,6 +288,8 @@ struct cfg_root : cfg::node
 		cfg::_int<-60*60*24*365*100LL, 60*60*24*365*100LL> console_time_offset{ this, "Console time offset (s)", 0 }; // console time offset, limited to +/-100years
 		cfg::uint<0, umax> console_psid_high{this, "PSID high"};
 		cfg::uint<0, umax> console_psid_low{this, "PSID low"};
+		cfg::string hdd_model{this, "HDD Model Name", ""};
+		cfg::string hdd_serial{this, "HDD Serial Number", ""};
 	} sys{ this };
 
 	struct node_net : cfg::node


### PR DESCRIPTION
1. Fixed potential bugs in sys_game_get_system_sw_version().
2. Implemented sys_game_set_system_sw_version().
3. Improved the efficiency of the conversion from device names to mount points for sys_fs_mount() and sys_fs_newfs().
4. Implemented mount_info_map in sys_fs to keep proper track of mounted devices.
5. Further implemented cellFsArcadeHddSerialNumber (0xc0000007) so that the virtual HDD's model name and serial number are now configurable in config.yml.