### PR TITLE
Get the font directory from Windows

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLOverlays.cpp
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.cpp
@@ -299,8 +299,7 @@ namespace gl
 		}
 
 		// Create font file
-		std::vector<u8> glyph_data;
-		font->get_glyph_data(glyph_data);
+		std::vector<u8> glyph_data = font->get_glyph_data();
 
 		auto tex = std::make_unique<gl::texture>(GL_TEXTURE_2D_ARRAY, font_size.width, font_size.height, font_size.depth, 1, GL_R8);
 		tex->copy_from(glyph_data.data(), gl::texture::format::r, gl::texture::type::ubyte, {});

--- a/rpcs3/Emu/RSX/GL/GLOverlays.cpp
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.cpp
@@ -299,7 +299,7 @@ namespace gl
 		}
 
 		// Create font file
-		std::vector<u8> glyph_data = font->get_glyph_data();
+		const std::vector<u8> glyph_data = font->get_glyph_data();
 
 		auto tex = std::make_unique<gl::texture>(GL_TEXTURE_2D_ARRAY, font_size.width, font_size.height, font_size.depth, 1, GL_R8);
 		tex->copy_from(glyph_data.data(), gl::texture::format::r, gl::texture::type::ubyte, {});

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.cpp
@@ -108,7 +108,7 @@ namespace rsx
 			glyph_load_setup result;
 			result.font_names.push_back(font_name);
 
-			auto font_dirs = Emu.GetCallbacks().get_font_dirs();
+			const std::vector<std::string> font_dirs = Emu.GetCallbacks().get_font_dirs();
 			result.lookup_font_dirs.insert(result.lookup_font_dirs.end(), font_dirs.begin(), font_dirs.end());
 			// Search dev_flash for the font too
 			result.lookup_font_dirs.push_back(g_cfg_vfs.get_dev_flash() + "data/font/");

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
@@ -87,7 +87,7 @@ namespace rsx
 
 			// Renderer info
 			size3u get_glyph_data_dimensions() const { return { codepage::bitmap_width, codepage::bitmap_height, ::size32(m_glyph_map) }; }
-			void get_glyph_data(std::vector<u8>& bytes) const;
+			std::vector<u8> get_glyph_data() const;
 		};
 
 		// TODO: Singletons are cancer

--- a/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_fonts.h
@@ -73,7 +73,7 @@ namespace rsx
 
 			stbtt_aligned_quad get_char(char32_t c, f32& x_advance, f32& y_advance);
 
-			void render_text_ex(std::vector<vertex>& result, f32& x_advance, f32& y_advance, const char32_t* text, usz char_limit, u16 max_width, bool wrap);
+			std::vector<vertex> render_text_ex(f32& x_advance, f32& y_advance, const char32_t* text, usz char_limit, u16 max_width, bool wrap);
 
 			std::vector<vertex> render_text(const char32_t* text, u16 max_width = -1, bool wrap = false);
 

--- a/rpcs3/Emu/RSX/VK/VKOverlays.cpp
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.cpp
@@ -387,7 +387,7 @@ namespace vk
 	}
 
 	vk::image_view* ui_overlay_renderer::upload_simple_texture(vk::render_device& dev, vk::command_buffer& cmd,
-		vk::data_heap& upload_heap, u64 key, u32 w, u32 h, u32 layers, bool font, bool temp, void* pixel_src, u32 owner_uid)
+		vk::data_heap& upload_heap, u64 key, u32 w, u32 h, u32 layers, bool font, bool temp, const void* pixel_src, u32 owner_uid)
 	{
 		const VkFormat format = (font) ? VK_FORMAT_R8_UNORM : VK_FORMAT_B8G8R8A8_UNORM;
 		const u32 pitch = (font) ? w : w * 4;
@@ -517,7 +517,7 @@ namespace vk
 		}
 
 		// Create font resource
