### PR TITLE
Log Frame: Make clear act clear pending messages

### DIFF
--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -100,6 +100,12 @@ struct gui_listener : logs::listener
 		pending = queue.pop_all();
 		return pending.get();
 	}
+
+	void clear()
+	{
+		pending = lf_queue_slice<packet_t>();
+		queue.pop_all();
+	}
 };
 
 // GUI Listener instance
@@ -231,7 +237,8 @@ void log_frame::CreateAndConnectActions()
 	connect(m_clear_act, &QAction::triggered, [this]()
 	{
 		m_old_log_text.clear();
-		m_log->clear();
+		m_log->clear();	
+		s_gui_listener.clear();
 	});
 
 	m_clear_tty_act = new QAction(tr("Clear"), this);


### PR DESCRIPTION
Sometimes if a user ~~me~~ made a mistake which blows up the log the Clear command should be able to clear the pending messages as well. 