### PR TITLE
Round squircled axis values to the nearest whole number

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -255,8 +255,8 @@ std::tuple<u16, u16> PadHandlerBase::ConvertToSquirclePoint(u16 inX, u16 inY, in
 	const f32 newLen = (1 + std::pow(std::sin(2 * angle), 2.f) / (squircle_factor / 1000.f)) * r;
 
 	// we now have len and angle, convert to cartesian
-	const int newX = Clamp0To255(((newLen * std::cos(angle)) + 1) * 127.5f);
-	const int newY = Clamp0To255(((newLen * std::sin(angle)) + 1) * 127.5f);
+	const int newX = Clamp0To255(std::round(((newLen * std::cos(angle)) + 1) * 127.5f));
+	const int newY = Clamp0To255(std::round(((newLen * std::sin(angle)) + 1) * 127.5f));
 	return std::tuple<u16, u16>(newX, newY);
 }
 


### PR DESCRIPTION
For the default squircle value of 8000, I observed the following behavior:
`ConvertToSquirclePoint(128,128) --> (128,128)`. This makes sense to me.
`ConvertToSquirclePoint(127,127) --> (126,126)`. Huh.

If you don't cast the coordinate values to integer, you get the following:
`ConvertToSquirclePoint(128,128) --> (128.0625, 128.0625)`
`ConvertToSquirclePoint(127,127) --> (126.9375, 126.9375)`

To me, it makes sense to round the coordinate values to the nearest whole number instead of just casting them to integers. This way, joysticks centered at (127,127) remain centered at (127,127) instead of getting recentered to (126,126).

Implementing this allows me to implement #13636 without having to workaround joysticks being centered at (126,126).