### PR TITLE
gl: Fix blur_intensity GL_INVALID_OPERATION validation layers error

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLOverlays.cpp
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.cpp
@@ -448,7 +448,7 @@ namespace gl
 			program_handle.uniforms["timestamp"] = cmd.config.get_sinus_value();
 			program_handle.uniforms["albedo"] = cmd.config.color;
 			program_handle.uniforms["clip_bounds"] = cmd.config.clip_rect;
-			program_handle.uniforms["blur_intensity"] = static_cast<s32>(cmd.config.blur_strength);
+			program_handle.uniforms["blur_intensity"] = static_cast<f32>(cmd.config.blur_strength);
 			overlay_pass::run(cmd_, viewport, target, gl::image_aspect::color, true);
 		}
 


### PR DESCRIPTION
blur_intensity is a float, so the cast needs to be f32 instead of s32

Fixes validation layers spam when using OpenGL and an emulator overlay is visible on the screen

`E RSX: [DEBUG_OUTPUT] [API] [ERROR] [1]: GL_INVALID_OPERATION in glUniform1("blur_intensity"@9 is float, not int)`