### PR TITLE
overlays: fix media list dialog pad interception

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_media_list_dialog.cpp
@@ -262,6 +262,7 @@ namespace rsx
 				break;
 			}
 
+			m_interactive = false; // KLUDGE: Set interactive to false in order to stop pad interaction properly in close.
 			close(false, true);
 
 			if (return_code >= 0 && m_media && m_media->type != media_list_dialog::media_type::directory)


### PR DESCRIPTION
Fixes disabling pad interception when closing the media list dialog.
This is just a band-aid until the whole input loop refactoring is finished.

fixes #13463