### PR TITLE
rsx: Fix some corner cases in atlas region clipping

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -560,7 +560,7 @@ namespace rsx
 			const auto parent_w = surface->template get_surface_width<rsx::surface_metrics::bytes>();
 			const auto parent_h = surface->template get_surface_height<rsx::surface_metrics::bytes>();
 
-			const auto [src_offset, dst_offset, size] = rsx::intersect_region(surface->base_addr, parent_w, parent_h, 1, base_addr, child_w, child_h, 1, get_rsx_pitch());
+			const auto [src_offset, dst_offset, size] = rsx::intersect_region(surface->base_addr, parent_w, parent_h, base_addr, child_w, child_h, get_rsx_pitch());
 
 			if (!size.width || !size.height)
 			{

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -352,7 +352,7 @@ namespace rsx
 				const size2u src_size = { dimensions.width / section_bpp, dimensions.height };
 
 				const u32 dst_slice_begin = slice * attr.slice_h;      // Output slice low watermark
-				const u32 dst_slice_end = slice_begin + attr.height;   // Output slice high watermark
+				const u32 dst_slice_end = dst_slice_begin + attr.height;   // Output slice high watermark
 
 				const auto dst_y = dst_offset.y;
 				const auto dst_h = dst_size.height;
@@ -400,7 +400,7 @@ namespace rsx
 						static_cast<u16>(src_offset.x),         // src.x
 						static_cast<u16>(src_offset.y),         // src.y
 						static_cast<u16>(dst_offset.x),         // dst.x
-						static_cast<u16>(dst_y - slice_begin),  // dst.y
+						static_cast<u16>(dst_y - dst_slice_begin),  // dst.y
 						0,
 						src_w,
 						height,

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -323,50 +323,55 @@ namespace rsx
 					slice,
 					src_width, src_height,
 					dst_width, dst_height
-					});
+				});
 			};
 
 			auto add_local_resource = [&](auto& section, u32 address, u16 slice, bool scaling = true)
 			{
-				// Intersect this resource with the original one
+				// Intersect this resource with the original one.
+				// Note that intersection takes place in a normalized coordinate space (bpp = 1)
 				const u32 section_bpp = get_format_block_size_in_bytes(section->get_gcm_format());
-				const u32 normalized_width = (section->get_width() * section_bpp) / attr.bpp;
+				const u32 normalized_section_width = (section->get_width() * section_bpp);
+				const u32 normalized_attr_width = (attr.width * attr.bpp);
 
-				const auto [src_offset, dst_offset, dst_size] = rsx::intersect_region(
-					section->get_section_base(), normalized_width, section->get_height(), section_bpp, /* parent region (extractee) */
-					address, attr.width, attr.slice_h, attr.bpp, /* child region (extracted) */
+				auto [src_offset, dst_offset, dimensions] = rsx::intersect_region(
+					section->get_section_base(), normalized_section_width, section->get_height(), /* parent region (extractee) */
+					address, normalized_attr_width, attr.slice_h, /* child region (extracted) */
 					attr.pitch);
 
-				if (!dst_size.width || !dst_size.height)
+				if (!dimensions.width || !dimensions.height)
 				{
 					// Out of bounds, invalid intersection
 					return;
 				}
 
-				ensure(src_offset.x < normalized_width && src_offset.y < section->get_height());
-				ensure(dst_offset.x < attr.width && dst_offset.y < attr.slice_h);
+				// The intersection takes place in a normalized coordinate space. Now we convert back to domain-specific
+				src_offset.x /= section_bpp;
+				dst_offset.x /= attr.bpp;
+				const size2u dst_size = { dimensions.width / attr.bpp, dimensions.height };
+				const size2u src_size = { dimensions.width / section_bpp, dimensions.height };
 
-				const u32 slice_begin = slice * attr.slice_h;
-				const u32 slice_end = slice_begin + attr.height;
+				const u32 dst_slice_begin = slice * attr.slice_h;      // Output slice low watermark
+				const u32 dst_slice_end = slice_begin + attr.height;   // Output slice high watermark
 
 				const auto dst_y = dst_offset.y;
 				const auto dst_h = dst_size.height;
 
-				const auto section_end = dst_y + dst_h;
-				if (dst_y >= slice_end || section_end <= slice_begin)
+				const auto write_section_end = dst_y + dst_h;
+				if (dst_y >= dst_slice_end || write_section_end <= dst_slice_begin)
 				{
 					// Belongs to a different slice
 					return;
 				}
 
 				const u16 dst_w = static_cast<u16>(dst_size.width);
-				const u16 src_w = static_cast<u16>(dst_w * attr.bpp) / section_bpp;
-				const u16 height = std::min(slice_end, section_end) - dst_y;
+				const u16 src_w = static_cast<u16>(src_size.width);
+				const u16 height = std::min(dst_slice_end, write_section_end) - dst_y;
 
 				if (scaling)
 				{
 					// Since output is upscaled, also upscale on dst
-					const auto [_dst_x, _dst_y] = rsx::apply_resolution_scale<false>(static_cast<u16>(dst_offset.x), static_cast<u16>(dst_y - slice_begin), attr.width, attr.height);
+					const auto [_dst_x, _dst_y] = rsx::apply_resolution_scale<false>(static_cast<u16>(dst_offset.x), static_cast<u16>(dst_y - dst_slice_begin), attr.width, attr.height);
 					const auto [_dst_w, _dst_h] = rsx::apply_resolution_scale<true>(dst_w, height, attr.width, attr.height);
 
 					out.push_back

--- a/rpcs3/Emu/RSX/VK/VKCompute.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCompute.cpp
@@ -128,7 +128,7 @@ namespace vk
 		m_used_descriptors = 0;
 	}
 
-	void compute_task::load_program(VkCommandBuffer cmd)
+	void compute_task::load_program(const vk::command_buffer& cmd)
 	{
 		if (!m_program)
 		{
@@ -170,7 +170,7 @@ namespace vk
 		m_descriptor_set.bind(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline_layout);
 	}
 
-	void compute_task::run(VkCommandBuffer cmd, u32 invocations_x, u32 invocations_y, u32 invocations_z)
+	void compute_task::run(const vk::command_buffer& cmd, u32 invocations_x, u32 invocations_y, u32 invocations_z)
 	{
 		// CmdDispatch is outside renderpass scope only
 		if (vk::is_renderpass_open(cmd))
@@ -182,7 +182,7 @@ namespace vk
 		vkCmdDispatch(cmd, invocations_x, invocations_y, invocations_z);
 	}
 
-	void compute_task::run(VkCommandBuffer cmd, u32 num_invocations)
+	void compute_task::run(const vk::command_buffer& cmd, u32 num_invocations)
 	{
 		u32 invocations_x, invocations_y;
 		if (num_invocations > max_invocations_x)
@@ -282,13 +282,13 @@ namespace vk
 		m_program->bind_buffer({ m_data->value, m_data_offset, m_data_length }, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_descriptor_set);
 	}
 
-	void cs_shuffle_base::set_parameters(VkCommandBuffer cmd, const u32* params, u8 count)
+	void cs_shuffle_base::set_parameters(const vk::command_buffer& cmd, const u32* params, u8 count)
 	{
 		ensure(use_push_constants);
 		vkCmdPushConstants(cmd, m_pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, count * 4, params);
 	}
 
-	void cs_shuffle_base::run(VkCommandBuffer cmd, const vk::buffer* data, u32 data_length, u32 data_offset)
+	void cs_shuffle_base::run(const vk::command_buffer& cmd, const vk::buffer* data, u32 data_length, u32 data_offset)
 	{
 		m_data = data;
 		m_data_offset = data_offset;
@@ -328,7 +328,7 @@ namespace vk
 		m_program->bind_buffer({ m_data->value, m_data_offset, m_ssbo_length }, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_descriptor_set);
 	}
 
-	void cs_interleave_task::run(VkCommandBuffer cmd, const vk::buffer* data, u32 data_offset, u32 data_length, u32 zeta_offset, u32 stencil_offset)
+	void cs_interleave_task::run(const vk::command_buffer& cmd, const vk::buffer* data, u32 data_offset, u32 data_length, u32 zeta_offset, u32 stencil_offset)
 	{
 		u32 parameters[4] = { data_length, zeta_offset - data_offset, stencil_offset - data_offset, 0 };
 		set_parameters(cmd, parameters, 4);
@@ -389,7 +389,7 @@ namespace vk
 		m_program->bind_buffer({ dst->value, 0, 4 }, 1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_descriptor_set);
 	}
 
-	void cs_aggregator::run(VkCommandBuffer cmd, const vk::buffer* dst, const vk::buffer* src, u32 num_words)
+	void cs_aggregator::run(const vk::command_buffer& cmd, const vk::buffer* dst, const vk::buffer* src, u32 num_words)
 	{
 		this->dst = dst;
 		this->src = src;

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -49,10 +49,10 @@ namespace vk
 		virtual void bind_resources() {}
 		virtual void declare_inputs() {}
 
-		void load_program(VkCommandBuffer cmd);
+		void load_program(const vk::command_buffer& cmd);
 
-		void run(VkCommandBuffer cmd, u32 invocations_x, u32 invocations_y, u32 invocations_z);
-		void run(VkCommandBuffer cmd, u32 num_invocations);
+		void run(const vk::command_buffer& cmd, u32 invocations_x, u32 invocations_y, u32 invocations_z);
+		void run(const vk::command_buffer& cmd, u32 num_invocations);
 	};
 
 	struct cs_shuffle_base : compute_task
@@ -71,9 +71,9 @@ namespace vk
 
 		void bind_resources() override;
 
-		void set_parameters(VkCommandBuffer cmd, const u32* params, u8 count);
+		void set_parameters(const vk::command_buffer& cmd, const u32* params, u8 count);
 
-		void run(VkCommandBuffer cmd, const vk::buffer* data, u32 data_length, u32 data_offset = 0);
+		void run(const vk::command_buffer& cmd, const vk::buffer* data, u32 data_length, u32 data_offset = 0);
 	};
 
 	struct cs_shuffle_16 : cs_shuffle_base
@@ -139,7 +139,7 @@ namespace vk
 
 		void bind_resources() override;
 
-		void run(VkCommandBuffer cmd, const vk::buffer* data, u32 data_offset, u32 data_length, u32 zeta_offset, u32 stencil_offset);
+		void run(const vk::command_buffer& cmd, const vk::buffer* data, u32 data_offset, u32 data_length, u32 zeta_offset, u32 stencil_offset);
 	};
 
 	template<bool _SwapBytes = false>
@@ -359,7 +359,7 @@ namespace vk
 			m_program->bind_buffer({ m_data->value, m_data_offset, m_ssbo_length }, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_descriptor_set);
 		}
 
