### PR TITLE
PPUAnalyser: fix std::move misuse

### DIFF
--- a/rpcs3/Crypto/decrypt_binaries.cpp
+++ b/rpcs3/Crypto/decrypt_binaries.cpp
@@ -75,7 +75,6 @@ usz decrypt_binaries_t::decrypt(std::string klic_input)
 
 		fs::file elf_file;
 
-		bool tried = false;
 		bool invalid = false;
 		usz key_it = 0;
 		u32 file_magic{};

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -1008,11 +1008,11 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 						add_toc(toc);
 						add_func(func.addr, toc, 0);
 					}
-					else if (new_func.toc - func.toc != toc_add)
-					{
-						//func.toc = -1;
-						//new_func.toc = -1;
-					}
+					//else if (new_func.toc - func.toc != toc_add)
+					//{
+					//	func.toc = -1;
+					//	new_func.toc = -1;
+					//}
 
 					if (new_func.blocks.empty())
 					{
@@ -1055,11 +1055,11 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 						add_toc(toc);
 						add_func(func.addr, toc, 0);
 					}
-					else if (new_func.toc - func.toc != toc_add)
-					{
-						//func.toc = -1;
-						//new_func.toc = -1;
-					}
+					//else if (new_func.toc - func.toc != toc_add)
+					//{
+					//	func.toc = -1;
+					//	new_func.toc = -1;
+					//}
 
 					if (new_func.blocks.empty())
 					{
@@ -1472,7 +1472,8 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 			{
 				break;
 			}
-			else if (addr == start && op.opcode == ppu_instructions::NOP())
+
+			if (addr == start && op.opcode == ppu_instructions::NOP())
 			{
 				if (start == func.addr + func.size)
 				{
@@ -1483,16 +1484,19 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 				start += 4;
 				continue;
 			}
-			else if (type == ppu_itype::SC && op.opcode != ppu_instructions::SC(0))
+
+			if (type == ppu_itype::SC && op.opcode != ppu_instructions::SC(0))
 			{
 				break;
 			}
-			else if (addr == start && op.opcode == ppu_instructions::BLR())
+
+			if (addr == start && op.opcode == ppu_instructions::BLR())
 			{
 				start += 4;
 				continue;
 			}
-			else if (type == ppu_itype::B || type == ppu_itype::BC)
+
+			if (type == ppu_itype::B || type == ppu_itype::BC)
 			{
 				const u32 target = (op.aa ? 0 : addr) + (type == ppu_itype::B ? +op.bt24 : +op.bt14);
 
@@ -1539,7 +1543,7 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 		end = 0;
 	}
 
-	for (auto&& [_, func] : as_rvalue(std::move(fmap)))
+	for (auto&& [_, func] : as_rvalue(fmap))
 	{
 		if (func.attr & ppu_attr::no_size && entry)
 		{
@@ -1560,7 +1564,7 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 			continue;
 		}
 
-		for (auto [addr, size] : func.blocks)
+		for (const auto& [addr, size] : func.blocks)
 		{
 			if (!size)
 			{
@@ -1598,7 +1602,7 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 	for (auto& rel : this->relocs)
 	{
 		// Disabled (TODO)
-		if (1 || !vm::check_addr<4>(rel.addr))
+		//if (!vm::check_addr<4>(rel.addr))
 		{
 			continue;
 		}
@@ -1722,9 +1726,7 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 							break;
 						}
 
-						const auto found = fmap.find(target);
-
-						if (target != i_pos && found == fmap.cend())
+						if (target != i_pos && !fmap.contains(target))
 						{
 							if (block_set.count(target) == 0)
 							{
@@ -1782,9 +1784,7 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 			else if (is_good && is_fallback && lim < end)
 			{
 				// Register fallback target
-				const auto found = fmap.find(lim);
-
-				if (found == fmap.cend() && block_set.count(lim) == 0)
+				if (!fmap.contains(lim) && !block_set.contains(lim))
 				{
 					ppu_log.trace("Block target found: 0x%x (i_pos=0x%x)", lim, i_pos);
 					block_queue.emplace_back(lim, 0);

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -1,4 +1,4 @@
-﻿#include "stdafx.h"
+#include "stdafx.h"
 #include "sys_lwcond.h"
 
 #include "Emu/IdManager.h"
@@ -566,8 +566,6 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 		{
 			if (lv2_obj::wait_timeout(timeout, &ppu))
 			{
-				const u64 start_time = ppu.start_time;
-
 				// Wait for rescheduling
 				if (ppu.check_state())
 				{


### PR DESCRIPTION
There seems to be an unwanted - or at least mishandled - std::move of the ppu function map in ppu_module::analyse.
The object is used later again, so this seems like a bug to me.