### PR TITLE
RPCS3 Setup QoL Improvements

### DIFF
--- a/rpcs3/rpcs3qt/about_dialog.cpp
+++ b/rpcs3/rpcs3qt/about_dialog.cpp
@@ -31,6 +31,8 @@ about_dialog::about_dialog(QWidget* parent) : QDialog(parent), ui(new Ui::about_
 	connect(ui->website, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://www.rpcs3.net")); });
 	connect(ui->forum, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://forums.rpcs3.net")); });
 	connect(ui->patreon, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://www.patreon.com/Nekotekina")); });
+	connect(ui->discord, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://discord.me/RPCS3")); });
+	connect(ui->wiki, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://wiki.rpcs3.net/index.php?title=Main_Page")); });
 	connect(ui->close, &QPushButton::clicked, this, &QWidget::close);
 }
 

--- a/rpcs3/rpcs3qt/about_dialog.ui
+++ b/rpcs3/rpcs3qt/about_dialog.ui
@@ -353,6 +353,20 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="discord">
+       <property name="text">
+        <string>Discord</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="wiki">
+       <property name="text">
+        <string>Wiki</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="patreon">
        <property name="text">
         <string>Patreon</string>

--- a/rpcs3/rpcs3qt/about_dialog.ui
+++ b/rpcs3/rpcs3qt/about_dialog.ui
@@ -215,7 +215,7 @@
        <item>
         <widget class="QLabel" name="developers">
          <property name="text">
-          <string>&lt;p&gt;&lt;b&gt;Developers:&lt;/b&gt;&lt;br&gt;&lt;br&gt;¬DH&lt;br&gt;¬AlexAltea&lt;br&gt;¬Hykem&lt;br&gt;¬Oil&lt;br&gt;Nekotekina&lt;br&gt;¬Bigpet&lt;br&gt;¬gopalsr83&lt;br&gt;¬tambry&lt;br&gt;¬vlj&lt;br&gt;kd-11&lt;br&gt;¬jarveson&lt;br&gt;¬raven02&lt;br&gt;AniLeo&lt;br&gt;cornytrace&lt;br&gt;ssshadow&lt;br&gt;¬Numan&lt;br&gt;hcorion&lt;br&gt;Megamouse&lt;br&gt;¬flash-fire&lt;br&gt;DAGINATSUKO&lt;br&gt;GalCiv&lt;br&gt;eladash&lt;/p&gt;</string>
+          <string>&lt;p&gt;&lt;b&gt;Developers:&lt;/b&gt;&lt;br&gt;&lt;br&gt;¬DH&lt;br&gt;¬AlexAltea&lt;br&gt;¬Hykem&lt;br&gt;¬Oil&lt;br&gt;Nekotekina&lt;br&gt;¬Bigpet&lt;br&gt;¬gopalsr83&lt;br&gt;¬tambry&lt;br&gt;¬vlj&lt;br&gt;kd-11&lt;br&gt;¬jarveson&lt;br&gt;¬raven02&lt;br&gt;AniLeo&lt;br&gt;¬cornytrace&lt;br&gt;¬ssshadow&lt;br&gt;¬Numan&lt;br&gt;hcorion&lt;br&gt;Megamouse&lt;br&gt;¬flash-fire&lt;br&gt;DAGINATSUKO&lt;br&gt;GalCiv&lt;br&gt;eladash&lt;/p&gt;</string>
          </property>
          <property name="scaledContents">
           <bool>false</bool>
@@ -231,7 +231,7 @@
        <item>
         <widget class="QLabel" name="contributors">
          <property name="text">
-          <string>&lt;p&gt;&lt;b&gt;Contributors:&lt;/b&gt;&lt;br&gt;&lt;br&gt;BlackDaemon&lt;br&gt;elisha464&lt;br&gt;Aishou&lt;br&gt;krofna&lt;br&gt;xsacha&lt;br&gt;danilaml&lt;br&gt;unknownbrackets&lt;br&gt;Zangetsu38&lt;br&gt;lioncash&lt;br&gt;achurch&lt;br&gt;darkf&lt;br&gt;Syphurith&lt;br&gt;Blaypeg&lt;br&gt;Survanium90&lt;br&gt;georgemoralis&lt;br&gt;ikki84&lt;br&gt;scribam&lt;br&gt;TGE&lt;br&gt;velocity&lt;br&gt;Farseer&lt;br&gt;Dangles&lt;br&gt;ruipin&lt;br&gt;jbeich&lt;br&gt;CookiePLMonster&lt;br&gt;Whatcookie&lt;br&gt;rajkosto&lt;br&gt;Admiral Thrawn&lt;/p&gt;</string>
+          <string>&lt;p&gt;&lt;b&gt;Contributors:&lt;/b&gt;&lt;br&gt;&lt;br&gt;BlackDaemon&lt;br&gt;elisha464&lt;br&gt;Aishou&lt;br&gt;krofna&lt;br&gt;xsacha&lt;br&gt;danilaml&lt;br&gt;unknownbrackets&lt;br&gt;Zangetsu38&lt;br&gt;lioncash&lt;br&gt;achurch&lt;br&gt;darkf&lt;br&gt;Syphurith&lt;br&gt;Blaypeg&lt;br&gt;Survanium90&lt;br&gt;georgemoralis&lt;br&gt;ikki84&lt;br&gt;scribam&lt;br&gt;TGE&lt;br&gt;velocity&lt;br&gt;Farseer&lt;br&gt;Dangles&lt;br&gt;ruipin&lt;br&gt;jbeich&lt;br&gt;CookiePLMonster&lt;br&gt;Whatcookie&lt;br&gt;rajkosto&lt;br&gt;Admiral Thrawn&lt;br&gt;FlexBy&lt;br&gt;Dunastique&lt;br&gt;Jonathan44062&lt;br&gt;yurinator557&lt;br&gt;Satan&lt;br&gt;HoldTheMourning&lt;br&gt;illusion0001&lt;/p&gt;</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -135,7 +135,7 @@ bool gui_application::Init()
 
 	if (m_gui_settings->GetValue(gui::ib_show_welcome).toBool())
 	{
-		welcome_dialog* welcome = new welcome_dialog(m_gui_settings);
+		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, false);
 		welcome->exec();
 	}
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3298,12 +3298,15 @@ main_window::drop_type main_window::IsValidFile(const QMimeData& md, QStringList
 
 void main_window::dropEvent(QDropEvent* event)
 {
+	event->accept();
+
 	QStringList drop_paths;
 
 	switch (IsValidFile(*event->mimeData(), &drop_paths)) // get valid file paths and drop type
 	{
 	case drop_type::drop_error:
 	{
+		event->ignore();
 		break;
 	}
 	case drop_type::drop_pkg: // install the packages
@@ -3403,18 +3406,12 @@ void main_window::dropEvent(QDropEvent* event)
 
 void main_window::dragEnterEvent(QDragEnterEvent* event)
 {
-	if (IsValidFile(*event->mimeData()) != drop_type::drop_error)
-	{
-		event->accept();
-	}
+	event->setAccepted(IsValidFile(*event->mimeData()) != drop_type::drop_error);
 }
 
 void main_window::dragMoveEvent(QDragMoveEvent* event)
 {
-	if (IsValidFile(*event->mimeData()) != drop_type::drop_error)
-	{
-		event->accept();
-	}
+	event->setAccepted(IsValidFile(*event->mimeData()) != drop_type::drop_error);
 }
 
 void main_window::dragLeaveEvent(QDragLeaveEvent* event)

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -35,6 +35,7 @@
 #include "shortcut_dialog.h"
 #include "system_cmd_dialog.h"
 #include "emulated_pad_settings_dialog.h"
+#include "welcome_dialog.h"
 
 #include <thread>
 #include <charconv>
@@ -2737,6 +2738,12 @@ void main_window::CreateConnects()
 		m_updater.check_for_updates(false, false, false, this);
 	});
 
+	connect(ui->welcomeAct, &QAction::triggered, this, [this]()
+	{
+		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);
+		welcome->open();
+	});
+
 	connect(ui->aboutAct, &QAction::triggered, this, [this]
 	{
 		about_dialog dlg(this);
@@ -3388,4 +3395,25 @@ void main_window::dragMoveEvent(QDragMoveEvent* event)
 void main_window::dragLeaveEvent(QDragLeaveEvent* event)
 {
 	event->accept();
+}
+
+void main_window::keyPressEvent(QKeyEvent* event)
+{
+	QMainWindow::keyPressEvent(event);
+
+	if (event->isAutoRepeat() || event->modifiers())
+	{
+		return;
+	}
+
+	switch (event->key())
+	{
+	case Qt::Key_F1:
+	{
+		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);
+		welcome->open();
+		break;
+	}
+	default: break;
+	}
 }

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3364,14 +3364,8 @@ void main_window::dropEvent(QDropEvent* event)
 	}
 	case drop_type::drop_dir: // import valid games to gamelist (games.yaml)
 	{
-		if (!m_gui_settings->GetBootConfirmation(this))
-		{
-			return;
-		}
-
 		for (const auto& path : drop_paths)
 		{
-			Emu.GracefulShutdown(false);
 			AddGamesFromDir(path);
 		}
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3255,21 +3255,21 @@ main_window::drop_type main_window::IsValidFile(const QMimeData& md, QStringList
 		}
 		else if (info.suffix().toLower() == "pkg")
 		{
-			if (drop_type != drop_type::drop_pkg && drop_type != drop_type::drop_error)
+			if (drop_type != drop_type::drop_rap_edat_pkg && drop_type != drop_type::drop_error)
 			{
 				return drop_type::drop_error;
 			}
 
-			drop_type = drop_type::drop_pkg;
+			drop_type = drop_type::drop_rap_edat_pkg;
 		}
 		else if (info.suffix().toLower() == "rap" || info.suffix().toLower() == "edat")
 		{
-			if (info.size() < 0x10 || (drop_type != drop_type::drop_rap_edat && drop_type != drop_type::drop_error))
+			if (info.size() < 0x10 || (drop_type != drop_type::drop_rap_edat_pkg && drop_type != drop_type::drop_error))
 			{
 				return drop_type::drop_error;
 			}
 
-			drop_type = drop_type::drop_rap_edat;
+			drop_type = drop_type::drop_rap_edat_pkg;
 		}
 		else if (list.size() == 1)
 		{
@@ -3309,7 +3309,7 @@ void main_window::dropEvent(QDropEvent* event)
 		event->ignore();
 		break;
 	}
-	case drop_type::drop_pkg: // install the packages
+	case drop_type::drop_rap_edat_pkg: // install the packages
 	{
 		InstallPackages(drop_paths);
 		break;
@@ -3317,35 +3317,6 @@ void main_window::dropEvent(QDropEvent* event)
 	case drop_type::drop_pup: // install the firmware
 	{
 		InstallPup(drop_paths.first());
-		break;
-	}
-	case drop_type::drop_rap_edat: // import rap files to exdata dir
-	{
-		int installed_count = 0;
-
-		for (const auto& path : drop_paths)
-		{
-			const QFileInfo file_info = path;
-			const std::string extension = file_info.suffix().toLower().toStdString();
-			const std::string filename = sstr(file_info.fileName());
-
-			if (InstallFileInExData(extension, path, filename))
-			{
-				gui_log.success("Successfully copied %s file by drop: %s", extension, filename);
-				installed_count++;
-			}
-			else
-			{
-				gui_log.error("Could not copy %s file by drop: %s", extension, filename);
-			}
-		}
-
-		if (installed_count > 0)
-		{
-			// Refresh game list since we probably unlocked some games now.
-			m_game_list_frame->Refresh(true);
-		}
-
 		break;
 	}
 	case drop_type::drop_psf: // Display PARAM.SFO content

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -135,6 +135,7 @@ protected:
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dragMoveEvent(QDragMoveEvent* event) override;
 	void dragLeaveEvent(QDragLeaveEvent* event) override;
+	void keyPressEvent(QKeyEvent* event) override;
 
 private:
 	void ConfigureGuiFromSettings();

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -71,9 +71,8 @@ class main_window : public QMainWindow
 	enum class drop_type
 	{
 		drop_error,
-		drop_pkg,
+		drop_rap_edat_pkg,
 		drop_pup,
-		drop_rap_edat,
 		drop_psf,
 		drop_dir,
 		drop_game,

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -366,6 +366,7 @@
      <addaction name="languageAct0"/>
     </widget>
     <addaction name="updateAct"/>
+    <addaction name="welcomeAct"/>
     <addaction name="separator"/>
     <addaction name="languageMenu"/>
     <addaction name="separator"/>
@@ -746,6 +747,11 @@
   <action name="updateAct">
    <property name="text">
     <string>Check for Updates</string>
+   </property>
+  </action>
+  <action name="welcomeAct">
+   <property name="text">
+    <string>View The Welcome Dialog</string>
    </property>
   </action>
   <action name="confVFSDialogAct">

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -677,7 +677,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	{
 		if (percentage == resolution_scale_def)
 		{
-			return tr("100% (Default)", "Resolution scale");
+			return tr("100% (1280x720) (Default)", "Resolution scale");
 		}
 		return tr("%1% (%2x%3)", "Resolution scale").arg(percentage).arg(1280 * percentage / 100).arg(720 * percentage / 100);
 	};

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -8,17 +8,20 @@
 #include <QCheckBox>
 #include <QSvgWidget>
 
-welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent)
+welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool is_manual_show, QWidget* parent)
 	: QDialog(parent)
 	, ui(new Ui::welcome_dialog)
 	, m_gui_settings(std::move(gui_settings))
 {
 	ui->setupUi(this);
 
-	setWindowFlags(windowFlags() & Qt::WindowTitleHint);
 	setAttribute(Qt::WA_DeleteOnClose);
 
-	ui->okay->setEnabled(false);
+	setWindowFlag(Qt::WindowCloseButtonHint, is_manual_show);
+	ui->okay->setEnabled(is_manual_show);
+	ui->i_have_read->setChecked(is_manual_show);
+	ui->i_have_read->setEnabled(!is_manual_show);
+	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));
 	ui->label_3->setText(tr(
 		R"(
@@ -42,9 +45,15 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, QWidg
 		)"
 	).arg(gui::utils::get_link_style()));
 
-	connect(ui->i_have_read, &QCheckBox::clicked, [this](bool checked)
+	connect(ui->i_have_read, &QCheckBox::clicked, [this, is_manual_show](bool checked)
 	{
+		if (is_manual_show)
+		{
+			return;
+		}
+
 		ui->okay->setEnabled(checked);
+		setWindowFlag(Qt::WindowCloseButtonHint, checked);
 	});
 
 	connect(ui->do_not_show, &QCheckBox::clicked, [this](bool checked)

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -2,7 +2,10 @@
 #include "ui_welcome_dialog.h"
 
 #include "gui_settings.h"
+#include "shortcut_utils.h"
 #include "qt_utils.h"
+
+#include "Utilities/File.h"
 
 #include <QPushButton>
 #include <QCheckBox>
@@ -21,6 +24,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->okay->setEnabled(is_manual_show);
 	ui->i_have_read->setChecked(is_manual_show);
 	ui->i_have_read->setEnabled(!is_manual_show);
+	ui->do_not_show->setEnabled(!is_manual_show);
 	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));
 	ui->label_3->setText(tr(
@@ -63,7 +67,28 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 
 	connect(ui->okay, &QPushButton::clicked, this, &QDialog::accept);
 
+#ifdef _WIN32
+	ui->create_applications_menu_shortcut->setText(tr("&Create Start Menu shortcut"));
+#elif defined(__APPLE__)
+	ui->create_applications_menu_shortcut->setText(tr("&Create Launchpad shortcut"));
+#else
+	ui->create_applications_menu_shortcut->setText(tr("&Create Application Menu shortcut"));
+#endif
+
 	layout()->setSizeConstraint(QLayout::SetFixedSize);
+
+	connect(this, &QDialog::finished, this, [this]()
+	{
+		if (ui->create_desktop_shortcut->isChecked())
+		{
+			gui::utils::create_shortcut("RPCS3", "", "RPCS3", ":/rpcs3.svg", fs::get_temp_dir(), gui::utils::shortcut_location::desktop);
+		}
+
+		if (ui->create_applications_menu_shortcut->isChecked())
+		{
+			gui::utils::create_shortcut("RPCS3", "", "RPCS3", ":/rpcs3.svg", fs::get_temp_dir(), gui::utils::shortcut_location::applications);
+		}
+	});
 }
 
 welcome_dialog::~welcome_dialog()

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -16,6 +16,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, QWidg
 	ui->setupUi(this);
 
 	setWindowFlags(windowFlags() & Qt::WindowTitleHint);
+	setAttribute(Qt::WA_DeleteOnClose);
 
 	ui->okay->setEnabled(false);
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));

--- a/rpcs3/rpcs3qt/welcome_dialog.h
+++ b/rpcs3/rpcs3qt/welcome_dialog.h
@@ -14,7 +14,7 @@ class welcome_dialog : public QDialog
 	Q_OBJECT
 
 public:
-	explicit welcome_dialog(std::shared_ptr<gui_settings> gui_settings, QWidget* parent = nullptr);
+	explicit welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool is_manual_show, QWidget* parent = nullptr);
 	~welcome_dialog();
 
 private:

--- a/rpcs3/rpcs3qt/welcome_dialog.ui
+++ b/rpcs3/rpcs3qt/welcome_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>611</width>
-    <height>272</height>
+    <height>319</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -183,6 +183,33 @@
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="create_desktop_shortcut">
+       <property name="text">
+        <string>Create desktop shortcut</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="create_applications_menu_shortcut">
+       <property name="text">
+        <string>Create Start Menu shortcut</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>10</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item>
       <layout class="QHBoxLayout" name="button_layout">


### PR DESCRIPTION
* Allow to drag-and-drop RAP + EDAT + PKG together onto the UI. Previously PKG could not be dropped with other file types.
* Make "Add Games" not required to stop emulation.
* Fix memory leak in the welcome dialog.
* Make the Welcome Dialog accessible through F1 or the Help section in the main toolbar.
* Enable the Window Close button in the welcome dialog after "I have read the Quickstart" is checked.
* Allow creating shortcuts to RPCS3 in the welcome dialog. 
* Make the 100% Resolution Scale appear as "100% (1280x720) (Default)" instead of "100% (Default)"
* Add RPCS3 Discord and Wiki to the About Dialog.

![image](https://github.com/RPCS3/rpcs3/assets/18193363/6e5bbd9d-7a49-4f0d-81a3-cc42b62b3f8b)
