### PR TITLE
Update ffmpeg

### DIFF
--- a/.ci/build-linux.sh
+++ b/.ci/build-linux.sh
@@ -40,6 +40,7 @@ cmake ..                                               \
     -DCMAKE_RANLIB="$RANLIB"                           \
     -DUSE_SYSTEM_CURL=ON                               \
     -DUSE_SDL=ON                                       \
+    -DUSE_SYSTEM_FFMPEG=OFF                            \
     -DOpenGL_GL_PREFERENCE=LEGACY                      \
     -DLLVM_DIR=/opt/llvm/lib/cmake/llvm                \
     -DSTATIC_LINK_LLVM=ON                              \

--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -6,7 +6,7 @@ brew install -f --overwrite nasm ninja git p7zip create-dmg ccache pipenv
 #/usr/sbin/softwareupdate --install-rosetta --agree-to-license
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 arch -x86_64 /usr/local/bin/brew update
-arch -x86_64 /usr/local/bin/brew install -f --overwrite llvm@16 sdl2 glew cmake faudio vulkan-headers
+arch -x86_64 /usr/local/bin/brew install -f --overwrite llvm@16 sdl2 glew cmake faudio vulkan-headers ffmpeg
 arch -x86_64 /usr/local/bin/brew link -f llvm@16
 
 # moltenvk based on commit for 1.2.4 release
@@ -74,6 +74,7 @@ mkdir build && cd build || exit 1
     -DUSE_ALSA=OFF \
     -DUSE_PULSE=OFF \
     -DUSE_AUDIOUNIT=ON \
+    -DUSE_SYSTEM_FFMPEG=ON \
     -DLLVM_CCACHE_BUILD=OFF \
     -DLLVM_BUILD_RUNTIME=OFF \
     -DLLVM_BUILD_TOOLS=OFF \

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -267,32 +267,17 @@ if(USE_SYSTEM_FFMPEG)
 	target_link_libraries(3rdparty_ffmpeg INTERFACE ${FFMPEG_LIBRARIES})
 else()
 	if (NOT MSVC AND WIN32)
