### PR TITLE
sys_fs, sys_ss, and sys_usbd: LV2 syscalls enhancements

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -165,8 +165,8 @@ namespace fs
 	// Set virtual device with specified name (nullptr for deletion)
 	shared_ptr<device_base> set_virtual_device(const std::string& name, shared_ptr<device_base> device);
 
-	// Try to get parent directory (returns empty string on failure)
-	std::string get_parent_dir(std::string_view path, u32 levels = 1);
+	// Try to get normalized parent directory
+	std::string get_parent_dir(std::string_view path, u32 parent_level = 1);
 
 	// Get file information
 	bool stat(const std::string& path, stat_t& info);

--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -186,4 +186,23 @@ namespace fmt
 		const u8* buf;
 		usz len;
 	};
+
+	struct string_hash
+	{
+		using hash_type = std::hash<std::string_view>;
+		using is_transparent = void;
+
+		std::size_t operator()(const char* str) const
+		{
+			return hash_type{}(str);
+		}
+		std::size_t operator()(std::string_view str) const
+		{
+			return hash_type{}(str);
+		}
+		std::size_t operator()(std::string const& str) const
+		{
+			return hash_type{}(str);
+		}
+	};
 }

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -576,7 +576,7 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	null_func,//BIND_SYSC(sys_usbd_...),                    //555 (0x22B)
 	BIND_SYSC(sys_usbd_get_device_speed),                   //556 (0x22C)
 	null_func,//BIND_SYSC(sys_usbd_...),                    //557 (0x22D)
-	null_func,//BIND_SYSC(sys_usbd_...),                    //558 (0x22E)
+	BIND_SYSC(sys_usbd_unregister_extra_ldd),               //558 (0x22E)
 	BIND_SYSC(sys_usbd_register_extra_ldd),                 //559 (0x22F)
 	null_func,//BIND_SYSC(sys_...),                         //560 (0x230)  ROOT
 	null_func,//BIND_SYSC(sys_...),                         //561 (0x231)  ROOT

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -13,7 +13,6 @@
 #include "Emu/IdManager.h"
 #include "Emu/system_utils.hpp"
 #include "Emu/Cell/lv2/sys_process.h"
-#include "Utilities/StrUtil.h"
 
 #include <span>
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -3,6 +3,7 @@
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
 #include "Utilities/File.h"
+#include "Utilities/StrUtil.h"
 
 #include <string>
 #include <mutex>
@@ -218,26 +219,7 @@ public:
 	static bool vfs_unmount(std::string_view vpath);
 
 private:
-	struct string_hash
-	{
-		using hash_type = std::hash<std::string_view>;
-		using is_transparent = void;
-
-		std::size_t operator()(const char* str) const
-		{
-			return hash_type{}(str);
-		}
-		std::size_t operator()(std::string_view str) const
-		{
-			return hash_type{}(str);
-		}
-		std::size_t operator()(std::string const& str) const
-		{
-			return hash_type{}(str);
-		}
-	};
-
-	std::unordered_map<std::string, lv2_fs_mount_info, string_hash, std::equal_to<>> map;
+	std::unordered_map<std::string, lv2_fs_mount_info, fmt::string_hash, std::equal_to<>> map;
 };
 
 struct lv2_fs_object

--- a/rpcs3/Emu/Cell/lv2/sys_game.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_game.cpp
@@ -30,7 +30,7 @@ struct system_sw_version
 
 	~system_sw_version() = default;
 
-	u64 version;
+	atomic_t<u64> version;
 };
 
 struct board_storage

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "sys_prx.h"
 
+#include "Emu/System.h"
 #include "Emu/system_config.h"
 #include "Emu/VFS.h"
 #include "Emu/IdManager.h"
