### PR TITLE
jit: fix assertion in GDBJITRegistrationListener

### DIFF
--- a/Utilities/JIT.cpp
+++ b/Utilities/JIT.cpp
@@ -1505,7 +1505,7 @@ void jit_compiler::add(const std::string& path)
 
 	if (auto object_file = llvm::object::ObjectFile::createObjectFile(*cache))
 	{
-		m_engine->addObjectFile( std::move(*object_file) );
+		m_engine->addObjectFile(llvm::object::OwningBinary<llvm::object::ObjectFile>(std::move(*object_file), std::move(cache)));
 	}
 	else
 	{


### PR DESCRIPTION
This fixes the assertion `Second attempt to perform debug registration.` which happens in `GDBJITRegistrationListener`. It happens on Linux if compiled in debug mode. 

```
auto cache = ObjectCache::load(path);
```
This variable contains the code. A reference to it is added to the JIT compiler and then it is destroyed at the end of the function `jit_compiler::add` and the JIT compiler now has a reference to destroyed code.

I changed it to pass the ownership of the code to the JIT compiler.