### PR TITLE
Qt: Improve PS3 Binaries Decryption tool

### DIFF
--- a/rpcs3/Crypto/decrypt_binaries.cpp
+++ b/rpcs3/Crypto/decrypt_binaries.cpp
@@ -11,34 +11,66 @@
 
 LOG_CHANNEL(dec_log, "DECRYPT");
 
-void decrypt_sprx_libraries(std::vector<std::string> modules, std::function<std::string(std::string old_path, std::string path, bool tried)> input_cb)
+usz decrypt_binaries_t::decrypt(std::string klic_input)
 {
-	if (modules.empty())
+	if (m_index >= m_modules.size())
 	{
 		std::cout << "No paths specified" << std::endl; // For CLI
-		return;
+		m_index = umax;
+		return umax;
 	}
 
-	dec_log.notice("Decrypting binaries...");
-	std::cout << "Decrypting binaries..." << std::endl; // For CLI
-
-	// Always start with no KLIC
-	std::vector<u128> klics{u128{}};
-
-	if (const auto keys = g_fxo->try_get<loaded_npdrm_keys>())
+	if (m_klics.empty())
 	{
-		// Second klic: get it from a running game
-		if (const u128 klic = keys->last_key())
+		dec_log.notice("Decrypting binaries...");
+		std::cout << "Decrypting binaries..." << std::endl; // For CLI
+
+		// Always start with no KLIC
+		m_klics.emplace_back(u128{});
+
+		if (const auto keys = g_fxo->try_get<loaded_npdrm_keys>())
 		{
-			klics.emplace_back(klic);
+			// Second klic: get it from a running game
+			if (const u128 klic = keys->last_key())
+			{
+				m_klics.emplace_back(klic);
+			}
+		}
+
+		// Try to use the key that has been for the current running ELF
+		m_klics.insert(m_klics.end(), Emu.klic.begin(), Emu.klic.end());
+	}
+
+	if (std::string_view text = std::string_view{klic_input}.substr(klic_input.find_first_of('x') + 1); text.size() == 32)
+	{
+		// Allowed to fail (would simply repeat the operation if fails again)
+		u64 lo = 0;
+		u64 hi = 0;
+		bool success = false;
+
+		if (auto res = std::from_chars(text.data() + 0, text.data() + 16, lo, 16); res.ec == std::errc() && res.ptr == text.data() + 16)
+		{
+			if (res = std::from_chars(text.data() + 16, text.data() + 32, hi, 16); res.ec == std::errc() && res.ptr == text.data() + 32)
+			{
+				success = true;
+			}
+		}
+
+		if (success)
+		{
+			lo = std::bit_cast<be_t<u64>>(lo);
+			hi = std::bit_cast<be_t<u64>>(hi);
+
+			if (u128 input_key = ((u128{hi} << 64) | lo))
+			{
+				m_klics.emplace_back(input_key);
+			}
 		}
 	}
 
-	// Try to use the key that has been for the current running ELF
-	klics.insert(klics.end(), Emu.klic.begin(), Emu.klic.end());
-
-	for (const std::string& _module : modules)
+	while (m_index < m_modules.size())
 	{
+		const std::string& _module = m_modules[m_index];
 		const std::string old_path = _module;
 
 		fs::file elf_file;
@@ -50,7 +82,7 @@ void decrypt_sprx_libraries(std::vector<std::string> modules, std::function<std:
 
 		while (true)
 		{
-			for (; key_it < klics.size(); key_it++)
+			for (; key_it < m_klics.size(); key_it++)
 			{
 				if (!elf_file.open(old_path) || !elf_file.read(file_magic))
 				{
@@ -62,7 +94,7 @@ void decrypt_sprx_libraries(std::vector<std::string> modules, std::function<std:
 				case "SCE\0"_u32:
 				{
 					// First KLIC is no KLIC
-					elf_file = decrypt_self(std::move(elf_file), key_it != 0 ? reinterpret_cast<u8*>(&klics[key_it]) : nullptr);
+					elf_file = decrypt_self(std::move(elf_file), key_it != 0 ? reinterpret_cast<u8*>(&m_klics[key_it]) : nullptr);
 
 					if (!elf_file)
 					{
@@ -75,7 +107,7 @@ void decrypt_sprx_libraries(std::vector<std::string> modules, std::function<std:
 				case "NPD\0"_u32:
 				{
 					// EDAT / SDAT
-					elf_file = DecryptEDAT(elf_file, old_path, key_it != 0 ? 8 : 1, reinterpret_cast<u8*>(&klics[key_it]), true);
+					elf_file = DecryptEDAT(elf_file, old_path, key_it != 0 ? 8 : 1, reinterpret_cast<u8*>(&m_klics[key_it]), true);
 
 					if (!elf_file)
 					{
@@ -111,11 +143,13 @@ void decrypt_sprx_libraries(std::vector<std::string> modules, std::function<std:
 					new_file.write(elf_file.to_string());
 					dec_log.success("Decrypted %s -> %s", old_path, new_path);
 					std::cout << "Decrypted " << old_path << " -> " << new_path << std::endl; // For CLI
+					m_index++;
 				}
 				else
 				{
 					dec_log.error("Failed to create %s", new_path);
 					std::cout << "Failed to create " << new_path << std::endl; // For CLI
+					m_index = umax;
 				}
 
 				break;
@@ -124,42 +158,16 @@ void decrypt_sprx_libraries(std::vector<std::string> modules, std::function<std:
 			if (!invalid)
 			{
 				// Allow the user to manually type KLIC if decryption failed
-
-				const std::string filename = old_path.substr(old_path.find_last_of(fs::delim) + 1);
-				const std::string text = input_cb ? input_cb(old_path, filename, tried) : "";
-
-				if (!text.empty())
-				{
-					auto& klic = (tried ? klics.back() : klics.emplace_back());
-
-					ensure(text.size() == 32);
-
-					// It must succeed (only hex characters are present)
-					u64 lo_ = 0;
-					u64 hi_ = 0;
-					std::from_chars(&text[0], &text[16], lo_, 16);
-					std::from_chars(&text[16], &text[32], hi_, 16);
-
-					be_t<u64> lo = std::bit_cast<be_t<u64>>(lo_);
-					be_t<u64> hi = std::bit_cast<be_t<u64>>(hi_);
-
-					klic = (u128{+hi} << 64) | +lo;
-
-					// Retry with specified KLIC
-					key_it -= +std::exchange(tried, true); // Rewind on second and above attempt
-					dec_log.notice("KLIC entered for %s: %s", filename, klic);
-					continue;
-				}
-
-				dec_log.notice("User has cancelled entering KLIC.");
+				return m_index;
 			}
 
 			dec_log.error("Failed to decrypt \"%s\".", old_path);
 			std::cout << "Failed to decrypt \"" << old_path << "\"." << std::endl; // For CLI
-			break;
+			return m_index;
 		}
 	}
 
 	dec_log.notice("Finished decrypting all binaries.");
 	std::cout << "Finished decrypting all binaries." << std::endl; // For CLI
+	return m_index;
 }

--- a/rpcs3/Crypto/decrypt_binaries.h
+++ b/rpcs3/Crypto/decrypt_binaries.h
@@ -1,3 +1,26 @@
 #pragma once
 
-void decrypt_sprx_libraries(std::vector<std::string> modules, std::function<std::string(std::string old_path, std::string path, bool tried)> input_cb);
+class decrypt_binaries_t
+{
+    std::vector<u128> m_klics;
+    std::vector<std::string> m_modules;
+    usz m_index = 0;
+
+public:
+    decrypt_binaries_t(std::vector<std::string> modules) noexcept
+        : m_modules(std::move(modules))
+    {
+    }
+
+    usz decrypt(std::string klic_input = {});
+
+    bool done() const
+    {
+        return m_index >= m_klics.size();
+    }
+
+    const std::string& operator[](usz index) const
+    {
+        return ::at32(m_modules, index);
+    }
+};

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -468,7 +468,7 @@ error_code npDrmIsAvailable(vm::cptr<u8> k_licensee_addr, vm::cptr<char> drm_pat
 	if (k_licensee_addr)
 	{
 		std::memcpy(&k_licensee, k_licensee_addr.get_ptr(), sizeof(k_licensee));
-		sceNp.notice("npDrmIsAvailable(): KLicense key %s", std::bit_cast<be_t<u128>>(k_licensee));
+		sceNp.notice("npDrmIsAvailable(): KLicense key or KLIC=%s", std::bit_cast<be_t<u128>>(k_licensee));
 	}
 
 	if (Emu.GetFakeCat() == "PE")


### PR DESCRIPTION
* Make it non-blocking. This tool requires to copy the KLIC from the log, cannot do that conviently without access to log or without the ability to execute a game.
* Allow the prefix "KLIC=0x" to be added at the start of the KLIC text, and add this to the log message for it be easier to understand and search it by users.