### PR TITLE
vk: Add support for VK_EXT_custom_border_color

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -296,7 +296,7 @@ void VKGSRender::load_texture_env()
 				const auto wrap_s = vk::vk_wrap_mode(tex.wrap_s());
 				const auto wrap_t = vk::vk_wrap_mode(tex.wrap_t());
 				const auto wrap_r = vk::vk_wrap_mode(tex.wrap_r());
-				const auto border_color = vk::get_border_color(tex.border_color());
+				const auto border_color = vk::border_color_t(tex.border_color());
 
 				// Check if non-point filtering can even be used on this format
 				bool can_sample_linear;
@@ -427,7 +427,7 @@ void VKGSRender::load_texture_env()
 				const VkBool32 unnormalized_coords = !!(tex.format() & CELL_GCM_TEXTURE_UN);
 				const auto min_lod = tex.min_lod();
 				const auto max_lod = tex.max_lod();
-				const auto border_color = vk::get_border_color(tex.border_color());
+				const auto border_color = vk::border_color_t(tex.border_color());
 
 				if (vs_sampler_handles[i])
 				{

--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -78,17 +78,7 @@ namespace vk
 		}
 		default:
 		{
-			const auto color4 = rsx::decode_border_color(color);
-			if ((color4.r + color4.g + color4.b) > 1.35f)
-			{
-				//If color elements are brighter than roughly 0.5 average, use white border
-				return VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-			}
-
-			if (color4.a > 0.5f)
-				return VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
-
-			return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+			return VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
 		}
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -54,6 +54,7 @@ namespace vk
 			ensure(max_allowed_samplers);
 			rsx_log.warning("Trimming allocated samplers. Allocated = %u, Max = %u", allocated_sampler_count, limits.maxSamplerAllocationCount);
 
+#if 0
 			for (auto It = m_sampler_pool.begin(); It != m_sampler_pool.end();)
 			{
 				if (!It->second->has_refs())
@@ -65,6 +66,7 @@ namespace vk
 
 				++It;
 			}
+#endif
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -54,19 +54,16 @@ namespace vk
 			ensure(max_allowed_samplers);
 			rsx_log.warning("Trimming allocated samplers. Allocated = %u, Max = %u", allocated_sampler_count, limits.maxSamplerAllocationCount);
 
-#if 0
-			for (auto It = m_sampler_pool.begin(); It != m_sampler_pool.end();)
+			auto filter_expr = [](const cached_sampler_object_t& sampler)
 			{
-				if (!It->second->has_refs())
-				{
-					dispose(It->second);
-					It = m_sampler_pool.erase(It);
-					continue;
-				}
+				// Pick only where we have no ref
+				return !sampler.has_refs();
+			};
 
-				++It;
+			for (auto& object : m_sampler_pool.collect(filter_expr))
+			{
+				dispose(object);
 			}
-#endif
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -86,12 +86,8 @@ namespace vk
 	class resource_manager
 	{
 	private:
-		struct cached_sampler_object_t : public vk::sampler, public rsx::ref_counted
-		{
-			using vk::sampler::sampler;
-		};
+		sampler_pool_t m_sampler_pool;
 
-		std::unordered_map<u64, std::unique_ptr<cached_sampler_object_t>> m_sampler_pool;
 		std::deque<eid_scope_t> m_eid_map;
 		shared_mutex m_eid_map_lock;
 
@@ -108,28 +104,6 @@ namespace vk
 			return m_eid_map.back();
 		}
 
-		template<bool _signed = false>
-		u16 encode_fxp(f32 value)
-		{
-			u16 raw = u16(std::abs(value) * 256.);
-
-			if constexpr (!_signed)
-			{
-				return raw;
-			}
-			else
-			{
-				if (value >= 0.f) [[likely]]
-				{
-					return raw;
-				}
-				else
-				{
-					return u16(0 - raw) & 0x1fff;
-				}
-			}
-		}
-
 	public:
 
 		resource_manager() = default;