-		void run(VkCommandBuffer cmd, const vk::buffer* data, u32 src_offset, u32 src_length, u32 dst_offset)
+		void run(const vk::command_buffer& cmd, const vk::buffer* data, u32 src_offset, u32 src_length, u32 dst_offset)
 		{
 			u32 data_offset;
 			if (src_offset > dst_offset)
@@ -382,7 +382,7 @@ namespace vk
 	// Reverse morton-order block arrangement
 	struct cs_deswizzle_base : compute_task
 	{
-		virtual void run(VkCommandBuffer cmd, const vk::buffer* dst, u32 out_offset, const vk::buffer* src, u32 in_offset, u32 data_length, u32 width, u32 height, u32 depth, u32 mipmaps) = 0;
+		virtual void run(const vk::command_buffer& cmd, const vk::buffer* dst, u32 out_offset, const vk::buffer* src, u32 in_offset, u32 data_length, u32 width, u32 height, u32 depth, u32 mipmaps) = 0;
 	};
 
 	template <typename _BlockType, typename _BaseType, bool _SwapBytes>
@@ -461,12 +461,12 @@ namespace vk
 			m_program->bind_buffer({ dst_buffer->value, out_offset, block_length }, 1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, m_descriptor_set);
 		}
 
-		void set_parameters(VkCommandBuffer cmd)
+		void set_parameters(const vk::command_buffer& cmd)
 		{
 			vkCmdPushConstants(cmd, m_pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, push_constants_size, params.data);
 		}
 
