### PR TITLE
vk: Fix broken rendering on apple M-series GPUs

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -749,10 +749,10 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	// Confirmed in BLES01916 (The Evil Within) which uses RGB565 for some virtual texturing data.
 	backend_config.supports_hw_renormalization = (vk::get_driver_vendor() == vk::driver_vendor::NVIDIA);
 
-#ifndef __APPLE__
 	// Conditional rendering support
-	backend_config.supports_hw_conditional_render = true;
-#endif
+	// Do not use on MVK due to a speedhack we rely on (streaming results without stopping the current renderpass)
+	// If we break the renderpasses, MVK loses around 75% of its performance in troublesome spots compared to just doing a CPU sync
+	backend_config.supports_hw_conditional_render = (vk::get_driver_vendor() != vk::driver_vendor::MVK);
 
 	// Passthrough DMA
 	backend_config.supports_passthrough_dma = m_device->get_external_memory_host_support();

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -749,8 +749,10 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	// Confirmed in BLES01916 (The Evil Within) which uses RGB565 for some virtual texturing data.
 	backend_config.supports_hw_renormalization = (vk::get_driver_vendor() == vk::driver_vendor::NVIDIA);
 
+#ifndef __APPLE__
 	// Conditional rendering support
 	backend_config.supports_hw_conditional_render = true;
+#endif
 
 	// Passthrough DMA
 	backend_config.supports_passthrough_dma = m_device->get_external_memory_host_support();

--- a/rpcs3/Emu/RSX/VK/VKQueryPool.cpp
+++ b/rpcs3/Emu/RSX/VK/VKQueryPool.cpp
@@ -170,6 +170,8 @@ namespace vk
 
 	void query_pool_manager::get_query_result_indirect(vk::command_buffer& cmd, u32 index, VkBuffer dst, VkDeviceSize dst_offset)
 	{
+		// We're technically supposed to stop any active renderpasses before streaming the results out, but that doesn't matter on IMR hw
+		// On TBDR setups like the apple M series, the stop is required (results are all 0 if you don't flush the RP), but this introduces a very heavy performance loss.
 		vkCmdCopyQueryPoolResults(cmd, *query_slot_status[index].pool, index, 1, dst, dst_offset, 4, VK_QUERY_RESULT_WAIT_BIT);
 	}
 


### PR DESCRIPTION
Just disable conditional render. Tile-based GPUs are not compatible with some of our sneaky speedhacks for cond-render such as streaming query results while a renderpass is active. Doing it the "right way" cuts performance down significantly so the only viable approach is to disable the fast path entirely and force use of the fallback used by OpenGL.

Fixes https://github.com/RPCS3/rpcs3/issues/12158