### PR TITLE
Qt: Don't refresh mic and midi list in constructor

### DIFF
--- a/rpcs3/rpcs3qt/microphone_creator.cpp
+++ b/rpcs3/rpcs3qt/microphone_creator.cpp
@@ -10,7 +10,6 @@ constexpr auto qstr = QString::fromStdString;
 microphone_creator::microphone_creator()
 {
 	setObjectName("microphone_creator");
-	refresh_list();
 }
 
 // We need to recreate the localized string because the microphone creator is currently only created once.

--- a/rpcs3/rpcs3qt/midi_creator.cpp
+++ b/rpcs3/rpcs3qt/midi_creator.cpp
@@ -10,7 +10,6 @@ LOG_CHANNEL(cfg_log, "CFG");
 
 midi_creator::midi_creator()
 {
-	refresh_list();
 }
 
 // We need to recreate the localized string because the midi creator is currently only created once.


### PR DESCRIPTION
This is redundant since it's only used in the settings_dialog where it is manually refreshed anyway.

fixes #13884