### PR TITLE
np_handler: fix warning: check socket in discover_ip_address

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
@@ -75,7 +75,11 @@ s32 lv2_socket_native::create_socket()
 
 	auto socket_res = ::socket(native_domain, native_type, native_proto);
 
+#ifdef _WIN32
+	if (socket_res == INVALID_SOCKET)
+#else
 	if (socket_res == -1)
+#endif
 	{
 		return -get_last_error(false);
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
@@ -47,7 +47,11 @@ nt_p2p_port::nt_p2p_port(u16 port)
 	// Creates and bind P2P Socket
 	p2p_socket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
 
+#ifdef _WIN32
+	if (p2p_socket == INVALID_SOCKET)
+#else
 	if (p2p_socket == -1)
+#endif
 		fmt::throw_exception("Failed to create DGRAM socket for P2P socket: %s!", get_last_error(true));
 
 #ifdef _WIN32

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -476,6 +476,15 @@ namespace np
 	bool np_handler::discover_ip_address()
 	{
 		auto sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+#ifdef _WIN32
+		if (sockfd == INVALID_SOCKET)
+#else
+		if (sockfd == -1)
+#endif
+		{
+			nph_log.error("Creating socket to discover local ip failed: %d", get_native_error());
+			return false;
+		}
 
 		auto close_socket = [&]()
 		{
@@ -499,7 +508,7 @@ namespace np
 			return false; // offline
 		}
 
-		sockaddr_in client_addr;
+		sockaddr_in client_addr{};
 		socklen_t client_addr_size = sizeof(client_addr);
 		if (getsockname(sockfd, reinterpret_cast<struct sockaddr*>(&client_addr), &client_addr_size) != 0)
 		{

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -770,6 +770,16 @@ namespace rpcn
 			addr_rpcn_udp.sin_port = std::bit_cast<u16, be_t<u16>>(3657); // htons
 
 			sockfd = socket(AF_INET, SOCK_STREAM, 0);
+#ifdef _WIN32
+			if (sockfd == INVALID_SOCKET)
+#else
+			if (sockfd == -1)
+#endif
+			{
+				rpcn_log.error("connect: Failed to connect to RPCN server!");
+				state = rpcn_state::failure_connect;
+				return false;
+			}
 
 			if (::connect(sockfd, reinterpret_cast<struct sockaddr*>(&addr_rpcn), sizeof(addr_rpcn)) != 0)
 			{


### PR DESCRIPTION
No idea if this is necessary, but there's a warning for the socket return value