### PR TITLE
Update MVK to 1.2.4 for Vulkan SDK 1.3.250

### DIFF
--- a/3rdparty/MoltenVK/CMakeLists.txt
+++ b/3rdparty/MoltenVK/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(moltenvk
 	GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-	GIT_TAG db8512a
+	GIT_TAG 4c6bfbe
 	BUILD_IN_SOURCE 1
 	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK
 	CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK/fetchDependencies" --macos

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -4,7 +4,7 @@
 #include "Emu/system_config.h"
 
 #ifdef __APPLE__
-#include <MoltenVK/vk_mvk_moltenvk.h>
+#include <MoltenVK/mvk_config.h>
 #endif
 
 namespace vk


### PR DESCRIPTION
[Release notes](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.4): 

- Add support for extensions:
    - VK_KHR_map_memory2
- Deprecate the obsolete and non-standard VK_MVK_moltenvk extension.
    - Add mvk_config.h, mvk_private_api.h, and mvk_deprecated_api.h, and deprecate vk_mvk_moltenvk.h.
- Support BC compression on iOS/tvOS where available (iOS/tvOS 16.4 and above and supported by the GPU).
- Support separate depth and stencil attachments during dynamic rendering.
- Fix memory leak when waiting on timeline semaphores.
- Fix race condition when updating values in VkPastPresentationTimingGOOGLE, and ensure swapchain image presented time is always populated when requested.
- Report error, but do not fail on request for timestamp query pool that is too large for MTLCounterSampleBuffer, and fall back to emulation via CPU timestamps.
- Ensure shaders that use PhysicalStorageBufferAddresses encode the use of the associated MTLBuffer.
- Disable pipeline cache compression prior to macOS 10.15 and iOS/tvOS 13.0.
- Accumulate render stages when a resource is used by multiple descriptor bindings.
- Respect the bind point supplied to vkCmdBindDescriptorSets() / vkCmdPushDescriptorSets().
- Check if shader compiled before adding it to a pipeline, to avoid Metal validation error.
- Identify each unsupported device feature flag that the app attempts to enable.
- Populate deviceUUID from MTLDevice location and peer group info, which should be unique, and constant across OS reboots.
- Populate deviceLUID from MTLDevice.registryID.
- Avoid Metal validation warning when depth component swizzled away.
- Fix depth clamp and texture swizzle feature discovery on simulator builds.
- Advertise VK_KHR_depth_stencil_resolve extension on all devices.
- For correctness, set VkPhysicalDeviceLimits::lineWidthGranularity to 1.
- Improve GitHub CI production of binary artifacts on submission and release.
- Update dependency libraries to match Vulkan SDK 1.3.250.
- Update to latest SPIRV-Cross:
    - MSL: Fix for argument buffer index compare when invalid.
    - MSL: Fix dref lod workaround on combined texture/samplers.
    - MSL: Do not override variable name with v_ identifier.
    - MSL: Use name_id consistently in argument declaration.
    - MSL: Don't hit array copy path for pointer to array.
    - MSL: Use templated array type when emitting BDA to arrays.
