### PR TITLE
User Interface: Game searching improvements

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -236,6 +236,9 @@
     <ClCompile Include="QTGeneratedFiles\Debug\moc_game_compatibility.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_game_list.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug\moc_game_list_frame.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -471,6 +474,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_game_compatibility.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_game_list.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_game_list_frame.cpp">
@@ -1396,7 +1402,16 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent"</Command>
     </CustomBuild>
-    <ClInclude Include="rpcs3qt\game_list.h" />
+    <CustomBuild Include="rpcs3qt\game_list.h">
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWIN32_LEAN_AND_MEAN -DHAVE_VULKAN -DMINIUPNP_STATICLIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -DQT_MULTIMEDIA_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_SVG_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\SoundTouch\soundtouch\include" "-I.\..\3rdparty\cubeb\extra" "-I.\..\3rdparty\cubeb\cubeb\include" "-I.\..\3rdparty\flatbuffers\include" "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent" "-I$(QTDIR)\include\QtMultimedia" "-I$(QTDIR)\include\QtMultimediaWidgets" "-I$(QTDIR)\include\QtSvg"</Command>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Identity)...</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWIN32_LEAN_AND_MEAN -DHAVE_VULKAN -DMINIUPNP_STATICLIB -DHAVE_SDL2 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -DQT_MULTIMEDIA_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_SVG_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\SoundTouch\soundtouch\include" "-I.\..\3rdparty\cubeb\extra" "-I.\..\3rdparty\cubeb\cubeb\include" "-I.\..\3rdparty\flatbuffers\include" "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\libsdl-org\SDL\include" "-I.\..\3rdparty\XAudio2Redist\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent" "-I$(QTDIR)\include\QtMultimedia" "-I$(QTDIR)\include\QtMultimediaWidgets" "-I$(QTDIR)\include\QtSvg"</Command>
+    </CustomBuild>
     <ClInclude Include="rpcs3qt\game_list_grid_delegate.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="rpcs3qt\gl_gs_frame.h" />

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -941,6 +941,11 @@
     </ClCompile>
     <ClCompile Include="rpcs3qt\movie_item.cpp">
       <Filter>Gui\custom items</Filter>
+    <ClCompile Include="QTGeneratedFiles\Debug\moc_game_list.cpp">
+      <Filter>Generated Files\Debug</Filter>
+    </ClCompile>
+    <ClCompile Include="QTGeneratedFiles\Release\moc_game_list.cpp">
+      <Filter>Generated Files\Release</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -979,9 +984,6 @@
     </ClInclude>
     <ClInclude Include="rpcs3qt\gl_gs_frame.h">
       <Filter>Gui\game window</Filter>
-    </ClInclude>
-    <ClInclude Include="rpcs3qt\game_list.h">
-      <Filter>Gui\game list</Filter>
     </ClInclude>
     <ClInclude Include="rpcs3qt\game_list_grid_delegate.h">
       <Filter>Gui\game list</Filter>
@@ -1389,6 +1391,9 @@
     </CustomBuild>
     <CustomBuild Include="rpcs3qt\system_cmd_dialog.h">
       <Filter>Gui\dev tools</Filter>
+    </CustomBuild>
+    <CustomBuild Include="rpcs3qt\game_list.h">
+      <Filter>Gui\game list</Filter>
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -25,7 +25,6 @@
 
 #include <QKeyEvent>
 #include <QScrollBar>
-#include <QApplication>
 #include <QFontDatabase>
 #include <QCompleter>
 #include <QVBoxLayout>
@@ -333,7 +332,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 	const u32 pc = (m_debugger_list->m_pc & address_limits);
 	const u32 selected = (m_debugger_list->m_showing_selected_instruction ? m_debugger_list->m_selected_instruction : cpu->get_pc()) & address_limits;
 
-	const auto modifiers = QApplication::keyboardModifiers();
+	const auto modifiers = event->modifiers();
 
 	if (modifiers & Qt::ControlModifier)
 	{

--- a/rpcs3/rpcs3qt/game_list.cpp
+++ b/rpcs3/rpcs3qt/game_list.cpp
@@ -37,6 +37,19 @@ void game_list::mouseMoveEvent(QMouseEvent *event)
 	m_last_hover_item = new_item;
 }
 