-		message(STATUS "RPCS3: building ffmpeg submodule")
-
-		include(ProcessorCount)
-		ProcessorCount(N)
-		
-		ExternalProject_Add(ffmpeg-mingw
-			DOWNLOAD_COMMAND ""
-			SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ffmpeg
-			BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/ffmpeg
-			CONFIGURE_COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/ffmpeg/configure --prefix=./windows/x86_64 --arch=x86_64 --disable-avdevice --disable-programs --disable-avfilter --disable-postproc --disable-doc --disable-pthreads --enable-w32threads --disable-network --disable-everything --disable-encoders --disable-muxers --disable-hwaccels --disable-parsers --disable-protocols --enable-dxva2 --enable-static --disable-shared --enable-decoder=aac --enable-decoder=aac_latm --enable-decoder=atrac3 --enable-decoder=atrac3p --enable-decoder=mp3 --enable-decoder=pcm_s16le --enable-decoder=pcm_s8 --enable-decoder=h264 --enable-decoder=mpeg4 --enable-decoder=mpeg2video --enable-decoder=mjpeg --enable-decoder=mjpegb --enable-encoder=pcm_s16le --enable-encoder=ffv1 --enable-encoder=mpeg4 --enable-parser=h264 --enable-parser=mpeg4video --enable-parser=mpegaudio --enable-parser=mpegvideo --enable-parser=mjpeg --enable-parser=aac --enable-parser=aac_latm --enable-muxer=avi --enable-demuxer=h264 --enable-demuxer=m4v --enable-demuxer=mp3 --enable-demuxer=mpegvideo --enable-demuxer=mpegps --enable-demuxer=mjpeg --enable-demuxer=avi --enable-demuxer=aac --enable-demuxer=pmp --enable-demuxer=oma --enable-demuxer=pcm_s16le --enable-demuxer=pcm_s8 --enable-demuxer=wav --enable-hwaccel=h264_dxva2 --enable-indev=dshow --enable-protocol=file
-			BUILD_COMMAND make -j ${N}
-			INSTALL_COMMAND make install
-		)
-
-		target_link_directories(3rdparty_ffmpeg INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/ffmpeg/windows/x86_64/lib")
-		target_link_libraries(3rdparty_ffmpeg INTERFACE avformat avcodec avutil swscale swresample iconv)
+		message(FATAL_ERROR "-- RPCS3: building ffmpeg submodule is currently not supported")
 	else()
 		message(STATUS "RPCS3: using builtin ffmpeg")
 
 		if (WIN32)
-			set(FFMPEG_LIB_DIR "ffmpeg/windows/x86_64")
+			set(FFMPEG_LIB_DIR "ffmpeg/lib/windows/x86_64")
 			target_link_libraries(3rdparty_ffmpeg INTERFACE "Bcrypt.lib")
 		elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-			set(FFMPEG_LIB_DIR "ffmpeg/linux/x86_64")
+			set(FFMPEG_LIB_DIR "ffmpeg/lib/linux/ubuntu-20.04/x86_64")
 		elseif(APPLE)
-			set(FFMPEG_LIB_DIR "ffmpeg/macos/x86_64")
+			set(FFMPEG_LIB_DIR "ffmpeg/lib/macos/x86_64")
 		else()
 			message(FATAL_ERROR "Prebuilt ffmpeg is not available on this platform! Try USE_SYSTEM_FFMPEG=ON.")
 		endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(USE_VULKAN "Vulkan render backend" ON)
 option(USE_PRECOMPILED_HEADERS "Use precompiled headers" OFF)
 option(USE_SDL "Enables SDL input handler" OFF)
 option(USE_SYSTEM_SDL "Prefer system SDL instead of the builtin one" OFF)
+option(USE_SYSTEM_FFMPEG "Prefer system ffmpeg instead of the prebuild one" OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/buildfiles/cmake")
 

--- a/buildfiles/msvc/rpcs3_default.props
+++ b/buildfiles/msvc/rpcs3_default.props
@@ -24,7 +24,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>xxhash.lib;ws2_32.lib;Iphlpapi.lib;Bcrypt.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\3rdparty\ffmpeg\windows\x86_64</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\3rdparty\ffmpeg\lib\windows\x86_64</AdditionalLibraryDirectories>
       <StackReserveSize>8388608</StackReserveSize>
       <StackCommitSize>1048576</StackCommitSize>
     </Link>


### PR DESCRIPTION
Updates ffmpeg based on Vita3K repo to 5.1.2.

The new ffmpeg version is more optimized overall, so this is actually useful to performance during de/encoding.
Here some random timings of mostly the same scenes on repeat:
<details>
  <summary>Encoding (720p) ~20% faster</summary>
  
Old:
E Media: average: 5008.96 us
E Media: average: 5008.11 us
E Media: average: 5020.52 us
E Media: average: 5576.87 us
E Media: average: 6629.70 us
E Media: average: 6560.65 us

New:
E Media: average: 4092.24 us
E Media: average: 4101.77 us
E Media: average: 4087.86 us
E Media: average: 4050.64 us
E Media: average: 5006.84 us
E Media: average: 5860.35 us
</details>
<details>
  <summary>Encoding (4K) ~20% faster</summary>

4K Old:
E Media: average: 27370.50 us
E Media: average: 27518.19 us
E Media: average: 27480.09 us
E Media: average: 27321.86 us

4K New:
E Media: average: 21630.02 us
E Media: average: 21576.04 us
E Media: average: 21503.02 us
E Media: average: 21505.84 us
</details>
<details>
  <summary>Decoding (720p) ~10% faster</summary>
  
Old:
E cellVdec: average: 2724.74 us
E cellVdec: average: 2601.69 us
E cellVdec: average: 2631.09 us
E cellVdec: average: 2621.00 us
E cellVdec: average: 2594.64 us
E cellVdec: average: 2601.26 us
E cellVdec: average: 2602.29 us

New:
E cellVdec: average: 2476.39 us
E cellVdec: average: 2348.26 us
E cellVdec: average: 2372.78 us
E cellVdec: average: 2334.19 us
E cellVdec: average: 2346.55 us
E cellVdec: average: 2312.74 us
E cellVdec: average: 2347.38 us
</details>

The new commit drops the source and uses CI (see .github) and a patch with the options to build the libs.
The artifacts are created automatically on our fork in the github actions section.
The codecs seem to be the same still:

![image](https://github.com/RPCS3/rpcs3/assets/23019877/541b509d-9e43-46de-82f0-f64e542e3bef)

