### PR TITLE
vk: Improved OOM handling

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -207,10 +207,11 @@ namespace vk
 			case rsx::problem_severity::low:
 				return (rtt->unused_check_count() >= 2);
 			case rsx::problem_severity::moderate:
-				return (rtt->unused_check_count() >= 1);
 			case rsx::problem_severity::severe:
+				return (rtt->unused_check_count() >= 1);
 			case rsx::problem_severity::fatal:
 				// We're almost dead anyway. Remove forcefully.
+				rtt->clear_rw_barrier();
 				vk::get_resource_manager()->dispose(rtt);
 				return true;
 			default:


### PR DESCRIPTION
- Always release barrier references before destroying surfaces. In rare cases the surface may be detached without a collapse ever being triggered.

Fixes https://github.com/RPCS3/rpcs3/issues/13935