### PR TITLE
Qt: Optimize hard list refresh

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -671,6 +671,7 @@
     <ClCompile Include="rpcs3qt\localized.cpp" />
     <ClCompile Include="rpcs3qt\log_viewer.cpp" />
     <ClCompile Include="rpcs3qt\microphone_creator.cpp" />
+    <ClCompile Include="rpcs3qt\movie_item.cpp" />
     <ClCompile Include="rpcs3qt\osk_dialog_frame.cpp" />
     <ClCompile Include="rpcs3qt\pad_led_settings_dialog.cpp" />
     <ClCompile Include="rpcs3qt\pad_motion_settings_dialog.cpp" />
@@ -696,6 +697,7 @@
     <ClCompile Include="rpcs3qt\shortcut_utils.cpp" />
     <ClCompile Include="rpcs3qt\skylander_dialog.cpp" />
     <ClCompile Include="rpcs3qt\system_cmd_dialog.cpp" />
+    <ClCompile Include="rpcs3qt\table_item_delegate.cpp" />
     <ClCompile Include="rpcs3qt\tooltips.cpp" />
     <ClCompile Include="rpcs3qt\update_manager.cpp" />
     <ClCompile Include="rpcs3qt\qt_camera_video_surface.cpp" />

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -936,6 +936,12 @@
     <ClCompile Include="QTGeneratedFiles\Release\moc_system_cmd_dialog.cpp">
       <Filter>Generated Files\Release</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\table_item_delegate.cpp">
+      <Filter>Gui\custom items</Filter>
+    </ClCompile>
+    <ClCompile Include="rpcs3qt\movie_item.cpp">
+      <Filter>Gui\custom items</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SRC_FILES
     memory_string_searcher.cpp
     memory_viewer_panel.cpp
     microphone_creator.cpp
+    movie_item.cpp
     msg_dialog_frame.cpp
     osk_dialog_frame.cpp
     pad_led_settings_dialog.cpp
