### PR TITLE
vk/rsx: Improve out-of-memory handling

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -250,8 +250,8 @@ struct gl_render_target_traits
 	{
 		return (surface->get_internal_format() == ref->get_internal_format() &&
 				surface->get_spp() == sample_count &&
-				surface->get_surface_width<rsx::surface_metrics::pixels>() >= width &&
-				surface->get_surface_height<rsx::surface_metrics::pixels>() >= height);
+				surface->get_surface_width<rsx::surface_metrics::pixels>() == width &&
+				surface->get_surface_height<rsx::surface_metrics::pixels>() == height);
 	}
 
 	static

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -219,6 +219,7 @@ namespace vk
 			case rsx::problem_severity::severe:
 			case rsx::problem_severity::fatal:
 				// We're almost dead anyway. Remove forcefully.
+				vk::get_resource_manager()->dispose(rtt);
 				return true;
 			default:
 				fmt::throw_exception("Unreachable");

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -30,7 +30,7 @@ namespace vk
 		}
 		else if (total_device_memory >= 1024)
 		{
-			quota = 768;
+			quota = std::max<u64>(512, (total_device_memory * 30) / 100);
 		}
 		else if (total_device_memory >= 768)
 		{

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -405,8 +405,8 @@ namespace vk
 		{
 			return (surface->format() == ref->format() &&
 				surface->get_spp() == sample_count &&
-				surface->get_surface_width() >= width &&
-				surface->get_surface_height() >= height);
+				surface->get_surface_width() == width &&
+				surface->get_surface_height() == height);
 		}
 
 		static void prepare_surface_for_drawing(vk::command_buffer& cmd, vk::render_target* surface)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -1259,11 +1259,21 @@ namespace vk
 		}
 
 		// Nuke temporary resources. They will still be visible to the GPU.
+		auto gc = vk::get_resource_manager();
 		any_released |= !m_cached_images.empty();
+		for (auto& img : m_cached_images)
+		{
+			gc->dispose(img.data);
+		}
 		m_cached_images.clear();
 		m_cached_memory_size = 0;
 
 		any_released |= !m_temporary_subresource_cache.empty();
+		for (auto& e : m_temporary_subresource_cache)
+		{
+			ensure(e.second.second);
+			release_temporary_subresource(e.second.second);
+		}
 		m_temporary_subresource_cache.clear();
 
 		return any_released;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -1396,13 +1396,17 @@ namespace vk
 		const auto total_device_memory = m_device->get_memory_mapping().device_local_total_bytes / 0x100000;
 		u64 quota = 0;
 
-		if (total_device_memory >= 1024)
+		if (total_device_memory >= 2048)
 		{
 			quota = std::min<u64>(3072, (total_device_memory * 40) / 100);
 		}
+		else if (total_device_memory >= 1024)
+		{
+			quota = std::max<u64>(204, (total_device_memory * 30) / 100);
+		}
 		else if (total_device_memory >= 768)
 		{
-			quota = 256;
+			quota = 192;
 		}
 		else
 		{

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -679,11 +679,11 @@ namespace vk
 
 		if (g_cfg.video.disable_vulkan_mem_allocator)
 		{
-			m_allocator = std::make_unique<vk::mem_allocator_vk>(dev, pdev);
+			m_allocator = std::make_unique<vk::mem_allocator_vk>(*this, pdev);
 		}
 		else
 		{
-			m_allocator = std::make_unique<vk::mem_allocator_vma>(dev, pdev);
+			m_allocator = std::make_unique<vk::mem_allocator_vma>(*this, pdev);
 		}
 
 		// Useful for debugging different VRAM configurations

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -686,13 +686,9 @@ namespace vk
 			m_allocator = std::make_unique<vk::mem_allocator_vma>(dev, pdev);
 		}
 
-		if (pgpu->props.deviceID == 0x13c2)
-		{
-			// GTX970 workaround/hack
-			// The driver reports a full working 4GB of memory which is incorrect.
-			// Limit to ~2.5GB to allow vma to avoid running over the headroom of 0.5G.
-			memory_map.device_local_total_bytes = 2560ULL * 0x100000ULL;
-		}
+		// Useful for debugging different VRAM configurations
+		const u64 vram_allocation_limit = g_cfg.video.vk.vram_allocation_limit * 0x100000ull;
+		memory_map.device_local_total_bytes = std::min(memory_map.device_local_total_bytes, vram_allocation_limit);
 	}
 
 	void render_device::destroy()

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
@@ -153,7 +153,12 @@ namespace vk
 		rsx_log.warning("Rebalanced memory types successfully");
 	}
 
