### PR TITLE
vk: Rewrite descriptor allocations

### DIFF
--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -5,10 +5,7 @@
 
 namespace rsx
 {
-	template <typename Ty>
-	concept is_simple_pod_v = (std::is_trivially_constructible_v<Ty>) && (std::is_trivially_destructible_v <Ty>);
-
-	template <typename Ty> requires is_simple_pod_v<Ty>
+	template <typename Ty> requires std::is_trivially_destructible_v<Ty>
 	struct simple_array
 	{
 	public:

--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -6,6 +6,9 @@
 namespace rsx
 {
 	template <typename Ty>
+	concept is_simple_pod_v = (std::is_trivially_constructible_v<Ty>) && (std::is_trivially_destructible_v <Ty>);
+
+	template <typename Ty> requires is_simple_pod_v<Ty>
 	struct simple_array
 	{
 	public:

--- a/rpcs3/Emu/RSX/VK/VKCompute.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCompute.cpp
@@ -16,13 +16,13 @@ namespace vk
 
 	void compute_task::init_descriptors()
 	{
-		std::vector<VkDescriptorPoolSize> descriptor_pool_sizes;
-		std::vector<VkDescriptorSetLayoutBinding> bindings;
+		rsx::simple_array<VkDescriptorPoolSize> descriptor_pool_sizes;
+		rsx::simple_array<VkDescriptorSetLayoutBinding> bindings;
 
 		const auto layout = get_descriptor_layout();
 		for (const auto &e : layout)
 		{
-			descriptor_pool_sizes.push_back({e.first, u32(VK_MAX_COMPUTE_TASKS * e.second)});
+			descriptor_pool_sizes.push_back({e.first, e.second});
 
 			for (unsigned n = 0; n < e.second; ++n)
 			{
@@ -38,7 +38,7 @@ namespace vk
 		}
 
 		// Reserve descriptor pools
-		m_descriptor_pool.create(*g_render_device, descriptor_pool_sizes.data(), ::size32(descriptor_pool_sizes), VK_MAX_COMPUTE_TASKS, 3);
+		m_descriptor_pool.create(*g_render_device, descriptor_pool_sizes);
 		m_descriptor_layout = vk::descriptors::create_layout(bindings);
 
 		VkPipelineLayoutCreateInfo layout_info = {};
@@ -146,7 +146,7 @@ namespace vk
 
 		ensure(m_used_descriptors < VK_MAX_COMPUTE_TASKS);
 
-		m_descriptor_set = m_descriptor_pool.allocate(m_descriptor_layout, VK_TRUE, m_used_descriptors++);
+		m_descriptor_set = m_descriptor_pool.allocate(m_descriptor_layout, VK_TRUE);
 
 		bind_resources();
 

--- a/rpcs3/Emu/RSX/VK/VKCompute.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCompute.cpp
@@ -119,15 +119,6 @@ namespace vk
 		}
 	}
 
-	void compute_task::free_resources()
-	{
-		if (m_used_descriptors == 0)
-			return;
-
-		m_descriptor_pool.reset(0);
-		m_used_descriptors = 0;
-	}
-
 	void compute_task::load_program(const vk::command_buffer& cmd)
 	{
 		if (!m_program)
@@ -155,14 +146,7 @@ namespace vk
 
 		ensure(m_used_descriptors < VK_MAX_COMPUTE_TASKS);
 
-		VkDescriptorSetAllocateInfo alloc_info = {};
-		alloc_info.descriptorPool = m_descriptor_pool;
-		alloc_info.descriptorSetCount = 1;
-		alloc_info.pSetLayouts = &m_descriptor_layout;
-		alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-
-		CHECK_RESULT(vkAllocateDescriptorSets(*g_render_device, &alloc_info, m_descriptor_set.ptr()));
-		m_used_descriptors++;
+		m_descriptor_set = m_descriptor_pool.allocate(m_descriptor_layout, VK_TRUE, m_used_descriptors++);
 
 		bind_resources();
 

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -44,8 +44,6 @@ namespace vk
 		void create();
 		void destroy();
 
-		void free_resources();
-
 		virtual void bind_resources() {}
 		virtual void declare_inputs() {}
 

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -993,7 +993,6 @@ void VKGSRender::end()
 	}
 
 	// Allocate descriptor set
-	check_descriptors();
 	m_current_frame->descriptor_set = allocate_descriptor_set();
 
 	// Load program execution environment

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -966,11 +966,6 @@ void VKGSRender::end()
 			m_aux_frame_context.grab_resources(*m_current_frame);
 			m_current_frame = &m_aux_frame_context;
 		}
-		else if (m_current_frame->used_descriptors)
-		{
-			m_current_frame->descriptor_pool.reset(0);
-			m_current_frame->used_descriptors = 0;
-		}
 
 		ensure(!m_current_frame->swap_command_buffer);
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1322,13 +1322,10 @@ void VKGSRender::check_descriptors()
 {
 	// Ease resource pressure if the number of draw calls becomes too high or we are running low on memory resources
 	const auto required_descriptors = rsx::method_registers.current_draw_clause.pass_count();
-	if (!m_current_frame->descriptor_pool.can_allocate(required_descriptors, m_current_frame->used_descriptors))
+	if (!m_current_frame->descriptor_pool.can_allocate(required_descriptors, 0))
 	{
 		// Should hard sync before resetting descriptors for spec compliance
 		flush_command_queue(true);
-
-		m_current_frame->descriptor_pool.reset(0);
-		m_current_frame->used_descriptors = 0;
 	}
 }
 
@@ -1336,7 +1333,7 @@ VkDescriptorSet VKGSRender::allocate_descriptor_set()
 {
 	if (!m_shader_interpreter.is_interpreter(m_program)) [[likely]]
 	{
-		return m_current_frame->descriptor_pool.allocate(descriptor_layouts, VK_TRUE, m_current_frame->used_descriptors++);
+		return m_current_frame->descriptor_pool.allocate(descriptor_layouts, VK_TRUE, 0);
 	}
 	else
 	{

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -936,8 +936,6 @@ VKGSRender::~VKGSRender()
 		ctx.buffer_views_to_clean.clear();
 	}
 
-	m_descriptor_pool.destroy();
-
 	// Textures
 	m_rtts.destroy();
 	m_texture_cache.destroy();
@@ -964,6 +962,9 @@ VKGSRender::~VKGSRender()
 
 	// Global resources
 	vk::destroy_global_resources();
+
+	// Destroy at the end in case of lingering callbacks
+	m_descriptor_pool.destroy();
 
 	// Device handles/contexts
 	m_swapchain->destroy();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -406,6 +406,7 @@ namespace
 			bindings[idx].descriptorCount = 1;
 			bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 			bindings[idx].binding = binding_table.vertex_buffers_first_bind_slot + i;
+			bindings[idx].pImmutableSamplers = nullptr;
 			idx++;
 		}
 
@@ -413,6 +414,7 @@ namespace
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.fragment_constant_buffers_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -420,6 +422,7 @@ namespace
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.fragment_state_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -427,6 +430,7 @@ namespace
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.fragment_texture_params_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -434,6 +438,7 @@ namespace
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 		bindings[idx].binding = binding_table.vertex_constant_buffers_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -441,6 +446,7 @@ namespace
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS;
 		bindings[idx].binding = binding_table.vertex_params_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -448,6 +454,7 @@ namespace
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 		bindings[idx].binding = binding_table.conditional_render_predicate_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -455,6 +462,7 @@ namespace
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.rasterizer_env_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -466,6 +474,7 @@ namespace
 			bindings[idx].descriptorCount = 1;
 			bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 			bindings[idx].binding = binding;
+			bindings[idx].pImmutableSamplers = nullptr;
 			idx++;
 		}
 
@@ -475,6 +484,7 @@ namespace
 			bindings[idx].descriptorCount = 1;
 			bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 			bindings[idx].binding = binding_table.vertex_textures_first_bind_slot + i;
+			bindings[idx].pImmutableSamplers = nullptr;
 			idx++;
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -120,8 +120,9 @@ private:
 	volatile vk::host_data_t* m_host_data_ptr = nullptr;
 	std::unique_ptr<vk::buffer> m_host_object_data;
 
-	VkDescriptorSetLayout descriptor_layouts;
-	VkPipelineLayout pipeline_layout;
+	vk::descriptor_pool m_descriptor_pool;
+	VkDescriptorSetLayout m_descriptor_layouts;
+	VkPipelineLayout m_pipeline_layout;
 
 	vk::framebuffer_holder* m_draw_fbo = nullptr;
 
@@ -229,7 +230,6 @@ private:
 	void check_heap_status(u32 flags = VK_HEAP_CHECK_ALL);
 	void check_present_status();
 
-	void check_descriptors();
 	VkDescriptorSet allocate_descriptor_set();
 
 	vk::vertex_upload_info upload_vertex_data();

--- a/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
@@ -177,7 +177,6 @@ namespace vk
 
 		vk::descriptor_set descriptor_set;
 		vk::descriptor_pool descriptor_pool;
-		u32 used_descriptors = 0;
 
 		rsx::flags32_t flags = 0;
 

--- a/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
@@ -176,7 +176,6 @@ namespace vk
 		VkSemaphore present_wait_semaphore = VK_NULL_HANDLE;
 
 		vk::descriptor_set descriptor_set;
-		vk::descriptor_pool descriptor_pool;
 
 		rsx::flags32_t flags = 0;
 
@@ -185,7 +184,7 @@ namespace vk
 		u32 present_image = -1;
 		command_buffer_chunk* swap_command_buffer = nullptr;
 
-		//Heap pointers
+		// Heap pointers
 		s64 attrib_heap_ptr = 0;
 		s64 vtx_env_heap_ptr = 0;
 		s64 frag_env_heap_ptr = 0;
@@ -199,14 +198,12 @@ namespace vk
 
 		u64 last_frame_sync_time = 0;
 
-		//Copy shareable information
+		// Copy shareable information
 		void grab_resources(frame_context_t& other)
 		{
 			present_wait_semaphore = other.present_wait_semaphore;
 			acquire_signal_semaphore = other.acquire_signal_semaphore;
 			descriptor_set.swap(other.descriptor_set);
-			descriptor_pool = other.descriptor_pool;
-			used_descriptors = other.used_descriptors;
 			flags = other.flags;
 
 			attrib_heap_ptr = other.attrib_heap_ptr;
@@ -221,7 +218,7 @@ namespace vk
 			rasterizer_env_heap_ptr = other.rasterizer_env_heap_ptr;
 		}
 
-		//Exchange storage (non-copyable)
+		// Exchange storage (non-copyable)
 		void swap_storage(frame_context_t& other)
 		{
 			std::swap(buffer_views_to_clean, other.buffer_views_to_clean);

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -35,14 +35,6 @@ namespace vk
 	u64 g_num_processed_frames = 0;
 	u64 g_num_total_frames = 0;
 
-	void reset_compute_tasks()
-	{
-		for (const auto &p : g_compute_tasks)
-		{
-			p.second->free_resources();
-		}
-	}
-
 	void reset_overlay_passes()
 	{
 		for (const auto& p : g_overlay_passes)
@@ -53,7 +45,7 @@ namespace vk
 
 	void reset_global_resources()
 	{
-		vk::reset_compute_tasks();
+		// FIXME: These two shouldn't exist
 		vk::reset_resolve_resources();
 		vk::reset_overlay_passes();
 

--- a/rpcs3/Emu/RSX/VK/VKOverlays.cpp
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.cpp
@@ -288,12 +288,6 @@ namespace vk
 
 	void overlay_pass::free_resources()
 	{
-		if (m_used_descriptors == 0)
-			return;
-
-		m_descriptor_pool.reset(0);
-		m_used_descriptors = 0;
-
 		m_vao.reset_allocation_stats();
 		m_ubo.reset_allocation_stats();
 	}

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -48,7 +48,6 @@ namespace vk
 		descriptor_set m_descriptor_set;
 		VkDescriptorSetLayout m_descriptor_layout = nullptr;
 		VkPipelineLayout m_pipeline_layout = nullptr;
-		u32 m_used_descriptors = 0;
 
 		VkFilter m_sampler_filter = VK_FILTER_LINEAR;
 		u32 m_num_usable_samplers = 1;

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -199,11 +199,6 @@ void VKGSRender::frame_context_cleanup(vk::frame_context_t *ctx)
 	// Resource cleanup.
 	// TODO: This is some outdated crap.
 	{
-		if (m_text_writer)
-		{
-			m_text_writer->reset_descriptors();
-		}
-
 		if (m_overlay_manager && m_overlay_manager->has_dirty())
 		{
 			auto ui_renderer = vk::get_overlay_pass<vk::ui_overlay_renderer>();

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.cpp
@@ -246,9 +246,6 @@ namespace vk
 
 	void reset_resolve_resources()
 	{
-		for (auto &e : g_resolve_helpers) e.second->free_resources();
-		for (auto &e : g_unresolve_helpers) e.second->free_resources();
-
 		if (g_depth_resolver) g_depth_resolver->free_resources();
 		if (g_depth_unresolver) g_depth_unresolver->free_resources();
 		if (g_stencil_resolver) g_stencil_resolver->free_resources();

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -41,6 +41,11 @@ namespace vk
 		return &g_resource_manager;
 	}
 
+	garbage_collector* get_gc()
+	{
+		return &g_resource_manager;
+	}
+
 	void resource_manager::trim()
 	{
 		// For any managed resources, try to keep the number of unused/idle resources as low as possible.

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -518,23 +518,7 @@ namespace vk
 
 	VkDescriptorSet shader_interpreter::allocate_descriptor_set()
 	{
-		if (!m_descriptor_pool.can_allocate(1u, m_used_descriptors))
-		{
-			m_descriptor_pool.reset(0);
-			m_used_descriptors = 0;
-		}
-
-		VkDescriptorSetAllocateInfo alloc_info = {};
-		alloc_info.descriptorPool = m_descriptor_pool;
-		alloc_info.descriptorSetCount = 1;
-		alloc_info.pSetLayouts = &m_shared_descriptor_layout;
-		alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-
-		VkDescriptorSet new_descriptor_set;
-		CHECK_RESULT(vkAllocateDescriptorSets(m_device, &alloc_info, &new_descriptor_set));
-
-		m_used_descriptors++;
-		return new_descriptor_set;
+		return m_descriptor_pool.allocate(m_shared_descriptor_layout, VK_TRUE, 0);
 	}
 
 	glsl::program* shader_interpreter::get(const vk::pipeline_props& properties, const program_hash_util::fragment_program_utils::fragment_program_metadata& metadata)

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -233,7 +233,7 @@ namespace vk
 	std::pair<VkDescriptorSetLayout, VkPipelineLayout> shader_interpreter::create_layout(VkDevice dev)
 	{
 		const auto& binding_table = vk::get_current_renderer()->get_pipeline_binding_table();
-		std::vector<VkDescriptorSetLayoutBinding> bindings(binding_table.total_descriptor_bindings);
+		rsx::simple_array<VkDescriptorSetLayoutBinding> bindings(binding_table.total_descriptor_bindings);
 
 		u32 idx = 0;
 
@@ -378,13 +378,15 @@ namespace vk
 	{
 		const auto max_draw_calls = dev.get_descriptor_max_draw_calls();
 
-		std::vector<VkDescriptorPoolSize> sizes;
-		sizes.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER , 6 * max_draw_calls });
-		sizes.push_back({ VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER , 3 * max_draw_calls });
-		sizes.push_back({ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER , 68 * max_draw_calls });
-		sizes.push_back({ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 3 * max_draw_calls });
+		rsx::simple_array<VkDescriptorPoolSize> sizes =
+		{
+			{ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER , 6 },
+			{ VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER , 3 },
+			{ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER , 68 },
+			{ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 3 }
+		};
 
-		m_descriptor_pool.create(dev, sizes.data(), ::size32(sizes), max_draw_calls, 2);
+		m_descriptor_pool.create(dev, sizes, max_draw_calls);
 	}
 
 	void shader_interpreter::init(const vk::render_device& dev)
@@ -518,7 +520,7 @@ namespace vk
 
 	VkDescriptorSet shader_interpreter::allocate_descriptor_set()
 	{
-		return m_descriptor_pool.allocate(m_shared_descriptor_layout, VK_TRUE, 0);
+		return m_descriptor_pool.allocate(m_shared_descriptor_layout);
 	}
 
 	glsl::program* shader_interpreter::get(const vk::pipeline_props& properties, const program_hash_util::fragment_program_utils::fragment_program_metadata& metadata)

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -244,6 +244,7 @@ namespace vk
 			bindings[idx].descriptorCount = 1;
 			bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 			bindings[idx].binding = binding_table.vertex_buffers_first_bind_slot + i;
+			bindings[idx].pImmutableSamplers = nullptr;
 			idx++;
 		}
 
@@ -251,6 +252,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.fragment_constant_buffers_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -258,6 +260,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.fragment_state_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -265,6 +268,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.fragment_texture_params_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -272,6 +276,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 		bindings[idx].binding = binding_table.vertex_constant_buffers_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -279,6 +284,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS;
 		bindings[idx].binding = binding_table.vertex_params_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -286,6 +292,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 		bindings[idx].binding = binding_table.conditional_render_predicate_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -293,6 +300,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.rasterizer_env_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -300,6 +308,7 @@ namespace vk
 		bindings[idx].descriptorCount = 16;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.textures_first_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		m_fragment_textures_start = bindings[idx].binding;
 		idx++;
@@ -308,6 +317,7 @@ namespace vk
 		bindings[idx].descriptorCount = 16;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.textures_first_bind_slot + 1;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -315,6 +325,7 @@ namespace vk
 		bindings[idx].descriptorCount = 16;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.textures_first_bind_slot + 2;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -322,6 +333,7 @@ namespace vk
 		bindings[idx].descriptorCount = 16;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.textures_first_bind_slot + 3;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -329,6 +341,7 @@ namespace vk
 		bindings[idx].descriptorCount = 4;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 		bindings[idx].binding = binding_table.textures_first_bind_slot + 4;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		idx++;
 
@@ -336,6 +349,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 		bindings[idx].binding = binding_table.textures_first_bind_slot + 5;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		m_vertex_instruction_start = bindings[idx].binding;
 		idx++;
@@ -344,6 +358,7 @@ namespace vk
 		bindings[idx].descriptorCount = 1;
 		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		bindings[idx].binding = binding_table.textures_first_bind_slot + 6;
+		bindings[idx].pImmutableSamplers = nullptr;
 
 		m_fragment_instruction_start = bindings[idx].binding;
 		idx++;

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.h
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.h
@@ -42,7 +42,6 @@ namespace vk
 		std::unordered_map<pipeline_key, std::unique_ptr<glsl::program>, key_hasher> m_program_cache;
 		std::unordered_map<u64, std::unique_ptr<glsl::shader>> m_fs_cache;
 		vk::descriptor_pool m_descriptor_pool;
-		u32 m_used_descriptors = 0;
 
 		u32 m_vertex_instruction_start = 0;
 		u32 m_fragment_instruction_start = 0;

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -40,16 +40,16 @@ namespace vk
 
 		void init_descriptor_set(vk::render_device &dev)
 		{
-			VkDescriptorPoolSize descriptor_pools[1] =
+			rsx::simple_array<VkDescriptorPoolSize> descriptor_pools =
 			{
-				{ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 120 },
+				{ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1 },
 			};
 
 			// Reserve descriptor pools
-			m_descriptor_pool.create(dev, descriptor_pools, 1, 120, 2);
+			m_descriptor_pool.create(dev, descriptor_pools);
 
 			// Scale and offset data plus output color
-			std::vector<VkDescriptorSetLayoutBinding> bindings =
+			rsx::simple_array<VkDescriptorSetLayoutBinding> bindings =
 			{
 				{
 					.binding = 0,
@@ -205,7 +205,7 @@ namespace vk
 		{
 			ensure(m_used_descriptors < 120);
 
-			m_descriptor_set = m_descriptor_pool.allocate(m_descriptor_layout, VK_TRUE, m_used_descriptors++);
+			m_descriptor_set = m_descriptor_pool.allocate(m_descriptor_layout);
 
 			float scale[] = { scale_x, scale_y };
 			float colors[] = { color[0], color[1], color[2], color[3] };

--- a/rpcs3/Emu/RSX/VK/VKTextOut.h
+++ b/rpcs3/Emu/RSX/VK/VKTextOut.h
@@ -205,14 +205,7 @@ namespace vk
 		{
 			ensure(m_used_descriptors < 120);
 
-			VkDescriptorSetAllocateInfo alloc_info = {};
-			alloc_info.descriptorPool = m_descriptor_pool;
-			alloc_info.descriptorSetCount = 1;
-			alloc_info.pSetLayouts = &m_descriptor_layout;
-			alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-
-			CHECK_RESULT(vkAllocateDescriptorSets(device, &alloc_info, m_descriptor_set.ptr()));
-			m_used_descriptors++;
+			m_descriptor_set = m_descriptor_pool.allocate(m_descriptor_layout, VK_TRUE, m_used_descriptors++);
 
 			float scale[] = { scale_x, scale_y };
 			float colors[] = { color[0], color[1], color[2], color[3] };
@@ -358,15 +351,6 @@ namespace vk
 			{
 				vkCmdDraw(cmd, counts[i], 1, offsets[i], i);
 			}
-		}
-
-		void reset_descriptors()
-		{
-			if (m_used_descriptors == 0)
-				return;
-
-			m_descriptor_pool.reset(0);
-			m_used_descriptors = 0;
 		}
 
 		void set_scale(double scale)

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -1,5 +1,6 @@
 #include "Emu/IdManager.h"
 #include "descriptors.h"
+#include "garbage_collector.h"
 
 namespace vk
 {
@@ -63,7 +64,7 @@ namespace vk
 			g_fxo->get<dispatch_manager>().flush_all();
 		}
 
-		VkDescriptorSetLayout create_layout(const std::vector<VkDescriptorSetLayoutBinding>& bindings)
+		VkDescriptorSetLayout create_layout(const rsx::simple_array<VkDescriptorSetLayoutBinding>& bindings)
 		{
 			VkDescriptorSetLayoutCreateInfo infos = {};
 			infos.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -105,65 +106,56 @@ namespace vk
 		}
 	}
 
-	void descriptor_pool::create(const vk::render_device& dev, VkDescriptorPoolSize* sizes, u32 size_descriptors_count, u32 max_sets, u8 subpool_count)
+	void descriptor_pool::create(const vk::render_device& dev, const rsx::simple_array<VkDescriptorPoolSize>& pool_sizes, u32 max_sets)
 	{
-		ensure(subpool_count);
+		ensure(max_sets > 16);
+
+		auto scaled_pool_sizes = pool_sizes;
+		for (auto& size : scaled_pool_sizes)
+		{
+			ensure(size.descriptorCount < 32); // Sanity check. Remove before commit.
+			size.descriptorCount *= max_sets;
+		}
 
 		info.flags = dev.get_descriptor_update_after_bind_support() ? VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT : 0;
 		info.maxSets = max_sets;
-		info.poolSizeCount = size_descriptors_count;
-		info.pPoolSizes = sizes;
+		info.poolSizeCount = scaled_pool_sizes.size();
+		info.pPoolSizes = scaled_pool_sizes.data();
 		info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
 
 		m_owner = &dev;
-		m_device_pools.resize(subpool_count);
-
-		for (auto& pool : m_device_pools)
-		{
-			CHECK_RESULT(vkCreateDescriptorPool(dev, &info, nullptr, &pool));
-		}
-
-		m_current_pool_handle = m_device_pools[0];
+		next_subpool();
 	}
 
 	void descriptor_pool::destroy()
 	{
-		if (m_device_pools.empty()) return;
+		if (m_device_subpools.empty()) return;
 
-		for (auto& pool : m_device_pools)
+		for (auto& pool : m_device_subpools)
 		{
-			vkDestroyDescriptorPool((*m_owner), pool, nullptr);
-			pool = VK_NULL_HANDLE;
+			vkDestroyDescriptorPool((*m_owner), pool.handle, nullptr);
+			pool.handle = VK_NULL_HANDLE;
 		}
 
 		m_owner = nullptr;
 	}
 
-	void descriptor_pool::reset(VkDescriptorPoolResetFlags flags)
+	void descriptor_pool::reset(u32 subpool_id, VkDescriptorPoolResetFlags flags)
 	{
-		m_descriptor_set_cache.clear();
-		m_current_pool_index = (m_current_pool_index + 1) % u32(m_device_pools.size());
-		m_current_pool_handle = m_device_pools[m_current_pool_index];
-		CHECK_RESULT(vkResetDescriptorPool(*m_owner, m_current_pool_handle, flags));
+		std::lock_guard lock(m_subpool_lock);
+
+		CHECK_RESULT(vkResetDescriptorPool(*m_owner, m_device_subpools[subpool_id].handle, flags));
+		m_device_subpools[subpool_id].busy = VK_FALSE;
 	}
 
-	VkDescriptorSet descriptor_pool::allocate(VkDescriptorSetLayout layout, VkBool32 use_cache, u32 used_count)
+	VkDescriptorSet descriptor_pool::allocate(VkDescriptorSetLayout layout, VkBool32 use_cache)
 	{
 		if (use_cache)
 		{
 			if (m_descriptor_set_cache.empty())
 			{
 				// For optimal cache utilization, each pool should only allocate one layout
-				if (m_cached_layout != layout)
-				{
-					m_cached_layout = layout;
-					m_allocation_request_cache.resize(max_cache_size);
-
-					for (auto& layout_ : m_allocation_request_cache)
-					{
-						layout_ = m_cached_layout;
-					}
-				}
+				m_cached_layout = layout;
 			}
 			else if (m_cached_layout != layout)
 			{
@@ -175,6 +167,11 @@ namespace vk
 			}
 		}
 
+		if (!can_allocate(use_cache ? 4 : 1, m_current_subpool_offset))
+		{
+			next_subpool();
+		}
+
 		VkDescriptorSet new_descriptor_set;
 		VkDescriptorSetAllocateInfo alloc_info = {};
 		alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -184,8 +181,12 @@ namespace vk
 
 		if (use_cache)
 		{
-			ensure(used_count < info.maxSets);
-			const auto alloc_size = std::min<u32>(info.maxSets - used_count, max_cache_size);
+			const auto alloc_size = std::min<u32>(info.maxSets - m_current_subpool_offset, max_cache_size);
+			m_allocation_request_cache.resize(alloc_size);
+			for (auto& layout_ : m_allocation_request_cache)
+			{
+				layout_ = m_cached_layout;
+			}
 
 			ensure(m_descriptor_set_cache.empty());
 			alloc_info.descriptorSetCount = alloc_size;
@@ -202,6 +203,51 @@ namespace vk
 		}
 
 		return new_descriptor_set;
+	}
+
+	void descriptor_pool::next_subpool()
+	{
+		if (m_current_subpool_index != umax)
+		{
+			// Enqueue release using gc
+			auto release_func = [subpool_index=m_current_subpool_index, this]()
+			{
+				this->reset(subpool_index, 0);
+			};
+
+			auto cleanup_obj = std::make_unique<gc_wrapper_t>(release_func);
+			vk::get_gc()->dispose(cleanup_obj);
+		}
+
+		std::lock_guard lock(m_subpool_lock);
+
+		m_current_subpool_offset = 0;
+		m_current_subpool_index = umax;
+
+		for (u32 index = 0; index < m_device_subpools.size(); ++index)
+		{
+			if (!m_device_subpools[index].busy)
+			{
+				m_current_subpool_index = index;
+				break;
+			}
+		}
+
+		if (m_current_subpool_index == umax)
+		{
+			VkDescriptorPool subpool = VK_NULL_HANDLE;
+			CHECK_RESULT(vkCreateDescriptorPool(*m_owner, &info, nullptr, &subpool));
+
+			m_device_subpools.push_back(
+			{
+				.handle = subpool,
+				.busy = VK_FALSE
+			});
+
+			m_current_subpool_index = m_device_subpools.size() - 1;
+		}
+
+		m_device_subpools[m_current_subpool_index].busy = VK_TRUE;
 	}
 
 	descriptor_set::descriptor_set(VkDescriptorSet set)

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -37,10 +37,10 @@ namespace vk
 
 		operator VkDescriptorPool() { return m_current_pool_handle; }
 		FORCE_INLINE bool valid() const { return (!m_device_subpools.empty()); }
-		FORCE_INLINE u32 max_sets() const { return info.maxSets; }
+		FORCE_INLINE u32 max_sets() const { return m_create_info.maxSets; }
 
 	private:
-		FORCE_INLINE bool can_allocate(u32 required_count, u32 already_used_count = 0) const { return (required_count + already_used_count) <= info.maxSets; };
+		FORCE_INLINE bool can_allocate(u32 required_count, u32 already_used_count = 0) const { return (required_count + already_used_count) <= m_create_info.maxSets; };
 		void reset(u32 subpool_id, VkDescriptorPoolResetFlags flags);
 		void next_subpool();
 
@@ -51,7 +51,8 @@ namespace vk
 		};
 
 		const vk::render_device* m_owner = nullptr;
-		VkDescriptorPoolCreateInfo info = {};
+		VkDescriptorPoolCreateInfo m_create_info = {};
+		rsx::simple_array<VkDescriptorPoolSize> m_create_info_pool_sizes;
 
 		rsx::simple_array<logical_subpool_t> m_device_subpools;
 		VkDescriptorPool m_current_pool_handle = VK_NULL_HANDLE;

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -10,30 +10,55 @@
 
 namespace vk
 {
+	struct gc_wrapper_t
+	{
+		std::function<void()> m_callback;
+
+		gc_wrapper_t(std::function<void()> callback)
+			: m_callback(callback)
+		{}
+
+		~gc_wrapper_t()
+		{
+			m_callback();
+		}
+	};
+
 	class descriptor_pool
 	{
 	public:
 		descriptor_pool() = default;
 		~descriptor_pool() = default;
 
-		void create(const vk::render_device& dev, VkDescriptorPoolSize* sizes, u32 size_descriptors_count, u32 max_sets, u8 subpool_count);
+		void create(const vk::render_device& dev, const rsx::simple_array<VkDescriptorPoolSize>& pool_sizes, u32 max_sets = 1024);
 		void destroy();
-		void reset(VkDescriptorPoolResetFlags flags);
 
-		VkDescriptorSet allocate(VkDescriptorSetLayout layout, VkBool32 use_cache, u32 used_count);
+		VkDescriptorSet allocate(VkDescriptorSetLayout layout, VkBool32 use_cache = VK_TRUE);
 
 		operator VkDescriptorPool() { return m_current_pool_handle; }
-		FORCE_INLINE bool valid() const { return (!m_device_pools.empty()); }
+		FORCE_INLINE bool valid() const { return (!m_device_subpools.empty()); }
 		FORCE_INLINE u32 max_sets() const { return info.maxSets; }
-		FORCE_INLINE bool can_allocate(u32 required_count, u32 used_count) const { return (used_count + required_count) <= info.maxSets; };
 
 	private:
+		FORCE_INLINE bool can_allocate(u32 required_count, u32 already_used_count = 0) const { return (required_count + already_used_count) <= info.maxSets; };
+		void reset(u32 subpool_id, VkDescriptorPoolResetFlags flags);
+		void next_subpool();
+
+		struct logical_subpool_t
+		{
+			VkDescriptorPool handle;
+			VkBool32 busy;
+		};
+
 		const vk::render_device* m_owner = nullptr;
 		VkDescriptorPoolCreateInfo info = {};
 
-		rsx::simple_array<VkDescriptorPool> m_device_pools;
+		rsx::simple_array<logical_subpool_t> m_device_subpools;
 		VkDescriptorPool m_current_pool_handle = VK_NULL_HANDLE;
-		u32 m_current_pool_index = 0;
+		u32 m_current_subpool_index = umax;
+		u32 m_current_subpool_offset = 0;
+
+		shared_mutex m_subpool_lock;
 
 		static constexpr size_t max_cache_size = 64;
 		VkDescriptorSetLayout m_cached_layout = VK_NULL_HANDLE;
@@ -122,6 +147,6 @@ namespace vk
 		void init();
 		void flush();
 
-		VkDescriptorSetLayout create_layout(const std::vector<VkDescriptorSetLayoutBinding>& bindings);
+		VkDescriptorSetLayout create_layout(const rsx::simple_array<VkDescriptorSetLayoutBinding>& bindings);
 	}
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -20,7 +20,10 @@ namespace vk
 
 		~gc_wrapper_t()
 		{
-			m_callback();
+			if (m_callback)
+			{
+				m_callback();
+			}
 		}
 	};
 
@@ -36,7 +39,7 @@ namespace vk
 		VkDescriptorSet allocate(VkDescriptorSetLayout layout, VkBool32 use_cache = VK_TRUE);
 
 		operator VkDescriptorPool() { return m_current_pool_handle; }
-		FORCE_INLINE bool valid() const { return (!m_device_subpools.empty()); }
+		FORCE_INLINE bool valid() const { return !m_device_subpools.empty(); }
 		FORCE_INLINE u32 max_sets() const { return m_create_info.maxSets; }
 
 	private:

--- a/rpcs3/Emu/RSX/VK/vkutils/garbage_collector.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/garbage_collector.h
@@ -1,0 +1,56 @@
+#include <util/types.hpp>
+
+#include <functional>
+
+namespace vk
+{
+	class disposable_t
+	{
+		void* ptr;
+		std::function<void(void*)> deleter;
+
+		disposable_t(void* ptr_, std::function<void(void*)> deleter_) :
+			ptr(ptr_), deleter(deleter_) {}
+	public:
+
+		disposable_t() = delete;
+		disposable_t(const disposable_t&) = delete;
+
+		disposable_t(disposable_t&& other) :
+			ptr(std::exchange(other.ptr, nullptr)),
+			deleter(other.deleter)
+		{}
+
+		~disposable_t()
+		{
+			if (ptr)
+			{
+				deleter(ptr);
+				ptr = nullptr;
+			}
+		}
+
+		template <typename T>
+		static disposable_t make(T* raw)
+		{
+			return disposable_t(raw, [](void* raw)
+			{
+				delete static_cast<T*>(raw);
+			});
+		}
+	};
+
+	struct garbage_collector
+	{
+		virtual void dispose(vk::disposable_t& object) = 0;
+
+		template<typename T>
+		void dispose(std::unique_ptr<T>& object)
+		{
+			auto ptr = vk::disposable_t::make(object.release());
+			dispose(ptr);
+		}
+	};
+
+	garbage_collector* get_gc();
+}

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -45,6 +45,7 @@
     <ClInclude Include="Emu\RSX\VK\vkutils\descriptors.h" />
     <ClInclude Include="Emu\RSX\VK\vkutils\barriers.h" />
     <ClInclude Include="Emu\RSX\VK\vkutils\framebuffer_object.hpp" />
+    <ClInclude Include="Emu\RSX\VK\vkutils\garbage_collector.h" />
     <ClInclude Include="Emu\RSX\VK\vkutils\image.h" />
     <ClInclude Include="Emu\RSX\VK\vkutils\image_helpers.h" />
     <ClInclude Include="Emu\RSX\VK\vkutils\scratch.h" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -171,6 +171,9 @@
     <ClInclude Include="Emu\RSX\VK\upscalers\nearest_pass.hpp">
       <Filter>upscalers</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\vkutils\garbage_collector.h">
+      <Filter>vkutils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="vkutils">


### PR DESCRIPTION
Removes the old method of using per-frame descriptor pools that was copied from the original vulkan tutorials in 2016. It scales very poorly and forces us to have callbacks all over the place as well as setting hard limits on number of descriptor sets that can be allocated per frame.

This PR makes a few changes to the vulkan backend:
1. Some minor refactoring of the garbage collector allowing callbacks to be pushed to the dispose queue. These execute in-order so we can safely reclaim resources once the execution queue releases them.
2. You can now allocate as many descriptors as your driver and setup can handle (virtually infinite). The allocator will just create more pools as demand increases.

Some more cleanup is needed - we should never have any of those "reset_resources" or "reset_global_resources" calls anywhere as the backends are intended to be event-driven.

Fixes https://github.com/RPCS3/rpcs3/issues/12710