### PR TITLE
vk: Use synchronization2 extension for events

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
+++ b/rpcs3/Emu/RSX/VK/VKAsyncScheduler.h
@@ -29,6 +29,7 @@ namespace vk
 		// Sync
 		event* m_sync_label = nullptr;
 		atomic_t<bool> m_sync_required = false;
+		VkDependencyInfoKHR m_dependency_info{};
 
 		static constexpr u32 events_pool_size = 16384;
 		std::vector<std::unique_ptr<vk::event>> m_events_pool;
@@ -39,12 +40,12 @@ namespace vk
 
 		shared_mutex m_submit_mutex;
 
-		void init_config_options(vk_gpu_scheduler_mode mode);
+		void init_config_options(vk_gpu_scheduler_mode mode, const VkDependencyInfoKHR& queue_dependency);
 		void delayed_init();
 		void insert_sync_event();
 
 	public:
-		AsyncTaskScheduler(vk_gpu_scheduler_mode mode); // This ctor stops default initialization by fxo
+		AsyncTaskScheduler(vk_gpu_scheduler_mode mode, const VkDependencyInfoKHR& queue_dependency);
 		~AsyncTaskScheduler();
 
 		command_buffer* get_current();

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -478,7 +478,7 @@ void VKGSRender::load_texture_env()
 			// Sync any async scheduler tasks
 			if (auto ev = async_task_scheduler.get_primary_sync_label())
 			{
-				ev->gpu_wait(*m_current_command_buffer, { .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR });
+				ev->gpu_wait(*m_current_command_buffer, m_async_compute_dependency_info);
 			}
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -478,7 +478,7 @@ void VKGSRender::load_texture_env()
 			// Sync any async scheduler tasks
 			if (auto ev = async_task_scheduler.get_primary_sync_label())
 			{
-				ev->gpu_wait(*m_current_command_buffer);
+				ev->gpu_wait(*m_current_command_buffer, { .sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR });
 			}
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -822,8 +822,25 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 
 	if (backend_config.supports_asynchronous_compute)
 	{
+		m_async_compute_memory_barrier =
+		{
+			.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER_2_KHR,
+			.pNext = nullptr,
+			.srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR | VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT_KHR,
+			.srcAccessMask = VK_ACCESS_2_MEMORY_WRITE_BIT_KHR,
+			.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT_KHR | VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT_KHR,
+			.dstAccessMask = VK_ACCESS_2_SHADER_SAMPLED_READ_BIT_KHR
+		};
+
+		m_async_compute_dependency_info =
+		{
+			.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO_KHR,
+			.memoryBarrierCount = 1,
+			.pMemoryBarriers = &m_async_compute_memory_barrier
+		};
+
 		// Run only if async compute can be used.
-		g_fxo->init<vk::AsyncTaskScheduler>(g_cfg.video.vk.asynchronous_scheduler);
+		g_fxo->init<vk::AsyncTaskScheduler>(g_cfg.video.vk.asynchronous_scheduler, m_async_compute_dependency_info);
 	}
 
 	if (backend_config.supports_host_gpu_labels)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -91,6 +91,9 @@ private:
 	std::unique_ptr<vk::buffer_view> m_volatile_attribute_storage;
 	std::unique_ptr<vk::buffer_view> m_vertex_layout_storage;
 