-		std::vector<u8> bytes = font->get_glyph_data();
+		const std::vector<u8> bytes = font->get_glyph_data();
 
 		return upload_simple_texture(cmd.get_command_pool().get_owner(), cmd, upload_heap, key, image_size.width, image_size.height, image_size.depth,
 				true, false, bytes.data(), -1);

--- a/rpcs3/Emu/RSX/VK/VKOverlays.cpp
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.cpp
@@ -517,8 +517,7 @@ namespace vk
 		}
 
 		// Create font resource
-		std::vector<u8> bytes;
-		font->get_glyph_data(bytes);
+		std::vector<u8> bytes = font->get_glyph_data();
 
 		return upload_simple_texture(cmd.get_command_pool().get_owner(), cmd, upload_heap, key, image_size.width, image_size.height, image_size.depth,
 				true, false, bytes.data(), -1);

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -152,7 +152,7 @@ namespace vk
 		ui_overlay_renderer();
 
 		vk::image_view* upload_simple_texture(vk::render_device& dev, vk::command_buffer& cmd,
-			vk::data_heap& upload_heap, u64 key, u32 w, u32 h, u32 layers, bool font, bool temp, void* pixel_src, u32 owner_uid);
+			vk::data_heap& upload_heap, u64 key, u32 w, u32 h, u32 layers, bool font, bool temp, const void* pixel_src, u32 owner_uid);
 
 		void init(vk::command_buffer& cmd, vk::data_heap& upload_heap);
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -94,6 +94,7 @@ struct EmuCallbacks
 	std::function<bool(const std::string&, std::string&, s32&, s32&, s32&)> get_image_info; // (filename, sub_type, width, height, CellSearchOrientation)
 	std::function<bool(const std::string&, s32, s32, s32&, s32&, u8*, bool)> get_scaled_image; // (filename, target_width, target_height, width, height, dst, force_fit)
 	std::string(*resolve_path)(std::string_view) = [](std::string_view arg){ return std::string{arg}; }; // Resolve path using Qt
+	std::function<std::vector<std::string>()> get_font_dirs;
 };
 
 namespace utils

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -36,6 +36,7 @@
 
 #include <QFileInfo> // This shouldn't be outside rpcs3qt...
 #include <QImageReader> // This shouldn't be outside rpcs3qt...
+#include <QStandardPaths> // This shouldn't be outside rpcs3qt...
 #include <thread>
 
 LOG_CHANNEL(sys_log, "SYS");
@@ -329,6 +330,22 @@ EmuCallbacks main_application::CreateCallbacks()
 	{
 		// May result in an empty string if path does not exist
 		return QFileInfo(QString::fromUtf8(sv.data(), static_cast<int>(sv.size()))).canonicalFilePath().toStdString();
+	};
+
+	callbacks.get_font_dirs = []()
+	{
+		auto locations = QStandardPaths::standardLocations(QStandardPaths::FontsLocation);
+		std::vector<std::string> font_dirs;
+		for (const auto& location : locations)
+		{
+			auto font_dir = location.toStdString();
+			if (!font_dir.ends_with('/'))
+			{
+				font_dir += '/';
+			}
+			font_dirs.push_back(font_dir);
+		}
+		return font_dirs;
 	};
 
 	return callbacks;

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -334,11 +334,11 @@ EmuCallbacks main_application::CreateCallbacks()
 
 	callbacks.get_font_dirs = []()
 	{
-		auto locations = QStandardPaths::standardLocations(QStandardPaths::FontsLocation);
+		const QStringList locations = QStandardPaths::standardLocations(QStandardPaths::FontsLocation);
 		std::vector<std::string> font_dirs;
-		for (const auto& location : locations)
+		for (const QString& location : locations)
 		{
-			auto font_dir = location.toStdString();
+			std::string font_dir = location.toStdString();
 			if (!font_dir.ends_with('/'))
 			{
 				font_dir += '/';


### PR DESCRIPTION
Get the font directory from Windows instead of hard coding it to `C:/Windows/Fonts/`. Also contains a small refactor of `font::render_text_ex`.