### PR TITLE
Qt: Fix data race and undefined behaviour in games_config, fix premature futurewatcher cancelation

### DIFF
--- a/rpcs3/Emu/games_config.cpp
+++ b/rpcs3/Emu/games_config.cpp
@@ -19,12 +19,20 @@ games_config::~games_config()
 	}
 }
 
+const std::map<std::string, std::string> games_config::get_games() const
+{
+	std::lock_guard lock(m_mutex);
+	return m_games;
+}
+
 std::string games_config::get_path(const std::string& title_id) const
 {
 	if (title_id.empty())
 	{
 		return {};
 	}
+
+	std::lock_guard lock(m_mutex);
 
 	if (const auto it = m_games.find(title_id); it != m_games.cend())
 	{
@@ -36,6 +44,8 @@ std::string games_config::get_path(const std::string& title_id) const
 
 bool games_config::add_game(const std::string& key, const std::string& path)
 {
+	std::lock_guard lock(m_mutex);
+
 	// Access or create node if does not exist
 	if (auto it = m_games.find(key); it != m_games.end())
 	{
@@ -64,6 +74,8 @@ bool games_config::add_game(const std::string& key, const std::string& path)
 
 bool games_config::save()
 {
+	std::lock_guard lock(m_mutex);
+
 	YAML::Emitter out;
 	out << m_games;
 
@@ -81,6 +93,8 @@ bool games_config::save()
 
 void games_config::load()
 {
+	std::lock_guard lock(m_mutex);
+
 	m_games.clear();
 
 	if (fs::file f{fs::get_config_dir() + "/games.yml", fs::read + fs::create})

--- a/rpcs3/Emu/games_config.h
+++ b/rpcs3/Emu/games_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Utilities/mutex.h"
 #include <map>
 
 class games_config
@@ -10,7 +11,7 @@ public:
 
 	void set_save_on_dirty(bool enabled) { m_save_on_dirty = enabled; }
 
-	const std::map<std::string, std::string>& get_games() const { return m_games; }
+	const std::map<std::string, std::string> get_games() const;
 	bool is_dirty() const { return m_dirty; }
 
 	std::string get_path(const std::string& title_id) const;
@@ -22,6 +23,7 @@ private:
 	void load();
 
 	std::map<std::string, std::string> m_games;
+	mutable shared_mutex m_mutex;
 
 	bool m_dirty = false;
 	bool m_save_on_dirty = true;

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -133,8 +133,10 @@ namespace gui
 		template <typename T>
 		void stop_future_watcher(QFutureWatcher<T>& watcher, bool cancel, std::shared_ptr<atomic_t<bool>> cancel_flag = nullptr)
 		{
-			if (watcher.isStarted() || watcher.isRunning())
+			if (watcher.isPaused() || watcher.isRunning())
 			{
+				watcher.resume();
+
 				if (cancel)
 				{
 					watcher.cancel();


### PR DESCRIPTION
- Fixes a potential data race and undefined behaviour when iterating over games.yml content
- Fixes premature futurewatcher cancelation which led to the abortion of the directory parser (isStarted is basically always true)

fixes #13767