-		void run(VkCommandBuffer cmd, const vk::buffer* dst, u32 out_offset, const vk::buffer* src, u32 in_offset, u32 data_length, u32 width, u32 height, u32 depth, u32 mipmaps) override
+		void run(const vk::command_buffer& cmd, const vk::buffer* dst, u32 out_offset, const vk::buffer* src, u32 in_offset, u32 data_length, u32 width, u32 height, u32 depth, u32 mipmaps) override
 		{
 			dst_buffer = dst;
 			src_buffer = src;
@@ -501,7 +501,7 @@ namespace vk
 
 		void bind_resources() override;
 
-		void run(VkCommandBuffer cmd, const vk::buffer* dst, const vk::buffer* src, u32 num_words);
+		void run(const vk::command_buffer& cmd, const vk::buffer* dst, const vk::buffer* src, u32 num_words);
 	};
 
 	// TODO: Replace with a proper manager

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -831,7 +831,7 @@ void VKGSRender::emit_geometry(u32 sub_index)
 	}
 
 	bool reload_state = (!m_current_draw.subdraw_id++);
-	vk::renderpass_op(*m_current_command_buffer, [&](VkCommandBuffer cmd, VkRenderPass pass, VkFramebuffer fbo)
+	vk::renderpass_op(*m_current_command_buffer, [&](const vk::command_buffer& cmd, VkRenderPass pass, VkFramebuffer fbo)
 	{
 		if (get_render_pass() == pass && m_draw_fbo->value == fbo)
 		{

--- a/rpcs3/Emu/RSX/VK/VKHelpers.h
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.h
@@ -74,8 +74,8 @@ namespace vk
 		VkImageAspectFlags flags, vk::data_heap &upload_heap, u32 heap_align, rsx::flags32_t image_setup_flags);
 
 	// Other texture management helpers
-	void copy_image_to_buffer(VkCommandBuffer cmd, const vk::image* src, const vk::buffer* dst, const VkBufferImageCopy& region, bool swap_bytes = false);
-	void copy_buffer_to_image(VkCommandBuffer cmd, const vk::buffer* src, const vk::image* dst, const VkBufferImageCopy& region);
+	void copy_image_to_buffer(const vk::command_buffer& cmd, const vk::image* src, const vk::buffer* dst, const VkBufferImageCopy& region, bool swap_bytes = false);
+	void copy_buffer_to_image(const vk::command_buffer& cmd, const vk::buffer* src, const vk::image* dst, const VkBufferImageCopy& region);
 	u64  calculate_working_buffer_size(u64 base_size, VkImageAspectFlags aspect);
 
 	void copy_image_typeless(const command_buffer &cmd, image *src, image *dst, const areai& src_rect, const areai& dst_rect,

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.cpp
@@ -341,7 +341,7 @@ namespace vk
 		g_renderpass_cache.clear();
 	}
 
-	void begin_renderpass(VkCommandBuffer cmd, VkRenderPass pass, VkFramebuffer target, const coordu& framebuffer_region)
+	void begin_renderpass(const vk::command_buffer& cmd, VkRenderPass pass, VkFramebuffer target, const coordu& framebuffer_region)
 	{
 		auto& renderpass_info = g_current_renderpass[cmd];
 		if (renderpass_info.pass == pass && renderpass_info.fbo == target)
@@ -366,7 +366,7 @@ namespace vk
 		renderpass_info = { pass, target };
 	}
 
-	void begin_renderpass(VkDevice dev, VkCommandBuffer cmd, u64 renderpass_key, VkFramebuffer target, const coordu& framebuffer_region)
+	void begin_renderpass(VkDevice dev, const vk::command_buffer& cmd, u64 renderpass_key, VkFramebuffer target, const coordu& framebuffer_region)
 	{
 		if (renderpass_key != g_cached_renderpass_key)
 		{
@@ -377,18 +377,18 @@ namespace vk
 		begin_renderpass(cmd, g_cached_renderpass, target, framebuffer_region);
 	}
 
-	void end_renderpass(VkCommandBuffer cmd)
+	void end_renderpass(const vk::command_buffer& cmd)
 	{
 		vkCmdEndRenderPass(cmd);
 		g_current_renderpass[cmd] = {};
 	}
 
-	bool is_renderpass_open(VkCommandBuffer cmd)
+	bool is_renderpass_open(const vk::command_buffer& cmd)
 	{
 		return g_current_renderpass[cmd].pass != VK_NULL_HANDLE;
 	}
 
-	void renderpass_op(VkCommandBuffer cmd, const renderpass_op_callback_t& op)
+	void renderpass_op(const vk::command_buffer& cmd, const renderpass_op_callback_t& op)
 	{
 		const auto& active = g_current_renderpass[cmd];
 		op(cmd, active.pass, active.fbo);

--- a/rpcs3/Emu/RSX/VK/VKRenderPass.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderPass.h
@@ -6,6 +6,7 @@
 namespace vk
 {
 	class image;
+	class command_buffer;
 
 	u64 get_renderpass_key(const std::vector<vk::image*>& images, const std::vector<u8>& input_attachment_ids = {});
 	u64 get_renderpass_key(const std::vector<vk::image*>& images, u64 previous_key);
@@ -16,11 +17,11 @@ namespace vk
 
 	// Renderpass scope management helpers.
 	// NOTE: These are not thread safe by design.
-	void begin_renderpass(VkDevice dev, VkCommandBuffer cmd, u64 renderpass_key, VkFramebuffer target, const coordu& framebuffer_region);
-	void begin_renderpass(VkCommandBuffer cmd, VkRenderPass pass, VkFramebuffer target, const coordu& framebuffer_region);
-	void end_renderpass(VkCommandBuffer cmd);
-	bool is_renderpass_open(VkCommandBuffer cmd);
+	void begin_renderpass(VkDevice dev, const vk::command_buffer& cmd, u64 renderpass_key, VkFramebuffer target, const coordu& framebuffer_region);
+	void begin_renderpass(const vk::command_buffer& cmd, VkRenderPass pass, VkFramebuffer target, const coordu& framebuffer_region);
+	void end_renderpass(const vk::command_buffer& cmd);
+	bool is_renderpass_open(const vk::command_buffer& cmd);
 
-	using renderpass_op_callback_t = std::function<void(VkCommandBuffer, VkRenderPass, VkFramebuffer)>;
-	void renderpass_op(VkCommandBuffer cmd, const renderpass_op_callback_t& op);
+	using renderpass_op_callback_t = std::function<void(const vk::command_buffer&, VkRenderPass, VkFramebuffer)>;
+	void renderpass_op(const vk::command_buffer& cmd, const renderpass_op_callback_t& op);
 }

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -125,7 +125,7 @@ namespace vk
 			m_program->bind_uniform({ VK_NULL_HANDLE, resolved_view->value, resolve->current_layout }, "resolve", VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, m_descriptor_set);
 		}
 
-		void run(VkCommandBuffer cmd, vk::viewable_image* msaa_image, vk::viewable_image* resolve_image)
+		void run(const vk::command_buffer& cmd, vk::viewable_image* msaa_image, vk::viewable_image* resolve_image)
 		{
 			ensure(msaa_image->samples() > 1);
 			ensure(resolve_image->samples() == 1);

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -98,6 +98,14 @@ namespace vk
 		g_last_completed_event = std::max(event_id, g_last_completed_event.load());
 	}
 
+	void print_debug_markers()
+	{
+		for (const auto marker : g_resource_manager.gather_debug_markers())
+		{
+			marker->dump();
+		}
+	}
+
 	static constexpr f32 size_in_GiB(u64 size)
 	{
 		return size / (1024.f * 1024.f * 1024.f);

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -57,6 +57,7 @@ namespace vk
 		u64 eid;
 		const vk::render_device* m_device;
 		std::vector<disposable_t> m_disposables;
+		std::vector<std::unique_ptr<device_debug_marker>> m_debug_markers;
 
 		eid_scope_t(u64 _eid):
 			eid(_eid), m_device(g_render_device)
@@ -72,11 +73,13 @@ namespace vk
 			std::swap(eid, other.eid);
 			std::swap(m_device, other.m_device);
 			std::swap(m_disposables, other.m_disposables);
+			std::swap(m_debug_markers, other.m_debug_markers);
 		}
 
 		void discard()
 		{
 			m_disposables.clear();
+			m_debug_markers.clear();
 		}
 	};
 
@@ -187,6 +190,13 @@ namespace vk
 			get_current_eid_scope().m_disposables.emplace_back(std::move(disposable));
 		}
 
+		inline void dispose(std::unique_ptr<vk::device_debug_marker>& object)
+		{
+			// Special case as we may need to read these out.
+			// FIXME: We can manage these markers better and remove this exception.
+			get_current_eid_scope().m_debug_markers.emplace_back(std::move(object));
+		}
+
 		template<typename T>
 		inline void dispose(std::unique_ptr<T>& object)
 		{
@@ -221,6 +231,19 @@ namespace vk
 		}
 
 		void trim();
+
+		std::vector<const device_debug_marker*> gather_debug_markers() const
+		{
+			std::vector<const device_debug_marker*> result;
+			for (const auto& scope : m_eid_map)
+			{
+				for (const auto& item : scope.m_debug_markers)
+				{
+					result.push_back(item.get());
+				}
+			}
+			return result;
+		}
 	};
 
 	struct vmm_allocation_t

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -57,7 +57,7 @@ namespace vk
 		u64 eid;
 		const vk::render_device* m_device;
 		std::vector<disposable_t> m_disposables;
-		std::vector<std::unique_ptr<device_debug_marker>> m_debug_markers;
+		std::vector<std::unique_ptr<gpu_debug_marker>> m_debug_markers;
 
 		eid_scope_t(u64 _eid):
 			eid(_eid), m_device(g_render_device)
@@ -190,7 +190,7 @@ namespace vk
 			get_current_eid_scope().m_disposables.emplace_back(std::move(disposable));
 		}
 
