### PR TITLE
File.cpp: revert get_parent_dir change

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -385,7 +385,7 @@ shared_ptr<fs::device_base> fs::set_virtual_device(const std::string& name, shar
 	return get_device_manager().set_device(name, std::move(device));
 }
 
-std::string fs::get_parent_dir(std::string_view path, u32 parent_level)
+std::string_view fs::get_parent_dir_view(std::string_view path, u32 parent_level)
 {
 	std::string_view result = path;
 
@@ -433,7 +433,7 @@ std::string fs::get_parent_dir(std::string_view path, u32 parent_level)
 		return "/";
 	}
 
-	return std::string{result};
+	return result;
 }
 
 bool fs::stat(const std::string& path, stat_t& info)

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -387,24 +387,53 @@ shared_ptr<fs::device_base> fs::set_virtual_device(const std::string& name, shar
 
 std::string fs::get_parent_dir(std::string_view path, u32 parent_level)
 {
-	std::string normalized_path = std::filesystem::path(path).lexically_normal().string();
+	std::string_view result = path;
 
-#ifdef _WIN32
-	std::replace(normalized_path.begin(), normalized_path.end(), '\\', '/');
-#endif
+	// Number of path components to remove
+	usz to_remove = parent_level;
 
-	if (normalized_path.ends_with('/'))
-		normalized_path.pop_back();
-
-	while (parent_level--)
+	while (to_remove--)
 	{
-		if (const auto pos = normalized_path.find_last_of('/'); pos != umax)
-			normalized_path = normalized_path.substr(0, pos);
+		// Trim contiguous delimiters at the end
+		if (usz sz = result.find_last_not_of(delim) + 1)
+		{
+			result = result.substr(0, sz);
+		}
 		else
+		{
+			return "/";
+		}
+
+		const auto elem = result.substr(result.find_last_of(delim) + 1);
+
+		if (elem.empty() || elem.size() == result.size())
+		{
 			break;
+		}
+
+		if (elem == ".")
+		{
+			to_remove += 1;
+		}
+
+		if (elem == "..")
+		{
+			to_remove += 2;
+		}
+
+		result.remove_suffix(elem.size());
 	}
 
-	return normalized_path.empty() ? "/" : normalized_path;
+	if (usz sz = result.find_last_not_of(delim) + 1)
+	{
+		result = result.substr(0, sz);
+	}
+	else
+	{
+		return "/";
+	}
+
+	return std::string{result};
 }
 
 bool fs::stat(const std::string& path, stat_t& info)

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -166,7 +166,13 @@ namespace fs
 	shared_ptr<device_base> set_virtual_device(const std::string& name, shared_ptr<device_base> device);
 
 	// Try to get parent directory
-	std::string get_parent_dir(std::string_view path, u32 parent_level = 1);
+	std::string_view get_parent_dir_view(std::string_view path, u32 parent_level = 1);
+
+	// String (typical use) version
+	inline std::string get_parent_dir(std::string_view path, u32 parent_level = 1)
+	{
+		return std::string{get_parent_dir_view(path, parent_level)};
+	}
 
 	// Get file information
 	bool stat(const std::string& path, stat_t& info);

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -165,7 +165,7 @@ namespace fs
 	// Set virtual device with specified name (nullptr for deletion)
 	shared_ptr<device_base> set_virtual_device(const std::string& name, shared_ptr<device_base> device);
 
-	// Try to get normalized parent directory
+	// Try to get parent directory
 	std::string get_parent_dir(std::string_view path, u32 parent_level = 1);
 
 	// Get file information


### PR DESCRIPTION
Should fix #14031 .
Tagging @brian218 to explain the change.
Issues's problem is that std::path("＄locks") returns "ï¼„locks/" with japanese locale.
Keep in mind that we already call setlocal("C") on startup so some code overwrites it.


Some places in code also use the pattern `(file_path.substr(get_parent_dir(file2_path_in_x_directory, x_times).size()) == trail path from parent directory)` which breaks with the code on master.