### PR TITLE
overlays: do not play sounds on fast auto repeat

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
@@ -68,7 +68,7 @@ namespace rsx
 			}
 		}
 
-		void home_menu_dialog::on_button_pressed(pad_button button_press)
+		void home_menu_dialog::on_button_pressed(pad_button button_press, bool is_auto_repeat)
 		{
 			if (fade_animation.active) return;
 
@@ -86,7 +86,7 @@ namespace rsx
 				break;
 			}
 
-			const page_navigation navigation = m_main_menu.handle_button_press(button_press);
+			const page_navigation navigation = m_main_menu.handle_button_press(button_press, is_auto_repeat, m_auto_repeat_ms_interval);
 
 			switch (navigation)
 			{

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.h
@@ -14,7 +14,7 @@ namespace rsx
 			home_menu_dialog();
 
 			void update() override;
-			void on_button_pressed(pad_button button_press) override;
+			void on_button_pressed(pad_button button_press, bool is_auto_repeat) override;
 
 			compiled_resource get_compiled() override;
 

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_page.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_page.cpp
@@ -127,7 +127,7 @@ namespace rsx
 			}
 		}
 
-		page_navigation home_menu_page::handle_button_press(pad_button button_press)
+		page_navigation home_menu_page::handle_button_press(pad_button button_press, bool is_auto_repeat, u64 auto_repeat_interval_ms)
 		{
 			if (m_message_box && m_message_box->visible())
 			{
@@ -142,7 +142,7 @@ namespace rsx
 
 			if (home_menu_page* page = get_current_page(false))
 			{
-				return page->handle_button_press(button_press);
+				return page->handle_button_press(button_press, is_auto_repeat, auto_repeat_interval_ms);
 			}
 
 			switch (button_press)
@@ -237,7 +237,11 @@ namespace rsx
 			}
 			}
 
-			Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/snd_cursor.wav");
+			// Play a sound unless this is a fast auto repeat which would induce a nasty noise
+			if (!is_auto_repeat || auto_repeat_interval_ms >= user_interface::m_auto_repeat_ms_interval_default)
+			{
+				Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/snd_cursor.wav");
+			}
 			return page_navigation::stay;
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_page.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_page.h
@@ -16,7 +16,7 @@ namespace rsx
 
 			void set_current_page(home_menu_page* page);
 			home_menu_page* get_current_page(bool include_this);
-			page_navigation handle_button_press(pad_button button_press);
+			page_navigation handle_button_press(pad_button button_press, bool is_auto_repeat, u64 auto_repeat_interval_ms);
 
 			void translate(s16 _x, s16 _y) override;
 			compiled_resource& get_compiled() override;

--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
@@ -4,6 +4,7 @@
 #include "overlay_media_list_dialog.h"
 
 #include "Emu/Cell/Modules/cellMusic.h"
+#include "Emu/System.h"
 #include "Emu/VFS.h"
 #include "Utilities/StrUtil.h"
 #include "Utilities/Thread.h"
@@ -141,8 +142,10 @@ namespace rsx
 			m_description->back_color.a = 0.f;
 		}
 
-		void media_list_dialog::on_button_pressed(pad_button button_press)
+		void media_list_dialog::on_button_pressed(pad_button button_press, bool is_auto_repeat)
 		{
+			bool play_cursor_sound = true;
+
 			switch (button_press)
 			{
 			case pad_button::cross:
@@ -150,10 +153,14 @@ namespace rsx
 					break;
 				return_code = m_list->get_selected_index();
 				m_stop_input_loop = true;
+				play_cursor_sound = false;
+				Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/snd_decide.wav");
 				break;
 			case pad_button::circle:
 				return_code = selection_code::canceled;
 				m_stop_input_loop = true;
+				play_cursor_sound = false;
+				Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/snd_cancel.wav");
 				break;
 			case pad_button::dpad_up:
 				m_list->select_previous();
@@ -170,6 +177,12 @@ namespace rsx
 			default:
 				rsx_log.trace("[ui] Button %d pressed", static_cast<u8>(button_press));
 				break;
+			}
+
+			// Play a sound unless this is a fast auto repeat which would induce a nasty noise
+			if (play_cursor_sound && (!is_auto_repeat || m_auto_repeat_ms_interval >= m_auto_repeat_ms_interval_default))
+			{
+				Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/snd_cursor.wav");
 			}
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.h
@@ -35,7 +35,7 @@ namespace rsx
 
 			media_list_dialog();
 
-			void on_button_pressed(pad_button button_press) override;
+			void on_button_pressed(pad_button button_press, bool is_auto_repeat) override;
 
 			compiled_resource get_compiled() override;
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -128,7 +128,7 @@ namespace rsx
 			return result;
 		}
 
-		void message_dialog::on_button_pressed(pad_button button_press)
+		void message_dialog::on_button_pressed(pad_button button_press, bool /*is_auto_repeat*/)
 		{
 			if (fade_animation.active) return;
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
@@ -67,7 +67,7 @@ namespace rsx
 			compiled_resource get_compiled() override;
 
 			void update() override;
-			void on_button_pressed(pad_button button_press) override;
+			void on_button_pressed(pad_button button_press, bool is_auto_repeat) override;
 			void close(bool use_callback, bool stop_pad_interception) override;
 
 			error_code show(bool is_blocking, const std::string& text, const MsgDialogType& type, std::function<void(s32 status)> on_close);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -642,7 +642,7 @@ namespace rsx
 			}
 		}
 