-		inline void dispose(std::unique_ptr<vk::device_debug_marker>& object)
+		inline void dispose(std::unique_ptr<vk::gpu_debug_marker>& object)
 		{
 			// Special case as we may need to read these out.
 			// FIXME: We can manage these markers better and remove this exception.
@@ -232,9 +232,9 @@ namespace vk
 
 		void trim();
 
-		std::vector<const device_debug_marker*> gather_debug_markers() const
+		std::vector<const gpu_debug_marker*> gather_debug_markers() const
 		{
-			std::vector<const device_debug_marker*> result;
+			std::vector<const gpu_debug_marker*> result;
 			for (const auto& scope : m_eid_map)
 			{
 				for (const auto& item : scope.m_debug_markers)

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -46,7 +46,7 @@ namespace vk
 		}
 	}
 
-	void copy_image_to_buffer(VkCommandBuffer cmd, const vk::image* src, const vk::buffer* dst, const VkBufferImageCopy& region, bool swap_bytes)
+	void copy_image_to_buffer(const vk::command_buffer& cmd, const vk::image* src, const vk::buffer* dst, const VkBufferImageCopy& region, bool swap_bytes)
 	{
 		// Always validate
 		ensure(src->current_layout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL || src->current_layout == VK_IMAGE_LAYOUT_GENERAL);
@@ -55,6 +55,9 @@ namespace vk
 		{
 			vk::end_renderpass(cmd);
 		}
+
+		ensure((region.imageExtent.width + region.imageOffset.x) <= src->width());
+		ensure((region.imageExtent.height + region.imageOffset.y) <= src->height());
 
 		switch (src->format())
 		{
@@ -183,7 +186,7 @@ namespace vk
 		}
 	}
 
-	void copy_buffer_to_image(VkCommandBuffer cmd, const vk::buffer* src, const vk::image* dst, const VkBufferImageCopy& region)
+	void copy_buffer_to_image(const vk::command_buffer& cmd, const vk::buffer* src, const vk::image* dst, const VkBufferImageCopy& region)
 	{
 		// Always validate
 		ensure(dst->current_layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL || dst->current_layout == VK_IMAGE_LAYOUT_GENERAL);
@@ -738,7 +741,7 @@ namespace vk
 		}
 	}
 
