### PR TITLE
Fix rpcn config reset

### DIFF
--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -677,6 +677,7 @@ namespace np
 
 		if (g_cfg.net.psn_status >= np_psn_status::psn_fake)
 		{
+			g_cfg_rpcn.load(); // Ensures config is loaded even if rpcn is not running for simulated
 			std::string s_npid = g_cfg_rpcn.get_npid();
 			ensure(!s_npid.empty()); // It should have been generated before this
 


### PR DESCRIPTION
Config was only loaded for rpcn which resulted in config reset when using Simulated.
Thanks @CookiePLMonster for debugging.