### PR TITLE
vk: Handle VK_ERROR_FRAGMENTATION when allocating descriptor pools

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1202,6 +1202,12 @@ bool VKGSRender::on_vram_exhausted(rsx::problem_severity severity)
 	return any_cache_relieved;
 }
 
+void VKGSRender::on_descriptor_pool_fragmentation()
+{
+	// Just flush everything. Unless the hardware is very deficient, this should happen very rarely.
+	flush_command_queue(true, true);
+}
+
 void VKGSRender::notify_tile_unbound(u32 tile)
 {
 	//TODO: Handle texture writeback

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1202,8 +1202,15 @@ bool VKGSRender::on_vram_exhausted(rsx::problem_severity severity)
 	return any_cache_relieved;
 }
 
-void VKGSRender::on_descriptor_pool_fragmentation()
+void VKGSRender::on_descriptor_pool_fragmentation(bool is_fatal)
 {
+	if (!is_fatal)
+	{
+		// It is very likely that the release is simply in progress (enqueued)
+		m_primary_cb_list.wait_all();
+		return;
+	}
+
 	// Just flush everything. Unless the hardware is very deficient, this should happen very rarely.
 	flush_command_queue(true, true);
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -263,6 +263,9 @@ public:
 	// External callback to handle out of video memory problems
 	bool on_vram_exhausted(rsx::problem_severity severity);
 
+	// Handle pool creation failure due to fragmentation
+	void on_descriptor_pool_fragmentation();
+
 	// Conditional rendering
 	void begin_conditional_rendering(const std::vector<rsx::reports::occlusion_query_info*>& sources) override;
 	void end_conditional_rendering() override;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -264,7 +264,7 @@ public:
 	bool on_vram_exhausted(rsx::problem_severity severity);
 
 	// Handle pool creation failure due to fragmentation
-	void on_descriptor_pool_fragmentation();
+	void on_descriptor_pool_fragmentation(bool is_fatal);
 
 	// Conditional rendering
 	void begin_conditional_rendering(const std::vector<rsx::reports::occlusion_query_info*>& sources) override;

--- a/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
@@ -345,6 +345,14 @@ namespace vk
 			}
 		}
 
+		void wait_all()
+		{
+			for (auto& cb : m_cb_list)
+			{
+				cb.wait();
+			}
+		}
+
 		inline command_buffer_chunk* next()
 		{
 			const auto result_id = ++m_current_index % Count;

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -268,4 +268,12 @@ namespace vk
 
 		renderer->emergency_query_cleanup(&cmd);
 	}
+
+	void on_descriptor_pool_fragmentation()
+	{
+		if (auto vkthr = dynamic_cast<VKGSRender*>(rsx::get_current_renderer()))
+		{
+			vkthr->on_descriptor_pool_fragmentation();
+		}
+	}
 }

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -269,11 +269,11 @@ namespace vk
 		renderer->emergency_query_cleanup(&cmd);
 	}
 
-	void on_descriptor_pool_fragmentation()
+	void on_descriptor_pool_fragmentation(bool is_fatal)
 	{
 		if (auto vkthr = dynamic_cast<VKGSRender*>(rsx::get_current_renderer()))
 		{
-			vkthr->on_descriptor_pool_fragmentation();
+			vkthr->on_descriptor_pool_fragmentation(is_fatal);
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -5,7 +5,7 @@
 namespace vk
 {
 	// Error handler callback
-	extern void on_descriptor_pool_fragmentation();
+	extern void on_descriptor_pool_fragmentation(bool fatal);
 
 	namespace descriptors
 	{
@@ -228,24 +228,18 @@ namespace vk
 		m_current_subpool_offset = 0;
 		m_current_subpool_index = umax;
 
-		// Only attempt recovery once. Can be bumped up if we have a more complex setup in future.
-		int retries = 1;
+		const int max_retries = 2;
+		int retries = max_retries;
 
-		while (m_current_subpool_index == umax)
+		do
 		{
 			for (u32 index = 0; index < m_device_subpools.size(); ++index)
 			{
 				if (!m_device_subpools[index].busy)
 				{
 					m_current_subpool_index = index;
-					break;
+					goto done; // Nested break
 				}
-			}
-
-			if (m_current_subpool_index != umax)
-			{
-				// We found something, exit early
-				break;
 			}
 
 			VkDescriptorPool subpool = VK_NULL_HANDLE;
@@ -254,12 +248,12 @@ namespace vk
 				if (retries-- && (result == VK_ERROR_FRAGMENTATION_EXT))
 				{
 					rsx_log.warning("Descriptor pool creation failed with fragmentation error. Will attempt to recover.");
-					vk::on_descriptor_pool_fragmentation();
+					vk::on_descriptor_pool_fragmentation(!retries);
 					continue;
 				}
 
 				vk::die_with_error(result);
-				break;
+				fmt::throw_exception("Unreachable");
 			}
 
 			// New subpool created successfully
@@ -272,8 +266,10 @@ namespace vk
 			});
 
 			m_current_subpool_index = m_device_subpools.size() - 1;
-		}
 
+		} while (m_current_subpool_index == umax);
+
+	done:
 		m_device_subpools[m_current_subpool_index].busy = VK_TRUE;
 		m_current_pool_handle = m_device_subpools[m_current_subpool_index].handle;
 	}

--- a/rpcs3/Emu/RSX/VK/vkutils/shared.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/shared.cpp
@@ -96,6 +96,9 @@ namespace vk
 		case VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR:
 			error_message = "Invalid external handle (VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR)";
 			break;
+		case VK_ERROR_FRAGMENTATION_EXT:
+			error_message = "Descriptor pool creation failed (VK_ERROR_FRAGMENTATION)";
+			break;
 		default:
 			error_message = fmt::format("Unknown Code (%Xh, %d)%s", static_cast<s32>(error_code), static_cast<s32>(error_code), src_loc{line, col, file, func});
 			break;


### PR DESCRIPTION
The intel driver only support 1 million descriptor objects (we use update-after-bind everywhere) which sounds like a lot until you consider that we consume something like 50 of them every draw call. The moment a complex scene appears the driver implodes.
This fix adds a fallback in the form of a full stall to reset the queues. The downside to this is that intel GPUs will never be able to render high-draw-call-count titles at any reasonable framerates. Anything with over 10k draws will just crater.

Fixes https://github.com/RPCS3/rpcs3/issues/13997