### PR TITLE
Add SPU patterns

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -43,6 +43,9 @@
 #include <functional>
 #include <unordered_map>
 
+// Helper function
+llvm::Value* peek_through_bitcasts(llvm::Value*);
+
 enum class i2 : char
 {
 };
@@ -147,7 +150,7 @@ struct llvm_value_t
 
 	std::tuple<> match(llvm::Value*& value, llvm::Module*) const
 	{
-		if (value != this->value)
+		if (peek_through_bitcasts(value) != peek_through_bitcasts(this->value))
 		{
 			value = nullptr;
 		}
@@ -503,9 +506,6 @@ using llvm_common_t = std::enable_if_t<(is_llvm_expr_of<T, Types>::ok && ...), t
 template <typename... Args>
 using llvm_match_tuple = decltype(std::tuple_cat(std::declval<llvm_expr_t<Args>&>().match(std::declval<llvm::Value*&>(), nullptr)...));
 
-// Helper function
-llvm::Value* peek_through_bitcasts(llvm::Value*);
-
 template <typename T, typename U = llvm_common_t<llvm_value_t<T>>>
 struct llvm_match_t
 {
@@ -532,7 +532,7 @@ struct llvm_match_t
 
 	std::tuple<> match(llvm::Value*& value, llvm::Module*) const
 	{
-		if (value != this->value)
+		if (peek_through_bitcasts(value) != peek_through_bitcasts(this->value))
 		{
 			value = nullptr;
 		}

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9175,6 +9175,13 @@ public:
 			return;
 		}
 
+		if (const auto [ok_re_acc, div] = match_expr(a, re_accurate(match<f32[4]>())); ok_re_acc)
+		{
+			erase_stores(b);
+			set_vr(op.rt, b / div);
+			return;
+		}
+
 		set_vr(op.rt, fm(a, b));
 	}
 
@@ -9661,18 +9668,18 @@ public:
 			return;
 
 		// Match division (fast)
-		if (auto [ok_fnma, divb, diva] = match_expr(a, fnms(c, MT, MT)); ok_fnma)
-		{
-			if (auto [ok_fm] = match_expr(c, fm(diva, b)); ok_fm)
-			{
-				if (auto [ok_re] = match_expr(b, spu_re(divb)); ok_re)
-				{
-					erase_stores(b, c);
-					set_vr(op.rt4, diva / divb);
-					return;
-				}
-			}
-		}
+		// if (auto [ok_fnma, divb, diva] = match_expr(a, fnms(c, MT, MT)); ok_fnma)
+		// {
+		// 	if (auto [ok_fm] = match_expr(c, fm(diva, b)); ok_fm)
+		// 	{
+		// 		if (auto [ok_re] = match_expr(b, spu_re(divb)); ok_re)
+		// 		{
+		// 			erase_stores(b, c);
+		// 			set_vr(op.rt4, diva / divb);
+		// 			return;
+		// 		}
+		// 	}
+		// }
 
 		auto check_accurate_reciprocal_pattern_for_float = [&](float float_value) -> bool
 		{

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9591,6 +9591,17 @@ public:
 			}
 		}
 
+		// Seen in NFS:MW
+		if (auto [ok_fnms, a1] = match_expr(a, fnms(MT, b, fsplat<f32[4]>(1.00000011920928955078125))); ok_fnms)
+		{
+			if (auto [ok_re, div] = match_expr(b, spu_re(MT)); ok_re && a1.eq(div))
+			{
+				erase_stores(b);
+				set_vr(op.rt4, re_accurate(div));
+				return;
+			}
+		}
+
 		if (auto [ok_re, mystery] = match_expr(b, spu_re(MT)); ok_re)
 		{
 			spu_log.todo("[%s:0x%05x] Unmatched spu_re found", m_hash, m_pos);


### PR DESCRIPTION
Optimizes pattern: FREST, FI, FNMS, FMA into accurate 1/x.
Optimizes pattern: FREST, FI, FNMS, FMA, FM into full division(seen in Watch Dogs).

Includes Nekotina's fix for match_expr.

WIP as I try to figure out a weird bug.