-	mem_allocator_vma::mem_allocator_vma(VkDevice dev, VkPhysicalDevice pdev) : mem_allocator_base(dev, pdev)
+	mem_allocator_base::mem_allocator_base(const vk::render_device& dev, VkPhysicalDevice)
+		: m_device(dev), m_allocation_flags(0)
+	{}
+
+	mem_allocator_vma::mem_allocator_vma(const vk::render_device& dev, VkPhysicalDevice pdev)
+		: mem_allocator_base(dev, pdev)
 	{
 		// Initialize stats pool
 		std::fill(stats.begin(), stats.end(), VmaBudget{});
@@ -164,11 +169,11 @@ namespace vk
 
 		std::vector<VkDeviceSize> heap_limits;
 		const auto vram_allocation_limit = g_cfg.video.vk.vram_allocation_limit * 0x100000ull;
-		if (vram_allocation_limit < g_render_device->get_memory_mapping().device_local_total_bytes)
+		if (vram_allocation_limit < dev.get_memory_mapping().device_local_total_bytes)
 		{
 			VkPhysicalDeviceMemoryProperties memory_properties;
 			vkGetPhysicalDeviceMemoryProperties(pdev, &memory_properties);
-			for (int i = 0; i < memory_properties.memoryHeapCount; ++i)
+			for (u32 i = 0; i < memory_properties.memoryHeapCount; ++i)
 			{
 				const u64 max_sz = (memory_properties.memoryHeaps[i].flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
 					? vram_allocation_limit

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -55,7 +55,7 @@ namespace vk
 	public:
 		using mem_handle_t = void*;
 
-		mem_allocator_base(VkDevice dev, VkPhysicalDevice /*pdev*/) : m_device(dev), m_allocation_flags(0) {}
+		mem_allocator_base(const vk::render_device& dev, VkPhysicalDevice /*pdev*/);
 		virtual ~mem_allocator_base() = default;
 
 		virtual void destroy() = 0;
@@ -83,7 +83,7 @@ namespace vk
 	class mem_allocator_vma : public mem_allocator_base
 	{
 	public:
-		mem_allocator_vma(VkDevice dev, VkPhysicalDevice pdev);
+		mem_allocator_vma(const vk::render_device& dev, VkPhysicalDevice pdev);
 		~mem_allocator_vma() override = default;
 
 		void destroy() override;
@@ -112,7 +112,7 @@ namespace vk
 	class mem_allocator_vk : public mem_allocator_base
 	{
 	public:
-		mem_allocator_vk(VkDevice dev, VkPhysicalDevice pdev) : mem_allocator_base(dev, pdev) {}
+		mem_allocator_vk(const vk::render_device& dev, VkPhysicalDevice pdev) : mem_allocator_base(dev, pdev) {}
 		~mem_allocator_vk() override = default;
 
 		void destroy() override {}

--- a/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/scratch.cpp
@@ -125,8 +125,8 @@ namespace vk
 	{
 		auto create_texture = [&]()
 		{
-			u32 new_width = utils::align(requested_width, 1024u);
-			u32 new_height = utils::align(requested_height, 1024u);
+			u32 new_width = utils::align(requested_width, 256u);
+			u32 new_height = utils::align(requested_height, 256u);
 
 			return new vk::image(*g_render_device, g_render_device->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 				VK_IMAGE_TYPE_2D, format, new_width, new_height, 1, 1, 1, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_LAYOUT_UNDEFINED,

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -191,6 +191,7 @@ struct cfg_root : cfg::node
 			cfg::_bool asynchronous_texture_streaming{ this, "Asynchronous Texture Streaming 2", false };
 			cfg::uint<0, 100> rcas_sharpening_intensity{ this, "FidelityFX CAS Sharpening Intensity", 50, true };
 			cfg::_enum<vk_gpu_scheduler_mode> asynchronous_scheduler{ this, "Asynchronous Queue Scheduler", vk_gpu_scheduler_mode::safe };
+			cfg::uint<256, 65536> vram_allocation_limit{ this, "VRAM allocation limit (MB)", 65536, false };
 
 		} vk{ this };
 


### PR DESCRIPTION
This work is mostly focused on getting the vulkan renderer working in overallocated scenarios, such as having upscaling and MSAA enabled with a limited budget. The code was aggressively tested and tuned at 1.5GB, 1GB and 750MB to ensure crashing does not happen easily. I was able to run the test scenario for about 15 minutes without crashing, though on a subsequent run the crash could be reproduced in a few minutes. This is an extreme torture test (5k render res on a AAA title and less than 1G of VRAM allocated) so real-world situations should fare much better.

A new option has also been added (config file only) to control how much VRAM you want to allocate to rpcs3. This is mostly useful for debugging purposes.

This changeset is not final, the memory spilling behavior is not so great as it can be triggered from any location in the code (it serves as an interrupt of sorts) and there is no way to know that the resource we just created one instruction above got removed by some error handler silently. Some major work needs to go into that with centralized resource placement. Performance will be worse when memory is low, but anything is better than random crashes.