+void game_list::keyPressEvent(QKeyEvent* event)
+{
+	const auto modifiers = event->modifiers();
+
+	if (modifiers == Qt::ControlModifier && event->key() == Qt::Key_F && !event->isAutoRepeat())
+	{
+		Q_EMIT FocusToSearchBar();
+		return;
+	}
+
+	QTableWidget::keyPressEvent(event);
+}
+
 void game_list::leaveEvent(QEvent */*event*/)
 {
 	if (m_last_hover_item)

--- a/rpcs3/rpcs3qt/game_list.cpp
+++ b/rpcs3/rpcs3qt/game_list.cpp
@@ -45,3 +45,13 @@ void game_list::leaveEvent(QEvent */*event*/)
 		m_last_hover_item = nullptr;
 	}
 }
+
+void game_list::FocusAndSelectFirstEntryIfNoneIs()
+{
+	if (QTableWidgetItem* item = itemAt(0, 0); item && selectedIndexes().isEmpty())
+	{
+		setCurrentItem(item);
+	}
+
+	setFocus();
+}

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -2,6 +2,7 @@
 
 #include <QTableWidget>
 #include <QMouseEvent>
+#include <QKeyEvent>
 #include <QPixmap>
 
 #include "game_compatibility.h"
@@ -32,16 +33,22 @@ Q_DECLARE_METATYPE(game_info)
 */
 class game_list : public QTableWidget
 {
+	Q_OBJECT
+
 public:
 	void clear_list(); // Use this instead of clearContents
 
 public Q_SLOTS:
 	void FocusAndSelectFirstEntryIfNoneIs();
 
+Q_SIGNALS:
+	void FocusToSearchBar();
+
 protected:
 	movie_item* m_last_hover_item = nullptr;
 
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseMoveEvent(QMouseEvent *event) override;
+	void keyPressEvent(QKeyEvent *event) override;
 	void leaveEvent(QEvent *event) override;
 };

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -35,6 +35,9 @@ class game_list : public QTableWidget
 public:
 	void clear_list(); // Use this instead of clearContents
 
+public Q_SLOTS:
+	void FocusAndSelectFirstEntryIfNoneIs();
+
 protected:
 	movie_item* m_last_hover_item = nullptr;
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -197,6 +197,9 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 		QMessageBox::warning(this, tr("Warning!"), tr("Failed to retrieve the online compatibility database!\nFalling back to local database.\n\n%0").arg(error));
 	});
 
+	connect(m_game_list, &game_list::FocusToSearchBar, this, &game_list_frame::FocusToSearchBar);
+	connect(m_game_grid, &game_list::FocusToSearchBar, this, &game_list_frame::FocusToSearchBar);
+
 	for (int col = 0; col < m_columnActs.count(); ++col)
 	{
 		m_columnActs[col]->setCheckable(true);
@@ -2393,6 +2396,7 @@ void game_list_frame::RepaintIcons(const bool& from_settings)
 		connect(m_game_grid, &QTableWidget::customContextMenuRequested, this, &game_list_frame::ShowContextMenu);
 		connect(m_game_grid, &QTableWidget::itemSelectionChanged, this, &game_list_frame::ItemSelectionChangedSlot);
 		connect(m_game_grid, &QTableWidget::itemDoubleClicked, this, &game_list_frame::doubleClickedSlot);
+		connect(m_game_grid, &game_list::FocusToSearchBar, this, &game_list_frame::FocusToSearchBar);
 		m_central_widget->addWidget(m_game_grid);
 		m_central_widget->setCurrentWidget(m_game_grid);
 		m_game_grid->verticalScrollBar()->setValue(scroll_position);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2422,6 +2422,28 @@ void game_list_frame::SetSearchText(const QString& text)
 	Refresh();
 }
 
