### PR TITLE
Fix Welcome Dialog regression

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -148,7 +148,6 @@ bool main_window::Init([[maybe_unused]] bool with_cli_boot)
 	if (enable_play_last)
 	{
 		ui->sysPauseAct->setText(tr("&Play last played game"));
-		ui->sysPauseAct->setShortcut(QKeySequence("Ctrl+R"));
 		ui->sysPauseAct->setIcon(m_icon_play);
 		ui->toolbar_start->setToolTip(start_tooltip);
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -319,6 +319,12 @@ void main_window::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const Q
 
 	switch (shortcut_key)
 	{
+	case gui::shortcuts::shortcut::mw_welcome_dialog:
+	{
+		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);
+		welcome->open();
+		break;
+	}
 	case gui::shortcuts::shortcut::mw_toggle_fullscreen:
 	{
 		ui->toolbar_fullscreen->trigger();
@@ -3395,25 +3401,4 @@ void main_window::dragMoveEvent(QDragMoveEvent* event)
 void main_window::dragLeaveEvent(QDragLeaveEvent* event)
 {
 	event->accept();
-}
-
-void main_window::keyPressEvent(QKeyEvent* event)
-{
-	QMainWindow::keyPressEvent(event);
-
-	if (event->isAutoRepeat() || event->modifiers())
-	{
-		return;
-	}
-
-	switch (event->key())
-	{
-	case Qt::Key_F1:
-	{
-		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);
-		welcome->open();
-		break;
-	}
-	default: break;
-	}
 }

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -135,7 +135,6 @@ protected:
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dragMoveEvent(QDragMoveEvent* event) override;
 	void dragLeaveEvent(QDragLeaveEvent* event) override;
-	void keyPressEvent(QKeyEvent* event) override;
 
 private:
 	void ConfigureGuiFromSettings();

--- a/rpcs3/rpcs3qt/shortcut_settings.cpp
+++ b/rpcs3/rpcs3qt/shortcut_settings.cpp
@@ -16,6 +16,7 @@ void fmt_class_string<gui::shortcuts::shortcut>::format(std::string& out, u64 ar
 		case shortcut::mw_toggle_fullscreen: return "mw_toggle_fullscreen";
 		case shortcut::mw_exit_fullscreen: return "mw_exit_fullscreen";
 		case shortcut::mw_refresh: return "mw_refresh";
+		case shortcut::mw_welcome_dialog: return "mw_welcome_dialog";
 		case shortcut::gw_toggle_fullscreen: return "gw_toggle_fullscreen";
 		case shortcut::gw_exit_fullscreen: return "gw_exit_fullscreen";
 		case shortcut::gw_log_mark: return "gw_log_mark";
@@ -43,6 +44,7 @@ shortcut_settings::shortcut_settings()
 		{ shortcut::mw_toggle_fullscreen, shortcut_info{ "main_window_toggle_fullscreen", tr("Toggle Fullscreen"), "Alt+Return", shortcut_handler_id::main_window } },
 		{ shortcut::mw_exit_fullscreen, shortcut_info{ "main_window_exit_fullscreen", tr("Exit Fullscreen"), "Esc", shortcut_handler_id::main_window } },
 		{ shortcut::mw_refresh, shortcut_info{ "main_window_refresh", tr("Refresh"), "Ctrl+F5", shortcut_handler_id::main_window } },
+		{ shortcut::mw_welcome_dialog, shortcut_info{ "main_window_welcome_dialog", tr("Show Welcome Dialog"), "F1", shortcut_handler_id::main_window } },
 		{ shortcut::gw_toggle_fullscreen, shortcut_info{ "game_window_toggle_fullscreen", tr("Toggle Fullscreen"), "Alt+Return", shortcut_handler_id::game_window } },
 		{ shortcut::gw_exit_fullscreen, shortcut_info{ "game_window_exit_fullscreen", tr("Exit Fullscreen"), "Esc", shortcut_handler_id::game_window } },
 		{ shortcut::gw_log_mark, shortcut_info{ "game_window_log_mark", tr("Add Log Mark"), "Alt+L", shortcut_handler_id::game_window } },

--- a/rpcs3/rpcs3qt/shortcut_settings.h
+++ b/rpcs3/rpcs3qt/shortcut_settings.h
@@ -23,6 +23,7 @@ namespace gui
 			mw_toggle_fullscreen,
 			mw_exit_fullscreen,
 			mw_refresh,
+			mw_welcome_dialog,
 
 			gw_toggle_fullscreen,
 			gw_exit_fullscreen,

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -19,8 +19,8 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->setupUi(this);
 
 	setAttribute(Qt::WA_DeleteOnClose);
-
 	setWindowFlag(Qt::WindowCloseButtonHint, is_manual_show);
+
 	ui->okay->setEnabled(is_manual_show);
 	ui->i_have_read->setChecked(is_manual_show);
 	ui->i_have_read->setEnabled(!is_manual_show);
@@ -51,12 +51,12 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 
 	if (!is_manual_show)
 	{
-		connect(ui->i_have_read, &QCheckBox::clicked, [this](bool checked)
+		connect(ui->i_have_read, &QCheckBox::clicked, this, [this](bool checked)
 		{
 			ui->okay->setEnabled(checked);
 		});
 
-		connect(ui->do_not_show, &QCheckBox::clicked, [this](bool checked)
+		connect(ui->do_not_show, &QCheckBox::clicked, this, [this](bool checked)
 		{
 			m_gui_settings->SetValue(gui::ib_show_welcome, QVariant(!checked));
 		});

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -49,21 +49,18 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 		)"
 	).arg(gui::utils::get_link_style()));
 
-	connect(ui->i_have_read, &QCheckBox::clicked, [this, is_manual_show](bool checked)
+	if (!is_manual_show)
 	{
-		if (is_manual_show)
+		connect(ui->i_have_read, &QCheckBox::clicked, [this](bool checked)
 		{
-			return;
-		}
+			ui->okay->setEnabled(checked);
+		});
 
-		ui->okay->setEnabled(checked);
-		setWindowFlag(Qt::WindowCloseButtonHint, checked);
-	});
-
-	connect(ui->do_not_show, &QCheckBox::clicked, [this](bool checked)
-	{
-		m_gui_settings->SetValue(gui::ib_show_welcome, QVariant(!checked));
-	});
+		connect(ui->do_not_show, &QCheckBox::clicked, [this](bool checked)
+		{
+			m_gui_settings->SetValue(gui::ib_show_welcome, QVariant(!checked));
+		});
+	}
 
 	connect(ui->okay, &QPushButton::clicked, this, &QDialog::accept);
 


### PR DESCRIPTION
- Fixes weird closing of the welcome dialog when checking the "I have read..." checkbox
- Use a shortcut instead of the hardcoded keypress for the welcome dialog
- Remove some hardcoded shortcut hint that seems to be leftover code 