### PR TITLE
Qt: fix invisible first icon in game list

### DIFF
--- a/rpcs3/rpcs3qt/game_list_delegate.cpp
+++ b/rpcs3/rpcs3qt/game_list_delegate.cpp
@@ -2,6 +2,8 @@
 #include "movie_item.h"
 #include "gui_settings.h"
 
+#include <QHeaderView>
+
 game_list_delegate::game_list_delegate(QObject* parent)
 	: table_item_delegate(parent, true)
 {}
@@ -15,8 +17,12 @@ void game_list_delegate::paint(QPainter* painter, const QStyleOptionViewItem& op
 	{
 		if (const QTableWidget* table = static_cast<const QTableWidget*>(parent()))
 		{
+			// We need to remove the headers from our calculation. The visualItemRect starts at 0,0 while the visibleRegion doesn't.
+			QRegion visible_region = table->visibleRegion();
+			visible_region.translate(-table->verticalHeader()->width(), -table->horizontalHeader()->height());
+
 			if (const QTableWidgetItem* current_item = table->item(index.row(), index.column());
-				current_item && table->visibleRegion().intersects(table->visualItemRect(current_item)))
+				current_item && visible_region.intersects(table->visualItemRect(current_item)))
 			{
 				if (movie_item* item = static_cast<movie_item*>(table->item(index.row(), gui::game_list_columns::column_icon)))
 				{


### PR DESCRIPTION
- Fixes a bug that causes the first item in the game list to have an invisible icon.

Once the first icon got smaller than 30 pixels it wasn't counted as visible.
It turns out that the visibleRegion of the table has an offset that is exactly the size of the table headers.
So the visibleRegion started at (0,30), while the icons' visualRects started at the origin of the table itself (without headers).
When a small icon was at (0,0) with a height below 30 it would therefore never pass the visibility checks.

Simply offsetting the visibleRegion by the header size brought its position back to (0,0), meaning we can properly do the check.