+void game_list_frame::FocusAndSelectFirstEntryIfNoneIs()
+{
+	if (m_is_list_layout)
+	{
+		if (!m_game_list)
+		{
+			return;
+		}
+
+		m_game_list->FocusAndSelectFirstEntryIfNoneIs();
+	}
+	else
+	{
+		if (!m_game_grid)
+		{
+			return;
+		}
+
+		m_game_grid->FocusAndSelectFirstEntryIfNoneIs();
+	}
+}
+
 void game_list_frame::closeEvent(QCloseEvent *event)
 {
 	QDockWidget::closeEvent(event);

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -94,6 +94,7 @@ Q_SIGNALS:
 	void NotifyEmuSettingsChange();
 	void IconReady(movie_item* item);
 	void SizeOnDiskReady(const game_info& game);
+	void FocusToSearchBar();
 protected:
 	/** Override inherited method from Qt to allow signalling when close happened.*/
 	void closeEvent(QCloseEvent* event) override;

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -109,9 +109,9 @@ private:
 	void ShowCustomConfigIcon(const game_info& game);
 	void PopulateGameList();
 	void PopulateGameGrid(int maxCols, const QSize& image_size, const QColor& image_color);
-	bool IsEntryVisible(const game_info& game);
+	bool IsEntryVisible(const game_info& game, bool search_fallback = false);
 	void SortGameList() const;
-	bool SearchMatchesApp(const QString& name, const QString& serial) const;
+	bool SearchMatchesApp(const QString& name, const QString& serial, bool fallback = false) const;
 
 	bool RemoveCustomConfiguration(const std::string& title_id, const game_info& game = nullptr, bool is_interactive = false);
 	bool RemoveCustomPadConfiguration(const std::string& title_id, const game_info& game = nullptr, bool is_interactive = false);

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -77,6 +77,7 @@ public Q_SLOTS:
 	void SetShowCompatibilityInGrid(bool show);
 	void SetShowCustomIcons(bool show);
 	void SetPlayHoverGifs(bool play);
+	void FocusAndSelectFirstEntryIfNoneIs();
 
 private Q_SLOTS:
 	void OnRefreshFinished();

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2788,6 +2788,7 @@ void main_window::CreateConnects()
 
 	connect(ui->mw_searchbar, &QLineEdit::textChanged, m_game_list_frame, &game_list_frame::SetSearchText);
 	connect(ui->mw_searchbar, &QLineEdit::returnPressed, m_game_list_frame, &game_list_frame::FocusAndSelectFirstEntryIfNoneIs);
+	connect(m_game_list_frame, &game_list_frame::FocusToSearchBar, this, [this]() { ui->mw_searchbar->setFocus(); });
 }
 
 void main_window::CreateDockWindows()

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -276,6 +276,9 @@ bool main_window::Init([[maybe_unused]] bool with_cli_boot)
 	// Disable vsh if not present.
 	ui->bootVSHAct->setEnabled(fs::is_file(g_cfg_vfs.get_dev_flash() + "vsh/module/vsh.self"));
 
+	// Focus to search bar by default
+	ui->mw_searchbar->setFocus();
+
 	return true;
 }
 
@@ -2784,6 +2787,7 @@ void main_window::CreateConnects()
 	});
 
 	connect(ui->mw_searchbar, &QLineEdit::textChanged, m_game_list_frame, &game_list_frame::SetSearchText);
+	connect(ui->mw_searchbar, &QLineEdit::returnPressed, m_game_list_frame, &game_list_frame::FocusAndSelectFirstEntryIfNoneIs);
 }
 
 void main_window::CreateDockWindows()


### PR DESCRIPTION
* Focus to game searchbar on load.
* Make return key press focus to game list's first entry if game searchbar is focused.
* Ignore trademarks, hyphen, colons and duplicated spaces when searching games. (fallback when otherwise no search results have not been yielded):
   This means you can now search easily for game titles such as **"Spider-Man: Web of Shadows"** or **"Killzone®3 Demo"**.
* Make Ctrl+F focus to game search bar.

This pull request makes it easily doable to launch any game even from large game lists without lifting the hands from keyboard within no time!