### PR TITLE
System.cpp: Make boot of disc updates more strict

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -313,7 +313,7 @@ public:
 
 	void SetForceBoot(bool force_boot);
 
-	game_boot_result Load(const std::string& title_id = "", bool is_disc_patch = false);
+	game_boot_result Load(const std::string& title_id = "", bool is_disc_patch = false, usz recursion_count = 0);
 	void Run(bool start_playtime);
 	void RunPPU();
 	void FixGuestTime();


### PR DESCRIPTION
 * Ensure that only GD game data is used for booting an update.
 * Ensure that TITLE_ID matches between game update and disc. (otherwise maybe a different application created it with the same directory name as far as we know)
 * Ensure no theoretical recursion occurs in Load. (in reality you need to hack the filesystem with rpcs3 controlled by debugger for it to occur I believe but it shouldn't be possible in the first place)
 * Log an error explicitly about disc game update corruption.