### PR TITLE
gl: Refactor attachment clear logic

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTexture.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTexture.cpp
@@ -1101,4 +1101,34 @@ namespace gl
 		const coord3u dst_area = { {}, dst->size3D() };
 		copy_typeless(cmd, dst, src, dst_area, src_area);
 	}
+
+	void clear_attachments(gl::command_context& cmd, const clear_cmd_info& info)
+	{
+		// Compile the clear command at the end. Other intervening operations will
+		GLbitfield clear_mask = 0;
+		if (info.aspect_mask & gl::image_aspect::color)
+		{
+			for (u32 buffer_id = 0; buffer_id < info.clear_color.attachment_count; ++buffer_id)
+			{
+				cmd->color_maski(buffer_id, info.clear_color.mask);
+			}
+
+			cmd->clear_color(info.clear_color.r, info.clear_color.g, info.clear_color.b, info.clear_color.a);
+			clear_mask |= GL_COLOR_BUFFER_BIT;
+		}
+		if (info.aspect_mask & gl::image_aspect::depth)
+		{
+			cmd->depth_mask(GL_TRUE);
+			cmd->clear_depth(info.clear_depth.value);
+			clear_mask |= GL_DEPTH_BUFFER_BIT;
+		}
+		if (info.aspect_mask & gl::image_aspect::stencil)
+		{
+			cmd->stencil_mask(info.clear_stencil.mask);
+			cmd->clear_stencil(info.clear_stencil.value);
+			clear_mask |= GL_STENCIL_BUFFER_BIT;
+		}
+
+		glClear(clear_mask);
+	}
 }

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -37,26 +37,27 @@ namespace gl
 
 		struct
 		{
-			f32 value = 0;
+			f32 value;
 		}
-		clear_depth;
+		clear_depth{};
 
 		struct
 		{
-			u8 mask = 0;
-			u8 value = 0;
+			u8 mask;
+			u8 value;
 		}
-		clear_stencil;
+		clear_stencil{};
 
-		struct {
-			u32 mask = 0;
-			u8 attachment_count = 0;
-			u8 r = 0;
-			u8 g = 0;
-			u8 b = 0;
-			u8 a = 0;
+		struct
+		{
+			u32 mask;
+			u8 attachment_count;
+			u8 r;
+			u8 g;
+			u8 b;
+			u8 a;
 		}
-		clear_color;
+		clear_color{};
 	};
 
 	GLenum get_target(rsx::texture_dimension_extended type);

--- a/rpcs3/Emu/RSX/GL/GLTexture.h
+++ b/rpcs3/Emu/RSX/GL/GLTexture.h
@@ -31,6 +31,34 @@ namespace gl
 		u64 memory_required;
 	};
 
+	struct clear_cmd_info
+	{
+		GLbitfield aspect_mask = 0;
+
+		struct
+		{
+			f32 value = 0;
+		}
+		clear_depth;
+
+		struct
+		{
+			u8 mask = 0;
+			u8 value = 0;
+		}
+		clear_stencil;
+
+		struct {
+			u32 mask = 0;
+			u8 attachment_count = 0;
+			u8 r = 0;
+			u8 g = 0;
+			u8 b = 0;
+			u8 a = 0;
+		}
+		clear_color;
+	};
+
 	GLenum get_target(rsx::texture_dimension_extended type);
 	GLenum get_sized_internal_format(u32 texture_format);
 	std::tuple<GLenum, GLenum> get_format_type(u32 texture_format);
@@ -50,6 +78,8 @@ namespace gl
 		const void* src_offset, const int dst_level, const coord3u& dst_region, image_memory_requirements* mem_info);
 
 	void upload_texture(gl::command_context& cmd, texture* dst, u32 gcm_format, bool is_swizzled, const std::vector<rsx::subresource_layout>& subresources_layout);
+
+	void clear_attachments(gl::command_context& cmd, const clear_cmd_info& info);
 
 	namespace debug
 	{

--- a/rpcs3/Emu/RSX/GL/glutils/fbo.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/fbo.cpp
@@ -169,15 +169,6 @@ namespace gl
 		glClear(static_cast<GLbitfield>(buffers_));
 	}
 
-	void fbo::clear(buffers buffers_, color4f color_value, double depth_value, u8 stencil_value) const
-	{
-		save_binding_state save(*this);
-		glClearColor(color_value.r, color_value.g, color_value.b, color_value.a);
-		glClearDepth(depth_value);
-		glClearStencil(stencil_value);
-		clear(buffers_);
-	}
-
 	void fbo::copy_from(const void* pixels, const sizei& size, gl::texture::format format_, gl::texture::type type_, class pixel_unpack_settings pixel_settings) const
 	{
 		save_binding_state save(*this);

--- a/rpcs3/Emu/RSX/GL/glutils/fbo.h
+++ b/rpcs3/Emu/RSX/GL/glutils/fbo.h
@@ -211,7 +211,6 @@ namespace gl
 		void draw_elements(const buffer& buffer, GLenum mode, GLsizei count, const GLuint* indices) const;
 
 		void clear(buffers buffers_) const;
-		void clear(buffers buffers_, color4f color_value, double depth_value, u8 stencil_value) const;
 
 		void copy_from(const void* pixels, const sizei& size, gl::texture::format format_, gl::texture::type type_, class pixel_unpack_settings pixel_settings = pixel_unpack_settings()) const;
 		void copy_from(const buffer& buf, const sizei& size, gl::texture::format format_, gl::texture::type type_, class pixel_unpack_settings pixel_settings = pixel_unpack_settings()) const;


### PR DESCRIPTION
Make the whole thing a standalone command wrapper to avoid unnecessary state meddling. Previously any changes made before the actual clear step were overwritten by other intermediary steps. In the dragon's dogma case, a memory barrier forced attachment merging which destroyed the state before the glClear was issued.

Fixes https://github.com/RPCS3/rpcs3/issues/13693