### PR TITLE
debugger: Bugfixes

### DIFF
--- a/rpcs3/rpcs3qt/call_stack_list.cpp
+++ b/rpcs3/rpcs3qt/call_stack_list.cpp
@@ -2,6 +2,8 @@
 
 #include "Utilities/StrFmt.h"
 
+#include <QKeyEvent>
+
 constexpr auto qstr = QString::fromStdString;
 
 call_stack_list::call_stack_list(QWidget* parent) : QListWidget(parent)
@@ -15,6 +17,12 @@ call_stack_list::call_stack_list(QWidget* parent) : QListWidget(parent)
 
 	// Hide until used in order to allow as much space for registers panel as possible
 	hide();
+}
+
+void call_stack_list::keyPressEvent(QKeyEvent* event)
+{
+	QListWidget::keyPressEvent(event);
+	event->ignore(); // Propagate the event to debugger_frame
 }
 
 void call_stack_list::HandleUpdate(const std::vector<std::pair<u32, u32>>& call_stack)

--- a/rpcs3/rpcs3qt/call_stack_list.cpp
+++ b/rpcs3/rpcs3qt/call_stack_list.cpp
@@ -13,7 +13,7 @@ call_stack_list::call_stack_list(QWidget* parent) : QListWidget(parent)
 	setSelectionMode(QAbstractItemView::ExtendedSelection);
 
 	// connects
-	connect(this, &QListWidget::itemDoubleClicked, this, &call_stack_list::OnCallStackListDoubleClicked);
+	connect(this, &QListWidget::itemDoubleClicked, this, &call_stack_list::ShowItemAddress);
 
 	// Hide until used in order to allow as much space for registers panel as possible
 	hide();
@@ -23,6 +23,11 @@ void call_stack_list::keyPressEvent(QKeyEvent* event)
 {
 	QListWidget::keyPressEvent(event);
 	event->ignore(); // Propagate the event to debugger_frame
+
+	if (!event->modifiers() && event->key() == Qt::Key_Return)
+	{
+		ShowItemAddress();
+	}
 }
 
 void call_stack_list::HandleUpdate(const std::vector<std::pair<u32, u32>>& call_stack)
@@ -40,7 +45,7 @@ void call_stack_list::HandleUpdate(const std::vector<std::pair<u32, u32>>& call_
 	setVisible(!call_stack.empty());
 }
 
-void call_stack_list::OnCallStackListDoubleClicked()
+void call_stack_list::ShowItemAddress()
 {
 	if (QListWidgetItem* call_stack_item = currentItem())
 	{

--- a/rpcs3/rpcs3qt/call_stack_list.cpp
+++ b/rpcs3/rpcs3qt/call_stack_list.cpp
@@ -42,6 +42,9 @@ void call_stack_list::HandleUpdate(const std::vector<std::pair<u32, u32>>& call_
 
 void call_stack_list::OnCallStackListDoubleClicked()
 {
-	const u32 address = currentItem()->data(Qt::UserRole).value<u32>();
-	Q_EMIT RequestShowAddress(address);
+	if (QListWidgetItem* call_stack_item = currentItem())
+	{
+		const u32 address = call_stack_item->data(Qt::UserRole).value<u32>();
+		Q_EMIT RequestShowAddress(address);
+	}
 }

--- a/rpcs3/rpcs3qt/call_stack_list.h
+++ b/rpcs3/rpcs3qt/call_stack_list.h
@@ -21,4 +21,6 @@ public Q_SLOTS:
 	void HandleUpdate(const std::vector<std::pair<u32, u32>>& call_stack);
 private Q_SLOTS:
 	void OnCallStackListDoubleClicked();
+private:
+	void keyPressEvent(QKeyEvent* event) override;
 };

--- a/rpcs3/rpcs3qt/call_stack_list.h
+++ b/rpcs3/rpcs3qt/call_stack_list.h
@@ -20,7 +20,7 @@ Q_SIGNALS:
 public Q_SLOTS:
 	void HandleUpdate(const std::vector<std::pair<u32, u32>>& call_stack);
 private Q_SLOTS:
-	void OnCallStackListDoubleClicked();
+	void ShowItemAddress();
 private:
 	void keyPressEvent(QKeyEvent* event) override;
 };

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1334,6 +1334,11 @@ void debugger_frame::DoStep(bool step_over)
 
 void debugger_frame::EnableUpdateTimer(bool enable) const
 {
+	if (m_update->isActive() == enable)
+	{
+		return;
+	}
+
 	enable ? m_update->start(10) : m_update->stop();
 }
 

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -76,7 +76,7 @@ class debugger_frame : public custom_dock_widget
 	std::shared_ptr<gui_settings> m_gui_settings;
 
 	cpu_thread* get_cpu();
-	std::function<cpu_thread*()> make_check_cpu(cpu_thread* cpu);
+	std::function<cpu_thread*()> make_check_cpu(cpu_thread* cpu, bool unlocked = false);
 	void open_breakpoints_settings();
 
 public:


### PR DESCRIPTION
* Do not access IDM's containers when their FXO entry is inactive.
* Save smart thread pointers in the debugger instead of raw pointers.
* Fix segfault when a double click signal occurs after ui callstack has been cleared.
* Add return key press in addition to double click to jump to callstack item address.
* Fix debugger shortcuts when callstack is the focused widget.

Fixes #13865 