@@ -144,20 +118,14 @@ namespace vk
 		vk::sampler* get_sampler(const vk::render_device& dev, vk::sampler* previous,
 			VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
 			VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
-			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
+			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, const vk::border_color_t& border_color,
 			VkBool32 depth_compare = VK_FALSE, VkCompareOp depth_compare_mode = VK_COMPARE_OP_NEVER)
 		{
-			u64 key = u16(clamp_u) | u64(clamp_v) << 3 | u64(clamp_w) << 6;
-			key |= u64(unnormalized_coordinates) << 9;            // 1 bit
-			key |= u64(min_filter) << 10 | u64(mag_filter) << 11; // 1 bit each
-			key |= u64(mipmap_mode) << 12;   // 1 bit
-			key |= u64(border_color) << 13;  // 3 bits
-			key |= u64(depth_compare) << 16; // 1 bit
-			key |= u64(depth_compare_mode) << 17;  // 3 bits
-			key |= u64(encode_fxp(min_lod)) << 20; // 12 bits
-			key |= u64(encode_fxp(max_lod)) << 32; // 12 bits
-			key |= u64(encode_fxp<true>(mipLodBias)) << 44; // 13 bits
-			key |= u64(max_anisotropy) << 57;               // 4 bits
+			const auto key = m_sampler_pool.compute_storage_key(
+				clamp_u, clamp_v, clamp_w,
+				unnormalized_coordinates, mipLodBias, max_anisotropy, min_lod, max_lod,
+				min_filter, mag_filter, mipmap_mode, border_color,
+				depth_compare, depth_compare_mode);
 
 			if (previous)
 			{
@@ -166,11 +134,9 @@ namespace vk
 				as_cached_object->release();
 			}
 
-			if (const auto found = m_sampler_pool.find(key);
-				found != m_sampler_pool.end())
+			if (const auto found = m_sampler_pool.find(key))
 			{
-				found->second->add_ref();
-				return found->second.get();
+				return found;
 			}
 
 			auto result = std::make_unique<cached_sampler_object_t>(
@@ -179,9 +145,9 @@ namespace vk
 				min_filter, mag_filter, mipmap_mode, border_color,
 				depth_compare, depth_compare_mode);
 
-			auto It = m_sampler_pool.emplace(key, std::move(result));
-			auto ret = It.first->second.get();
-			ret->add_ref();
+			result->add_ref();
+			auto ret = result.get();
+			m_sampler_pool.emplace(key, result);
 			return ret;
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -136,6 +136,7 @@ namespace vk
 
 			if (const auto found = m_sampler_pool.find(key))
 			{
+				found->add_ref();
 				return found;
 			}
 
@@ -145,9 +146,8 @@ namespace vk
 				min_filter, mag_filter, mipmap_mode, border_color,
 				depth_compare, depth_compare_mode);
 
-			result->add_ref();
-			auto ret = result.get();
-			m_sampler_pool.emplace(key, result);
+			auto ret = m_sampler_pool.emplace(key, result);
+			ret->add_ref();
 			return ret;
 		}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -85,13 +85,15 @@ namespace vk
 			ensure(_vkGetPhysicalDeviceFeatures2KHR); // "vkGetInstanceProcAddress failed to find entry point!"
 			_vkGetPhysicalDeviceFeatures2KHR(dev, &features2);
 
-			shader_types_support.allow_float64   = !!features2.features.shaderFloat64;
-			shader_types_support.allow_float16   = !!shader_support_info.shaderFloat16;
-			shader_types_support.allow_int8      = !!shader_support_info.shaderInt8;
-			optional_features_support.framebuffer_loops   = !!fbo_loops_info.attachmentFeedbackLoopLayout;
-			optional_features_support.barycentric_coords  = !!shader_barycentric_info.fragmentShaderBarycentric;
+			shader_types_support.allow_float64 = !!features2.features.shaderFloat64;
+			shader_types_support.allow_float16 = !!shader_support_info.shaderFloat16;
+			shader_types_support.allow_int8    = !!shader_support_info.shaderInt8;
+
 			optional_features_support.custom_border_color = !!custom_border_color_info.customBorderColors && !!custom_border_color_info.customBorderColorWithoutFormat;
