### PR TITLE
progress dialog fix

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1535,7 +1535,7 @@ void ppu_thread::cpu_task()
 			// Wait until the progress dialog is closed.
 			// We don't want to open a cell dialog while a native progress dialog is still open.
 			thread_ctrl::wait_on<atomic_wait::op_ne>(g_progr_ptotal, 0);
-			g_fxo->get<progress_dialog_server>().show_overlay_message_only = true;
+			g_fxo->get<progress_dialog_workaround>().show_overlay_message_only = true;
 
 			// Sadly we can't postpone initializing guest time because we need to run PPU threads
 			// (the farther it's postponed, the less accuracy of guest time has been lost)

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -71,7 +71,7 @@ void progress_dialog_server::operator()()
 			renderer->is_initialized.wait(false, atomic_wait_timeout(5 * 1000000000ull));
 
 			auto manager  = g_fxo->try_get<rsx::overlays::display_manager>();
-			show_overlay_message = show_overlay_message_only;
+			show_overlay_message = g_fxo->get<progress_dialog_workaround>().show_overlay_message_only;
 
 			if (manager && !show_overlay_message)
 			{

--- a/rpcs3/Emu/system_progress.hpp
+++ b/rpcs3/Emu/system_progress.hpp
@@ -39,7 +39,10 @@ struct progress_dialog_server
 	~progress_dialog_server();
 
 	static constexpr auto thread_name = "Progress Dialog Server"sv;
-	
+};
+
+struct progress_dialog_workaround
+{
 	// We don't want to show the native dialog during gameplay.
 	atomic_t<bool> show_overlay_message_only = false;
 };


### PR DESCRIPTION
For some reason setting the member of the progress_dialog_server to true doesn't work.
But it works if i again add the workaround.

I don't know why :)