### PR TITLE
Optimize some trace log messages

### DIFF
--- a/Utilities/Config.cpp
+++ b/Utilities/Config.cpp
@@ -7,6 +7,12 @@
 
 LOG_CHANNEL(cfg_log, "CFG");
 
+template <>
+void fmt_class_string<cfg::node>::format(std::string& out, u64 arg)
+{
+ 	out += get_object(arg).to_string();
+}
+
 namespace cfg
 {
 	_base::_base(type _type)

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -335,9 +335,12 @@ static void ppu_initialize_modules(ppu_linkage_info* link, utils::serial* ar = n
 	u32 alloc_addr = 0;
 
 	// "Use" all the modules for correct linkage
-	for (auto& _module : registered)
+	if (ppu_loader.trace)
 	{
-		ppu_loader.trace("Registered static module: %s", _module->name);
+		for (auto& _module : registered)
+		{
+			ppu_loader.trace("Registered static module: %s", _module->name);
+		}
 	}
 
 	struct hle_vars_save

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2267,7 +2267,7 @@ static T ppu_load_acquire_reservation(ppu_thread& ppu, u32 addr)
 		ppu.use_full_rdata = false;
 	}
 
-	if ((addr & addr_mask) == (ppu.last_faddr & addr_mask))
+	if (ppu_log.trace && (addr & addr_mask) == (ppu.last_faddr & addr_mask))
 	{
 		ppu_log.trace(u8"LARX after fail: addr=0x%x, faddr=0x%x, time=%u c", addr, ppu.last_faddr, (perf0.get() - ppu.last_ftsc));
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -29,7 +29,7 @@ error_code _sys_lwcond_create(ppu_thread& ppu, vm::ptr<u32> lwcond_id, u32 lwmut
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_lwcond.warning(u8"_sys_lwcond_create(lwcond_id=*0x%x, lwmutex_id=0x%x, control=*0x%x, name=0x%llx (“%s”))", lwcond_id, lwmutex_id, control, name, lv2_obj::name64(std::bit_cast<be_t<u64>>(name)));
+	sys_lwcond.warning(u8"_sys_lwcond_create(lwcond_id=*0x%x, lwmutex_id=0x%x, control=*0x%x, name=0x%llx (“%s”))", lwcond_id, lwmutex_id, control, name, lv2_obj::name_64{std::bit_cast<be_t<u64>>(name)});
 
 	u32 protocol;
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -27,7 +27,7 @@ error_code _sys_lwmutex_create(ppu_thread& ppu, vm::ptr<u32> lwmutex_id, u32 pro
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_lwmutex.trace(u8"_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, has_name=0x%x, name=0x%llx (“%s”))", lwmutex_id, protocol, control, has_name, name, lv2_obj::name64(std::bit_cast<be_t<u64>>(name)));
+	sys_lwmutex.trace(u8"_sys_lwmutex_create(lwmutex_id=*0x%x, protocol=0x%x, control=*0x%x, has_name=0x%x, name=0x%llx (“%s”))", lwmutex_id, protocol, control, has_name, name, lv2_obj::name_64{std::bit_cast<be_t<u64>>(name)});
 
 	if (protocol != SYS_SYNC_FIFO && protocol != SYS_SYNC_RETRY && protocol != SYS_SYNC_PRIORITY)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -93,17 +93,13 @@ public:
 		return ptr && ptr->exists;
 	}
 
-	static std::string name64(u64 name_u64)
+	// wrapper for name64 string formatting
+	struct name_64
 	{
-		const auto ptr = reinterpret_cast<const char*>(&name_u64);
+		u64 data;
+	};
 
-		// NTS string, ignore invalid/newline characters
-		// Example: "lv2\n\0tx" will be printed as "lv2"
-		std::string str{ptr, std::find(ptr, ptr + 7, '\0')};
-		str.erase(std::remove_if(str.begin(), str.end(), [](uchar c){ return !std::isprint(c); }), str.end());
-
-		return str;
-	}
+	static std::string name64(u64 name_u64);
 
 	// Find and remove the object from the linked list
 	template <bool ModifyNode = true, typename T>

--- a/rpcs3/Emu/NP/np_dnshook.cpp
+++ b/rpcs3/Emu/NP/np_dnshook.cpp
@@ -102,7 +102,7 @@ namespace np
 	s32 dnshook::analyze_dns_packet(s32 s, const u8* buf, u32 len)
 	{
 		std::lock_guard lock(mutex);
-		
+
 		dnshook_log.trace("DNS REQUEST:\n%s", fmt::buf_to_hexstring(buf, len));
 
 		struct dns_header

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -518,7 +518,8 @@ namespace np
 		}
 
 		local_ip_addr = client_addr.sin_addr.s_addr;
-		nph_log.trace("discover_ip_address: IP was determined to be %s", ip_to_string(local_ip_addr));
+		if (nph_log.trace)
+			nph_log.trace("discover_ip_address: IP was determined to be %s", ip_to_string(local_ip_addr));
 		close_socket();
 		return true;
 	}

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -251,7 +251,8 @@ namespace rsx
 
 			if ((location & ~7) != (CELL_GCM_CONTEXT_DMA_NOTIFY_MAIN_0 & ~7))
 			{
-				rsx_log.trace("NV4097_NOTIFY: invalid context = 0x%x", method_registers.context_dma_notify());
+				if (rsx_log.trace)
+					rsx_log.trace("NV4097_NOTIFY: invalid context = 0x%x", method_registers.context_dma_notify());
 				return;
 			}
 

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -736,7 +736,7 @@ u32 keyboard_pad_handler::GetKeyCode(const QString& keyName)
 	if (seq.count() == 1)
 		key_code = seq[0];
 	else
-		input_log.notice("GetKeyCode(%s): seq.count() = %d", sstr(keyName), seq.count());
+		input_log.notice("GetKeyCode(%s): seq.count() = %d", keyName, seq.count());
 
 	return key_code;
 }

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -131,7 +131,7 @@ void pad_thread::Init()
 		input_log.notice("Reloaded empty pad config");
 	}
 
-	input_log.trace("Using pad config:\n%s", g_cfg_input.to_string());
+	input_log.trace("Using pad config:\n%s", g_cfg_input);
 
 	std::shared_ptr<keyboard_pad_handler> keyptr;
 

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -250,7 +250,7 @@ EmuCallbacks main_application::CreateCallbacks()
 			}
 			else
 			{
-				sys_log.error("get_image_info failed to read '%s'. Error='%s'", filename, reader.errorString().toStdString());
+				sys_log.error("get_image_info failed to read '%s'. Error='%s'", filename, reader.errorString());
 			}
 		});
 		return success;
