### PR TITLE
rsx: Improve surface cache trimming

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -1448,6 +1448,9 @@ namespace rsx
 			{
 				pre_task_callback(cmd);
 
+				rsx_log.warning("[PERFORMANCE WARNING] Invalidated resource pool has exceeded the desired limit. A trim will now be attempted. Current=%u, Limit=%u",
+					invalidated_resources.size(), max_invalidated_resources_count);
+
 				// Check invalidated resources as they can have long dependency chains
 				trim_invalidated_resources(cmd, memory_pressure);
 

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -74,6 +74,7 @@ namespace rsx
 		std::vector<surface_type> superseded_surfaces;
 
 		std::list<surface_storage_type> invalidated_resources;
+		const u64 max_invalidated_resources_count = 256ull;
 		u64 cache_tag = 1ull; // Use 1 as the start since 0 is default tag on new surfaces
 		u64 write_tag = 1ull;
 
@@ -1361,7 +1362,25 @@ namespace rsx
 			return true;
 		}
 
-		virtual bool handle_memory_pressure(command_list_type cmd, problem_severity severity)
+		void trim_invalidated_resources(command_list_type cmd, problem_severity severity)
+		{
+			// It is possible to have stale invalidated resources holding references to other invalidated resources.
+			// This can bloat the VRAM usage significantly especially if the references are never collapsed.
+			for (auto& surface : invalidated_resources)
+			{
+				if (!surface->has_refs() || surface->old_contents.empty())
+				{
+					continue;
+				}
+
+				if (can_collapse_surface(surface, severity))
+				{
+					surface->memory_barrier(cmd, rsx::surface_access::transfer_read);
+				}
+			}
+		}
+
+		void collapse_dirty_surfaces(command_list_type cmd, problem_severity severity)
 		{
 			auto process_list_function = [&](surface_ranged_map& data, const utils::address_range& range)
 			{
@@ -1390,14 +1409,54 @@ namespace rsx
 				}
 			};
 
