### PR TITLE
Qt: don't refresh game grid after emu stop

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1842,7 +1842,7 @@ void main_window::OnEmuStop()
 	ui->confCamerasAct->setEnabled(true);
 
 	// Refresh game list in order to update time played
-	if (m_game_list_frame)
+	if (m_game_list_frame && m_is_list_mode)
 	{
 		m_game_list_frame->Refresh();
 	}


### PR DESCRIPTION
It is not necessary to refresh the game grid after stopping a game.
Fixes some annoyingly flashing grid. (which seems longer than usual on top of that)