### PR TITLE
Qt: add checkbox to restart dialog

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -135,6 +135,7 @@ namespace gui
 	const gui_save ib_confirm_boot = gui_save(main_window, "confirmationBoxBootGame",  true);
 	const gui_save ib_obsolete_cfg = gui_save(main_window, "confirmationObsoleteCfg",  true);
 	const gui_save ib_same_buttons = gui_save(main_window, "confirmationSameButtons",  true);
+	const gui_save ib_restart_hint = gui_save(main_window, "confirmationRestart",      true);
 
 	const gui_save fd_install_pkg  = gui_save(main_window, "lastExplorePathPKG",  "");
 	const gui_save fd_install_pup  = gui_save(main_window, "lastExplorePathPUP",  "");

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -91,9 +91,10 @@ extern void process_qt_events()
 main_window::main_window(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget *parent)
 	: QMainWindow(parent)
 	, ui(new Ui::main_window)
-	, m_gui_settings(std::move(gui_settings))
+	, m_gui_settings(gui_settings)
 	, m_emu_settings(std::move(emu_settings))
 	, m_persistent_settings(std::move(persistent_settings))
+	, m_updater(nullptr, gui_settings)
 {
 	Q_INIT_RESOURCE(resources);
 

--- a/rpcs3/rpcs3qt/settings.cpp
+++ b/rpcs3/rpcs3qt/settings.cpp
@@ -13,6 +13,11 @@ settings::settings(QObject* parent) : QObject(parent),
 
 settings::~settings()
 {
+	sync();
+}
+
+void settings::sync()
+{
 	if (m_settings)
 	{
 		m_settings->sync();

--- a/rpcs3/rpcs3qt/settings.h
+++ b/rpcs3/rpcs3qt/settings.h
@@ -29,6 +29,8 @@ public:
 	explicit settings(QObject* parent = nullptr);
 	~settings();
 
+	void sync();
+
 	QString GetSettingsDir() const;
 
 	QVariant GetValue(const QString& key, const QString& name, const QVariant& def) const;

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1984,6 +1984,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		SubscribeTooltip(ui->cb_show_pup_install, tooltips.settings.show_pup_install);
 		SubscribeTooltip(ui->cb_show_obsolete_cfg_dialog, tooltips.settings.show_obsolete_cfg);
 		SubscribeTooltip(ui->cb_show_same_buttons_dialog, tooltips.settings.show_same_buttons);
+		SubscribeTooltip(ui->cb_show_restart_hint, tooltips.settings.show_restart_hint);
 		SubscribeTooltip(ui->gb_updates, tooltips.settings.check_update_start);
 		SubscribeTooltip(ui->gb_uuid, tooltips.settings.uuid);
 
@@ -2073,6 +2074,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		ui->cb_show_pup_install->setChecked(m_gui_settings->GetValue(gui::ib_pup_success).toBool());
 		ui->cb_show_obsolete_cfg_dialog->setChecked(m_gui_settings->GetValue(gui::ib_obsolete_cfg).toBool());
 		ui->cb_show_same_buttons_dialog->setChecked(m_gui_settings->GetValue(gui::ib_same_buttons).toBool());
+		ui->cb_show_restart_hint->setChecked(m_gui_settings->GetValue(gui::ib_restart_hint).toBool());
 
 		ui->combo_updates->addItem(tr("Yes", "Updates"), gui::update_on);
 		ui->combo_updates->addItem(tr("Background", "Updates"), gui::update_bkg);
@@ -2119,6 +2121,10 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		connect(ui->cb_show_same_buttons_dialog, &QCheckBox::toggled, [this](bool checked)
 		{
 			m_gui_settings->SetValue(gui::ib_same_buttons, checked);
+		});
+		connect(ui->cb_show_restart_hint, &QCheckBox::toggled, [this](bool checked)
+		{
+			m_gui_settings->SetValue(gui::ib_restart_hint, checked);
 		});
 
 		connect(ui->cb_custom_colors, &QCheckBox::toggled, [this](bool checked)

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -3823,6 +3823,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="cb_show_restart_hint">
+                 <property name="text">
+                  <string>Show Restart Dialog</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <spacer name="guiTabSpacerRight">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -200,6 +200,7 @@ public:
 		const QString show_pup_install   = tr("Shows a dialog when firmware was installed successfully.");
 		const QString show_obsolete_cfg  = tr("Shows a dialog when obsolete settings were found.");
 		const QString show_same_buttons  = tr("Shows a dialog in the game pad configuration when the same button was assigned twice.");
+		const QString show_restart_hint  = tr("Shows a dialog when RPCS3 is ready to restart after an update.");
 		const QString check_update_start = tr("Checks if an update is available on startup and asks if you want to update.\nIf \"Automatic\" is selected, the update will run automatically without user confirmation.\nIf \"Background\" is selected, the check is done silently in the background and a new download option is shown in the top right corner of the menu if a new version was found.");
 		const QString use_rich_presence  = tr("Enables use of Discord Rich Presence to show what game you are playing on Discord.\nRequires a restart of RPCS3 to completely close the connection.");
 		const QString discord_state      = tr("Tell your friends what you are doing.");

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -3,6 +3,7 @@
 #include "localized.h"
 #include "rpcs3_version.h"
 #include "downloader.h"
+#include "gui_settings.h"
 #include "Utilities/StrUtil.h"
 #include "Utilities/File.h"
 #include "Emu/System.h"
@@ -38,6 +39,11 @@
 #endif
 
 LOG_CHANNEL(update_log, "UPDATER");
+
+update_manager::update_manager(QObject* parent, std::shared_ptr<gui_settings> gui_settings)
+	: QObject(parent), m_gui_settings(std::move(gui_settings))
+{
+}
 
 void update_manager::check_for_updates(bool automatic, bool check_only, bool auto_accept, QWidget* parent)
 {
@@ -637,7 +643,8 @@ bool update_manager::handle_rpcs3(const QByteArray& data, bool auto_accept)
 
 	if (!auto_accept)
 	{
-		QMessageBox::information(m_parent, tr("Auto-updater"), tr("Update successful!\nRPCS3 will now restart."));
+		m_gui_settings->ShowInfoBox(tr("Auto-updater"), tr("Update successful!<br>RPCS3 will now restart.<br>"), gui::ib_restart_hint, m_parent);
+		m_gui_settings->sync(); // Make sure to sync before terminating RPCS3
 	}
 
 	Emu.GracefulShutdown(false);

--- a/rpcs3/rpcs3qt/update_manager.h
+++ b/rpcs3/rpcs3qt/update_manager.h
@@ -7,6 +7,7 @@
 #include <string>
 
 class downloader;
+class gui_settings;
 
 class update_manager final :  public QObject
 {
@@ -15,6 +16,8 @@ class update_manager final :  public QObject
 private:
 	downloader* m_downloader = nullptr;
 	QWidget* m_parent        = nullptr;
+
+	std::shared_ptr<gui_settings> m_gui_settings;
 
 	// This message is empty if there is no download available
 	QString m_update_message;
@@ -36,7 +39,7 @@ private:
 	bool handle_rpcs3(const QByteArray& data, bool auto_accept);
 
 public:
-	update_manager() = default;
+	update_manager(QObject* parent, std::shared_ptr<gui_settings> gui_settings);
 	void check_for_updates(bool automatic, bool check_only, bool auto_accept, QWidget* parent = nullptr);
 	void update(bool auto_accept);
 


### PR DESCRIPTION
- Adds a "don't show again" checkbox to the restart hint at the end of a RPCS3 update

![image](https://user-images.githubusercontent.com/23019877/232859099-c8cd5c57-6df2-4ed7-a8e2-5232344cd19c.png)