+			process_list_function(m_render_targets_storage, m_render_targets_memory_range);
+			process_list_function(m_depth_stencil_storage, m_depth_stencil_memory_range);
+		}
+
+		virtual bool handle_memory_pressure(command_list_type cmd, problem_severity severity)
+		{
 			ensure(severity >= rsx::problem_severity::moderate);
 			const auto old_usage = m_active_memory_used;
 
 			// Try and find old surfaces to remove
-			process_list_function(m_render_targets_storage, m_render_targets_memory_range);
-			process_list_function(m_depth_stencil_storage, m_depth_stencil_memory_range);
+			collapse_dirty_surfaces(cmd, severity);
+
+			// Check invalidated resources as they can have long dependency chains
+			if (invalidated_resources.size() > max_invalidated_resources_count ||
+				severity >= rsx::problem_severity::severe)
+			{
+				trim_invalidated_resources(cmd, severity);
+			}
 
 			return (m_active_memory_used < old_usage);
+		}
+
+		void run_cleanup_internal(
+			command_list_type cmd,
+			rsx::problem_severity memory_pressure,
+			u32 max_surface_store_memory_mb,
+			std::function<void(command_list_type)> pre_task_callback)
+		{
+			if (check_memory_usage(max_surface_store_memory_mb * 0x100000))
+			{
+				pre_task_callback(cmd);
+
+				const auto severity = std::max(memory_pressure, rsx::problem_severity::moderate);
+				handle_memory_pressure(cmd, severity);
+			}
+			else if (invalidated_resources.size() > max_invalidated_resources_count)
+			{
+				pre_task_callback(cmd);
+
+				// Check invalidated resources as they can have long dependency chains
+				trim_invalidated_resources(cmd, memory_pressure);
+
+				if ((invalidated_resources.size() + 16u) > max_invalidated_resources_count)
+				{
+					// We didn't release enough resources, scan the active RTTs as well
+					collapse_dirty_surfaces(cmd, memory_pressure);
+				}
+			}
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -401,7 +401,7 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 	m_gl_texture_cache.on_frame_end();
 	m_vertex_cache->purge();
 
-	auto removed_textures = m_rtts.free_invalidated(cmd);
+	auto removed_textures = m_rtts.trim(cmd);
 	m_framebuffer_cache.remove_if([&](auto& fbo)
 	{
 		if (fbo.unused_check_count() >= 2) return true; // Remove if stale

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -390,13 +390,9 @@ struct gl_render_targets : public rsx::surface_store<gl_render_target_traits>
 		invalidated_resources.clear();
 	}
 
-	std::vector<GLuint> free_invalidated(gl::command_context& cmd)
+	std::vector<GLuint> trim(gl::command_context& cmd)
 	{
-		// Do not allow more than 256M of RSX memory to be used by RTTs
-		if (check_memory_usage(256 * 0x100000))
-		{
-			handle_memory_pressure(cmd, rsx::problem_severity::moderate);
-		}
+		run_cleanup_internal(cmd, rsx::problem_severity::moderate, 256, [](gl::command_context&) {});
 
 		std::vector<GLuint> removed;
 		invalidated_resources.remove_if([&](auto &rtt)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -876,6 +876,9 @@ VKGSRender::~VKGSRender()
 		g_fxo->get<vk::AsyncTaskScheduler>().destroy();
 	}
 
+	// GC cleanup
+	vk::get_resource_manager()->flush();
+
 	// Host data
 	if (m_host_object_data)
 	{
@@ -945,7 +948,9 @@ VKGSRender::~VKGSRender()
 	// Overlay text handler
 	m_text_writer.reset();
 
-	//Pipeline descriptors
+	// Pipeline descriptors
+	m_descriptor_pool.destroy();
+
 	vkDestroyPipelineLayout(*m_device, m_pipeline_layout, nullptr);
 	vkDestroyDescriptorSetLayout(*m_device, m_descriptor_layouts, nullptr);
 
@@ -962,9 +967,6 @@ VKGSRender::~VKGSRender()
 
 	// Global resources
 	vk::destroy_global_resources();
-
-	// Destroy at the end in case of lingering callbacks
-	m_descriptor_pool.destroy();
 
 	// Device handles/contexts
 	m_swapchain->destroy();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1151,7 +1151,7 @@ bool VKGSRender::on_vram_exhausted(rsx::problem_severity severity)
 	if (m_rtts.handle_memory_pressure(*m_current_command_buffer, severity))
 	{
 		surface_cache_relieved = true;
-		m_rtts.free_invalidated(*m_current_command_buffer, severity);
+		m_rtts.trim(*m_current_command_buffer, severity);
 	}
 
 	const bool any_cache_relieved = (texture_cache_relieved || surface_cache_relieved);

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -125,7 +125,7 @@ void VKGSRender::advance_queued_frames()
 	vk::vmm_check_memory_usage();
 
 	// m_rtts storage is double buffered and should be safe to tag on frame boundary
-	m_rtts.free_invalidated(*m_current_command_buffer, vk::vmm_determine_memory_load_severity());
+	m_rtts.trim(*m_current_command_buffer, vk::vmm_determine_memory_load_severity());
 
 	// Texture cache is also double buffered to prevent use-after-free
 	m_texture_cache.on_frame_end();

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -642,7 +642,7 @@ namespace vk
 		bool is_overallocated();
 		bool can_collapse_surface(const std::unique_ptr<vk::render_target>& surface, rsx::problem_severity severity) override;
 		bool handle_memory_pressure(vk::command_buffer& cmd, rsx::problem_severity severity) override;
-		void free_invalidated(vk::command_buffer& cmd, rsx::problem_severity memory_pressure);
+		void trim(vk::command_buffer& cmd, rsx::problem_severity memory_pressure);
 	};
 }
 //h

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -76,6 +76,11 @@ namespace vk
 
 		void destroy()
 		{
+			flush();
+		}
+
+		void flush()
+		{
 			m_eid_map.clear();
 			m_sampler_pool.clear();
 		}

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -217,7 +217,7 @@ namespace vk
 				this->reset(subpool_index, 0);
 			};
 
-			auto cleanup_obj = std::make_unique<gc_wrapper_t>(release_func);
+			auto cleanup_obj = std::make_unique<gc_callback_t>(release_func);
 			vk::get_gc()->dispose(cleanup_obj);
 		}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -10,15 +10,15 @@
 
 namespace vk
 {
-	struct gc_wrapper_t
+	struct gc_callback_t
 	{
 		std::function<void()> m_callback;
 
-		gc_wrapper_t(std::function<void()> callback)
+		gc_callback_t(std::function<void()> callback)
 			: m_callback(callback)
 		{}
 
-		~gc_wrapper_t()
+		~gc_callback_t()
 		{
 			if (m_callback)
 			{


### PR DESCRIPTION
Improves VRAM utilization drastically especially with some games known for excessive number of surface cache objects (e.g the insomniac engine)
Changeset:
1. If the number of "invalidated" i.e temp storage items reaches a set limit, attempt to collapse some objects to free up memory. Currently the hard limit is 256 which is arbitrary but seems to keep VRAM usage under 2GB at default settings which is what we want.
2. When handing out-of-memory situations, remove invalidated resources by collapsing as many dependency chains as we can. This was missing previously, and made it so that out-of-memory recovery was not recovering tons of memory in some situations.
3. Minor tweaks to avoid crash on exit after the descriptor rewrite PR.

Fixes https://github.com/RPCS3/rpcs3/issues/13928