@@ -320,7 +320,7 @@ EmuCallbacks main_application::CreateCallbacks()
 			}
 			else
 			{
-				sys_log.error("get_scaled_image failed to read '%s'. Error='%s'", path, reader.errorString().toStdString());
+				sys_log.error("get_scaled_image failed to read '%s'. Error='%s'", path, reader.errorString());
 			}
 		});
 		return success;

--- a/rpcs3/rpcs3qt/cg_disasm_window.cpp
+++ b/rpcs3/rpcs3qt/cg_disasm_window.cpp
@@ -13,9 +13,6 @@
 
 LOG_CHANNEL(gui_log, "GUI");
 
-constexpr auto qstr = QString::fromStdString;
-inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-
 cg_disasm_window::cg_disasm_window(std::shared_ptr<gui_settings> gui_settings)
 	: m_gui_settings(std::move(gui_settings))
 {
@@ -111,15 +108,15 @@ void cg_disasm_window::ShowDisasm() const
 {
 	if (QFileInfo(m_path_last).isFile())
 	{
-		CgBinaryDisasm disasm(sstr(m_path_last));
+		CgBinaryDisasm disasm(m_path_last.toStdString());
 		disasm.BuildShaderBody();
-		m_disasm_text->setText(qstr(disasm.GetArbShader()));
-		m_glsl_text->setText(qstr(disasm.GetGlslShader()));
+		m_disasm_text->setText(QString::fromStdString(disasm.GetArbShader()));
+		m_glsl_text->setText(QString::fromStdString(disasm.GetGlslShader()));
 		m_gui_settings->SetValue(gui::fd_cg_disasm, m_path_last);
 	}
 	else if (!m_path_last.isEmpty())
 	{
-		gui_log.error("CgDisasm: Failed to open %s", sstr(m_path_last));
+		gui_log.error("CgDisasm: Failed to open %s", m_path_last);
 	}
 }
 

--- a/rpcs3/rpcs3qt/config_checker.cpp
+++ b/rpcs3/rpcs3qt/config_checker.cpp
@@ -84,7 +84,7 @@ bool config_checker::check_config(QString content, QString& result, bool is_log)
 
 	if (!config.from_string(content.toStdString()))
 	{
-		gui_log.error("log_viewer: Failed to parse config:\n%s", content.toStdString());
+		gui_log.error("log_viewer: Failed to parse config:\n%s", content);
 		result = tr("Cannot find any config!");
 		return false;
 	}

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -325,7 +325,7 @@ void emu_settings::EnhanceComboBox(QComboBox* combobox, emu_settings_type type, 
 			const QVariantList var_list = combobox->itemData(i).toList();
 			if (var_list.size() != 2 || !var_list[0].canConvert<QString>())
 			{
-				fmt::throw_exception("Invalid data found in combobox entry %d (text='%s', listsize=%d, itemcount=%d)", i, sstr(combobox->itemText(i)), var_list.size(), combobox->count());
+				fmt::throw_exception("Invalid data found in combobox entry %d (text='%s', listsize=%d, itemcount=%d)", i, combobox->itemText(i), var_list.size(), combobox->count());
 			}
 
 			if (value == var_list[0].toString())
@@ -381,7 +381,7 @@ void emu_settings::EnhanceComboBox(QComboBox* combobox, emu_settings_type type, 
 			const QVariantList var_list = combobox->itemData(index).toList();
 			if (var_list.size() != 2 || !var_list[0].canConvert<QString>())
 			{
-				fmt::throw_exception("Invalid data found in combobox entry %d (text='%s', listsize=%d, itemcount=%d)", index, sstr(combobox->itemText(index)), var_list.size(), combobox->count());
+				fmt::throw_exception("Invalid data found in combobox entry %d (text='%s', listsize=%d, itemcount=%d)", index, combobox->itemText(index), var_list.size(), combobox->count());
 			}
 			SetSetting(type, sstr(var_list[0]));
 		}
@@ -531,8 +531,7 @@ void emu_settings::EnhanceDateTimeEdit(QDateTimeEdit* date_time_edit, emu_settin
 		if (!val.isValid() || val < min || val > max)
 		{
 			cfg_log.error("EnhanceDateTimeEdit '%s' tried to set an invalid value: %s. Setting to default: %s Allowed range: [%s, %s]",
-				cfg_adapter::get_setting_name(type), val.toString(Qt::ISODate).toStdString(), def.toString(Qt::ISODate).toStdString(),
-				min.toString(Qt::ISODate).toStdString(), max.toString(Qt::ISODate).toStdString());
+				cfg_adapter::get_setting_name(type), val.toString(Qt::ISODate), def.toString(Qt::ISODate), min.toString(Qt::ISODate), max.toString(Qt::ISODate));
 			val = def;
 			m_broken_types.insert(type);
 			SetSetting(type, sstr(def.toString(Qt::ISODate)));
@@ -795,7 +794,7 @@ void emu_settings::EnhanceRadioButton(QButtonGroup* button_group, emu_settings_t
 	{
 		ensure(def_pos >= 0);
 
-		cfg_log.error("EnhanceRadioButton '%s' tried to set an invalid value: %s. Setting to default: %s.", cfg_adapter::get_setting_name(type), sstr(selected), sstr(def));
+		cfg_log.error("EnhanceRadioButton '%s' tried to set an invalid value: %s. Setting to default: %s.", cfg_adapter::get_setting_name(type), selected, def);
 		m_broken_types.insert(type);
 
 		// Select the default option on invalid setting string
@@ -1299,7 +1298,7 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 				type_string += loc;
 			}
 		}
-		fmt::throw_exception("Missing translation for emu setting (original=%s, type='%s'=%d, index=%d)", original.toStdString(), type_string.empty() ? "?" : type_string, static_cast<int>(type), index);
+		fmt::throw_exception("Missing translation for emu setting (original=%s, type='%s'=%d, index=%d)", original, type_string.empty() ? "?" : type_string, static_cast<int>(type), index);
 	}
 
 	return original;

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -14,7 +14,6 @@
 LOG_CHANNEL(compat_log, "Compat");
 
 constexpr auto qstr = QString::fromStdString;
-inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 game_compatibility::game_compatibility(std::shared_ptr<gui_settings> gui_settings, QWidget* parent)
 	: QObject(parent)
@@ -46,19 +45,19 @@ void game_compatibility::handle_download_finished(const QByteArray& content)
 
 		if (file.exists())
 		{
-			compat_log.notice("Database file found: %s", sstr(m_filepath));
+			compat_log.notice("Database file found: %s", m_filepath);
 		}
 
 		if (!file.open(QIODevice::WriteOnly))
 		{
-			compat_log.error("Database Error - Could not write database to file: %s", sstr(m_filepath));
+			compat_log.error("Database Error - Could not write database to file: %s", m_filepath);
 			return;
 		}
 
 		file.write(content);
 		file.close();
 
-		compat_log.success("Wrote database to file: %s", sstr(m_filepath));
+		compat_log.success("Wrote database to file: %s", m_filepath);
 	}
 
 	// We have a new database in map, therefore refresh gamelist to new state
@@ -116,7 +115,7 @@ bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_downl
 	{
 		if (!json_results[key].isObject())
 		{
-			compat_log.error("Database Error - Unusable object %s", sstr(key));
+			compat_log.error("Database Error - Unusable object %s", key);
 			continue;
 		}
 
@@ -187,7 +186,7 @@ bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_downl
 		}
 
 		// Add status to map
-		m_compat_database.emplace(std::pair<std::string, compat::status>(sstr(key), status));
+		m_compat_database.emplace(std::pair<std::string, compat::status>(key.toStdString(), status));
 	}
 
 	return true;
