### PR TITLE
CI: use more recent FreeBSD packages again

### DIFF
--- a/.ci/install-freebsd.sh
+++ b/.ci/install-freebsd.sh
@@ -3,7 +3,7 @@
 # shellcheck shell=sh disable=SC2096
 
 # RPCS3 often needs recent Qt5 and Vulkan-Headers
-#sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
+sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
 
 export ASSUME_ALWAYS_YES=true
 pkg info # debug


### PR DESCRIPTION
`llvm16` [built fine](https://pkg-status.freebsd.org/beefy16/data/131amd64-default/b848aeb67d45/logs/llvm16-16.0.5.log) and available again:
```
$ fetch -s https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/llvm16-16.0.5.pkg
198935032
```