@@ -842,7 +843,7 @@ error_code _sys_prx_register_module(ppu_thread& ppu, vm::cptr<char> name, vm::pt
 
 	if (info.type & 0x1)
 	{
-		if (g_ps3_process_info.get_cellos_appname() == "vsh.self"sv)
+		if (Emu.IsVsh())
 		{
 			ppu_manual_load_imports_exports(info.lib_stub_ea.addr(), info.lib_stub_size, info.lib_entries_ea.addr(), info.lib_entries_size, *std::make_unique<std::basic_string<bool>>());
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.h
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.h
@@ -66,8 +66,8 @@ error_code sys_usbd_finalize(ppu_thread& ppu, u32 handle);
 error_code sys_usbd_get_device_list(ppu_thread& ppu, u32 handle, vm::ptr<UsbInternalDevice> device_list, u32 max_devices);
 error_code sys_usbd_get_descriptor_size(ppu_thread& ppu, u32 handle, u32 device_handle);
 error_code sys_usbd_get_descriptor(ppu_thread& ppu, u32 handle, u32 device_handle, vm::ptr<void> descriptor, u32 desc_size);
-error_code sys_usbd_register_ldd(ppu_thread& ppu, u32 handle, vm::ptr<char> s_product, u16 slen_product);
-error_code sys_usbd_unregister_ldd(ppu_thread& ppu);
+error_code sys_usbd_register_ldd(ppu_thread& ppu, u32 handle, vm::cptr<char> s_product, u16 slen_product);
+error_code sys_usbd_unregister_ldd(ppu_thread& ppu, u32 handle, vm::cptr<char> s_product, u16 slen_product);
 error_code sys_usbd_open_pipe(ppu_thread& ppu, u32 handle, u32 device_handle, u32 unk1, u64 unk2, u64 unk3, u32 endpoint, u64 unk4);
 error_code sys_usbd_open_default_pipe(ppu_thread& ppu, u32 handle, u32 device_handle);
 error_code sys_usbd_close_pipe(ppu_thread& ppu, u32 handle, u32 pipe_handle);
@@ -84,4 +84,5 @@ error_code sys_usbd_event_port_send(ppu_thread& ppu, u32 handle, u64 arg1, u64 a
 error_code sys_usbd_allocate_memory(ppu_thread& ppu);
 error_code sys_usbd_free_memory(ppu_thread& ppu);
 error_code sys_usbd_get_device_speed(ppu_thread& ppu);
-error_code sys_usbd_register_extra_ldd(ppu_thread& ppu, u32 handle, vm::ptr<char> s_product, u16 slen_product, u16 id_vendor, u16 id_product_min, u16 id_product_max);
+error_code sys_usbd_register_extra_ldd(ppu_thread& ppu, u32 handle, vm::cptr<char> s_product, u16 slen_product, u16 id_vendor, u16 id_product_min, u16 id_product_max);
+error_code sys_usbd_unregister_extra_ldd(ppu_thread& ppu, u32 handle, vm::cptr<char> s_product, u16 slen_product);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3460,7 +3460,7 @@ utils::serial* Emulator::DeserialManager() const
 
 bool Emulator::IsVsh()
 {
-	return g_ps3_process_info.get_cellos_appname() == "vsh.self"sv;
+	return g_ps3_process_info.self_info.prog_id_hdr.program_authority_id >> 52 == 0x107; // Not only VSH but also all LV2 SELFs need the special treatment
 }
 
 bool Emulator::IsValidSfb(const std::string& path)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3460,7 +3460,7 @@ utils::serial* Emulator::DeserialManager() const
 
 bool Emulator::IsVsh()
 {
-	return g_ps3_process_info.self_info.prog_id_hdr.program_authority_id >> 52 == 0x107; // Not only VSH but also all LV2 SELFs need the special treatment
+	return g_ps3_process_info.self_info.prog_id_hdr.program_authority_id >> 52 == 0x107; // Not only VSH but also most CoreOS LV2 SELFs need the special treatment
 }
 
 bool Emulator::IsValidSfb(const std::string& path)

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -956,7 +956,7 @@ bool vfs::host::rename(const std::string& from, const std::string& to, const lv2
 
 			file.restore_data.seek_pos = file.file.pos();
 
-			if (!(file.mp->flags & (lv2_mp_flag::read_only + lv2_mp_flag::cache)) && file.flags & CELL_FS_O_ACCMODE)
+			if (!(file.mp.read_only && file.mp->flags & lv2_mp_flag::cache) && file.flags & CELL_FS_O_ACCMODE)
 			{
 				file.file.sync(); // For cellGameContentPermit atomicity
 			}


### PR DESCRIPTION
 - Implemented sys_fs_mount() with argument prot=1 for mounting VFS devices in read only mode (mainly used by XMB).
 - Further implemented Update Manager service so that the progress of firmware update in XMB can go to 99%, tested in DEX&DECR.
 - Implemented sys_usbd_unregister_extra_ldd() and improved the other ldd-related syscalls.