### PR TITLE
Fixup debugger_frame double events

### DIFF
--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -267,6 +267,17 @@ void debugger_list::scroll(s32 steps)
 
 void debugger_list::keyPressEvent(QKeyEvent* event)
 {
+	// Always accept event (so it would not bubble upwards, debugger_frame already sees it)
+	struct accept_event_t
+	{
+		QKeyEvent* event;
+
+		~accept_event_t() noexcept
+		{
+			event->accept();
+		}
+	} accept_event{event};
+
 	if (!isActiveWindow())
 	{
 		QListWidget::keyPressEvent(event);


### PR DESCRIPTION
QListWidget::keyPressEvent sets event->isAccepted to false when using some key combinations such as Alt or Ctrl, simply always accept event to avoid event repeatation in debugger_frame.