-	static void gpu_deswizzle_sections_impl(VkCommandBuffer cmd, vk::buffer* scratch_buf, u32 dst_offset, int word_size, int word_count, bool swap_bytes, std::vector<VkBufferImageCopy>& sections)
+	static void gpu_deswizzle_sections_impl(const vk::command_buffer& cmd, vk::buffer* scratch_buf, u32 dst_offset, int word_size, int word_count, bool swap_bytes, std::vector<VkBufferImageCopy>& sections)
 	{
 		// NOTE: This has to be done individually for every LOD
 		vk::cs_deswizzle_base* job = nullptr;

--- a/rpcs3/Emu/RSX/VK/vkutils/barriers.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/barriers.cpp
@@ -8,7 +8,7 @@
 namespace vk
 {
 	void insert_image_memory_barrier(
-		VkCommandBuffer cmd, VkImage image,
+		const vk::command_buffer& cmd, VkImage image,
 		VkImageLayout current_layout, VkImageLayout new_layout,
 		VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage,
 		VkAccessFlags src_mask, VkAccessFlags dst_mask,
@@ -33,7 +33,7 @@ namespace vk
 		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
 	}
 
-	void insert_buffer_memory_barrier(VkCommandBuffer cmd, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize length, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask)
+	void insert_buffer_memory_barrier(const vk::command_buffer& cmd, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize length, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask)
 	{
 		if (vk::is_renderpass_open(cmd))
 		{
@@ -53,7 +53,7 @@ namespace vk
 		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 1, &barrier, 0, nullptr);
 	}
 
-	void insert_global_memory_barrier(VkCommandBuffer cmd, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_access, VkAccessFlags dst_access)
+	void insert_global_memory_barrier(const vk::command_buffer& cmd, VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_access, VkAccessFlags dst_access)
 	{
 		if (vk::is_renderpass_open(cmd))
 		{
@@ -67,7 +67,7 @@ namespace vk
 		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 1, &barrier, 0, nullptr, 0, nullptr);
 	}
 
-	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range)
+	void insert_texture_barrier(const vk::command_buffer& cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range)
 	{
 		// NOTE: Sampling from an attachment in ATTACHMENT_OPTIMAL layout on some hw ends up with garbage output
 		// Transition to GENERAL if this resource is both input and output
@@ -105,7 +105,7 @@ namespace vk
 		vkCmdPipelineBarrier(cmd, src_stage, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
 	}
 
-	void insert_texture_barrier(VkCommandBuffer cmd, vk::image* image, VkImageLayout new_layout)
+	void insert_texture_barrier(const vk::command_buffer& cmd, vk::image* image, VkImageLayout new_layout)
 	{
 		insert_texture_barrier(cmd, image->value, image->current_layout, new_layout, { image->aspect(), 0, 1, 0, 1 });
 		image->current_layout = new_layout;

--- a/rpcs3/Emu/RSX/VK/vkutils/barriers.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/barriers.h
@@ -5,19 +5,20 @@
 namespace vk
 {
 	class image;
+	class command_buffer;
 
 	//Texture barrier applies to a texture to ensure writes to it are finished before any reads are attempted to avoid RAW hazards
-	void insert_texture_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range);
-	void insert_texture_barrier(VkCommandBuffer cmd, vk::image* image, VkImageLayout new_layout);
+	void insert_texture_barrier(const vk::command_buffer& cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, VkImageSubresourceRange range);
+	void insert_texture_barrier(const vk::command_buffer& cmd, vk::image* image, VkImageLayout new_layout);
 
-	void insert_buffer_memory_barrier(VkCommandBuffer cmd, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize length,
+	void insert_buffer_memory_barrier(const vk::command_buffer& cmd, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize length,
 		VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask);
 
-	void insert_image_memory_barrier(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout,
+	void insert_image_memory_barrier(const vk::command_buffer& cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout,
 		VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage, VkAccessFlags src_mask, VkAccessFlags dst_mask,
 		const VkImageSubresourceRange& range);
 
-	void insert_global_memory_barrier(VkCommandBuffer cmd,
+	void insert_global_memory_barrier(const vk::command_buffer& cmd,
 		VkPipelineStageFlags src_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
 		VkPipelineStageFlags dst_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
 		VkAccessFlags src_access = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT,

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -360,7 +360,7 @@ namespace vk
 		}
 	}
 
-	void descriptor_set::bind(VkCommandBuffer cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout)
+	void descriptor_set::bind(const vk::command_buffer& cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout)
 	{
 		if ((m_push_type_mask & ~m_update_after_bind_mask) || (m_pending_writes.size() >= max_cache_size))
 		{
@@ -368,11 +368,6 @@ namespace vk
 		}
 
 		vkCmdBindDescriptorSets(cmd, bind_point, layout, 0, 1, &m_handle, 0, nullptr);
-	}
-
-	void descriptor_set::bind(const command_buffer& cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout)
-	{
-		bind(static_cast<VkCommandBuffer>(cmd), bind_point, layout);
 	}
 
 	void descriptor_set::flush()

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -67,8 +67,7 @@ namespace vk
 		void push(const VkDescriptorImageInfo* image_info, u32 count, VkDescriptorType type, u32 binding);
 		void push(rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask = umax);
 
-		void bind(VkCommandBuffer cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout);
-		void bind(const command_buffer& cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout);
+		void bind(const vk::command_buffer& cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout);
 
 		void flush();
 

--- a/rpcs3/Emu/RSX/VK/vkutils/image_helpers.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/image_helpers.cpp
@@ -55,7 +55,7 @@ namespace vk
 		return{ final_mapping[1], final_mapping[2], final_mapping[3], final_mapping[0] };
 	}
 
-	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range,
+	void change_image_layout(const vk::command_buffer& cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range,
 		u32 src_queue_family, u32 dst_queue_family, u32 src_access_mask_bits, u32 dst_access_mask_bits)
 	{
 		if (vk::is_renderpass_open(cmd))
@@ -207,7 +207,7 @@ namespace vk
 		vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
 	}
 
-	void change_image_layout(VkCommandBuffer cmd, vk::image* image, VkImageLayout new_layout, const VkImageSubresourceRange& range)
+	void change_image_layout(const vk::command_buffer& cmd, vk::image* image, VkImageLayout new_layout, const VkImageSubresourceRange& range)
 	{
 		if (image->current_layout == new_layout) return;
 
@@ -215,7 +215,7 @@ namespace vk
 		image->current_layout = new_layout;
 	}
 
-	void change_image_layout(VkCommandBuffer cmd, vk::image* image, VkImageLayout new_layout)
+	void change_image_layout(const vk::command_buffer& cmd, vk::image* image, VkImageLayout new_layout)
 	{
 		if (image->current_layout == new_layout) return;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/image_helpers.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/image_helpers.h
@@ -4,15 +4,17 @@
 namespace vk
 {
 	class image;
+	class command_buffer;
+
 	extern VkComponentMapping default_component_map;
 
 	VkImageAspectFlags get_aspect_flags(VkFormat format);
 	VkComponentMapping apply_swizzle_remap(const std::array<VkComponentSwizzle, 4>& base_remap, const std::pair<std::array<u8, 4>, std::array<u8, 4>>& remap_vector);
 
-	void change_image_layout(VkCommandBuffer cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range,
+	void change_image_layout(const vk::command_buffer& cmd, VkImage image, VkImageLayout current_layout, VkImageLayout new_layout, const VkImageSubresourceRange& range,
 		u32 src_queue_family = VK_QUEUE_FAMILY_IGNORED, u32 dst_queue_family = VK_QUEUE_FAMILY_IGNORED,
 		u32 src_access_mask_bits = 0xFFFFFFFF, u32 dst_access_mask_bits = 0xFFFFFFFF);
 
-	void change_image_layout(VkCommandBuffer cmd, vk::image* image, VkImageLayout new_layout, const VkImageSubresourceRange& range);
-	void change_image_layout(VkCommandBuffer cmd, vk::image* image, VkImageLayout new_layout);
+	void change_image_layout(const vk::command_buffer& cmd, vk::image* image, VkImageLayout new_layout, const VkImageSubresourceRange& range);
+	void change_image_layout(const vk::command_buffer& cmd, vk::image* image, VkImageLayout new_layout);
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/shared.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/shared.cpp
@@ -7,6 +7,8 @@
 
 namespace vk
 {
+	extern void print_debug_markers();
+
 	void die_with_error(VkResult error_code, std::string message,
 		const char* file,
 		const char* func,
@@ -103,6 +105,8 @@ namespace vk
 		{
 		default:
 		case 0:
+			print_debug_markers();
+
 			if (!message.empty()) message += "\n\n";
 			fmt::throw_exception("%sAssertion Failed! Vulkan API call failed with unrecoverable error: %s%s", message, error_message, src_loc{line, col, file, func});
 		case 1:

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
@@ -10,6 +10,9 @@
 #include "util/sysinfo.hpp"
 #include "util/asm.hpp"
 
+// FIXME: namespace pollution
+#include "../VKResourceManager.h"
+
 namespace vk
 {
 	fence::fence(VkDevice dev)
@@ -167,6 +170,135 @@ namespace vk
 		{
 			return (*m_value == 0xCAFEBABE) ? VK_EVENT_RESET : VK_EVENT_SET;
 		}
+	}
+
+	device_marker_pool::device_marker_pool(const vk::render_device& dev, u32 count)
+		: pdev(&dev), m_count(count)
+	{}
+
+	std::tuple<VkBuffer, u64, volatile u32*> device_marker_pool::allocate()
+	{
+		if (!m_buffer || m_offset >= m_count)
+		{
+			create_impl();
+		}
+
+		const auto out_offset = m_offset;
+		m_offset ++;
+		return { m_buffer->value, out_offset * 4, m_mapped + out_offset };
+	}
+
+	void device_marker_pool::create_impl()
+	{
+		if (m_buffer)
+		{
+			m_buffer->unmap();
+			vk::get_resource_manager()->dispose(m_buffer);
+		}
+
+		m_buffer = std::make_unique<buffer>
+		(
+			*pdev,
+			m_count * 4,
+			pdev->get_memory_mapping().host_visible_coherent,
+			VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+			VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+			0,
+			VMM_ALLOCATION_POOL_SYSTEM
+		);
+
+		m_mapped = reinterpret_cast<volatile u32*>(m_buffer->map(0, VK_WHOLE_SIZE));
+		m_offset = 0;
+	}
+
+	device_debug_marker::device_debug_marker(device_marker_pool& pool, std::string message)
+		: m_device(*pool.pdev), m_message(std::move(message))
+	{
+		std::tie(m_buffer, m_buffer_offset, m_value) = pool.allocate();
+		*m_value = 0xCAFEBABE;
+	}
+
+	device_debug_marker::~device_debug_marker()
+	{
+		if (!m_printed)
+		{
+			dump();
+		}
+
+		m_value = nullptr;
+	}
+
+	void device_debug_marker::signal(const command_buffer& cmd, VkPipelineStageFlags stages, VkAccessFlags access)
+	{
+		insert_global_memory_barrier(cmd, stages, VK_PIPELINE_STAGE_TRANSFER_BIT, access, VK_ACCESS_TRANSFER_WRITE_BIT);
+		vkCmdFillBuffer(cmd, m_buffer, m_buffer_offset, 4, 0xDEADBEEF);
+	}
+
+	void device_debug_marker::dump()
+	{
+		if (*m_value == 0xCAFEBABE)
+		{
+			rsx_log.error("DEBUG MARKER NOT REACHED: %s", m_message);
+		}
+
+		m_printed = true;
+	}
+
+	void device_debug_marker::dump() const
+	{
+		if (*m_value == 0xCAFEBABE)
+		{
+			rsx_log.error("DEBUG MARKER NOT REACHED: %s", m_message);
+		}
+		else
+		{
+			rsx_log.error("DEBUG MARKER: %s", m_message);
+		}
+	}
+
+	// FIXME
+	static std::unique_ptr<device_marker_pool> g_device_marker_pool;
+
+	device_marker_pool& get_shared_marker_pool(const vk::render_device& dev)
+	{
+		if (!g_device_marker_pool)
+		{
+			g_device_marker_pool = std::make_unique<device_marker_pool>(dev, 65536);
+		}
+		return *g_device_marker_pool;
+	}
+
+	void device_debug_marker::insert(
+		const vk::render_device& dev,
+		const vk::command_buffer& cmd,
+		std::string message,
+		VkPipelineStageFlags stages,
+		VkAccessFlags access)
+	{
+		auto result = std::make_unique<device_debug_marker>(get_shared_marker_pool(dev), message);
+		result->signal(cmd, stages, access);
+		vk::get_resource_manager()->dispose(result);
+	}
+
+	debug_marker_scope::debug_marker_scope(const vk::command_buffer& cmd, const std::string& message)
+		: dev(&cmd.get_command_pool().get_owner()), cb(&cmd), message(message)
+	{
+		vk::device_debug_marker::insert(
+			*dev,
+			*cb,
+			fmt::format("0x%x: Enter %s", rsx::get_shared_tag(), message)
+		);
+	}
+
+	debug_marker_scope::~debug_marker_scope()
+	{
+		ensure(cb && cb->is_recording());
+
+		vk::device_debug_marker::insert(
+			*dev,
+			*cb,
+			fmt::format("0x%x: Exit %s", rsx::get_shared_tag(), message)
+		);
 	}
 
 	VkResult wait_for_fence(fence* pFence, u64 timeout)

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
@@ -281,23 +281,23 @@ namespace vk
 	}
 
 	debug_marker_scope::debug_marker_scope(const vk::command_buffer& cmd, const std::string& message)
-		: dev(&cmd.get_command_pool().get_owner()), cb(&cmd), message(message)
+		: m_device(&cmd.get_command_pool().get_owner()), m_cb(&cmd), m_message(message), m_tag(rsx::get_shared_tag())
 	{
 		vk::device_debug_marker::insert(
-			*dev,
-			*cb,
-			fmt::format("0x%x: Enter %s", rsx::get_shared_tag(), message)
+			*m_device,
+			*m_cb,
+			fmt::format("0x%x: Enter %s", m_tag, m_message)
 		);
 	}
 
 	debug_marker_scope::~debug_marker_scope()
 	{
-		ensure(cb && cb->is_recording());
+		ensure(m_cb && m_cb->is_recording());
 
 		vk::device_debug_marker::insert(
-			*dev,
-			*cb,
-			fmt::format("0x%x: Exit %s", rsx::get_shared_tag(), message)
+			*m_device,
+			*m_cb,
+			fmt::format("0x%x: Exit %s", m_tag, m_message)
 		);
 	}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -132,9 +132,10 @@ namespace vk
 
 	class debug_marker_scope
 	{
-		const vk::render_device* dev;
-		const vk::command_buffer* cb;
-		std::string message;
+		const vk::render_device* m_device;
+		const vk::command_buffer* m_cb;
+		std::string m_message;
+		u32 m_tag;
 
 	public:
 		debug_marker_scope(const vk::command_buffer& cmd, const std::string& text);

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -103,7 +103,7 @@ namespace vk
 		const vk::render_device* pdev = nullptr;
 	};
 
-	class device_debug_marker
+	class gpu_debug_marker
 	{
 		std::string m_message;
 		bool m_printed = false;
@@ -114,9 +114,9 @@ namespace vk
 		volatile u32* m_value = nullptr;
 
 	public:
-		device_debug_marker(device_marker_pool& pool, std::string message);
-		~device_debug_marker();
-		device_debug_marker(const event&) = delete;
+		gpu_debug_marker(device_marker_pool& pool, std::string message);
+		~gpu_debug_marker();
+		gpu_debug_marker(const event&) = delete;
 
 		void signal(const command_buffer& cmd, VkPipelineStageFlags stages, VkAccessFlags access);
 		void dump();

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -559,8 +559,8 @@ namespace rsx
 	 * Extracts from 'parent' a region that fits in 'child'
 	 */
 	static inline std::tuple<position2u, position2u, size2u> intersect_region(
-		u32 parent_address, u16 parent_w, u16 parent_h, u16 parent_bpp,
-		u32 child_address, u16 child_w, u16 child_h, u32 child_bpp,
+		u32 parent_address, u16 parent_w, u16 parent_h,
+		u32 child_address, u16 child_w, u16 child_h,
 		u32 pitch)
 	{
 		if (child_address < parent_address)
@@ -569,7 +569,7 @@ namespace rsx
 			const auto src_x = 0u;
 			const auto src_y = 0u;
 			const auto dst_y = (offset / pitch);
-			const auto dst_x = (offset % pitch) / child_bpp;
+			const auto dst_x = (offset % pitch);
 			const auto w = std::min<u32>(parent_w, std::max<u32>(child_w, dst_x) - dst_x); // Clamp negatives to 0!
 			const auto h = std::min<u32>(parent_h, std::max<u32>(child_h, dst_y) - dst_y);
 
@@ -579,7 +579,7 @@ namespace rsx
 		{
 			const auto offset = child_address - parent_address;
 			const auto src_y = (offset / pitch);
-			const auto src_x = (offset % pitch) / parent_bpp;
+			const auto src_x = (offset % pitch);
 			const auto dst_x = 0u;
 			const auto dst_y = 0u;
 			const auto w = std::min<u32>(child_w, std::max<u32>(parent_w, src_x) - src_x);


### PR DESCRIPTION
When the bpp values of the two intersecting regions are different the math gets fucked up. Instead, just force a normalized coordinate system like we do in the surface cache already.
Other changes:
- Adds some debug marker objects which are GPU breadcrumbs with some text information to aid debugging. They get printed in-order after a DEVICE_LOST error. By default there are none, but when debugging a stubborn issue they are a life saver.
- Force all helper APIs to use wrapped command buffer objects. This should have been done years ago but I kept kicking the can down the road.

Should fix the remaining crashes with the R&C engine:
Fixes https://github.com/RPCS3/rpcs3/issues/12585