### PR TITLE
[Hotfix] System.cpp: Updated the definition of user-space LV2 CoreOS SELFs

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3465,7 +3465,7 @@ utils::serial* Emulator::DeserialManager() const
 
 bool Emulator::IsVsh()
 {
-	return g_ps3_process_info.self_info.valid && (g_ps3_process_info.self_info.prog_id_hdr.program_authority_id >> 52 == 0x107); // Not only VSH but also most CoreOS LV2 SELFs need the special treatment
+	return g_ps3_process_info.self_info.valid && (g_ps3_process_info.self_info.prog_id_hdr.program_authority_id >> 36 == 0x1070000); // Not only VSH but also most CoreOS LV2 SELFs need the special treatment
 }
 
 bool Emulator::IsValidSfb(const std::string& path)


### PR DESCRIPTION
It seems like a few non-system SELFs could be affected by the previous definition (by #13840).
In this PR, I modified the definition of user-space LV2 CoreOS SELFs (determined by `Emu.IsVsh()`) to be stricter.