### PR TITLE
PPU: Sleep after returning from thread entry function

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2055,12 +2055,7 @@ void ppu_thread::fast_call(u32 addr, u64 rtoc)
 
 	auto at_ret = [&]()
 	{
-		if (std::uncaught_exceptions())
-		{
-			cpu_on_stop();
-			current_function = old_func;
-		}
-		else if (old_cia)
+		if (old_cia)
 		{
 			if (state & cpu_flag::again)
 			{
@@ -2070,6 +2065,18 @@ void ppu_thread::fast_call(u32 addr, u64 rtoc)
 			cia = old_cia;
 			gpr[2] = old_rtoc;
 			lr = old_lr;
+		}
+		else if (state & cpu_flag::ret && cia == g_fxo->get<ppu_function_manager>().func_addr(1, true) + 4)
+		{
+			std::string ret;
+			dump_all(ret);
+
+			ppu_log.error("Returning from the thread entry function! (func=0x%x)", entry_func.addr);
+			ppu_log.notice("Thread context: %s", ret);
+
+			lv2_obj::sleep(*this);
+
+			state += cpu_flag::again; // For savestates
 		}
 
 		current_function = old_func;


### PR DESCRIPTION
I tested what happens if I let a thread return without calling sys_ppu_thread_exit, at first when a debugger was attached the process was paused.
But after detaching it the process would emit a thread dump but the other threads kept running!
This is what happens in #13274 which lets its thread do that and even relies on that, because just before the return of the entry function there is a store that releases the main PPU thread from a loop waiting for that byte to be set.

Fixes #13274.