### PR TITLE
Logs/Debugger: Go-To-Address signal from log text

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -71,6 +71,7 @@ class debugger_frame : public custom_dock_widget
 	call_stack_list* m_call_stack_list;
 	instruction_editor_dialog* m_inst_editor = nullptr;
 	register_editor_dialog* m_reg_editor = nullptr;
+	QDialog* m_goto_dialog = nullptr;
 
 	std::shared_ptr<gui_settings> m_gui_settings;
 
@@ -91,6 +92,7 @@ public:
 	void WritePanels();
 	void EnableButtons(bool enable);
 	void ShowGotoAddressDialog();
+	void PerformGoToRequest(const QString& text_argument);
 	u64 EvaluateExpression(const QString& expression);
 	void ClearBreakpoints() const; // Fallthrough method into breakpoint_list.
 	void ClearCallStack();

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -241,6 +241,13 @@ void log_frame::CreateAndConnectActions()
 		m_tty->clear();
 	});
 
+	m_perform_goto_on_debugger = new QAction(tr("Go-To On The Debugger"), this);
+	connect(m_perform_goto_on_debugger, &QAction::triggered, [this]()
+	{
+		QPlainTextEdit* pte = (m_tabWidget->currentIndex() == 1 ? m_tty : m_log);
+		Q_EMIT PerformGoToOnDebugger(pte->textCursor().selectedText());
+	});
+
 	m_stack_act_tty = new QAction(tr("Stack Mode (TTY)"), this);
 	m_stack_act_tty->setCheckable(true);
 	connect(m_stack_act_tty, &QAction::toggled, [this](bool checked)
@@ -336,6 +343,13 @@ void log_frame::CreateAndConnectActions()
 	{
 		QMenu* menu = m_log->createStandardContextMenu();
 		menu->addAction(m_clear_act);
+		menu->addAction(m_perform_goto_on_debugger);
+
+		std::shared_ptr<bool> goto_signal_accepted = std::make_shared<bool>(false);
+		Q_EMIT PerformGoToOnDebugger("", true, goto_signal_accepted);
+		m_perform_goto_on_debugger->setEnabled(m_log->textCursor().hasSelection() && *goto_signal_accepted);
+		m_perform_goto_on_debugger->setToolTip(tr("Jump to the selected hexadecimal address from the log text on the debugger."));
+
 		menu->addSeparator();
 		menu->addActions(m_log_level_acts->actions());
 		menu->addSeparator();
@@ -349,6 +363,13 @@ void log_frame::CreateAndConnectActions()
 	{
 		QMenu* menu = m_tty->createStandardContextMenu();
 		menu->addAction(m_clear_tty_act);
+		menu->addAction(m_perform_goto_on_debugger);
+
+		std::shared_ptr<bool> goto_signal_accepted = std::make_shared<bool>(false);
+		Q_EMIT PerformGoToOnDebugger("", true, goto_signal_accepted);
+		m_perform_goto_on_debugger->setEnabled(m_tty->textCursor().hasSelection() && *goto_signal_accepted);
+		m_perform_goto_on_debugger->setToolTip(tr("Jump to the selected hexadecimal address from the TTY text on the debugger."));
+
 		menu->addSeparator();
 		menu->addAction(m_tty_act);
 		menu->addAction(m_stack_act_tty);

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -30,6 +30,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void LogFrameClosed();
+	void PerformGoToOnDebugger(const QString& text_argument, bool test_only = false, std::shared_ptr<bool> signal_accepted = nullptr);
 protected:
 	/** Override inherited method from Qt to allow signalling when close happened.*/
 	void closeEvent(QCloseEvent* event) override;
@@ -71,6 +72,7 @@ private:
 
 	QAction* m_clear_act = nullptr;
 	QAction* m_clear_tty_act = nullptr;
+	QAction* m_perform_goto_on_debugger = nullptr;
 
 	QActionGroup* m_log_level_acts = nullptr;
 	QAction* m_nothing_act = nullptr;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2793,6 +2793,22 @@ void main_window::CreateDockWindows()
 		}
 	});
 
+	connect(m_log_frame, &log_frame::PerformGoToOnDebugger, this, [this](const QString& text_argument, bool test_only, std::shared_ptr<bool> signal_accepted)
+	{
+		if (m_debugger_frame && m_debugger_frame->isVisible())
+		{
+			if (signal_accepted)
+			{
+				*signal_accepted = true;
+			}
+
+			if (!test_only)
+			{
+				m_debugger_frame->PerformGoToRequest(text_argument);
+			}
+		}
+	});
+
 	connect(m_debugger_frame, &debugger_frame::DebugFrameClosed, this, [this]()
 	{
 		if (ui->showDebuggerAct->isChecked())


### PR DESCRIPTION
Usage:
1. You select an address from text on the log or TTY, such as "0x12345678".
2. Right click to show context menu.
3. Click on the added "Go-To On The Debugger" action to jump directly to that address on the debugger.


Additional:
* Make the "Go To Address" dialog non-blocking, simply refocus the existing dialog if one is shown already. This allows to copy addresses from the debugger.