### PR TITLE
Qt: Replace some QApplication::processEvents() and QDialog::exec()

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -72,7 +72,7 @@ struct EmuCallbacks
 	std::function<void()> on_resume;
 	std::function<void()> on_stop;
 	std::function<void()> on_ready;
-	std::function<bool()> on_missing_fw;
+	std::function<void()> on_missing_fw;
 	std::function<void(std::shared_ptr<atomic_t<bool>>, int)> on_emulation_stop_no_response;
 	std::function<void(std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, stx::atomic_ptr<std::string>*, std::shared_ptr<void>)> on_save_state_progress;
 	std::function<void(bool enabled)> enable_disc_eject;
@@ -183,7 +183,8 @@ public:
 	static constexpr std::string_view game_id_boot_prefix = "%RPCS3_GAMEID%:";
 	static constexpr std::string_view vfs_boot_prefix = "%RPCS3_VFS%:";
 
-	Emulator() = default;
+	Emulator() noexcept = default;
+	~Emulator() noexcept = default;
 
 	void SetCallbacks(EmuCallbacks&& cb)
 	{
@@ -366,7 +367,7 @@ public:
 
 	bool IsRunning() const { return m_state == system_state::running; }
 	bool IsPaused()  const { return m_state >= system_state::paused; } // ready/starting are also considered paused by this function
-	bool IsStopped() const { return m_state <= system_state::stopping; }
+	bool IsStopped(bool test_fully = false) const { return test_fully ? m_state == system_state::stopped : m_state <= system_state::stopping; }
 	bool IsReady()   const { return m_state == system_state::ready; }
 	bool IsStarting() const { return m_state == system_state::starting; }
 	auto GetStatus(bool fixup = true) const { system_state state = m_state; return fixup && state == system_state::frozen ? system_state::paused : fixup && state == system_state::stopping ? system_state::stopped : state; }

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -155,7 +155,7 @@ void headless_application::InitializeCallbacks()
 	callbacks.enable_disc_eject  = [](bool) {};
 	callbacks.enable_disc_insert = [](bool) {};
 
-	callbacks.on_missing_fw = []() { return false; };
+	callbacks.on_missing_fw = []() {};
 
 	callbacks.handle_taskbar_progress = [](s32, s32) {};
 

--- a/rpcs3/rpcs3qt/about_dialog.cpp
+++ b/rpcs3/rpcs3qt/about_dialog.cpp
@@ -11,6 +11,7 @@
 about_dialog::about_dialog(QWidget* parent) : QDialog(parent), ui(new Ui::about_dialog)
 {
 	ui->setupUi(this);
+	setAttribute(Qt::WA_DeleteOnClose);
 
 	ui->close->setDefault(true);
 	ui->icon->load(QStringLiteral(":/rpcs3.svg"));

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -141,6 +141,7 @@ private:
 	static u32 RemoveContentPathList(const std::vector<std::string>& path_list, const std::string& desc);
 	static bool RemoveContentBySerial(const std::string& base_dir, const std::string& serial, const std::string& desc);
 	static std::vector<std::string> GetDirListBySerial(const std::string& base_dir, const std::string& serial);
+	void BatchActionBySerials(progress_dialog* pdlg, const std::set<std::string>& serials, QString progressLabel, std::function<bool(const std::string&)> action, std::function<void(u32, u32)> cancel_log, bool refresh_on_finish, bool can_be_concurrent = false, std::function<bool()> should_wait_cb = {});
 	static std::string GetCacheDirBySerial(const std::string& serial);
 	static std::string GetDataDirBySerial(const std::string& serial);
 	std::string CurrentSelectionPath();

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -577,8 +577,12 @@ void gui_application::InitializeCallbacks()
 
 	callbacks.on_missing_fw = [this]()
 	{
-		if (!m_main_window) return false;
-		return m_main_window->OnMissingFw();
+		if (!m_main_window)
+		{
+			return;
+		}
+
+		m_main_window->OnMissingFw();
 	};
 
 	callbacks.handle_taskbar_progress = [this](s32 type, s32 value)

--- a/rpcs3/rpcs3qt/log_viewer.cpp
+++ b/rpcs3/rpcs3qt/log_viewer.cpp
@@ -187,7 +187,7 @@ void log_viewer::show_context_menu(const QPoint& pos)
 	connect(config, &QAction::triggered, this, [this]()
 	{
 		config_checker* dlg = new config_checker(this, m_full_log, true);
-		dlg->exec();
+		dlg->open();
 	});
 
 	connect(filter, &QAction::triggered, this, [this]()

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -88,7 +88,7 @@ public:
 	~main_window();
 	bool Init(bool with_cli_boot);
 	QIcon GetAppIcon() const;
-	bool OnMissingFw();
+	void OnMissingFw();
 	bool InstallPackages(QStringList file_paths = {}, bool from_boot = false);
 	void InstallPup(QString file_path = "");
 
@@ -123,7 +123,7 @@ private Q_SLOTS:
 	void BootSavestate();
 	void BootRsxCapture(std::string path = "");
 	void DecryptSPRXLibraries();
-	static void show_boot_error(game_boot_result status);
+	void show_boot_error(game_boot_result status);
 
 	void SaveWindowState() const;
 	void SetIconSizeActions(int idx) const;


### PR DESCRIPTION
Both functions are discouraged by Qt for various reasons, it is of course unrealistic to replace them all