-			features                                     = features2.features;
+			optional_features_support.barycentric_coords  = !!shader_barycentric_info.fragmentShaderBarycentric;
+			optional_features_support.framebuffer_loops   = !!fbo_loops_info.attachmentFeedbackLoopLayout;
+
+			features = features2.features;
 
 			if (descriptor_indexing_support)
 			{

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -100,9 +100,11 @@ namespace vk
 
 		optional_features_support.shader_stencil_export    = device_extensions.is_supported(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
 		optional_features_support.conditional_rendering    = device_extensions.is_supported(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
+		optional_features_support.custom_border_color      = device_extensions.is_supported(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
 		optional_features_support.external_memory_host     = device_extensions.is_supported(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
 		optional_features_support.sampler_mirror_clamped   = device_extensions.is_supported(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
 		optional_features_support.unrestricted_depth_range = device_extensions.is_supported(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
+
 		optional_features_support.debug_utils              = instance_extensions.is_supported(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
 		optional_features_support.surface_capabilities_2   = instance_extensions.is_supported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 	}
@@ -467,6 +469,11 @@ namespace vk
 		if (pgpu->optional_features_support.barycentric_coords)
 		{
 			requested_extensions.push_back(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
+		}
+
+		if (pgpu->optional_features_support.custom_border_color)
+		{
+			requested_extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
 		}
 
 		enabled_features.robustBufferAccess = VK_TRUE;

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -167,6 +167,7 @@ namespace vk
 		bool get_descriptor_indexing_support() const { return pgpu->descriptor_indexing_support; }
 		bool get_framebuffer_loops_support() const { return pgpu->optional_features_support.framebuffer_loops; }
 		bool get_barycoords_support() const { return pgpu->optional_features_support.barycentric_coords; }
+		bool get_custom_border_color_support() const { pgpu->optional_features_support.custom_border_color; }
 
 		u64 get_descriptor_update_after_bind_support() const { return pgpu->descriptor_indexing_support.update_after_bind_mask; }
 		u32 get_descriptor_max_draw_calls() const { return pgpu->descriptor_max_draw_calls; }

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -167,7 +167,7 @@ namespace vk
 		bool get_descriptor_indexing_support() const { return pgpu->descriptor_indexing_support; }
 		bool get_framebuffer_loops_support() const { return pgpu->optional_features_support.framebuffer_loops; }
 		bool get_barycoords_support() const { return pgpu->optional_features_support.barycentric_coords; }
-		bool get_custom_border_color_support() const { pgpu->optional_features_support.custom_border_color; }
+		bool get_custom_border_color_support() const { return pgpu->optional_features_support.custom_border_color; }
 
 		u64 get_descriptor_update_after_bind_support() const { return pgpu->descriptor_indexing_support.update_after_bind_mask; }
 		u32 get_descriptor_max_draw_calls() const { return pgpu->descriptor_max_draw_calls; }

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -41,6 +41,17 @@ namespace vk
 		PFN_vkGetMemoryHostPointerPropertiesEXT _vkGetMemoryHostPointerPropertiesEXT;
 	};
 
+	struct descriptor_indexing_features
+	{
+		bool supported = false;
+		u64 update_after_bind_mask = 0;
+
+		descriptor_indexing_features(bool supported = false)
+			: supported(supported) {}
+
+		operator bool() { return supported; }
+	};
+
 	class physical_device
 	{
 		VkInstance parent = VK_NULL_HANDLE;
@@ -54,19 +65,22 @@ namespace vk
 		gpu_shader_types_support shader_types_support{};
 		VkPhysicalDeviceDriverPropertiesKHR driver_properties{};
 
-		bool stencil_export_support : 1 = false;
-		bool conditional_render_support : 1 = false;
-		bool external_memory_host_support : 1 = false;
-		bool unrestricted_depth_range_support : 1 = false;
-		bool surface_capabilities_2_support : 1 = false;
-		bool debug_utils_support : 1 = false;
-		bool sampler_mirror_clamped_support : 1 = false;
-		bool descriptor_indexing_support : 1 = false;
-		bool framebuffer_loops_support : 1 = false;
-		bool barycoords_support : 1 = false;
-
 		u32 descriptor_max_draw_calls = DESCRIPTOR_MAX_DRAW_CALLS;
-		u64 descriptor_update_after_bind_mask = 0;
+		descriptor_indexing_features descriptor_indexing_support{};
+
+		struct
+		{
+			bool barycentric_coords = false;
+			bool conditional_rendering = false;
+			bool custom_border_color = false;
+			bool debug_utils = false;
+			bool external_memory_host = false;
+			bool framebuffer_loops = false;
+			bool sampler_mirror_clamped = false;
+			bool shader_stencil_export = false;
+			bool surface_capabilities_2 = false;
+			bool unrestricted_depth_range = false;
+		} optional_features_support;
 
 		friend class render_device;
 	private:
@@ -140,21 +154,21 @@ namespace vk
 		const pipeline_binding_table& get_pipeline_binding_table() const { return m_pipeline_binding_table; }
 		const gpu_shader_types_support& get_shader_types_support() const { return pgpu->shader_types_support; }
 
-		bool get_shader_stencil_export_support() const { return pgpu->stencil_export_support; }
+		bool get_shader_stencil_export_support() const { return pgpu->optional_features_support.shader_stencil_export; }
 		bool get_depth_bounds_support() const { return pgpu->features.depthBounds != VK_FALSE; }
 		bool get_alpha_to_one_support() const { return pgpu->features.alphaToOne != VK_FALSE; }
 		bool get_anisotropic_filtering_support() const { return pgpu->features.samplerAnisotropy != VK_FALSE; }
 		bool get_wide_lines_support() const { return pgpu->features.wideLines != VK_FALSE; }
-		bool get_conditional_render_support() const { return pgpu->conditional_render_support; }
-		bool get_unrestricted_depth_range_support() const { return pgpu->unrestricted_depth_range_support; }
-		bool get_external_memory_host_support() const { return pgpu->external_memory_host_support; }
-		bool get_surface_capabilities_2_support() const { return pgpu->surface_capabilities_2_support; }
-		bool get_debug_utils_support() const { return g_cfg.video.renderdoc_compatiblity && pgpu->debug_utils_support; }
+		bool get_conditional_render_support() const { return pgpu->optional_features_support.conditional_rendering; }
+		bool get_unrestricted_depth_range_support() const { return pgpu->optional_features_support.unrestricted_depth_range; }
+		bool get_external_memory_host_support() const { return pgpu->optional_features_support.external_memory_host; }
+		bool get_surface_capabilities_2_support() const { return pgpu->optional_features_support.surface_capabilities_2; }
+		bool get_debug_utils_support() const { return g_cfg.video.renderdoc_compatiblity && pgpu->optional_features_support.debug_utils; }
 		bool get_descriptor_indexing_support() const { return pgpu->descriptor_indexing_support; }
-		bool get_framebuffer_loops_support() const { return pgpu->framebuffer_loops_support; }
-		bool get_barycoords_support() const { return pgpu->barycoords_support; }
+		bool get_framebuffer_loops_support() const { return pgpu->optional_features_support.framebuffer_loops; }
+		bool get_barycoords_support() const { return pgpu->optional_features_support.barycentric_coords; }
 
-		u64 get_descriptor_update_after_bind_support() const { return pgpu->descriptor_update_after_bind_mask; }
+		u64 get_descriptor_update_after_bind_support() const { return pgpu->descriptor_indexing_support.update_after_bind_mask; }
 		u32 get_descriptor_max_draw_calls() const { return pgpu->descriptor_max_draw_calls; }
 
 		VkQueue get_present_queue() const { return m_present_queue; }

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
@@ -186,4 +186,29 @@ namespace vk
 
 		m_custom_color_sampler_pool.emplace (key.base_key, std::move(object));
 	}
+
+	std::vector<std::unique_ptr<cached_sampler_object_t>> sampler_pool_t::collect(std::function<bool(const cached_sampler_object_t&)> predicate)
+	{
+		std::vector<std::unique_ptr<cached_sampler_object_t>> result;
+
+		const auto collect_fn = [&](auto& container)
+		{
+			for (auto It = container.begin(); It != container.end();)
+			{
+				if (!predicate(*It->second))
+				{
+					It++;
+					continue;
+				}
+
+				result.emplace_back(std::move(It->second));
+				It = container.erase(It);
+			}
+		};
+
+		collect_fn(m_generic_sampler_pool);
+		collect_fn(m_custom_color_sampler_pool);
+
+		return result;
+	}
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
@@ -163,11 +163,11 @@ namespace vk
 		}
 
 		const auto block = m_custom_color_sampler_pool.equal_range(key.base_key);
-		for (auto It = block.first; It != block.second; ++It)
+		for (auto it = block.first; it != block.second; ++it)
 		{
-			if (It->second->key.border_color_key == key.border_color_key)
+			if (it->second->key.border_color_key == key.border_color_key)
 			{
-				return It->second.get();
+				return it->second.get();
 			}
 		}
 
@@ -194,16 +194,16 @@ namespace vk
 
 		const auto collect_fn = [&](auto& container)
 		{
-			for (auto It = container.begin(); It != container.end();)
+			for (auto it = container.begin(); it != container.end();)
 			{
-				if (!predicate(*It->second))
+				if (!predicate(*it->second))
 				{
-					It++;
+					it++;
 					continue;
 				}
 
-				result.emplace_back(std::move(It->second));
-				It = container.erase(It);
+				result.emplace_back(std::move(it->second));
+				it = container.erase(it);
 			}
 		};
 

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.cpp
@@ -4,9 +4,42 @@
 
 namespace vk
 {
+	extern VkBorderColor get_border_color(u32);
+
+	static VkBorderColor get_closest_border_color_enum(const color4f& color4)
+	{
+		if ((color4.r + color4.g + color4.b) > 1.35f)
+		{
+			//If color elements are brighter than roughly 0.5 average, use white border
+			return VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+		}
+
+		if (color4.a > 0.5f)
+			return VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+
+		return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+	}
+
+	border_color_t::border_color_t(u32 encoded_color)
+	{
+		value = vk::get_border_color(encoded_color);
+
+		if (value != VK_BORDER_COLOR_FLOAT_CUSTOM_EXT)
+		{
+			// Nothing to do
+			return;
+		}
+
+		color_value = rsx::decode_border_color(encoded_color);
+		if (!g_render_device->get_custom_border_color_support())
+		{
+			value = get_closest_border_color_enum(color_value);
+		}
+	}
+
 	sampler::sampler(const vk::render_device& dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
 		VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
-		VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
+		VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, const vk::border_color_t& border_color,
 		VkBool32 depth_compare, VkCompareOp depth_compare_mode)
 		: m_device(dev)
 	{
@@ -25,7 +58,20 @@ namespace vk
 		info.minFilter = min_filter;
 		info.mipmapMode = mipmap_mode;
 		info.compareOp = depth_compare_mode;
-		info.borderColor = border_color;
+		info.borderColor = border_color.value;
+
+		VkSamplerCustomBorderColorCreateInfoEXT custom_color_info;
+		if (border_color.value == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT)
+		{
+			custom_color_info =
+			{
+				.sType = VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT,
+				.format = VK_FORMAT_UNDEFINED
+			};
+
+			std::memcpy(custom_color_info.customBorderColor.float32, border_color.color_value.rgba, sizeof(float) * 4);
+			info.pNext = &custom_color_info;
+		}
 
 		CHECK_RESULT(vkCreateSampler(m_device, &info, nullptr, &value));
 		vmm_notify_object_allocated(VMM_ALLOCATION_POOL_SAMPLER);
@@ -39,7 +85,7 @@ namespace vk
 
 	bool sampler::matches(VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
 		VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
-		VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
+		VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, const vk::border_color_t& border_color,
 		VkBool32 depth_compare, VkCompareOp depth_compare_mode)
 	{
 		if (info.magFilter != mag_filter || info.minFilter != min_filter || info.mipmapMode != mipmap_mode ||

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.h
@@ -5,6 +5,29 @@
 
 namespace vk
 {
+	struct border_color_t
+	{
+		VkBorderColor value;
+		color4f color_value;
+
+		border_color_t(u32 encoded_color);
+
+		bool operator == (const border_color_t& that) const
+		{
+			if (this->value != that.value)
+			{
+				return false;
+			}
+
+			if (this->value != VK_BORDER_COLOR_FLOAT_CUSTOM_EXT)
+			{
+				return true;
+			}
+
+			return this->color_value == that.color_value;
+		}
+	};
+
 	struct sampler
 	{
 		VkSampler value;
@@ -12,14 +35,14 @@ namespace vk
 
 		sampler(const vk::render_device& dev, VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
 			VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
-			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
+			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, const border_color_t& border_color,
 			VkBool32 depth_compare = false, VkCompareOp depth_compare_mode = VK_COMPARE_OP_NEVER);
 
 		~sampler();
 
 		bool matches(VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
 			VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
-			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, VkBorderColor border_color,
+			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, const border_color_t& border_color,
 			VkBool32 depth_compare = false, VkCompareOp depth_compare_mode = VK_COMPARE_OP_NEVER);
 
 		sampler(const sampler&) = delete;

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.h
@@ -80,9 +80,9 @@ namespace vk
 
 		void clear();
 
-		vk::sampler* find(const sampler_pool_key_t& key) const;
+		cached_sampler_object_t* find(const sampler_pool_key_t& key) const;
 
-		void emplace(const sampler_pool_key_t& key, std::unique_ptr<cached_sampler_object_t>& object);
+		cached_sampler_object_t* emplace(const sampler_pool_key_t& key, std::unique_ptr<cached_sampler_object_t>& object);
 
 		std::vector<std::unique_ptr<cached_sampler_object_t>> collect(std::function<bool(const cached_sampler_object_t&)> predicate);
 	};

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.h
@@ -83,5 +83,7 @@ namespace vk
 		vk::sampler* find(const sampler_pool_key_t& key) const;
 
 		void emplace(const sampler_pool_key_t& key, std::unique_ptr<cached_sampler_object_t>& object);
+
+		std::vector<std::unique_ptr<cached_sampler_object_t>> collect(std::function<bool(const cached_sampler_object_t&)> predicate);
 	};
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/sampler.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sampler.h
@@ -7,6 +7,7 @@ namespace vk
 {
 	struct border_color_t
 	{
+		u32 storage_key;
 		VkBorderColor value;
 		color4f color_value;
 
@@ -49,5 +50,38 @@ namespace vk
 		sampler(sampler&&) = delete;
 	private:
 		VkDevice m_device;
+	};
+
+	// Caching helpers
+	struct sampler_pool_key_t
+	{
+		u64 base_key;
+		u32 border_color_key;
+	};
+
+	struct cached_sampler_object_t : public vk::sampler, public rsx::ref_counted
+	{
+		sampler_pool_key_t key;
+		using vk::sampler::sampler;
+	};
+
+	class sampler_pool_t
+	{
+		std::unordered_map<u64, std::unique_ptr<cached_sampler_object_t>> m_generic_sampler_pool;
+		std::unordered_map<u64, std::unique_ptr<cached_sampler_object_t>> m_custom_color_sampler_pool;
+
+	public:
+
+		sampler_pool_key_t compute_storage_key(
+			VkSamplerAddressMode clamp_u, VkSamplerAddressMode clamp_v, VkSamplerAddressMode clamp_w,
+			VkBool32 unnormalized_coordinates, float mipLodBias, float max_anisotropy, float min_lod, float max_lod,
+			VkFilter min_filter, VkFilter mag_filter, VkSamplerMipmapMode mipmap_mode, const vk::border_color_t& border_color,
+			VkBool32 depth_compare, VkCompareOp depth_compare_mode);
+
+		void clear();
+
+		vk::sampler* find(const sampler_pool_key_t& key) const;
+
+		void emplace(const sampler_pool_key_t& key, std::unique_ptr<cached_sampler_object_t>& object);
 	};
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
@@ -286,7 +286,7 @@ namespace vk
 		vk::gpu_debug_marker::insert(
 			*m_device,
 			*m_cb,
-			fmt::format("0x%x: Enter %s", m_tag, m_message)
+			fmt::format("0x%llx: Enter %s", m_tag, m_message)
 		);
 	}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -135,7 +135,7 @@ namespace vk
 		const vk::render_device* m_device;
 		const vk::command_buffer* m_cb;
 		std::string m_message;
-		u32 m_tag;
+		u64 m_tag;
 
 	public:
 		debug_marker_scope(const vk::command_buffer& cmd, const std::string& text);

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -914,4 +914,26 @@ namespace rsx
 
 		return base * scale;
 	}
+
+	template<bool _signed = false>
+	u16 encode_fx12(f32 value)
+	{
+		u16 raw = u16(std::abs(value) * 256.);
+
+		if constexpr (!_signed)
+		{
+			return raw;
+		}
+		else
+		{
+			if (value >= 0.f) [[likely]]
+			{
+				return raw;
+			}
+			else
+			{
+				return u16(0 - raw) & 0x1fff;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Turns out some games are really using some unusual border colors (e.g transparent white)
Previous fallback will still exist in case of GPUs without support for this.
Also includes a refactor of how we handle optional features, so that a migration up is easier if we decide to raise our base vulkan version to 1.1 or higher.

Fixes https://github.com/RPCS3/rpcs3/issues/12451