### PR TITLE
vk: Batch query copy requests to reduce number of vulkan commands used

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2915,11 +2915,11 @@ void VKGSRender::begin_conditional_rendering(const std::vector<rsx::reports::occ
 
 		// Range latching. Because of how the query pool manages allocations using a stack, we get an inverse sequential set of handles/indices that we can easily group together.
 		// This drastically boosts performance on some drivers like the NVIDIA proprietary one that seems to have a rather high cost for every individual query transer command.
-		std::pair<u32, u32> query_range = { umax, 0 };
+		struct { u32 first, last; } query_range = { umax, 0 };
 
 		auto copy_query_range_impl = [&]()
 		{
-			const auto count = (query_range.second - query_range.first + 1);
+			const auto count = (query_range.last - query_range.first + 1);
 			m_occlusion_query_manager->get_query_result_indirect(*m_current_command_buffer, query_range.first, count, scratch->value, dst_offset);
 			dst_offset += count * 4;
 		};
@@ -2944,9 +2944,9 @@ void VKGSRender::begin_conditional_rendering(const std::vector<rsx::reports::occ
 				}
 
 				// Tail?
-				if ((query_range.second + 1) == index)
+				if ((query_range.last + 1) == index)
 				{
-					query_range.second = index;
+					query_range.last = index;
 					continue;
 				}
 

--- a/rpcs3/Emu/RSX/VK/VKQueryPool.cpp
+++ b/rpcs3/Emu/RSX/VK/VKQueryPool.cpp
@@ -168,11 +168,11 @@ namespace vk
 		return query_info.data;
 	}
 
-	void query_pool_manager::get_query_result_indirect(vk::command_buffer& cmd, u32 index, VkBuffer dst, VkDeviceSize dst_offset)
+	void query_pool_manager::get_query_result_indirect(vk::command_buffer& cmd, u32 index, u32 count, VkBuffer dst, VkDeviceSize dst_offset)
 	{
 		// We're technically supposed to stop any active renderpasses before streaming the results out, but that doesn't matter on IMR hw
 		// On TBDR setups like the apple M series, the stop is required (results are all 0 if you don't flush the RP), but this introduces a very heavy performance loss.
-		vkCmdCopyQueryPoolResults(cmd, *query_slot_status[index].pool, index, 1, dst, dst_offset, 4, VK_QUERY_RESULT_WAIT_BIT);
+		vkCmdCopyQueryPoolResults(cmd, *query_slot_status[index].pool, index, count, dst, dst_offset, 4, VK_QUERY_RESULT_WAIT_BIT);
 	}
 
 	void query_pool_manager::free_query(vk::command_buffer&/*cmd*/, u32 index)

--- a/rpcs3/Emu/RSX/VK/VKQueryPool.h
+++ b/rpcs3/Emu/RSX/VK/VKQueryPool.h
@@ -47,7 +47,7 @@ namespace vk
 
 		bool check_query_status(u32 index);
 		u32  get_query_result(u32 index);
-		void get_query_result_indirect(vk::command_buffer& cmd, u32 index, VkBuffer dst, VkDeviceSize dst_offset);
+		void get_query_result_indirect(vk::command_buffer& cmd, u32 index, u32 count, VkBuffer dst, VkDeviceSize dst_offset);
 
 		u32 allocate_query(vk::command_buffer& cmd);
 		void free_query(vk::command_buffer&/*cmd*/, u32 index);


### PR DESCRIPTION
RPCS3 emits query begin/end pairs corresponding to PS3 occlusion queries. Some PS3 games spam occlussion queries quite a lot, and we can end up generating hundreds of these per frame. We then read the data back using vkCmdCopyQueryResults with VK_RESULT_WAIT_BIT set to copy over the data to a buffer when available.
Unfortunately, this command and flag combo has an unusually high cost on NVIDIA drivers. We can't bring down the number of queries requested, but we can exploit the fact that our query generator uses a stack-based allocator which almost guarantees that every set of query objects will have adjacent descending query indices. This setup allows us to group the indices into larger batches for the copy operation which results in a major speedup.
Fixes the unbearable single-digit hitching in Spiderman: Web of Shadows and brings it up to a 60fps lock in most scenes.