### PR TITLE
vk: Use pipeline barriers for proper event sync

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -217,7 +217,7 @@ namespace vk
 		};
 
 		// Create event object for this transfer and queue signal op
-		dma_fence = std::make_unique<vk::event>(*m_device, sync_domain::any);
+		dma_fence = std::make_unique<vk::event>(*m_device, sync_domain::host);
 		dma_fence->signal(cmd,
 		{
 			.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -691,7 +691,7 @@ namespace vk
 		rsx_log.notice("%u extensions loaded:", ::size32(requested_extensions));
 		for (const auto& ext : requested_extensions)
 		{
-			rsx_log.always()("** Using %s", ext);
+			rsx_log.notice("** Using %s", ext);
 		}
 
 		// Initialize queues

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -721,6 +721,7 @@ namespace vk
 		{
 			_vkCmdSetEvent2KHR = reinterpret_cast<PFN_vkCmdSetEvent2KHR>(vkGetDeviceProcAddr(dev, "vkCmdSetEvent2KHR"));
 			_vkCmdWaitEvents2KHR = reinterpret_cast<PFN_vkCmdWaitEvents2KHR>(vkGetDeviceProcAddr(dev, "vkCmdWaitEvents2KHR"));
+			_vkCmdPipelineBarrier2KHR = reinterpret_cast<PFN_vkCmdPipelineBarrier2KHR>(vkGetDeviceProcAddr(dev, "vkCmdPipelineBarrier2KHR"));
 		}
 
 		memory_map = vk::get_memory_mapping(pdev);

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -138,6 +138,7 @@ namespace vk
 		PFN_vkCmdInsertDebugUtilsLabelEXT _vkCmdInsertDebugUtilsLabelEXT = nullptr;
 		PFN_vkCmdSetEvent2KHR _vkCmdSetEvent2KHR = nullptr;
 		PFN_vkCmdWaitEvents2KHR _vkCmdWaitEvents2KHR = nullptr;
+		PFN_vkCmdPipelineBarrier2KHR _vkCmdPipelineBarrier2KHR = nullptr;
 
 	public:
 		render_device() = default;

--- a/rpcs3/Emu/RSX/VK/vkutils/garbage_collector.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/garbage_collector.h
@@ -44,6 +44,8 @@ namespace vk
 	{
 		virtual void dispose(vk::disposable_t& object) = 0;
 
+		virtual void add_exit_callback(std::function<void()> callback) = 0;
+
 		template<typename T>
 		void dispose(std::unique_ptr<T>& object)
 		{

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.cpp
@@ -280,8 +280,6 @@ namespace vk
 			return;
 		}
 
-		ensure(m_vk_event);
-
 		if (m_domain != sync_domain::host)
 		{
 			// As long as host is not involved, keep things consistent.
@@ -333,7 +331,6 @@ namespace vk
 	{
 		if (m_backend != sync_backend::gpu_label) [[ likely ]]
 		{
-			ensure(m_vk_event);
 			vkSetEvent(*m_device, m_vk_event);
 			return;
 		}
@@ -343,7 +340,7 @@ namespace vk
 
 	void event::gpu_wait(const command_buffer& cmd, const VkDependencyInfoKHR& dependency) const
 	{
-		ensure(m_vk_event && m_domain != sync_domain::host);
+		ensure(m_domain != sync_domain::host);
 
 		if (m_backend == sync_backend::events_v2) [[ likely ]]
 		{

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -64,7 +64,7 @@ namespace vk
 		};
 
 		const vk::render_device* m_device = nullptr;
-		sync_domain m_domain = sync_domain::any;
+		sync_domain m_domain = sync_domain::host;
 		sync_backend m_backend = sync_backend::events_v1;
 
 		// For events_v1 and events_v2
@@ -131,7 +131,7 @@ namespace vk
 		};
 
 		VkBuffer m_buffer_handle = VK_NULL_HANDLE;
-		u32 m_buffer_offset = 0;
+		u64 m_buffer_offset = 0;
 		volatile u32* m_ptr = nullptr;
 
 	public:

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -9,6 +9,7 @@
 namespace vk
 {
 	class command_buffer;
+	class gpu_label;
 	class image;
 
 	enum class sync_domain
@@ -55,9 +56,21 @@ namespace vk
 
 	class event
 	{
+		enum class sync_backend
+		{
+			events_v1,
+			events_v2,
+			gpu_label
+		};
+
 		const vk::render_device* m_device = nullptr;
+		sync_backend m_backend = sync_backend::events_v1;
+
+		// For events_v1 and events_v2
 		VkEvent m_vk_event = VK_NULL_HANDLE;
-		bool v2 = true;
+
+		// For gpu_label
+		std::unique_ptr<gpu_label> m_label{};
 
 		void resolve_dependencies(const command_buffer& cmd, const VkDependencyInfoKHR& dependency);
 
@@ -88,38 +101,60 @@ namespace vk
 		operator VkSemaphore() const;
 	};
 
-	class gpu_debug_marker_pool
+	// Custom primitives
+	class gpu_label_pool
 	{
-		std::unique_ptr<buffer> m_buffer;
+	public:
+		gpu_label_pool(const vk::render_device& dev, u32 count);
+		std::tuple<VkBuffer, u64, volatile u32*> allocate();
+
+	private:
+		void create_impl();
+
+		const vk::render_device* pdev = nullptr;
+		std::unique_ptr<buffer> m_buffer{};
 		volatile u32* m_mapped = nullptr;
 		u64 m_offset = 0;
 		u32 m_count = 0;
-
-		void create_impl();
-
-	public:
-		gpu_debug_marker_pool(const vk::render_device& dev, u32 count);
-		std::tuple<VkBuffer, u64, volatile u32*> allocate();
-
-		const vk::render_device* pdev = nullptr;
 	};
 
-	class gpu_debug_marker
+	class gpu_label
+	{
+	protected:
+		enum label_constants : u32
+		{
+			set_ = 0xCAFEBABE,
+			reset_ = 0xDEADBEEF
+		};
+
+		VkBuffer m_buffer_handle = VK_NULL_HANDLE;
+		u32 m_buffer_offset = 0;
+		volatile u32* m_ptr = nullptr;
+
+	public:
+		gpu_label(gpu_label_pool& pool);
+		virtual ~gpu_label();
+
+		void signal(const vk::command_buffer& cmd, const VkDependencyInfoKHR& dependency);
+		void reset() { *m_ptr = label_constants::reset_; }
+		bool signaled() const { return label_constants::set_ == *m_ptr; }
+	};
+
+	class gpu_debug_marker_pool : public gpu_label_pool
+	{
+		using gpu_label_pool::gpu_label_pool;
+	};
+
+	class gpu_debug_marker : public gpu_label
 	{
 		std::string m_message;
 		bool m_printed = false;
-
-		VkDevice m_device = VK_NULL_HANDLE;
-		VkBuffer m_buffer = VK_NULL_HANDLE;
-		u64 m_buffer_offset = 0;
-		volatile u32* m_value = nullptr;
 
 	public:
 		gpu_debug_marker(gpu_debug_marker_pool& pool, std::string message);
 		~gpu_debug_marker();
 		gpu_debug_marker(const event&) = delete;
 
-		void signal(const command_buffer& cmd, VkPipelineStageFlags stages, VkAccessFlags access);
 		void dump();
 		void dump() const;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -59,6 +59,8 @@ namespace vk
 		VkEvent m_vk_event = VK_NULL_HANDLE;
 		bool v2 = true;
 
+		void resolve_dependencies(const command_buffer& cmd, const VkDependencyInfoKHR& dependency);
+
 	public:
 		event(const render_device& dev, sync_domain domain);
 		~event();

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -14,7 +14,7 @@ namespace vk
 
 	enum class sync_domain
 	{
-		any = 0,
+		host = 0,
 		gpu = 1
 	};
 
@@ -64,6 +64,7 @@ namespace vk
 		};
 
 		const vk::render_device* m_device = nullptr;
+		sync_domain m_domain = sync_domain::any;
 		sync_backend m_backend = sync_backend::events_v1;
 
 		// For events_v1 and events_v2
@@ -106,6 +107,8 @@ namespace vk
 	{
 	public:
 		gpu_label_pool(const vk::render_device& dev, u32 count);
+		virtual ~gpu_label_pool();
+
 		std::tuple<VkBuffer, u64, volatile u32*> allocate();
 
 	private:
@@ -137,6 +140,7 @@ namespace vk
 
 		void signal(const vk::command_buffer& cmd, const VkDependencyInfoKHR& dependency);
 		void reset() { *m_ptr = label_constants::reset_; }
+		void set() { *m_ptr = label_constants::set_; }
 		bool signaled() const { return label_constants::set_ == *m_ptr; }
 	};
 


### PR DESCRIPTION
Turns out the acquire barrier in vkCmdSetEvent2 may not synchronize host operations properly. This is mostly a grey area in the spec, so let's not take any chances.

TODO:
- [x] Restore custom label primitives for older gen AMD hardware

Fixes https://github.com/RPCS3/rpcs3/issues/14106