-		void osk_dialog::on_button_pressed(pad_button button_press)
+		void osk_dialog::on_button_pressed(pad_button button_press, bool is_auto_repeat)
 		{
 			if (!pad_input_enabled)
 				return;
@@ -886,7 +886,8 @@ namespace rsx
 				break;
 			}
 
-			if (play_cursor_sound)
+			// Play a sound unless this is a fast auto repeat which would induce a nasty noise
+			if (play_cursor_sound && (!is_auto_repeat || m_auto_repeat_ms_interval >= m_auto_repeat_ms_interval_default))
 			{
 				Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/snd_cursor.wav");
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -123,7 +123,7 @@ namespace rsx
 
 			void set_visible(bool visible);
 
-			void on_button_pressed(pad_button button_press) override;
+			void on_button_pressed(pad_button button_press, bool is_auto_repeat) override;
 			void on_key_pressed(u32 led, u32 mkey, u32 key_code, u32 out_key_code, bool pressed, std::u32string key) override;
 			void on_text_changed();
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -121,7 +121,7 @@ namespace rsx
 			}
 		}
 
-		void save_dialog::on_button_pressed(pad_button button_press)
+		void save_dialog::on_button_pressed(pad_button button_press, bool is_auto_repeat)
 		{
 			if (fade_animation.active) return;
 
@@ -170,7 +170,8 @@ namespace rsx
 					close(true, true);
 				};
 			}
-			else
+			// Play a sound unless this is a fast auto repeat which would induce a nasty noise
+			else if (!is_auto_repeat || m_auto_repeat_ms_interval >= m_auto_repeat_ms_interval_default)
 			{
 				Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/snd_cursor.wav");
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.h
@@ -34,7 +34,7 @@ namespace rsx
 			save_dialog();
 
 			void update() override;
-			void on_button_pressed(pad_button button_press) override;
+			void on_button_pressed(pad_button button_press, bool is_auto_repeat) override;
 
 			compiled_resource get_compiled() override;
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.cpp
@@ -96,7 +96,7 @@ namespace rsx
 			}
 		}
 
-		void user_list_dialog::on_button_pressed(pad_button button_press)
+		void user_list_dialog::on_button_pressed(pad_button button_press, bool is_auto_repeat)
 		{
 			if (fade_animation.active) return;
 
@@ -153,7 +153,8 @@ namespace rsx
 					close(true, true);
 				};
 			}
-			else
+			// Play a sound unless this is a fast auto repeat which would induce a nasty noise
+			else if (!is_auto_repeat || m_auto_repeat_ms_interval >= m_auto_repeat_ms_interval_default)
 			{
 				Emu.GetCallbacks().play_sound(fs::get_config_dir() + "sounds/snd_cursor.wav");
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_user_list_dialog.h
@@ -31,7 +31,7 @@ namespace rsx
 			user_list_dialog();
 
 			void update() override;
-			void on_button_pressed(pad_button button_press) override;
+			void on_button_pressed(pad_button button_press, bool is_auto_repeat) override;
 
 			compiled_resource get_compiled() override;
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -94,7 +94,7 @@ namespace rsx
 						timestamp[pad_index] = steady_clock::now();
 						initial_timestamp[pad_index] = timestamp[pad_index];
 						last_auto_repeat_button[pad_index] = is_auto_repeat_button ? button_id : pad_button::pad_button_max_enum;
-						on_button_pressed(static_cast<pad_button>(button_id));
+						on_button_pressed(static_cast<pad_button>(button_id), false);
 					}
 					else if (is_auto_repeat_button)
 					{
@@ -104,7 +104,7 @@ namespace rsx
 						{
 							// The auto-repeat button was pressed for at least the given threshold in ms and will trigger at an interval.
 							timestamp[pad_index] = steady_clock::now();
-							on_button_pressed(static_cast<pad_button>(button_id));
+							on_button_pressed(static_cast<pad_button>(button_id), true);
 						}
 						else if (last_auto_repeat_button[pad_index] == pad_button::pad_button_max_enum)
 						{

--- a/rpcs3/Emu/RSX/Overlays/overlays.h
+++ b/rpcs3/Emu/RSX/Overlays/overlays.h
@@ -91,9 +91,10 @@ namespace rsx
 				interrupted = -4
 			};
 
+			static constexpr u64 m_auto_repeat_ms_interval_default = 200;
+
 		protected:
 			Timer m_input_timer;
-			static constexpr u64 m_auto_repeat_ms_interval_default = 200;
 			u64 m_auto_repeat_ms_interval = m_auto_repeat_ms_interval_default;
 			std::set<u8> m_auto_repeat_buttons = {
 				pad_button::dpad_up,
@@ -156,7 +157,7 @@ namespace rsx
 
 			compiled_resource get_compiled() override = 0;
 
-			virtual void on_button_pressed(pad_button /*button_press*/) {}
+			virtual void on_button_pressed(pad_button /*button_press*/, bool /*is_auto_repeat*/) {}
 			virtual void on_key_pressed(u32 /*led*/, u32 /*mkey*/, u32 /*key_code*/, u32 /*out_key_code*/, bool /*pressed*/, std::u32string /*key*/) {}
 
 			virtual void close(bool use_callback, bool stop_pad_interception);


### PR DESCRIPTION
Currently there's a nasty sound stakkato going on if you keep the dpad pressed to the left in the home menu for example.