### PR TITLE
Trophies: Add more sanity checks to pugixml backend

### DIFF
--- a/Utilities/rXml.cpp
+++ b/Utilities/rXml.cpp
@@ -5,54 +5,81 @@ rXmlNode::rXmlNode()
 {
 }
 
-rXmlNode::rXmlNode(const pugi::xml_node &node)
+rXmlNode::rXmlNode(const pugi::xml_node& node)
 {
 	handle = node;
 }
 
 std::shared_ptr<rXmlNode> rXmlNode::GetChildren()
 {
-	// it.begin() returns node_iterator*, *it.begin() return node*.
-	pugi::xml_object_range<pugi::xml_node_iterator> it = handle.children();
-	pugi::xml_node begin = *it.begin();
+	if (handle)
+	{
+		if (const pugi::xml_node child = handle.first_child())
+		{
+			return std::make_shared<rXmlNode>(child);
+		}
+	}
 
-	if (begin)
-	{
-		return std::make_shared<rXmlNode>(begin);
-	}
-	else
-	{
-		return nullptr;
-	}
+	return nullptr;
 }
 
 std::shared_ptr<rXmlNode> rXmlNode::GetNext()
 {
-	pugi::xml_node result = handle.next_sibling();
-	if (result)
+	if (handle)
 	{
-		return std::make_shared<rXmlNode>(result);
+		if (const pugi::xml_node result = handle.next_sibling())
+		{
+			return std::make_shared<rXmlNode>(result);
+		}
 	}
-	else
-	{
-		return nullptr;
-	}
+
+	return nullptr;
 }
 
 std::string rXmlNode::GetName()
 {
-	return handle.name();
+	if (handle)
+	{
+		if (const pugi::char_t* name = handle.name())
+		{
+			return name;
+		}
+	}
+
+	return {};
 }
 
-std::string rXmlNode::GetAttribute(const std::string &name)
+std::string rXmlNode::GetAttribute(const std::string& name)
 {
-	auto pred = [&name](pugi::xml_attribute attr) { return (name == attr.name()); };
-	return handle.find_attribute(pred).value();
+	if (handle)
+	{
+		const auto pred = [&name](const pugi::xml_attribute& attr) { return (name == attr.name()); };
+		if (const pugi::xml_attribute attr = handle.find_attribute(pred))
+		{
+			if (const pugi::char_t* value = attr.value())
+			{
+				return value;
+			}
+		}
+	}
+
+	return {};
 }
 
 std::string rXmlNode::GetNodeContent()
 {
-	return handle.text().get();
+	if (handle)
+	{
+		if (const pugi::xml_text text = handle.text())
+		{
+			if (const pugi::char_t* value = text.get())
+			{
+				return value;
+			}
+		}
+	}
+
+	return {};
 }
 
 rXmlDocument::rXmlDocument()
@@ -61,10 +88,20 @@ rXmlDocument::rXmlDocument()
 
 pugi::xml_parse_result rXmlDocument::Read(const std::string& data)
 {
-	return handle.load_buffer(data.data(), data.size());
+	if (handle)
+	{
+		return handle.load_buffer(data.data(), data.size());
+	}
+
+	return {};
 }
 
 std::shared_ptr<rXmlNode> rXmlDocument::GetRoot()
 {
-	return std::make_shared<rXmlNode>(handle.root());
+	if (const pugi::xml_node root = handle.root())
+	{
+		return std::make_shared<rXmlNode>(root);
+	}
+
+	return nullptr;
 }

--- a/Utilities/rXml.h
+++ b/Utilities/rXml.h
@@ -19,11 +19,11 @@
 struct rXmlNode
 {
 	rXmlNode();
-	rXmlNode(const pugi::xml_node &);
+	rXmlNode(const pugi::xml_node& node);
 	std::shared_ptr<rXmlNode> GetChildren();
 	std::shared_ptr<rXmlNode> GetNext();
 	std::string GetName();
-	std::string GetAttribute(const std::string &name);
+	std::string GetAttribute(const std::string& name);
 	std::string GetNodeContent();
 
 	pugi::xml_node handle{};

--- a/rpcs3/Loader/TROPUSR.cpp
+++ b/rpcs3/Loader/TROPUSR.cpp
@@ -12,7 +12,10 @@ enum : u32
 std::shared_ptr<rXmlNode> trophy_xml_document::GetRoot()
 {
 	auto trophy_base = rXmlDocument::GetRoot();
-	ensure(trophy_base);
+	if (!trophy_base)
+	{
+		return nullptr;
+	}
 
 	if (auto trophy_conf = trophy_base->GetChildren();
 		trophy_conf && trophy_conf->GetName() == "trophyconf")
@@ -178,7 +181,11 @@ bool TROPUSRLoader::Generate(const std::string& filepath, const std::string& con
 	m_table6.clear();
 
 	auto trophy_base = doc.GetRoot();
-	ensure(trophy_base);
+	if (!trophy_base)
+	{
+		trp_log.error("TROPUSRLoader::Generate: Failed to read file (root is null): %s", filepath);
+		return false;
+	}
 
 	for (std::shared_ptr<rXmlNode> n = trophy_base->GetChildren(); n; n = n->GetNext())
 	{
@@ -276,7 +283,11 @@ u32 TROPUSRLoader::GetUnlockedPlatinumID(u32 trophy_id, const std::string& confi
 	}
 
 	auto trophy_base = doc.GetRoot();
-	ensure(trophy_base);
+	if (!trophy_base)
+	{
+		trp_log.error("TROPUSRLoader::GetUnlockedPlatinumID: Failed to read file (root is null): %s", config_path);
+		return false;
+	}
 
 	const usz trophy_count = m_table4.size();
 

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -968,6 +968,7 @@ void trophy_manager_dialog::PopulateGameTable()
 	m_game_table->setRowCount(static_cast<int>(m_trophies_db.size()));
 
 	m_game_combo->clear();
+	m_game_combo->blockSignals(true);
 
 	qRegisterMetaType<QVector<int>>("QVector<int>");
 	QList<int> indices;
@@ -999,6 +1000,8 @@ void trophy_manager_dialog::PopulateGameTable()
 	}
 
 	m_game_combo->model()->sort(0, Qt::AscendingOrder);
+	m_game_combo->blockSignals(false);
+	m_game_combo->setCurrentIndex(0);
 
 	m_game_table->setSortingEnabled(true); // Enable sorting only after using setItem calls
 


### PR DESCRIPTION
Turns out we never cared to check whether pugixml returns valid objects.
This led to the possibility of assersions in the pugixml backend when calling functions on invalid root nodes.

Let's just log errors and skip the trophy enumerations instead in these cases.

Also fixes the random selection of a game when opening the trophy manager.