+	VkDependencyInfoKHR m_async_compute_dependency_info{};
+	VkMemoryBarrier2KHR m_async_compute_memory_barrier{};
+
 public:
 	//vk::fbo draw_fbo;
 	std::unique_ptr<vk::vertex_cache> m_vertex_cache;

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -113,6 +113,7 @@ namespace vk
 		optional_features_support.conditional_rendering    = device_extensions.is_supported(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
 		optional_features_support.external_memory_host     = device_extensions.is_supported(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
 		optional_features_support.sampler_mirror_clamped   = device_extensions.is_supported(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
+		optional_features_support.synchronization_2        = device_extensions.is_supported(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
 		optional_features_support.unrestricted_depth_range = device_extensions.is_supported(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
 
 		optional_features_support.debug_utils              = instance_extensions.is_supported(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
@@ -486,6 +487,11 @@ namespace vk
 			requested_extensions.push_back(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
 		}
 
+		if (pgpu->optional_features_support.synchronization_2)
+		{
+			requested_extensions.push_back(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+		}
+
 		enabled_features.robustBufferAccess = VK_TRUE;
 		enabled_features.fullDrawIndexUint32 = VK_TRUE;
 		enabled_features.independentBlend = VK_TRUE;
@@ -670,6 +676,14 @@ namespace vk
 			device.pNext = &custom_border_color_features;
 		}
 
+		VkPhysicalDeviceSynchronization2FeaturesKHR synchronization2_info{};
+		if (pgpu->optional_features_support.synchronization_2)
+		{
+			synchronization2_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
+			synchronization2_info.pNext = const_cast<void*>(device.pNext);
+			device.pNext = &synchronization2_info;
+		}
+
 		CHECK_RESULT_EX(vkCreateDevice(*pgpu, &device, nullptr, &dev), message_on_error);
 
 		// Initialize queues
@@ -693,6 +707,12 @@ namespace vk
 			_vkSetDebugUtilsObjectNameEXT = reinterpret_cast<PFN_vkSetDebugUtilsObjectNameEXT>(vkGetDeviceProcAddr(dev, "vkSetDebugUtilsObjectNameEXT"));
 			_vkQueueInsertDebugUtilsLabelEXT = reinterpret_cast<PFN_vkQueueInsertDebugUtilsLabelEXT>(vkGetDeviceProcAddr(dev, "vkQueueInsertDebugUtilsLabelEXT"));
 			_vkCmdInsertDebugUtilsLabelEXT = reinterpret_cast<PFN_vkCmdInsertDebugUtilsLabelEXT>(vkGetDeviceProcAddr(dev, "vkCmdInsertDebugUtilsLabelEXT"));
+		}
+
+		if (pgpu->optional_features_support.synchronization_2)
+		{
+			_vkCmdSetEvent2KHR = reinterpret_cast<PFN_vkCmdSetEvent2KHR>(vkGetDeviceProcAddr(dev, "vkCmdSetEvent2KHR"));
+			_vkCmdWaitEvents2KHR = reinterpret_cast<PFN_vkCmdWaitEvents2KHR>(vkGetDeviceProcAddr(dev, "vkCmdWaitEvents2KHR"));
 		}
 
 		memory_map = vk::get_memory_mapping(pdev);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -79,6 +79,7 @@ namespace vk
 			bool sampler_mirror_clamped = false;
 			bool shader_stencil_export = false;
 			bool surface_capabilities_2 = false;
+			bool synchronization_2 = false;
 			bool unrestricted_depth_range = false;
 		} optional_features_support;
 
@@ -135,6 +136,8 @@ namespace vk
 		PFN_vkSetDebugUtilsObjectNameEXT _vkSetDebugUtilsObjectNameEXT = nullptr;
 		PFN_vkQueueInsertDebugUtilsLabelEXT _vkQueueInsertDebugUtilsLabelEXT = nullptr;
 		PFN_vkCmdInsertDebugUtilsLabelEXT _vkCmdInsertDebugUtilsLabelEXT = nullptr;
+		PFN_vkCmdSetEvent2KHR _vkCmdSetEvent2KHR = nullptr;
+		PFN_vkCmdWaitEvents2KHR _vkCmdWaitEvents2KHR = nullptr;
 
 	public:
 		render_device() = default;
@@ -168,6 +171,7 @@ namespace vk
 		bool get_framebuffer_loops_support() const { return pgpu->optional_features_support.framebuffer_loops; }
 		bool get_barycoords_support() const { return pgpu->optional_features_support.barycentric_coords; }
 		bool get_custom_border_color_support() const { return pgpu->optional_features_support.custom_border_color; }
+		bool get_synchronization2_support() const { return pgpu->optional_features_support.synchronization_2; }
 
 		u64 get_descriptor_update_after_bind_support() const { return pgpu->descriptor_indexing_support.update_after_bind_mask; }
 		u32 get_descriptor_max_draw_calls() const { return pgpu->descriptor_max_draw_calls; }

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -9,6 +9,7 @@
 namespace vk
 {
 	class command_buffer;
+	class image;
 
 	enum class sync_domain
 	{
@@ -54,20 +55,18 @@ namespace vk
 
 	class event
 	{
-		VkDevice m_device = VK_NULL_HANDLE;
+		const vk::render_device* m_device = nullptr;
 		VkEvent m_vk_event = VK_NULL_HANDLE;
-
-		std::unique_ptr<buffer> m_buffer;
-		volatile u32* m_value = nullptr;
+		bool v2 = true;
 
 	public:
 		event(const render_device& dev, sync_domain domain);
 		~event();
 		event(const event&) = delete;
 
-		void signal(const command_buffer& cmd, VkPipelineStageFlags stages, VkAccessFlags access);
+		void signal(const command_buffer& cmd, const VkDependencyInfoKHR& dependency);
 		void host_signal() const;
-		void gpu_wait(const command_buffer& cmd) const;
+		void gpu_wait(const command_buffer& cmd, const VkDependencyInfoKHR& dependency) const;
 		VkResult status() const;
 		void reset() const;
 	};


### PR DESCRIPTION
Vulkan 1.0 events kinda suck and caused artifacts in some titles which I had worked around using simple GPU lock structures. This PR introduces synchronization2 for these scenarios where synchronization1 is inadequate.

Closes https://github.com/RPCS3/rpcs3/issues/13718
(Hopefully) Closes https://github.com/RPCS3/rpcs3/issues/12021