### PR TITLE
Qt: game list fixes

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -1726,8 +1726,6 @@
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
-    <None Include="QTGeneratedFiles\Debug\pkg_install_dialog.moc" />
-    <None Include="QTGeneratedFiles\Release\pkg_install_dialog.moc" />
     <CustomBuild Include="rpcs3qt\patch_creator_dialog.ui">
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\uic.exe;%(AdditionalInputs)</AdditionalInputs>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Uic%27ing %(Identity)...</Message>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -960,12 +960,6 @@
     <ClCompile Include="rpcs3qt\flow_widget.cpp">
       <Filter>Gui\flow_layout</Filter>
     </ClCompile>
-    <ClCompile Include="QTGeneratedFiles\Debug\moc_flow_widget.cpp">
-      <Filter>Generated Files\Debug</Filter>
-    </ClCompile>
-    <ClCompile Include="QTGeneratedFiles\Release\moc_flow_widget.cpp">
-      <Filter>Generated Files\Release</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">
@@ -1429,13 +1423,5 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="rpcs3.rc" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="QTGeneratedFiles\Debug\pkg_install_dialog.moc">
-      <Filter>Generated Files\Debug</Filter>
-    </None>
-    <None Include="QTGeneratedFiles\Release\pkg_install_dialog.moc">
-      <Filter>Generated Files\Release</Filter>
-    </None>
   </ItemGroup>
 </Project>

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -922,15 +922,25 @@ void game_list_frame::OnRefreshFinished()
 
 	if (!std::exchange(m_initial_refresh_done, true))
 	{
+		// Resize to fit and get the ideal icon column width
+		ResizeColumnsToContents();
+		const int icon_column_width = m_game_list->columnWidth(gui::column_icon);
+
+		// Restore header layout from last session
 		const QByteArray state = m_gui_settings->GetValue(gui::gl_state).toByteArray();
 		if (!m_game_list->horizontalHeader()->restoreState(state) && m_game_list->rowCount())
 		{
-			// If no settings exist, resize to contents.
-			ResizeColumnsToContents();
+			// Nothing to do
 		}
 
+		// Make sure no columns are squished
 		FixNarrowColumns();
 
+		// Make sure that the icon column is large enough for the actual items.
+		// This is important if the list appeared as empty when closing the software before.
+		m_game_list->horizontalHeader()->resizeSection(gui::column_icon, icon_column_width);
+
+		// Save new header state
 		m_game_list->horizontalHeader()->restoreState(m_game_list->horizontalHeader()->saveState());
 	}
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2839,6 +2839,11 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 	const std::string selected_item = CurrentSelectionPath();
 
 	// Release old data
+	for (const auto& game : m_game_data)
+	{
+		game->item = nullptr;
+	}
+
 	m_game_list->clear_list();
 	m_game_grid->deleteLater();
 
@@ -2858,8 +2863,6 @@ void game_list_frame::PopulateGameGrid(int maxCols, const QSize& image_size, con
 
 	for (const auto& app : m_game_data)
 	{
-		app->item = nullptr;
-
 		if (IsEntryVisible(app))
 		{
 			matching_apps.push_back(app);

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -96,7 +96,7 @@ Q_SIGNALS:
 	void RequestBoot(const game_info& game, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "", const std::string& savestate = "");
 	void RequestIconSizeChange(const int& val);
 	void NotifyEmuSettingsChange();
-	void IconReady(movie_item* item);
+	void IconReady(const game_info& game);
 	void SizeOnDiskReady(const game_info& game);
 	void FocusToSearchBar();
 protected:

--- a/rpcs3/rpcs3qt/movie_item.h
+++ b/rpcs3/rpcs3qt/movie_item.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "util/atomic.hpp"
+#include "Utilities/mutex.h"
 
 #include <QTableWidgetItem>
 #include <QMovie>
 #include <QObject>
 #include <QThread>
 
-#include <mutex>
 #include <memory>
 #include <functional>
 
@@ -71,7 +71,7 @@ public:
 		return m_size_on_disk_loading_aborted;
 	}
 
-	std::mutex pixmap_mutex;
+	shared_mutex pixmap_mutex;
 
 private:
 	std::shared_ptr<QMovie> m_movie;

--- a/rpcs3/rpcs3qt/screenshot_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/screenshot_manager_dialog.cpp
@@ -81,11 +81,8 @@ void screenshot_manager_dialog::reload()
 	m_abort_parsing = true;
 	gui::utils::stop_future_watcher(m_parsing_watcher, true);
 
-	// Make sure the directory is mounted
-	vfs::mount("/dev_hdd0", rpcs3::utils::get_hdd0_dir());
-
 	const std::string screenshot_path_qt   = fs::get_config_dir() + "screenshots/";
-	const std::string screenshot_path_cell = vfs::get("/dev_hdd0/photo/");
+	const std::string screenshot_path_cell = rpcs3::utils::get_hdd0_dir() + "/photo/";
 
 	m_flow_widget->clear();
 	m_abort_parsing = false;

--- a/rpcs3/rpcs3qt/screenshot_manager_dialog.h
+++ b/rpcs3/rpcs3qt/screenshot_manager_dialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "flow_widget.h";
+#include "flow_widget.h"
 
 #include <QDialog>
 #include <QFutureWatcher>


### PR DESCRIPTION
- Fix segfault when accessing invalid pointers in IconReady function
- Fix narrow icon column when opening rpcs3 after closing it with a visibly empty list
- Don't mount dev_hdd0 in screenshot manager