### PR TITLE
Take advantage of WIN10 Thread Name API

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -15,6 +15,11 @@
 #include <Psapi.h>
 #include <process.h>
 #include <sysinfoapi.h>
+
+#include "util/dyn_lib.hpp"
+
+DYNAMIC_IMPORT_RENAME("Kernel32.dll", SetThreadDescriptionImport, "SetThreadDescription", HRESULT(HANDLE hThread, PCWSTR lpThreadDescription));
+
 #else
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -2074,6 +2079,13 @@ void thread_base::initialize(void (*error_cb)())
 
 void thread_base::set_name(std::string name)
 {
+#ifdef _WIN32
+	if (SetThreadDescriptionImport)
+	{
+		SetThreadDescriptionImport(GetCurrentThread(), utf8_to_wchar(name).c_str());
+	}
+#endif
+
 #ifdef _MSC_VER
 	struct THREADNAME_INFO
 	{

--- a/rpcs3/util/dyn_lib.hpp
+++ b/rpcs3/util/dyn_lib.hpp
@@ -110,3 +110,4 @@ namespace utils
 }
 
 #define DYNAMIC_IMPORT(lib, name, ...) inline constinit utils::dynamic_import<__VA_ARGS__> name(lib, #name);
+#define DYNAMIC_IMPORT_RENAME(lib, declare_name, lib_func_name, ...) inline constinit utils::dynamic_import<__VA_ARGS__> declare_name(lib, lib_func_name);


### PR DESCRIPTION
This allows to view thread name on visual studio on manual attachment without the need to be attached on boot.