### PR TITLE
Qt: add option to reset time played

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1302,6 +1302,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 	QAction* download_compat = menu.addAction(tr("&Download Compatibility Database"));
 	menu.addSeparator();
 	QAction* edit_notes = menu.addAction(tr("&Edit Tooltip Notes"));
+	QAction* reset_time_played = menu.addAction(tr("&Reset Time Played"));
 
 	QMenu* icon_menu = menu.addMenu(tr("&Custom Images"));
 	const std::array<QAction*, 3> custom_icon_actions =
@@ -1622,6 +1623,16 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 				m_notes.insert(serial, new_notes);
 				m_persistent_settings->SetValue(gui::persistent::notes, serial, new_notes);
 			}
+			Refresh();
+		}
+	});
+	connect(reset_time_played, &QAction::triggered, this, [this, name, serial]
+	{
+		if (QMessageBox::question(this, tr("Confirm Reset"), tr("Reset time played?\n\n%0 [%1]").arg(name).arg(serial)) == QMessageBox::Yes)
+		{
+			m_persistent_settings->SetPlaytime(serial, 0);
+			m_persistent_settings->SetLastPlayed(serial, 0);
+			m_persistent_settings->sync();
 			Refresh();
 		}
 	});


### PR DESCRIPTION
- add option to reset time played to game list context menu

![image](https://user-images.githubusercontent.com/23019877/232885400-2d0872ef-f037-4180-8946-359c15767f0a.png)
![image](https://user-images.githubusercontent.com/23019877/232882331-26f5e37c-1bbf-4992-86a9-93858c5b6eaa.png)
![image](https://user-images.githubusercontent.com/23019877/232882889-e689ad2e-1269-4b70-9ca4-cd0ecab9aacc.png)
![image](https://user-images.githubusercontent.com/23019877/232885469-c0fbe327-8f4d-4182-b8cc-9f283da5bd2a.png)


fixes #13615