@@ -81,6 +82,7 @@ set(SRC_FILES
     skylander_dialog.cpp
     syntax_highlighter.cpp
     system_cmd_dialog.cpp
+    table_item_delegate.cpp
     tooltips.cpp
     trophy_manager_dialog.cpp
     trophy_notification_frame.cpp

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -238,9 +238,10 @@ compat::status game_compatibility::GetCompatibility(const std::string& title_id)
 	{
 		return ::at32(Status_Data, "NoData");
 	}
-	else if (m_compat_database.count(title_id) > 0)
+
+	if (const auto it = m_compat_database.find(title_id); it != m_compat_database.cend())
 	{
-		return m_compat_database[title_id];
+		return it->second;
 	}
 
 	return ::at32(Status_Data, "NoResult");

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2727,6 +2727,8 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 
 	for (const auto& app : m_game_data)
 	{
+		app->item = nullptr;
+
 		if (IsEntryVisible(app))
 		{
 			matching_apps.push_back(app);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -150,14 +150,6 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 		m_games.pop_all();
 	});
 	connect(&m_repaint_watcher, &QFutureWatcher<movie_item*>::finished, this, &game_list_frame::OnRepaintFinished);
-	connect(&m_repaint_watcher, &QFutureWatcher<movie_item*>::resultReadyAt, this, [this](int index)
-	{
-		if (!m_is_list_layout) return;
-		if (movie_item* item = m_repaint_watcher.resultAt(index))
-		{
-			item->call_icon_func();
-		}
-	});
 	connect(this, &game_list_frame::IconReady, this, [this](movie_item* item)
 	{
 		if (!m_is_list_layout || !item) return;
@@ -892,19 +884,7 @@ void game_list_frame::OnRefreshFinished()
 
 void game_list_frame::OnRepaintFinished()
 {
-	if (m_is_list_layout)
-	{
-		// Fixate vertical header and row height
-		m_game_list->verticalHeader()->setMinimumSectionSize(m_icon_size.height());
-		m_game_list->verticalHeader()->setMaximumSectionSize(m_icon_size.height());
-
-		// Resize the icon column
-		m_game_list->resizeColumnToContents(gui::column_icon);
-
-		// Shorten the last section to remove horizontal scrollbar if possible
-		m_game_list->resizeColumnToContents(gui::column_count - 1);
-	}
-	else
+	if (!m_is_list_layout)
 	{
 		// The game grid needs to be recreated from scratch
 		int games_per_row = 0;

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -173,10 +173,8 @@ private:
 	QSet<QString> m_serials;
 	QMutex m_games_mutex;
 	lf_queue<game_info> m_games;
-	QFutureWatcher<void> m_size_watcher;
 	QFutureWatcher<void> m_refresh_watcher;
 	QFutureWatcher<movie_item*> m_repaint_watcher;
-	std::shared_ptr<atomic_t<bool>> m_size_watcher_cancel;
 	QSet<QString> m_hidden_list;
 	bool m_show_hidden{false};
 

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -80,7 +80,6 @@ public Q_SLOTS:
 
 private Q_SLOTS:
 	void OnRefreshFinished();
-	void OnRepaintFinished();
 	void OnCompatFinished();
 	void OnColClicked(int col);
 	void ShowContextMenu(const QPoint &pos);
@@ -102,6 +101,7 @@ protected:
 private:
 	QPixmap PaintedPixmap(const QPixmap& icon, bool paint_config_icon = false, bool paint_pad_config_icon = false, const QColor& color = QColor()) const;
 	QColor getGridCompatibilityColor(const QString& string) const;
+	void IconLoadFunction(game_info game, std::shared_ptr<atomic_t<bool>> cancel);
 
 	/** Sets the custom config icon. Only call this for list title items. */
 	void SetCustomConfigIcon(QTableWidgetItem* title_item, const game_info& game);
@@ -174,7 +174,6 @@ private:
 	QMutex m_games_mutex;
 	lf_queue<game_info> m_games;
 	QFutureWatcher<void> m_refresh_watcher;
-	QFutureWatcher<movie_item*> m_repaint_watcher;
 	QSet<QString> m_hidden_list;
 	bool m_show_hidden{false};
 

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -5,6 +5,7 @@
 #include "gui_save.h"
 #include "shortcut_utils.h"
 #include "Utilities/lockless.h"
+#include "Utilities/mutex.h"
 #include "Emu/System.h"
 
 #include <QMainWindow>
@@ -155,9 +156,17 @@ private:
 	std::shared_ptr<emu_settings> m_emu_settings;
 	std::shared_ptr<persistent_settings> m_persistent_settings;
 	QList<game_info> m_game_data;
-	std::vector<std::string> m_path_list;
+	struct path_entry
+	{
+		std::string path;
+		bool is_disc{};
+		bool is_from_yml{};
+	};
+	std::vector<path_entry> m_path_entries;
+	shared_mutex m_path_mutex;
+	std::set<std::string> m_path_list;
 	QSet<QString> m_serials;
-	QMutex m_mutex_cat;
+	QMutex m_games_mutex;
 	lf_queue<game_info> m_games;
 	QFutureWatcher<void> m_size_watcher;
 	QFutureWatcher<void> m_refresh_watcher;

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -92,6 +92,8 @@ Q_SIGNALS:
 	void RequestBoot(const game_info& game, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "", const std::string& savestate = "");
 	void RequestIconSizeChange(const int& val);
 	void NotifyEmuSettingsChange();
+	void IconReady(movie_item* item);
+	void SizeOnDiskReady(const game_info& game);
 protected:
 	/** Override inherited method from Qt to allow signalling when close happened.*/
 	void closeEvent(QCloseEvent* event) override;
@@ -126,6 +128,9 @@ private:
 
 	game_info GetGameInfoByMode(const QTableWidgetItem* item) const;
 	static game_info GetGameInfoFromItem(const QTableWidgetItem* item);
+
+	void WaitAndAbortRepaintThreads();
+	void WaitAndAbortSizeCalcThreads();
 
 	// Which widget we are displaying depends on if we are in grid or list mode.
 	QMainWindow* m_game_dock = nullptr;

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -81,7 +81,7 @@ movie_item* game_list_grid::addItem(const game_info& app, const QString& name, c
 			exp_size_f = m_icon_size + m_icon_size * m_margin_factor * 2;
 		}
 
-		QMovie* movie = item->movie();
+		std::shared_ptr<QMovie> movie = item->movie();
 		const bool draw_movie_frame = movie && movie->isValid() && item->get_active();
 		const QSize exp_size = (exp_size_f * device_pixel_ratio).toSize();
 

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -66,7 +66,10 @@ movie_item* game_list_grid::addItem(const game_info& app, const QString& name, c
 
 	item->set_icon_func([this, app, item](int)
 	{
-		ensure(item);
+		if (!item)
+		{
+			return;
+		}
 
 		const qreal device_pixel_ratio = devicePixelRatioF();
 

--- a/rpcs3/rpcs3qt/movie_item.cpp
+++ b/rpcs3/rpcs3qt/movie_item.cpp
@@ -129,7 +129,7 @@ void movie_item::set_size_calc_func(const size_calc_callback_t& func)
 
 void movie_item::wait_for_icon_loading(bool abort)
 {
-	if (m_icon_load_thread)
+	if (m_icon_load_thread && m_icon_load_thread->isRunning())
 	{
 		*m_icon_loading_aborted = abort;
 		m_icon_load_thread->wait();
@@ -139,7 +139,7 @@ void movie_item::wait_for_icon_loading(bool abort)
 
 void movie_item::wait_for_size_on_disk_loading(bool abort)
 {
-	if (m_size_calc_thread)
+	if (m_size_calc_thread && m_size_calc_thread->isRunning())
 	{
 		*m_size_on_disk_loading_aborted = abort;
 		m_size_calc_thread->wait();

--- a/rpcs3/rpcs3qt/movie_item.cpp
+++ b/rpcs3/rpcs3qt/movie_item.cpp
@@ -1,0 +1,148 @@
+#include "stdafx.h"
+#include "movie_item.h"
+
+movie_item::movie_item() : QTableWidgetItem()
+{
+	init_pointers();
+}
+
+movie_item::movie_item(const QString& text, int type) : QTableWidgetItem(text, type)
+{
+	init_pointers();
+}
+
+movie_item::movie_item(const QIcon& icon, const QString& text, int type) : QTableWidgetItem(icon, text, type)
+{
+	init_pointers();
+}
+
+movie_item::~movie_item()
+{
+	if (m_movie)
+	{
+		m_movie->stop();
+	}
+
+	wait_for_icon_loading(true);
+	wait_for_size_on_disk_loading(true);
+}
+
+void movie_item::init_pointers()
+{
+	m_icon_loading_aborted.reset(new atomic_t<bool>(false));
+	m_size_on_disk_loading_aborted.reset(new atomic_t<bool>(false));
+}
+
+void movie_item::set_active(bool active)
+{
+	if (!std::exchange(m_active, active) && active && m_movie)
+	{
+		m_movie->jumpToFrame(1);
+		m_movie->start();
+	}
+}
+
+void movie_item::init_movie(const QString& path)
+{
+	if (path.isEmpty() || !m_icon_callback) return;
+
+	m_movie.reset(new QMovie(path));
+
+	if (!m_movie->isValid())
+	{
+		m_movie.reset();
+		return;
+	}
+
+	QObject::connect(m_movie.get(), &QMovie::frameChanged, m_movie.get(), m_icon_callback);
+}
+
+void movie_item::call_icon_func() const
+{
+	if (m_icon_callback)
+	{
+		m_icon_callback(0);
+	}
+}
+
+void movie_item::set_icon_func(const icon_callback_t& func)
+{
+	m_icon_callback = func;
+	call_icon_func();
+}
+
+void movie_item::call_icon_load_func()
+{
+	wait_for_icon_loading(true);
+
+	if (!m_icon_load_callback || m_icon_loading)
+	{
+		return;
+	}
+
+	*m_icon_loading_aborted = false;
+	m_icon_loading = true;
+	m_icon_load_thread.reset(QThread::create([this]()
+	{
+		if (m_icon_load_callback)
+		{
+			m_icon_load_callback();
+		}
+	}));
+	m_icon_load_thread->start();
+}
+
+void movie_item::set_icon_load_func(const icon_load_callback_t& func)
+{
+	wait_for_icon_loading(true);
+
+	m_icon_loading = false;
+	m_icon_load_callback = func;
+}
+
+void movie_item::call_size_calc_func()
+{
+	wait_for_size_on_disk_loading(true);
+
+	if (!m_size_calc_callback || m_size_on_disk_loading)
+	{
+		return;
+	}
+
+	*m_size_on_disk_loading_aborted = false;
+	m_size_on_disk_loading = true;
+	m_size_calc_thread.reset(QThread::create([this]()
+	{
+		if (m_size_calc_callback)
+		{
+			m_size_calc_callback();
+		}
+	}));
+	m_size_calc_thread->start();
+}
+
+void movie_item::set_size_calc_func(const size_calc_callback_t& func)
+{
+	m_size_on_disk_loading = false;
+	m_size_calc_callback = func;
+}
+
+void movie_item::wait_for_icon_loading(bool abort)
+{
+	if (m_icon_load_thread)
+	{
+		*m_icon_loading_aborted = abort;
+		m_icon_load_thread->wait();
+		m_icon_load_thread.reset();
+	}
+}
+
+void movie_item::wait_for_size_on_disk_loading(bool abort)
+{
+	if (m_size_calc_thread)
+	{
+		*m_size_on_disk_loading_aborted = abort;
+		m_size_calc_thread->wait();
+		m_size_calc_thread.reset();
+	}
+}

--- a/rpcs3/rpcs3qt/movie_item.h
+++ b/rpcs3/rpcs3qt/movie_item.h
@@ -61,12 +61,12 @@ public:
 		return m_size_on_disk_loading;
 	}
 
-	std::shared_ptr<atomic_t<bool>> icon_loading_aborted() const
+	[[nodiscard]] std::shared_ptr<atomic_t<bool>> icon_loading_aborted() const
 	{
 		return m_icon_loading_aborted;
 	}
 
-	std::shared_ptr<atomic_t<bool>> size_on_disk_loading_aborted() const
+	[[nodiscard]] std::shared_ptr<atomic_t<bool>> size_on_disk_loading_aborted() const
 	{
 		return m_size_on_disk_loading_aborted;
 	}

--- a/rpcs3/rpcs3qt/movie_item.h
+++ b/rpcs3/rpcs3qt/movie_item.h
@@ -1,87 +1,89 @@
 #pragma once
 
+#include "util/atomic.hpp"
+
 #include <QTableWidgetItem>
 #include <QMovie>
 #include <QObject>
+#include <QThread>
 
+#include <mutex>
+#include <memory>
 #include <functional>
 
 using icon_callback_t = std::function<void(int)>;
+using icon_load_callback_t = std::function<void()>;
+using size_calc_callback_t = std::function<void()>;
 
 class movie_item : public QTableWidgetItem
 {
 public:
-	movie_item() : QTableWidgetItem()
-	{
-	}
-	movie_item(const QString& text, int type = Type) : QTableWidgetItem(text, type)
-	{
-	}
-	movie_item(const QIcon& icon, const QString& text, int type = Type) : QTableWidgetItem(icon, text, type)
-	{
-	}
+	movie_item();
+	movie_item(const QString& text, int type = Type);
+	movie_item(const QIcon& icon, const QString& text, int type = Type);
+	~movie_item();
 
-	~movie_item()
-	{
-		if (m_movie)
-		{
-			m_movie->stop();
-			delete m_movie;
-		}
-	}
+	void init_pointers();
 
-	void set_active(bool active)
-	{
-		if (!std::exchange(m_active, active) && active && m_movie)
-		{
-			m_movie->jumpToFrame(1);
-			m_movie->start();
-		}
-	}
+	void set_active(bool active);
 
 	[[nodiscard]] bool get_active() const
 	{
 		return m_active;
 	}
 
-	[[nodiscard]] QMovie* movie() const
+	[[nodiscard]] std::shared_ptr<QMovie> movie() const
 	{
 		return m_movie;
 	}
 
-	void init_movie(const QString& path)
+	void init_movie(const QString& path);
+
+	void call_icon_func() const;
+	void set_icon_func(const icon_callback_t& func);
+
+	void call_icon_load_func();
+	void set_icon_load_func(const icon_load_callback_t& func);
+
+	void call_size_calc_func();
+	void set_size_calc_func(const size_calc_callback_t& func);
+
+	void wait_for_icon_loading(bool abort);
+	void wait_for_size_on_disk_loading(bool abort);
+
+	bool icon_loading() const
 	{
-		if (path.isEmpty() || !m_icon_callback) return;
-
-		if (QMovie* movie = new QMovie(path); movie->isValid())
-		{
-			m_movie = movie;
-		}
-		else
-		{
-			delete movie;
-			return;
-		}
-
-		QObject::connect(m_movie, &QMovie::frameChanged, m_movie, m_icon_callback);
+		return m_icon_loading;
 	}
 
-	void call_icon_func() const
+	bool size_on_disk_loading() const
 	{
-		if (m_icon_callback)
-		{
-			m_icon_callback(0);
-		}
+		return m_size_on_disk_loading;
 	}
 
-	void set_icon_func(const icon_callback_t& func)
+	std::shared_ptr<atomic_t<bool>> icon_loading_aborted() const
 	{
-		m_icon_callback = func;
-		call_icon_func();
+		return m_icon_loading_aborted;
 	}
+
+	std::shared_ptr<atomic_t<bool>> size_on_disk_loading_aborted() const
+	{
+		return m_size_on_disk_loading_aborted;
+	}
+
+	std::mutex pixmap_mutex;
 
 private:
-	QMovie* m_movie = nullptr;
+	std::shared_ptr<QMovie> m_movie;
+	std::unique_ptr<QThread> m_icon_load_thread;
+	std::unique_ptr<QThread> m_size_calc_thread;
 	bool m_active = false;
+	atomic_t<bool> m_size_on_disk_loading = false;
+	atomic_t<bool> m_icon_loading = false;
+	size_calc_callback_t m_size_calc_callback = nullptr;
+	icon_load_callback_t m_icon_load_callback = nullptr;
 	icon_callback_t m_icon_callback = nullptr;
+
+	std::shared_ptr<atomic_t<bool>> m_icon_loading_aborted;
+	std::shared_ptr<atomic_t<bool>> m_size_on_disk_loading_aborted;
 };

--- a/rpcs3/rpcs3qt/table_item_delegate.cpp
+++ b/rpcs3/rpcs3qt/table_item_delegate.cpp
@@ -1,0 +1,68 @@
+#include "table_item_delegate.h"
+
+#include <QTableWidget>
+#include "movie_item.h"
+#include "gui_settings.h"
+
+table_item_delegate::table_item_delegate(QObject* parent, bool has_icons)
+	: QStyledItemDelegate(parent), m_has_icons(has_icons)
+{
+}
+
+void table_item_delegate::initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const
+{
+	// Remove the focus frame around selected items
+	option->state &= ~QStyle::State_HasFocus;
+
+	if (m_has_icons && index.column() == 0)
+	{
+		// Don't highlight icons
+		option->state &= ~QStyle::State_Selected;
+
+		// Center icons
+		option->decorationAlignment = Qt::AlignCenter;
+		option->decorationPosition = QStyleOptionViewItem::Top;
+	}
+
+	QStyledItemDelegate::initStyleOption(option, index);
+}
+
+void table_item_delegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+	if (index.column() == gui::game_list_columns::column_icon && option.state & QStyle::State_Selected)
+	{
+		// Add background highlight color to icons
+		painter->fillRect(option.rect, option.palette.color(QPalette::Highlight));
+	}
+
+	QStyledItemDelegate::paint(painter, option, index);
+
+	// Find out if the icon or size items are visible
+	if (index.column() == gui::game_list_columns::column_dir_size || (m_has_icons && index.column() == gui::game_list_columns::column_icon))
+	{
+		if (const QTableWidget* table = static_cast<const QTableWidget*>(parent()))
+		{
+			if (const QTableWidgetItem* current_item = table->item(index.row(), index.column());
+				current_item && table->visibleRegion().intersects(table->visualItemRect(current_item)))
+			{
+				if (movie_item* item = static_cast<movie_item*>(table->item(index.row(), gui::game_list_columns::column_icon)))
+				{
+					if (index.column() == gui::game_list_columns::column_dir_size)
+					{
+						if (!item->size_on_disk_loading())
+						{
+							item->call_size_calc_func();
+						}
+					}
+					else if (m_has_icons && index.column() == gui::game_list_columns::column_icon)
+					{
+						if (!item->icon_loading())
+						{
+							item->call_icon_load_func();
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/rpcs3/rpcs3qt/table_item_delegate.h
+++ b/rpcs3/rpcs3qt/table_item_delegate.h
@@ -10,34 +10,9 @@ private:
 	bool m_has_icons;
 
 public:
-	explicit table_item_delegate(QObject *parent = nullptr, bool has_icons = false) : QStyledItemDelegate(parent), m_has_icons(has_icons) {}
+	explicit table_item_delegate(QObject *parent = nullptr, bool has_icons = false);
 
-	void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override
-	{
-		// Remove the focus frame around selected items
-		option->state &= ~QStyle::State_HasFocus;
+	void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override;
 
-		if (m_has_icons && index.column() == 0)
-		{
-			// Don't highlight icons
-			option->state &= ~QStyle::State_Selected;
-
-			// Center icons
-			option->decorationAlignment = Qt::AlignCenter;
-			option->decorationPosition = QStyleOptionViewItem::Top;
-		}
-
-		QStyledItemDelegate::initStyleOption(option, index);
-	}
-
-	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
-	{
-		if (index.column() == 0 && option.state & QStyle::State_Selected)
-		{
-			// Add background highlight color to icons
-			painter->fillRect(option.rect, option.palette.color(QPalette::Highlight));
-		}
-
-		QStyledItemDelegate::paint(painter, option, index);
-	}
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 };


### PR DESCRIPTION
- Use const Node to fetch games.yml entries to prevent creation of new entries
- Decrease time spent in lock during list refresh
- Move path checks to async section of refresh.
We now only accumulate paths in the main thread and then do all the file interactions in the async thread pool.
This should increase responsiveness.
- Use lazy icon loading for list layout (only visible items)
- Use lazy dir size calculation for list layout (only visible items)