### PR TITLE
Qt: Save UI settings and geometry safely on closeEvent

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -230,6 +230,9 @@ bool debugger_frame::eventFilter(QObject* object, QEvent* event)
 
 void debugger_frame::closeEvent(QCloseEvent* event)
 {
+	SaveSettings();
+	m_gui_settings->sync();
+
 	QDockWidget::closeEvent(event);
 	Q_EMIT DebugFrameClosed();
 }

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -222,8 +222,6 @@ game_list_frame::~game_list_frame()
 	WaitAndAbortRepaintThreads();
 	gui::utils::stop_future_watcher(m_parsing_watcher, true);
 	gui::utils::stop_future_watcher(m_refresh_watcher, true);
-
-	SaveSettings();
 }
 
 void game_list_frame::OnColClicked(int col)
@@ -2226,6 +2224,9 @@ void game_list_frame::FocusAndSelectFirstEntryIfNoneIs()
 
 void game_list_frame::closeEvent(QCloseEvent *event)
 {
+	SaveSettings();
+	m_gui_settings->sync();
+
 	QDockWidget::closeEvent(event);
 	Q_EMIT GameListFrameClosed();
 }

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -109,7 +109,6 @@ main_window::main_window(std::shared_ptr<gui_settings> gui_settings, std::shared
 
 main_window::~main_window()
 {
-	SaveWindowState();
 }
 
 /* An init method is used so that RPCS3App can create the necessary connects before calling init (specifically the stylesheet connect).
@@ -1667,6 +1666,8 @@ void main_window::SaveWindowState() const
 	m_game_list_frame->SaveSettings();
 	// Save splitter state
 	m_debugger_frame->SaveSettings();
+
+	m_gui_settings->sync();
 }
 
 void main_window::RepaintThumbnailIcons()
@@ -3204,6 +3205,7 @@ void main_window::closeEvent(QCloseEvent* closeEvent)
 		Emu.GracefulShutdown(false);
 	}
 
+	SaveWindowState();
 	Emu.Quit(true);
 }
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -220,17 +220,21 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 	ChangeProfile(ui->chooseProfile->currentText());
 }
 
+void pad_settings_dialog::closeEvent(QCloseEvent* event)
+{
+	m_gui_settings->SetValue(gui::pads_geometry, saveGeometry());
+	m_gui_settings->sync();
+
+	QDialog::closeEvent(event);
+}
+
 pad_settings_dialog::~pad_settings_dialog()
 {
 	if (m_input_thread)
 	{
 		m_input_thread_state = input_thread_state::pausing;
-		auto& thread = *m_input_thread;
-		thread = thread_state::aborting;
-		thread();
+		*m_input_thread = thread_state::finished;
 	}
-
-	m_gui_settings->SetValue(gui::pads_geometry, saveGeometry());
 
 	if (!Emu.IsStopped())
 	{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -236,4 +236,5 @@ protected:
 	void mouseMoveEvent(QMouseEvent *event) override;
 	void wheelEvent(QWheelEvent *event) override;
 	bool eventFilter(QObject* object, QEvent* event) override;
+	void closeEvent(QCloseEvent* event) override;
 };

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -151,11 +151,18 @@ patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_set
 	download_update(true, false);
 }
 
-patch_manager_dialog::~patch_manager_dialog()
+void patch_manager_dialog::closeEvent(QCloseEvent* event)
 {
 	// Save gui settings
 	m_gui_settings->SetValue(gui::pm_geometry, saveGeometry());
 	m_gui_settings->SetValue(gui::pm_splitter_state, ui->splitter->saveState());
+	m_gui_settings->sync();
+
+	QDialog::closeEvent(event);
+}
+
+patch_manager_dialog::~patch_manager_dialog()
+{
 }
 
 int patch_manager_dialog::exec()

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -83,4 +83,5 @@ protected:
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dragMoveEvent(QDragMoveEvent* event) override;
 	void dragLeaveEvent(QDragLeaveEvent* event) override;
+	void closeEvent(QCloseEvent* event) override;
 };

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -267,6 +267,7 @@ void rsx_debugger::closeEvent(QCloseEvent* event)
 
 	m_gui_settings->SetValue(gui::rsx_states, states);
 	m_gui_settings->SetValue(gui::rsx_geometry, saveGeometry());
+	m_gui_settings->sync();
 
 	QDialog::closeEvent(event);
 }

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -589,6 +589,7 @@ void save_manager_dialog::SetIconSize(int size)
 void save_manager_dialog::closeEvent(QCloseEvent *event)
 {
 	m_gui_settings->SetValue(gui::sd_geometry, saveGeometry());
+	m_gui_settings->sync();
 
 	QDialog::closeEvent(event);
 }

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -2365,9 +2365,14 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	}
 }
 
-settings_dialog::~settings_dialog()
+void settings_dialog::closeEvent(QCloseEvent* event)
 {
 	m_gui_settings->SetValue(gui::cfg_geometry, saveGeometry());
+	m_gui_settings->sync();
+}
+
+settings_dialog::~settings_dialog()
+{
 }
 
 void settings_dialog::EnhanceSlider(emu_settings_type settings_type, QSlider* slider, QLabel* label, const QString& label_text) const

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -64,4 +64,5 @@ private:
 	void SubscribeDescription(QLabel* description);
 	void SubscribeTooltip(QObject* object, const QString& tooltip);
 	bool eventFilter(QObject* object, QEvent* event) override;
+	void closeEvent(QCloseEvent* event) override;
 };

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -1224,6 +1224,7 @@ void trophy_manager_dialog::closeEvent(QCloseEvent *event)
 	m_gui_settings->SetValue(gui::tr_splitterState, m_splitter->saveState());
 	m_gui_settings->SetValue(gui::tr_games_state,  m_game_table->horizontalHeader()->saveState());
 	m_gui_settings->SetValue(gui::tr_trophy_state, m_trophy_table->horizontalHeader()->saveState());
+	m_gui_settings->sync();
 
 	QWidget::closeEvent(event);
 }


### PR DESCRIPTION
* Paramters may have changed before the destructor of Qt objects have been called, save UI geometry and settings in closeEvent instead.
* Save to disk once the dialor or main window is closed so force application termination won't cause the settings to be lost.