@@ -202,20 +201,20 @@ void game_compatibility::RequestCompatibility(bool online)
 
 		if (!file.exists())
 		{
-			compat_log.notice("Database file not found: %s", sstr(m_filepath));
+			compat_log.notice("Database file not found: %s", m_filepath);
 			return;
 		}
 
 		if (!file.open(QIODevice::ReadOnly))
 		{
-			compat_log.error("Database Error - Could not read database from file: %s", sstr(m_filepath));
+			compat_log.error("Database Error - Could not read database from file: %s", m_filepath);
 			return;
 		}
 
 		const QByteArray content = file.readAll();
 		file.close();
 
-		compat_log.notice("Finished reading database from file: %s", sstr(m_filepath));
+		compat_log.notice("Finished reading database from file: %s", m_filepath);
 
 		// Create new map from database
 		ReadJSON(QJsonDocument::fromJson(content).object(), online);
@@ -312,13 +311,13 @@ compat::package_info game_compatibility::GetPkgInfo(const QString& pkg_path, gam
 
 	if (compat)
 	{
-		compat::status stat = compat->GetCompatibility(sstr(info.title_id));
+		compat::status stat = compat->GetCompatibility(info.title_id.toStdString());
 		if (!stat.patch_sets.empty())
 		{
 			// We currently only handle the first patch set
 			for (const auto& package : stat.patch_sets.front().packages)
 			{
-				if (sstr(info.version) == package.version)
+				if (info.version.toStdString() == package.version)
 				{
 					if (const std::string localized_title = package.get_title(title_key); !localized_title.empty())
 					{

--- a/rpcs3/rpcs3qt/game_list_base.cpp
+++ b/rpcs3/rpcs3qt/game_list_base.cpp
@@ -60,7 +60,7 @@ void game_list_base::IconLoadFunction(game_info game, qreal device_pixel_ratio, 
 
 			if (!logged)
 			{
-				game_list_log.warning("Could not load image from path %s", QDir(QString::fromStdString(game->info.icon_path)).absolutePath().toStdString());
+				game_list_log.warning("Could not load image from path %s", QDir(QString::fromStdString(game->info.icon_path)).absolutePath());
 			}
 		}
 	}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -877,7 +877,7 @@ void game_list_frame::CreateShortcuts(const game_info& gameinfo, const std::set<
 {
 	if (locations.empty())
 	{
-		game_list_log.error("Failed to create shortcuts for %s. No locations selected.", sstr(qstr(gameinfo->info.name).simplified()));
+		game_list_log.error("Failed to create shortcuts for %s. No locations selected.", qstr(gameinfo->info.name).simplified());
 		return;
 	}
 
@@ -927,7 +927,7 @@ void game_list_frame::CreateShortcuts(const game_info& gameinfo, const std::set<
 
 	if (!fs::create_path(target_icon_dir))
 	{
-		game_list_log.error("Failed to create shortcut path %s (%s)", sstr(qstr(gameinfo->info.name).simplified()), target_icon_dir, fs::g_tls_error);
+		game_list_log.error("Failed to create shortcut path %s (%s)", qstr(gameinfo->info.name).simplified(), target_icon_dir, fs::g_tls_error);
 		return;
 	}
 
@@ -954,11 +954,11 @@ void game_list_frame::CreateShortcuts(const game_info& gameinfo, const std::set<
 
 		if (!gameid_token_value.empty() && gui::utils::create_shortcut(gameinfo->info.name, target_cli_args, gameinfo->info.name, gameinfo->info.icon_path, target_icon_dir, location))
 		{
-			game_list_log.success("Created %s shortcut for %s", destination, sstr(qstr(gameinfo->info.name).simplified()));
+			game_list_log.success("Created %s shortcut for %s", destination, qstr(gameinfo->info.name).simplified());
 		}
 		else
 		{
-			game_list_log.error("Failed to create %s shortcut for %s", destination, sstr(qstr(gameinfo->info.name).simplified()));
+			game_list_log.error("Failed to create %s shortcut for %s", destination, qstr(gameinfo->info.name).simplified());
 			success = false;
 		}
 	}
@@ -1281,12 +1281,12 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 				{
 					if (QFile file(game_icon_path); file.exists() && !file.remove())
 					{
-						game_list_log.error("Could not remove old file: '%s'", sstr(game_icon_path), sstr(file.errorString()));
+						game_list_log.error("Could not remove old file: '%s'", game_icon_path, file.errorString());
 						QMessageBox::warning(this, tr("Warning!"), tr("Failed to remove the old file!"));
 						return;
 					}
 
-					game_list_log.success("Removed file: '%s'", sstr(game_icon_path));
+					game_list_log.success("Removed file: '%s'", game_icon_path);
 					if (action == icon_action::remove)
 					{
 						refresh = true;
@@ -1297,12 +1297,12 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 				{
 					if (!QFile::copy(icon_path, game_icon_path))
 					{
-						game_list_log.error("Could not import file '%s' to '%s'.", sstr(icon_path), sstr(game_icon_path));
+						game_list_log.error("Could not import file '%s' to '%s'.", icon_path, game_icon_path);
 						QMessageBox::warning(this, tr("Warning!"), tr("Failed to import the new file!"));
 					}
 					else
 					{
-						game_list_log.success("Imported file '%s' to '%s'", sstr(icon_path), sstr(game_icon_path));
+						game_list_log.success("Imported file '%s' to '%s'", icon_path, game_icon_path);
 						refresh = true;
 					}
 				}
@@ -1437,12 +1437,12 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 					RemoveCustomPadConfiguration(current_game.serial);
 				}
 				m_game_data.erase(std::remove(m_game_data.begin(), m_game_data.end(), gameinfo), m_game_data.end());
-				game_list_log.success("Removed %s %s in %s", sstr(gameinfo->localized_category), current_game.name, current_game.path);
+				game_list_log.success("Removed %s %s in %s", gameinfo->localized_category, current_game.name, current_game.path);
 				Refresh(true);
 			}
 			else
 			{
-				game_list_log.error("Failed to remove %s %s in %s (%s)", sstr(gameinfo->localized_category), current_game.name, current_game.path, fs::g_tls_error);
+				game_list_log.error("Failed to remove %s %s in %s (%s)", gameinfo->localized_category, current_game.name, current_game.path, fs::g_tls_error);
 				QMessageBox::critical(this, tr("Failure!"), remove_caches
 					? tr("Failed to remove %0 from drive!\nPath: %1\nCaches and custom configs have been left intact.").arg(name).arg(qstr(current_game.path))
 					: tr("Failed to remove %0 from drive!\nPath: %1").arg(name).arg(qstr(current_game.path)));
@@ -1682,11 +1682,11 @@ bool game_list_frame::RemoveShadersCache(const std::string& base_dir, bool is_in
 		if (QDir(filepath).removeRecursively())
 		{
 			++caches_removed;
-			game_list_log.notice("Removed shaders cache dir: %s", sstr(filepath));
+			game_list_log.notice("Removed shaders cache dir: %s", filepath);
 		}
 		else
 		{
-			game_list_log.warning("Could not completely remove shaders cache dir: %s", sstr(filepath));
+			game_list_log.warning("Could not completely remove shaders cache dir: %s", filepath);
 		}
 
 		++caches_total;
@@ -1733,11 +1733,11 @@ bool game_list_frame::RemovePPUCache(const std::string& base_dir, bool is_intera
 		if (QFile::remove(filepath))
 		{
 			++files_removed;
-			game_list_log.notice("Removed PPU cache file: %s", sstr(filepath));
+			game_list_log.notice("Removed PPU cache file: %s", filepath);
 		}
 		else
 		{
-			game_list_log.warning("Could not remove PPU cache file: %s", sstr(filepath));
+			game_list_log.warning("Could not remove PPU cache file: %s", filepath);
 		}
 
 		++files_total;
@@ -1784,11 +1784,11 @@ bool game_list_frame::RemoveSPUCache(const std::string& base_dir, bool is_intera
 		if (QFile::remove(filepath))
 		{
 			++files_removed;
-			game_list_log.notice("Removed SPU cache file: %s", sstr(filepath));
+			game_list_log.notice("Removed SPU cache file: %s", filepath);
 		}
 		else
 		{
-			game_list_log.warning("Could not remove SPU cache file: %s", sstr(filepath));
+			game_list_log.warning("Could not remove SPU cache file: %s", filepath);
 		}
 
 		++files_total;

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -299,7 +299,7 @@ void gs_frame::keyPressEvent(QKeyEvent *keyEvent)
 
 void gs_frame::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const QKeySequence& key_sequence)
 {
-	gui_log.notice("Game window registered shortcut: %s (%s)", shortcut_key, key_sequence.toString().toStdString());
+	gui_log.notice("Game window registered shortcut: %s (%s)", shortcut_key, key_sequence.toString());
 
 	switch (shortcut_key)
 	{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -185,7 +185,7 @@ void gui_application::SwitchTranslator(QTranslator& translator, const QString& f
 	else if (const QString default_code = QLocale(QLocale::English).bcp47Name(); language_code != default_code)
 	{
 		// show error, but ignore default case "en", since it is handled in source code
-		gui_log.error("No translation file found in: %s", file_path.toStdString());
+		gui_log.error("No translation file found in: %s", file_path);
 
 		// reset current language to default "en"
 		m_language_code = default_code;
@@ -227,7 +227,7 @@ void gui_application::LoadLanguage(const QString& language_code)
 
 	m_gui_settings->SetValue(gui::loc_language, m_language_code);
 
-	gui_log.notice("Current language changed to %s (%s)", locale_name.toStdString(), language_code.toStdString());
+	gui_log.notice("Current language changed to %s (%s)", locale_name, language_code);
 }
 
 QStringList gui_application::GetAvailableLanguageCodes()
@@ -249,7 +249,7 @@ QStringList gui_application::GetAvailableLanguageCodes()
 
 			if (language_codes.contains(language_code))
 			{
-				gui_log.error("Found duplicate language '%s' (%s)", language_code.toStdString(), filename.toStdString());
+				gui_log.error("Found duplicate language '%s' (%s)", language_code, filename);
 			}
 			else
 			{
@@ -715,7 +715,7 @@ void gui_application::OnChangeStyleSheetRequest()
 		}
 		else
 		{
-			gui_log.error("Could not find stylesheet '%s'. Using default.", stylesheet_name.toStdString());
+			gui_log.error("Could not find stylesheet '%s'. Using default.", stylesheet_name);
 			setStyleSheet(gui::stylesheets::default_style_sheet);
 		}
 	}

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -143,7 +143,7 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 
 	if (has_gui_setting && !GetValue(entry).toBool())
 	{
-		cfg_log.notice("%s Dialog for Entry %s was ignored", dialog_type, entry.name.toStdString());
+		cfg_log.notice("%s Dialog for Entry %s was ignored", dialog_type, entry.name);
 		return;
 	}
 
@@ -169,7 +169,7 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 		if (checkBox && checkBox->isChecked())
 		{
 			SetValue(entry, false);
-			cfg_log.notice("%s Dialog for Entry %s is now disabled", dialog_type, entry.name.toStdString());
+			cfg_log.notice("%s Dialog for Entry %s is now disabled", dialog_type, entry.name);
 		}
 	});
 

--- a/rpcs3/rpcs3qt/infinity_dialog.cpp
+++ b/rpcs3/rpcs3qt/infinity_dialog.cpp
@@ -545,7 +545,7 @@ figure_creator_dialog::figure_creator_dialog(QWidget* parent, u8 slot)
 
 bool figure_creator_dialog::create_blank_figure(u32 character, u8 series)
 {
-	infinity_log.trace("File path: %s Character: %d Series: %d", m_file_path.toStdString(), character, series);
+	infinity_log.trace("File path: %s Character: %d Series: %d", m_file_path, character, series);
 	fs::file inf_file(m_file_path.toStdString(), fs::read + fs::write + fs::create);
 	if (!inf_file)
 	{

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -129,7 +129,7 @@ static QTreeWidgetItem* find_node(QTreeWidgetItem* root, u32 id)
 		}
 	}
 
-	sys_log.fatal("find_node(root=%s, id=%d) failed", root ? root->text(0).toStdString() : "?", id);
+	sys_log.fatal("find_node(root=%s, id=%d) failed", root ? root->text(0) : "?", id);
 	return nullptr;
 }
 
@@ -146,7 +146,7 @@ static QTreeWidgetItem* add_volatile_node(QTreeWidgetItem* parent, const QString
 	}
 	else
 	{
-		sys_log.fatal("add_volatile_node(parent=%s, regexp=%s) failed", parent ? parent->text(0).toStdString() : "?", base_text.toStdString() + ".*");
+		sys_log.fatal("add_volatile_node(parent=%s, regexp=%s) failed", parent ? parent->text(0) : "?", base_text + ".*");
 	}
 	return node;
 }
@@ -1010,7 +1010,7 @@ void kernel_explorer::log(u32 level, QTreeWidgetItem* item)
 		m_log_buf = qstr(fmt::format("Kernel Explorer: %s\n", Emu.GetTitleAndTitleID()));
 		log(level + 1, item);
 
-		sys_log.success("%s", m_log_buf.toStdString());
+		sys_log.success("%s", m_log_buf);
 		return;
 	}
 

--- a/rpcs3/rpcs3qt/log_viewer.cpp
+++ b/rpcs3/rpcs3qt/log_viewer.cpp
@@ -162,11 +162,11 @@ void log_viewer::show_context_menu(const QPoint& pos)
 		{
 			log_file.write(m_log_text->toPlainText().toUtf8());
 			log_file.close();
-			gui_log.success("Exported filtered log to file '%s'", file_path.toStdString());
+			gui_log.success("Exported filtered log to file '%s'", file_path);
 		}
 		else
 		{
-			gui_log.error("Failed to export filtered log to file '%s'", file_path.toStdString());
+			gui_log.error("Failed to export filtered log to file '%s'", file_path);
 		}
 	});
 
@@ -242,7 +242,7 @@ void log_viewer::show_log()
 	}
 	else
 	{
-		gui_log.error("log_viewer: Failed to open %s", m_path_last.toStdString());
+		gui_log.error("log_viewer: Failed to open %s", m_path_last);
 		m_log_text->setPlainText(tr("Failed to open '%0'").arg(m_path_last));
 	}
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -312,7 +312,7 @@ void main_window::ResizeIcons(int index)
 
 void main_window::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const QKeySequence& key_sequence)
 {
-	gui_log.notice("Main window registered shortcut: %s (%s)", shortcut_key, key_sequence.toString().toStdString());
+	gui_log.notice("Main window registered shortcut: %s (%s)", shortcut_key, key_sequence.toString());
 
 	const system_state status = Emu.GetStatus();
 
@@ -781,7 +781,7 @@ bool main_window::InstallPackages(QStringList file_paths, bool from_boot)
 		if (QMessageBox::question(this, tr("PKG Decrypter / Installer"), tr("Do you want to install this package?\n\n%0").arg(info_string),
 			QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
 		{
-			gui_log.notice("PKG: Cancelled installation from drop.\n%s", sstr(info_string));
+			gui_log.notice("PKG: Cancelled installation from drop.\n%s", info_string);
 			return true;
 		}
 	}
@@ -1006,25 +1006,25 @@ bool main_window::HandlePackageInstallation(QStringList file_paths, bool from_bo
 			{
 			case package_reader::result::success:
 			{
-				gui_log.success("Successfully installed %s (title_id=%s, title=%s, version=%s).", sstr(package.path), sstr(package.title_id), sstr(package.title), sstr(package.version));
+				gui_log.success("Successfully installed %s (title_id=%s, title=%s, version=%s).", package.path, package.title_id, package.title, package.version);
 				break;
 			}
 			case package_reader::result::not_started:
 			case package_reader::result::started:
 			case package_reader::result::aborted:
 			{
-				gui_log.notice("Aborted installation of %s (title_id=%s, title=%s, version=%s).", sstr(package.path), sstr(package.title_id), sstr(package.title), sstr(package.version));
+				gui_log.notice("Aborted installation of %s (title_id=%s, title=%s, version=%s).", package.path, package.title_id, package.title, package.version);
 				break;
 			}
 			case package_reader::result::error:
 			{
-				gui_log.error("Failed to install %s (title_id=%s, title=%s, version=%s).", sstr(package.path), sstr(package.title_id), sstr(package.title), sstr(package.version));
+				gui_log.error("Failed to install %s (title_id=%s, title=%s, version=%s).", package.path, package.title_id, package.title, package.version);
 				break;
 			}
 			case package_reader::result::aborted_dirty:
 			case package_reader::result::error_dirty:
 			{
-				gui_log.error("Partially installed %s (title_id=%s, title=%s, version=%s).", sstr(package.path), sstr(package.title_id), sstr(package.title), sstr(package.version));
+				gui_log.error("Partially installed %s (title_id=%s, title=%s, version=%s).", package.path, package.title_id, package.title, package.version);
 				break;
 			}
 			}
@@ -1151,12 +1151,12 @@ bool main_window::HandlePackageInstallation(QStringList file_paths, bool from_bo
 
 			if (error == package_error::app_version)
 			{
-				gui_log.error("Cannot install %s.", sstr(package->path));
+				gui_log.error("Cannot install %s.", package->path);
 				QMessageBox::warning(this, tr("Warning!"), tr("The following package cannot be installed on top of the current data:\n%1!").arg(package->path));
 			}
 			else
 			{
-				gui_log.error("Failed to install %s.", sstr(package->path));
+				gui_log.error("Failed to install %s.", package->path);
 				QMessageBox::critical(this, tr("Failure!"), tr("Failed to install software from package:\n%1!"
 					"\nThis is very likely caused by external interference from a faulty anti-virus software."
 					"\nPlease add RPCS3 to your anti-virus\' whitelist or use better anti-virus software.").arg(package->path));
@@ -1198,7 +1198,7 @@ void main_window::InstallPup(QString file_path)
 		if (QMessageBox::question(this, tr("RPCS3 Firmware Installer"), tr("Install firmware: %1?").arg(file_path),
 			QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
 		{
-			gui_log.notice("Firmware: Cancelled installation from drop. File: %s", sstr(file_path));
+			gui_log.notice("Firmware: Cancelled installation from drop. File: %s", file_path);
 			return;
 		}
 	}
@@ -1391,7 +1391,7 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 
 		if (!vfs::mount("/pup_extract", sstr(dir_path) + '/'))
 		{
-			gui_log.error("Error while extracting firmware: Failed to mount '%s'", sstr(dir_path));
+			gui_log.error("Error while extracting firmware: Failed to mount '%s'", dir_path);
 			critical(tr("Firmware extraction failed: VFS mounting failed."));
 			return;
 		}
@@ -1402,7 +1402,7 @@ void main_window::HandlePupInstallation(const QString& file_path, const QString&
 			critical(tr("Firmware installation failed: Firmware contents could not be extracted."));
 		}
 
-		gui_log.success("Extracted PUP file to %s", sstr(dir_path));
+		gui_log.success("Extracted PUP file to %s", dir_path);
 		return;
 	}
 
@@ -1597,7 +1597,7 @@ void main_window::DecryptSPRXLibraries()
 
 		if (repeat_count >= 2)
 		{
-			gui_log.error("Failed to decrypt %s with specified KLIC, retrying.\n%s", path, sstr(hint));
+			gui_log.error("Failed to decrypt %s with specified KLIC, retrying.\n%s", path, hint);
 		}
 
 		input_dialog* dlg = new input_dialog(39, "", tr("Enter KLIC of %0").arg(qstr(filename)),
@@ -3126,11 +3126,11 @@ void main_window::RemoveFirmwareCache()
 		if (QDir(path).removeRecursively())
 		{
 			++caches_removed;
-			gui_log.notice("Removed firmware cache: %s", sstr(path));
+			gui_log.notice("Removed firmware cache: %s", path);
 		}
 		else
 		{
-			gui_log.warning("Could not remove firmware cache: %s", sstr(path));
+			gui_log.warning("Could not remove firmware cache: %s", path);
 		}
 
 		++caches_total;
@@ -3389,12 +3389,12 @@ void main_window::dropEvent(QDropEvent* event)
 
 		if (const auto error = Emu.BootGame(sstr(drop_paths.first()), "", true); error != game_boot_result::no_errors)
 		{
-			gui_log.error("Boot failed: reason: %s, path: %s", error, sstr(drop_paths.first()));
+			gui_log.error("Boot failed: reason: %s, path: %s", error, drop_paths.first());
 			show_boot_error(error);
 		}
 		else
 		{
-			gui_log.success("Elf Boot from drag and drop done: %s", sstr(drop_paths.first()));
+			gui_log.success("Elf Boot from drag and drop done: %s", drop_paths.first());
 			m_game_list_frame->Refresh(true);
 		}
 		break;

--- a/rpcs3/rpcs3qt/memory_string_searcher.cpp
+++ b/rpcs3/rpcs3qt/memory_string_searcher.cpp
@@ -119,8 +119,7 @@ u64 memory_viewer_panel::OnSearch(std::string wstr, u32 mode)
 
 		if (const usz pos = wstr.find_first_not_of(hex_chars); pos != umax)
 		{
-			gui_log.error("String '%s' cannot be interpreted as hexadecimal byte string due to unknown character '%c'.",
-				m_search_line->text().toStdString(), wstr[pos]);
+			gui_log.error("String '%s' cannot be interpreted as hexadecimal byte string due to unknown character '%c'.", m_search_line->text(), wstr[pos]);
 			return 0;
 		}
 

--- a/rpcs3/rpcs3qt/pad_motion_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_motion_settings_dialog.cpp
@@ -116,7 +116,7 @@ pad_motion_settings_dialog::pad_motion_settings_dialog(QDialog* parent, std::sha
 				std::lock_guard lock(m_config_mutex);
 				if (!m_config_entries[i]->axis.from_string(m_axis_names[i]->itemText(index).toStdString()))
 				{
-					cfg_log.error("Failed to convert motion axis string: %s", m_axis_names[i]->itemData(index).toString().toStdString());
+					cfg_log.error("Failed to convert motion axis string: %s", m_axis_names[i]->itemData(index).toString());
 				}
 			});
 		}

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -36,7 +36,7 @@ inline bool CreateConfigFile(const QString& dir, const QString& name)
 {
 	if (!QDir().mkpath(dir))
 	{
-		cfg_log.fatal("Failed to create dir %s", sstr(dir));
+		cfg_log.fatal("Failed to create dir %s", dir);
 		return false;
 	}
 
@@ -45,7 +45,7 @@ inline bool CreateConfigFile(const QString& dir, const QString& name)
 
 	if (!new_file.open(QIODevice::WriteOnly))
 	{
-		cfg_log.fatal("Failed to create file %s", sstr(filename));
+		cfg_log.fatal("Failed to create file %s", filename);
 		return false;
 	}
 
@@ -612,7 +612,7 @@ pad_device_info pad_settings_dialog::get_pad_info(QComboBox* combo, int index)
 
 	if (!user_data.canConvert<pad_device_info>())
 	{
-		cfg_log.fatal("get_pad_info: Cannot convert itemData for index %d and itemText %s", index, sstr(combo->itemText(index)));
+		cfg_log.fatal("get_pad_info: Cannot convert itemData for index %d and itemText %s", index, combo->itemText(index));
 		return {};
 	}
 
@@ -1570,7 +1570,7 @@ void pad_settings_dialog::ChangeDevice(int index)
 
 	if (!user_data.canConvert<pad_device_info>())
 	{
-		cfg_log.fatal("ChangeDevice: Cannot convert itemData for index %d and itemText %s", index, sstr(ui->chooseDevice->itemText(index)));
+		cfg_log.fatal("ChangeDevice: Cannot convert itemData for index %d and itemText %s", index, ui->chooseDevice->itemText(index));
 		return;
 	}
 

--- a/rpcs3/rpcs3qt/patch_creator_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.cpp
@@ -14,7 +14,6 @@
 LOG_CHANNEL(patch_log, "PAT");
 
 constexpr auto qstr = QString::fromStdString;
-inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 
 Q_DECLARE_METATYPE(patch_type)
 
@@ -215,7 +214,7 @@ void patch_creator_dialog::add_instruction(int row)
 	ui->instructionTable->setItem(row, patch_column::value, new QTableWidgetItem(value));
 	ui->instructionTable->setItem(row, patch_column::comment, new QTableWidgetItem(comment));
 
-	patch_log.notice("Patch Creator: Inserted instruction [ %s, %s, %s ] at row %d", sstr(combo_box->currentText()), sstr(offset), sstr(value), row);
+	patch_log.notice("Patch Creator: Inserted instruction [ %s, %s, %s ] at row %d", combo_box->currentText(), offset, value, row);
 	generate_yml();
 }
 
@@ -377,11 +376,11 @@ void patch_creator_dialog::export_patch()
 	{
 		patch_file.write(ui->patchEdit->toPlainText().toUtf8());
 		patch_file.close();
-		patch_log.success("Exported patch to file '%s'", sstr(file_path));
+		patch_log.success("Exported patch to file '%s'", file_path);
 	}
 	else
 	{
-		patch_log.fatal("Failed to export patch to file '%s'", sstr(file_path));
+		patch_log.fatal("Failed to export patch to file '%s'", file_path);
 	}
 }
 

--- a/rpcs3/rpcs3qt/persistent_settings.cpp
+++ b/rpcs3/rpcs3qt/persistent_settings.cpp
@@ -54,6 +54,6 @@ QString persistent_settings::GetCurrentUser(const QString& fallback) const
 		return user;
 	}
 
-	cfg_log.fatal("Could not parse user setting: '%s'.", user.toStdString());
+	cfg_log.fatal("Could not parse user setting: '%s'.", user);
 	return QString();
 }

--- a/rpcs3/rpcs3qt/qt_camera_error_handler.cpp
+++ b/rpcs3/rpcs3qt/qt_camera_error_handler.cpp
@@ -76,5 +76,5 @@ void qt_camera_error_handler::handle_capture_modes(QCamera::CaptureModes capture
 
 void qt_camera_error_handler::handle_camera_error(QCamera::Error error)
 {
-	camera_log.error("Error event: \"%s\" (error=%d)", m_camera ? m_camera->errorString().toStdString() : "", static_cast<int>(error));
+	camera_log.error("Error event: \"%s\" (error=%d)", m_camera ? m_camera->errorString() : "", static_cast<int>(error));
 }

--- a/rpcs3/rpcs3qt/qt_camera_handler.cpp
+++ b/rpcs3/rpcs3qt/qt_camera_handler.cpp
@@ -15,7 +15,7 @@ qt_camera_handler::qt_camera_handler() : camera_handler_base()
 	// List available cameras
 	for (const QCameraInfo& cameraInfo : QCameraInfo::availableCameras())
 	{
-		camera_log.success("Found camera: name=%s, description=%s", cameraInfo.deviceName().toStdString(), cameraInfo.description().toStdString());
+		camera_log.success("Found camera: name=%s, description=%s", cameraInfo.deviceName(), cameraInfo.description());
 	}
 
 	if (!g_cfg_camera.load())
@@ -48,7 +48,7 @@ void qt_camera_handler::set_camera(const QCameraInfo& camera_info)
 	// Determine if the camera is front facing, in which case we will need to flip the image horizontally.
 	const bool front_facing = camera_info.position() == QCamera::Position::FrontFace;
 
-	camera_log.success("Using camera: name=\"%s\", description=\"%s\", front_facing=%d", camera_info.deviceName().toStdString(), camera_info.description().toStdString(), front_facing);
+	camera_log.success("Using camera: name=\"%s\", description=\"%s\", front_facing=%d", camera_info.deviceName(), camera_info.description(), front_facing);
 
 	// Create camera and video surface
 	m_surface.reset(new qt_camera_video_surface(front_facing, nullptr));

--- a/rpcs3/rpcs3qt/qt_music_error_handler.cpp
+++ b/rpcs3/rpcs3qt/qt_music_error_handler.cpp
@@ -94,5 +94,5 @@ void qt_music_error_handler::handle_music_state(QMediaPlayer::State state)
 
 void qt_music_error_handler::handle_music_error(QMediaPlayer::Error error)
 {
-	music_log.error("Error event: \"%s\" (error=%s)", m_media_player ? m_media_player->errorString().toStdString() : "", error);
+	music_log.error("Error event: \"%s\" (error=%s)", m_media_player ? m_media_player->errorString() : "", error);
 }

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -16,7 +16,6 @@
 
 LOG_CHANNEL(gui_log, "GUI");
 
-inline std::string sstr(const QString& _in) { return _in.toStdString(); }
 constexpr auto qstr = QString::fromStdString;
 
 namespace gui
@@ -368,8 +367,8 @@ namespace gui
 			{
 				// Get Icon for the gs_frame from path. this handles presumably all possible use cases
 				const QString qpath = qstr(path);
-				const std::string path_list[] = { path, sstr(qpath.section("/", 0, -2, QString::SectionIncludeTrailingSep)),
-					                              sstr(qpath.section("/", 0, -3, QString::SectionIncludeTrailingSep)) };
+				const std::string path_list[] = { path, qpath.section("/", 0, -2, QString::SectionIncludeTrailingSep).toStdString(),
+					                              qpath.section("/", 0, -3, QString::SectionIncludeTrailingSep).toStdString() };
 
 				for (const std::string& pth : path_list)
 				{
@@ -427,7 +426,7 @@ namespace gui
 #ifdef _WIN32
 				// Remove double slashes and convert to native separators. Double slashes don't seem to work with the explorer call.
 				path.replace(QRegularExpression("[\\\\|/]+"), QDir::separator());
-				gui_log.notice("gui::utils::open_dir: About to open file path '%s' (original: '%s')", path.toStdString(), spath);
+				gui_log.notice("gui::utils::open_dir: About to open file path '%s' (original: '%s')", path, spath);
 
 				if (!QProcess::startDetached("explorer.exe", {"/select,", path}))
 				{
@@ -470,7 +469,7 @@ namespace gui
 
 		void open_dir(const QString& path)
 		{
-			open_dir(sstr(path));
+			open_dir(path.toStdString());
 		}
 
 		QTreeWidgetItem* find_child(QTreeWidgetItem* parent, const QString& text)

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -392,11 +392,11 @@ void Buffer::ShowContextMenu(const QPoint& pos)
 
 		if (m_image.save(path, "PNG", 100))
 		{
-			rsx_debugger.success("Saved image to '%s'", path.toStdString());
+			rsx_debugger.success("Saved image to '%s'", path);
 		}
 		else
 		{
-			rsx_debugger.error("Failure to save image to '%s'", path.toStdString());
+			rsx_debugger.error("Failure to save image to '%s'", path);
 		}
 	});
 

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -34,8 +34,6 @@ namespace
 	// Helper converters
 	constexpr auto qstr = QString::fromStdString;
 
-	[[maybe_unused]] inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-
 	QString FormatTimestamp(s64 time)
 	{
 		QDateTime dateTime;

--- a/rpcs3/rpcs3qt/settings.cpp
+++ b/rpcs3/rpcs3qt/settings.cpp
@@ -4,8 +4,6 @@
 
 #include "Utilities/File.h"
 
-inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-
 settings::settings(QObject* parent) : QObject(parent),
 	m_settings_dir(ComputeSettingsDir())
 {

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -822,11 +822,11 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 				idx = 0;
 				if (renderer.old_adapter.isEmpty())
 				{
-					rsx_log.warning("%s adapter config empty: setting to default!", sstr(renderer.name));
+					rsx_log.warning("%s adapter config empty: setting to default!", renderer.name);
 				}
 				else
 				{
-					rsx_log.warning("Last used %s adapter not found: setting to default!", sstr(renderer.name));
+					rsx_log.warning("Last used %s adapter not found: setting to default!", renderer.name);
 				}
 			}
 			ui->graphicsAdapterBox->setCurrentIndex(idx);
@@ -2428,7 +2428,7 @@ void settings_dialog::AddStylesheets()
 	}
 	else
 	{
-		cfg_log.warning("Trying to set an invalid stylesheets index: %d (%s)", index, sstr(m_current_stylesheet));
+		cfg_log.warning("Trying to set an invalid stylesheets index: %d (%s)", index, m_current_stylesheet);
 	}
 }
 

--- a/rpcs3/rpcs3qt/shortcut_handler.cpp
+++ b/rpcs3/rpcs3qt/shortcut_handler.cpp
@@ -38,7 +38,7 @@ shortcut_handler::shortcut_handler(gui::shortcuts::shortcut_handler_id handler_i
 			// TODO: do not allow same shortcuts and remove this connect
 			// activatedAmbiguously will trigger if you have the same key sequence for several shortcuts
 			const QKeySequence& key_sequence = m_shortcuts[key].key_sequence;
-			shortcut_log.error("Shortcut activated ambiguously: %s (%s)", key, key_sequence.toString().toStdString());
+			shortcut_log.error("Shortcut activated ambiguously: %s (%s)", key, key_sequence.toString());
 			handle_shortcut(key, key_sequence);
 		});
 	}
@@ -71,7 +71,7 @@ void shortcut_handler::update()
 
 void shortcut_handler::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const QKeySequence& key_sequence)
 {
-	shortcut_log.notice("Shortcut pressed: %s (%s)", shortcut_key, key_sequence.toString().toStdString());
+	shortcut_log.notice("Shortcut pressed: %s (%s)", shortcut_key, key_sequence.toString());
 
 	Q_EMIT shortcut_activated(shortcut_key, key_sequence);
 }

--- a/rpcs3/rpcs3qt/shortcut_utils.cpp
+++ b/rpcs3/rpcs3qt/shortcut_utils.cpp
@@ -328,7 +328,7 @@ namespace gui::utils
 
 		if (!description.empty())
 		{
-			fmt::append(file_content, "Comment=%s\n", QString::fromStdString(description).simplified().toStdString());
+			fmt::append(file_content, "Comment=%s\n", QString::fromStdString(description).simplified());
 		}
 
 		if (!src_icon_path.empty() && !target_icon_dir.empty())

--- a/rpcs3/rpcs3qt/system_cmd_dialog.cpp
+++ b/rpcs3/rpcs3qt/system_cmd_dialog.cpp
@@ -114,7 +114,7 @@ void system_cmd_dialog::send_command()
 	const qulonglong status = m_command_box->currentData().toULongLong(&ok);
 	if (!ok)
 	{
-		gui_log.error("system_cmd_dialog::send_command: command can not be converted to qulonglong: %s", m_command_box->currentText().toStdString());
+		gui_log.error("system_cmd_dialog::send_command: command can not be converted to qulonglong: %s", m_command_box->currentText());
 		QMessageBox::warning(this, tr("Listen!"), tr("The selected command is bugged.\nPlease contact a developer."));
 		return;
 	}
@@ -122,7 +122,7 @@ void system_cmd_dialog::send_command()
 	const qulonglong param = hex_value(m_value_input->text(), ok);
 	if (!ok)
 	{
-		gui_log.error("system_cmd_dialog::send_command: value can not be converted to qulonglong: %s", m_value_input->text().toStdString());
+		gui_log.error("system_cmd_dialog::send_command: value can not be converted to qulonglong: %s", m_value_input->text());
 		QMessageBox::information(this, tr("Listen!"), tr("Please select a proper value first."));
 		return;
 	}
@@ -137,7 +137,7 @@ void system_cmd_dialog::send_custom_command()
 	const qulonglong status = hex_value(m_custom_command_input->text(), ok);
 	if (!ok)
 	{
-		gui_log.error("system_cmd_dialog::send_custom_command: command can not be converted to qulonglong: %s", m_custom_command_input->text().toStdString());
+		gui_log.error("system_cmd_dialog::send_custom_command: command can not be converted to qulonglong: %s", m_custom_command_input->text());
 		QMessageBox::information(this, tr("Listen!"), tr("Please select a proper custom command first."));
 		return;
 	}
@@ -145,7 +145,7 @@ void system_cmd_dialog::send_custom_command()
 	const qulonglong param = hex_value(m_value_input->text(), ok);
 	if (!ok)
 	{
-		gui_log.error("system_cmd_dialog::send_custom_command: value can not be converted to qulonglong: %s", m_value_input->text().toStdString());
+		gui_log.error("system_cmd_dialog::send_custom_command: value can not be converted to qulonglong: %s", m_value_input->text());
 		QMessageBox::information(this, tr("Listen!"), tr("Please select a proper value first."));
 		return;
 	}

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -177,7 +177,7 @@ bool update_manager::handle_json(bool automatic, bool check_only, bool auto_acce
 
 	const qint64 diff_msec = cur_date.msecsTo(lts_date);
 
-	update_log.notice("Current: %s, latest: %s, difference: %lld ms", cur_str.toStdString(), lts_str.toStdString(), diff_msec);
+	update_log.notice("Current: %s, latest: %s, difference: %lld ms", cur_str, lts_str, diff_msec);
 
 	const Localized localized;
 

--- a/rpcs3/rpcs3qt/vfs_dialog.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog.cpp
@@ -12,8 +12,6 @@
 #include "Emu/System.h"
 #include "Emu/vfs_config.h"
 
-inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-
 vfs_dialog::vfs_dialog(std::shared_ptr<gui_settings> _gui_settings, QWidget* parent)
 	: QDialog(parent), m_gui_settings(std::move(_gui_settings))
 {

--- a/rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp
@@ -7,8 +7,6 @@
 
 #include "Emu/vfs_config.h"
 
-inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-
 vfs_dialog_usb_input::vfs_dialog_usb_input(const QString& name, const cfg::device_info& default_info, cfg::device_info* info, std::shared_ptr<gui_settings> _gui_settings, QWidget* parent)
 	: QDialog(parent), m_gui_settings(std::move(_gui_settings)), m_gui_save(gui::fs_dev_usb_list)
 {


### PR DESCRIPTION
- Removes the need to convert a QString to std::string when logging.
- Adds a fmt wrapper for name64 conversion
- Check log level before calling some potentially "expensive" trace calls