### PR TITLE
Memory Viewer Improvements

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -310,6 +310,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 			"\nKeys Ctrl+C: Copy instruction contents."
 			"\nKeys Ctrl+F: Find thread."
 			"\nKeys Alt+S: Capture SPU images of selected SPU or generalized form when used from PPU."
+			"\nKeys Alt+S: Launch a memory viewer pointed to the current RSX semaphores location when used from RSX."
 			"\nKeys Alt+R: Load last saved SPU state capture."
 			"\nKey D: SPU MFC commands logger, MFC debug setting must be enabled."
 			"\nKey D: Also PPU calling history logger, interpreter and non-zero call history size must be used."
@@ -642,6 +643,17 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 
 			if (modifiers & Qt::AltModifier)
 			{
+				if (cpu->id_type() == 0x55)
+				{
+					if (u32 addr = static_cast<rsx::thread*>(cpu)->label_addr)
+					{
+						// Memory viewer pointing to RSX semaphores
+						idm::make<memory_viewer_handle>(this, m_disasm, addr, make_check_cpu(nullptr));
+					}
+
+					return;
+				}
+
 				if (cpu->id_type() == 1)
 				{
 					new elf_memory_dumping_dialog(pc, m_gui_settings, this);

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -20,6 +20,7 @@
 #include <QWheelEvent>
 #include <QTimer>
 #include <QThread>
+#include <QKeyEvent>
 
 #include "util/logs.hpp"
 #include "util/asm.hpp"
@@ -886,6 +887,47 @@ void memory_viewer_panel::ShowMemory()
 void memory_viewer_panel::SetPC(const uint pc)
 {
 	m_addr = pc;
+}
+
+void memory_viewer_panel::keyPressEvent(QKeyEvent* event)
+{
+	if (!isActiveWindow())
+	{
+		QDialog::keyPressEvent(event);
+		return;
+	}
+
+	if (event->modifiers() == Qt::ControlModifier)
+	{
+		switch (const auto key = event->key())
+		{
+		case Qt::Key_PageUp:
+		case Qt::Key_PageDown:
+		{
+			scroll(key == Qt::Key_PageDown ? m_rowcount : 0u - m_rowcount);
+			break;
+		}
+		case Qt::Key_F5:
+		{
+			if (event->isAutoRepeat())
+			{
+				break;
+			}
+
+			// Single refresh
+			ShowMemory();
+			break;
+		}
+		case Qt::Key_F:
+		{
+			m_addr_line->setFocus();
+			break;
+		}
+		default: break;
+		}
+	}
+
+	QDialog::keyPressEvent(event);
 }
 
 void memory_viewer_panel::ShowImage(QWidget* parent, u32 addr, color_format format, u32 width, u32 height, bool flipv) const

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -898,9 +898,15 @@ void memory_viewer_panel::ShowImage(QWidget* parent, u32 addr, color_format form
 	}
 
 	const auto originalBuffer  = static_cast<u8*>(this->to_ptr(addr, memsize));
+
+	if (!originalBuffer)
+	{
+		return;
+	}
+
 	const auto convertedBuffer = new (std::nothrow) u8[memsize];
 
-	if (!originalBuffer || !convertedBuffer)
+	if (!convertedBuffer)
 	{
 		// OOM or invalid memory address, give up
 		return;

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -57,7 +57,9 @@ public:
 		RGB,
 		ARGB,
 		RGBA,
-		ABGR
+		ABGR,
+		G8,
+		G32MAX
 	};
 	Q_ENUM(color_format)
 

--- a/rpcs3/rpcs3qt/memory_viewer_panel.h
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.h
@@ -16,6 +16,7 @@ class QComboBox;
 class QLabel;
 class QThread;
 class QHBoxLayout;
+class QKeyEvent;
 
 class cpu_thread;
 class CPUDisAsm;
@@ -43,7 +44,7 @@ enum search_mode : unsigned
 	search_mode_last = 256,
 };
 
-class memory_viewer_panel : public QDialog
+class memory_viewer_panel final : public QDialog
 {
 	Q_OBJECT
 
@@ -112,10 +113,12 @@ private:
 	void* to_ptr(u32 addr, u32 size = 1) const;
 	void SetPC(const uint pc);
 
-	virtual void ShowMemory();
+	void ShowMemory();
 
 	void ShowImage(QWidget* parent, u32 addr, color_format format, u32 width, u32 height, bool flipv) const;
 	u64 OnSearch(std::string wstr, u32 mode);
+
+	void keyPressEvent(QKeyEvent* event) override;
 };
 
 // Lifetime management with IDM

--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -401,11 +401,10 @@ namespace utils
 		return minuend < subtrahend ? T{0} : static_cast<T>(minuend - subtrahend);
 	}
 
-
 	template <UnsignedInt T>
 	constexpr T mul_saturate(T factor1, T factor2)
 	{
-		return T{umax} / factor1 < factor2 ? T{umax} : static_cast<T>(factor1 * factor2);
+		return factor1 > 0 && T{umax} / factor1 < factor2 ? T{umax} : static_cast<T>(factor1 * factor2);
 	}
 
 	// Hack. Pointer cast util to workaround UB. Use with extreme care.


### PR DESCRIPTION
* Add auto-refresh mode for the memory viewer, refreshing contents in 60hz.
* Shortcut in RSX debugger to view RSX semaphores area. (Alt+S)
* Add Grey8 and a special G32MAX (shows the max color between sets of neighboring 4-byte groups) image formats.
* Fix memory leak in the memory viewer.
* Add Ctrl+PageDown, Ctrl+PageUp shortucts for faster scrolling.
* Add Ctrl+F to refocus on the address line.
* Add Ctrl+F5 for manual, single memory refresh.
* Added image scaling for image viewer with Ctrl+Plus, Ctrl+Minus.
* Added hover position for image viewer to see which address is being pointed at, when double clicking on it the image viewer is closed and the memory viewer jumps to the clicked memory data.