### PR TITLE
Random fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -40,7 +40,7 @@ struct lv2_update_manager
 	std::unordered_map<u32, u8> eeprom_map // offset, value
 	{
 		// system language
-	    // *i think* this gives english
+		// *i think* this gives english
 		{0x48C18, 0x00},
 		{0x48C19, 0x00},
 		{0x48C1A, 0x00},

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -731,17 +731,22 @@ game_boot_result Emulator::GetElfPathFromDir(std::string& elf_path, const std::s
 
 game_boot_result Emulator::BootGame(const std::string& path, const std::string& title_id, bool direct, cfg_mode config_mode, const std::string& config_path)
 {
-	auto save_args = std::make_tuple(m_path, argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_path);
+	auto save_args = std::make_tuple(m_path, m_path_original, argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_path);
 
 	auto restore_on_no_boot = [&](game_boot_result result)
 	{
 		if (IsStopped() || result != game_boot_result::no_errors)
 		{
-			std::tie(m_path, argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_path) = std::move(save_args);
+			std::tie(m_path, m_path_original, argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_path) = std::move(save_args);
 		}
 
 		return result;
 	};
+
+	if (m_path_original.empty() || config_mode != cfg_mode::continuous)
+	{
+		m_path_original = m_path;
+	}
 
 	m_path_old = m_path;
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -731,13 +731,13 @@ game_boot_result Emulator::GetElfPathFromDir(std::string& elf_path, const std::s
 
 game_boot_result Emulator::BootGame(const std::string& path, const std::string& title_id, bool direct, cfg_mode config_mode, const std::string& config_path)
 {
-	auto save_args = std::make_tuple(m_path, argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_mode);
+	auto save_args = std::make_tuple(m_path, argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_path);
 
 	auto restore_on_no_boot = [&](game_boot_result result)
 	{
 		if (IsStopped() || result != game_boot_result::no_errors)
 		{
-			std::tie(m_path, argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_mode) = std::move(save_args);
+			std::tie(m_path, argv, envp, data, disc, klic, hdd1, m_config_mode, m_config_path) = std::move(save_args);
 		}
 
 		return result;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2204,7 +2204,7 @@ void Emulator::FinalizeRunRequest()
 
 	if (m_savestate_extension_flags1 & SaveStateExtentionFlags1::ShouldCloseMenu)
 	{
-		std::thread([this, info = ProcureCurrentEmulationCourseInformation()]()
+		std::thread([this, info = GetEmulationIdentifier()]()
 		{
 			std::this_thread::sleep_for(2s);
 
@@ -2451,7 +2451,7 @@ void Emulator::GracefulShutdown(bool allow_autoexit, bool async_op, bool savesta
 		return;
 	}
 
-	auto perform_kill = [read_counter, allow_autoexit, this, info = ProcureCurrentEmulationCourseInformation()]()
+	auto perform_kill = [read_counter, allow_autoexit, this, info = GetEmulationIdentifier()]()
 	{
 		bool read_sysutil_signal = false;
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2036,7 +2036,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 
 		if (ppu_exec == elf_error::ok && !fs::is_file(g_cfg_vfs.get_dev_flash() + "sys/external/liblv2.sprx"))
 		{
-			const auto libs = g_cfg.core.libraries_control.get_set();
+			const auto& libs = g_cfg.core.libraries_control.get_set();
 
 			extern const std::map<std::string_view, int> g_prx_list;
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -189,7 +189,8 @@ public:
 
 	enum class stop_counter_t : u64{};
 
-	stop_counter_t ProcureCurrentEmulationCourseInformation() const
+	// Returns a different value each time we start a new emulation.
+	stop_counter_t GetEmulationIdentifier() const
 	{
 		return stop_counter_t{+m_stop_ctr};
 	}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -122,6 +122,7 @@ class Emulator final
 	std::string m_config_path;
 	std::string m_path;
 	std::string m_path_old;
+	std::string m_path_original;
 	std::string m_title_id;
 	std::string m_title;
 	std::string m_app_version;
@@ -233,6 +234,11 @@ public:
 	const std::string& GetBoot() const
 	{
 		return m_path;
+	}
+
+	const std::string& GetLastBoot() const
+	{
+		return m_path_original;
 	}
 
 	const std::string& GetTitleID() const

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -984,12 +984,15 @@ void debugger_frame::UpdateUnitList()
 
 void debugger_frame::OnSelectUnit()
 {
-	const QVariant data = m_choice_units->currentData();
-
-	cpu_thread* selected = data.canConvert<data_type>() ? data.value<data_type>()() : nullptr;
+	cpu_thread* selected = nullptr;
 
 	if (m_emu_state != system_state::stopped)
 	{
+		if (const QVariant data = m_choice_units->currentData(); data.canConvert<data_type>())
+		{
+			selected = data.value<data_type>()();
+		}
+
 		if (selected && m_cpu.get() == selected)
 		{
 			// They match, nothing to do.
@@ -1005,10 +1008,6 @@ void debugger_frame::OnSelectUnit()
 		{
 			return;
 		}
-	}
-	else
-	{
-		selected = nullptr;
 	}
 
 	m_disasm.reset();

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -805,9 +805,9 @@ std::function<cpu_thread*()> debugger_frame::make_check_cpu(cpu_thread* cpu, boo
 		shared.reset();
 	}
 
-	return [cpu, type, shared = std::move(shared), emu_course = Emu.ProcureCurrentEmulationCourseInformation()]() -> cpu_thread*
+	return [cpu, type, shared = std::move(shared), emulation_id = Emu.GetEmulationIdentifier()]() -> cpu_thread*
 	{
-		if (emu_course != Emu.ProcureCurrentEmulationCourseInformation())
+		if (emulation_id != Emu.GetEmulationIdentifier())
 		{
 			// Invalidate all data after Emu.Kill()
 			return nullptr;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -259,7 +259,7 @@ QString main_window::GetCurrentTitle()
 	QString title = qstr(Emu.GetTitleAndTitleID());
 	if (title.isEmpty())
 	{
-		title = qstr(Emu.GetBoot());
+		title = qstr(Emu.GetLastBoot());
 	}
 	return title;
 }
@@ -383,7 +383,7 @@ void main_window::OnPlayOrPause()
 			gui_log.notice("Booting from OnPlayOrPause...");
 			Boot(m_selected_game->info.path, m_selected_game->info.serial);
 		}
-		else if (const auto path = Emu.GetBoot(); !path.empty())
+		else if (const std::string path = Emu.GetLastBoot(); !path.empty())
 		{
 			if (const auto error = Emu.Load(); error != game_boot_result::no_errors)
 			{
@@ -1971,7 +1971,7 @@ void main_window::BootRecentAction(const QAction* act)
 		if (contains_path)
 		{
 			// clear menu of actions
-			for (auto action : m_recent_game_acts)
+			for (QAction* action : m_recent_game_acts)
 			{
 				ui->bootRecentMenu->removeAction(action);
 			}
@@ -2062,7 +2062,7 @@ void main_window::AddRecentAction(const q_string_pair& entry)
 	}
 
 	// clear menu of actions
-	for (auto action : m_recent_game_acts)
+	for (QAction* action : m_recent_game_acts)
 	{
 		ui->bootRecentMenu->removeAction(action);
 	}
@@ -2915,7 +2915,7 @@ void main_window::CreateDockWindows()
 
 					ui->toolbar_start->setIcon(m_icon_play);
 				}
-				else if (const auto& path = Emu.GetBoot(); !path.empty()) // Restartable games
+				else if (const std::string& path = Emu.GetLastBoot(); !path.empty()) // Restartable games
 				{
 					tooltip = tr("Restart %0").arg(GetCurrentTitle());
 
@@ -2979,7 +2979,7 @@ void main_window::ConfigureGuiFromSettings()
 	m_rg_entries = m_gui_settings->Var2List(m_gui_settings->GetValue(gui::rg_entries));
 
 	// clear recent games menu of actions
-	for (auto act : m_recent_game_acts)
+	for (QAction* act : m_recent_game_acts)
 	{
 		ui->bootRecentMenu->removeAction(act);
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -340,7 +340,7 @@ void main_window::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const Q
 			Emu.Pause();
 		break;
 	}
-	case gui::shortcuts::shortcut::mw_restart:
+	case gui::shortcuts::shortcut::mw_start:
 	{
 		if (status == system_state::paused)
 			Emu.Resume();
@@ -348,7 +348,7 @@ void main_window::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const Q
 			Emu.Run(true);
 		break;
 	}
-	case gui::shortcuts::shortcut::mw_start:
+	case gui::shortcuts::shortcut::mw_restart:
 	{
 		if (!Emu.GetBoot().empty())
 			Emu.Restart();

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1827,11 +1827,11 @@ void main_window::OnEmuPause() const
 void main_window::OnEmuStop()
 {
 	const QString title = GetCurrentTitle();
-	const QString play_tooltip = Emu.IsReady() ? tr("Play %0").arg(title) : tr("Resume %0").arg(title);
+	const QString play_tooltip = tr("Play %0").arg(title);
 
 	m_debugger_frame->UpdateUI();
 
-	ui->sysPauseAct->setText(Emu.IsReady() ? tr("&Play") : tr("&Resume"));
+	ui->sysPauseAct->setText(tr("&Play"));
 	ui->sysPauseAct->setIcon(m_icon_play);
 #ifdef _WIN32
 	m_thumb_playPause->setToolTip(play_tooltip);
@@ -1885,14 +1885,14 @@ void main_window::OnEmuStop()
 void main_window::OnEmuReady() const
 {
 	const QString title = GetCurrentTitle();
-	const QString play_tooltip = Emu.IsReady() ? tr("Play %0").arg(title) : tr("Resume %0").arg(title);
+	const QString play_tooltip = tr("Play %0").arg(title);
 
 	m_debugger_frame->EnableButtons(true);
 #ifdef _WIN32
 	m_thumb_playPause->setToolTip(play_tooltip);
 	m_thumb_playPause->setIcon(m_icon_thumb_play);
 #endif
-	ui->sysPauseAct->setText(Emu.IsReady() ? tr("&Play") : tr("&Resume"));
+	ui->sysPauseAct->setText(tr("&Play"));
 	ui->sysPauseAct->setIcon(m_icon_play);
 	ui->toolbar_start->setIcon(m_icon_play);
 	ui->toolbar_start->setText(tr("Play"));


### PR DESCRIPTION
- Debugger: don't query cpu if the emulation is stopped anyway
- Rename ProcureCurrentEmulationCourseInformation to GetEmulationIdentifier, which seems much easier to understand to me.
- Fix typo in restore_on_no_boot: duplicate m_config_mode vs m_config_path
- Fix start/restart shortcut mixup in main window. At least I think this makes more sense.
- Fix menu/thumbnail play button texts on stop and ready. They were always showing 'Resume' for no apparent reason (legacy code?).
- Always use last original boot path for GUI game boot actions.
This fixes an issue which caused decryption issues booting a recent game after booting a game from a loader.
The GUI should now always boot the loader and not some self.