### PR TITLE
Emu: Cache games.yml and only save when necessary

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(rpcs3_emu
     cache_utils.cpp
+    games_config.cpp
     IdManager.cpp
     localized_string.cpp
     savestate_utils.cpp

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -3,6 +3,7 @@
 #include "util/types.hpp"
 #include "util/atomic.hpp"
 #include "Utilities/bit_set.h"
+#include "games_config.h"
 #include <functional>
 #include <memory>
 #include <string>
@@ -119,7 +120,7 @@ class Emulator final
 	atomic_t<u64> m_pause_amend_time{0}; // increased when resumed
 	atomic_t<u64> m_stop_ctr{0}; // Increments when emulation is stopped
 
-	bool m_games_yml_invalidated = false;
+	games_config m_games_config;
 
 	video_renderer m_default_renderer;
 	std::string m_default_graphics_adapter;
@@ -285,6 +286,11 @@ public:
 	const std::string& GetUsr() const
 	{
 		return m_usr;
+	}
+
+	const games_config& GetGamesConfig() const
+	{
+		return m_games_config;
 	}
 
 	// Get deserialization manager

--- a/rpcs3/Emu/games_config.cpp
+++ b/rpcs3/Emu/games_config.cpp
@@ -1,0 +1,112 @@
+#include "stdafx.h"
+#include "games_config.h"
+#include "util/logs.hpp"
+#include "util/yaml.hpp"
+#include "Utilities/File.h"
+
+LOG_CHANNEL(cfg_log, "CFG");
+
+games_config::games_config()
+{
+	load();
+}
+
+games_config::~games_config()
+{
+	if (m_dirty)
+	{
+		save();
+	}
+}
+
+std::string games_config::get_path(const std::string& title_id) const
+{
+	if (title_id.empty())
+	{
+		return {};
+	}
+
+	if (const auto it = m_games.find(title_id); it != m_games.cend())
+	{
+		return it->second;
+	}
+
+	return {};
+}
+
+bool games_config::add_game(const std::string& key, const std::string& path)
+{
+	// Access or create node if does not exist
+	if (auto it = m_games.find(key); it != m_games.end())
+	{
+		if (it->second == path)
+		{
+			// Nothing to do
+			return true;
+		}
+
+		it->second = path;
+	}
+	else
+	{
+		m_games.emplace(key, path);
+	}
+
+	m_dirty = true;
+
+	if (m_save_on_dirty)
+	{
+		return save();
+	}
+
+	return true;
+}
+
+bool games_config::save()
+{
+	YAML::Emitter out;
+	out << m_games;
+
+	fs::pending_file temp(fs::get_config_dir() + "/games.yml");
+
+	if (temp.file && temp.file.write(out.c_str(), out.size()), temp.commit())
+	{
+		m_dirty = false;
+		return true;
+	}
+
+	cfg_log.error("Failed to save games.yml: %s", fs::g_tls_error);
+	return false;
+}
+
+void games_config::load()
+{
+	m_games.clear();
+
+	if (fs::file f{fs::get_config_dir() + "/games.yml", fs::read + fs::create})
+	{
+		auto [result, error] = yaml_load(f.to_string());
+
+		if (!error.empty())
+		{
+			cfg_log.error("Failed to load games.yml: %s", error);
+		}
+
+		if (!result.IsMap())
+		{
+			if (!result.IsNull())
+			{
+				cfg_log.error("Failed to load games.yml: type %d not a map", result.Type());
+			}
+			return;
+		}
+
+		for (const auto& entry : result)
+		{
+			if (!entry.first.Scalar().empty() && entry.second.IsScalar() && !entry.second.Scalar().empty())
+			{
+				m_games.emplace(entry.first.Scalar(), entry.second.Scalar());
+			}
+		}
+	}
+}

--- a/rpcs3/Emu/games_config.h
+++ b/rpcs3/Emu/games_config.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <map>
+
+class games_config
+{
+public:
+	games_config();
+	virtual ~games_config();
+
+	void set_save_on_dirty(bool enabled) { m_save_on_dirty = enabled; }
+
+	const std::map<std::string, std::string>& get_games() const { return m_games; }
+	bool is_dirty() const { return m_dirty; }
+
+	std::string get_path(const std::string& title_id) const;
+
+	bool add_game(const std::string& key, const std::string& path);
+	bool save();
+
+private:
+	void load();
+
+	std::map<std::string, std::string> m_games;
+
+	bool m_dirty = false;
+	bool m_save_on_dirty = true;
+};

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -67,6 +67,7 @@
     <ClCompile Include="Emu\Cell\Modules\libfs_utility_init.cpp" />
     <ClCompile Include="Emu\Cell\Modules\sys_crashdump.cpp" />
     <ClCompile Include="Emu\Cell\Modules\HLE_PATCHES.cpp" />
+    <ClCompile Include="Emu\games_config.cpp" />
     <ClCompile Include="Emu\Io\camera_config.cpp" />
     <ClCompile Include="Emu\Io\recording_config.cpp" />
     <ClCompile Include="Emu\Io\Turntable.cpp" />
@@ -497,6 +498,7 @@
     <ClInclude Include="Emu\Cell\Modules\libfs_utility_init.h" />
     <ClInclude Include="Emu\Cell\Modules\sys_crashdump.h" />
     <ClInclude Include="Emu\CPU\sse2neon.h" />
+    <ClInclude Include="Emu\games_config.h" />
     <ClInclude Include="Emu\Io\camera_config.h" />
     <ClInclude Include="Emu\Io\camera_handler_base.h" />
     <ClInclude Include="Emu\Io\music_handler_base.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1147,6 +1147,9 @@
     <ClCompile Include="Emu\RSX\Overlays\overlay_manager.cpp">
       <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\games_config.cpp">
+      <Filter>Emu</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -2310,6 +2313,9 @@
     </ClInclude>
     <ClInclude Include="io_buffer.h">
       <Filter>Emu\GPU\RSX\Common</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\games_config.h">
+      <Filter>Emu</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -516,28 +516,9 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 		add_dir(_hdd + "game/", false);
 		add_dir(_hdd + "disc/", true); // Deprecated
 
-		auto get_games = []() -> YAML::Node
+		for (const auto& [serial, path] : Emu.GetGamesConfig().get_games())
 		{
-			if (const fs::file games = fs::file(fs::get_config_dir() + "/games.yml", fs::read + fs::create))
-			{
-				auto [result, error] = yaml_load(games.to_string());
-
-				if (!error.empty())
-				{
-					game_list_log.error("Failed to load games.yml: %s", error);
-					return {};
-				}
-
-				return result;
-			}
-
-			game_list_log.error("Failed to load games.yml, check permissions.");
-			return {};
-		};
-
-		for (auto&& pair : get_games())
-		{
-			std::string game_dir = pair.second.Scalar();
+			std::string game_dir = path;
 
 			game_dir.resize(game_dir.find_last_not_of('/') + 1);
 
@@ -569,7 +550,7 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 						// Check if the remaining part is the only path component
 						if (frag.find_first_of('/') + 1 == 0)
 						{
-							game_list_log.trace("Removed duplicate for %s: %s", pair.first.Scalar(), pair.second.Scalar());
+							game_list_log.trace("Removed duplicate for %s: %s", serial, path);
 
 							if (static std::unordered_set<std::string> warn_once_list; warn_once_list.emplace(game_dir).second)
 							{
@@ -589,7 +570,7 @@ void game_list_frame::Refresh(const bool from_drive, const bool scroll_after)
 			}
 			else
 			{
-				game_list_log.trace("Invalid game path registered for %s: %s", pair.first.Scalar(), pair.second.Scalar());
+				game_list_log.trace("Invalid game path registered for %s: %s", serial, path);
 			}
 		}
 


### PR DESCRIPTION
- Only load games.yml once during lifetime of rpcs3.
- Only save games.yml once after adding games

This means that if you had 200 games in your /games folder, you will now have at least 200 reads less during startup than before.
The reduction in write during startup won't be as amazing, since we only saved the games.yml when an entry was added (at least with the commit prior to this one).