### PR TITLE
sys_process & VSH: Initial Support for Booting Games from XMB

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -412,7 +412,10 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 	// sys_sm_shutdown
 	const bool is_real_reboot = (ppu.gpr[11] == 379);
 
-	Emu.CallFromMainThread([is_real_reboot, argv = std::move(argv), envp = std::move(envp), data = std::move(data)]() mutable
+	// sys_process_spawns_a_self2
+	const bool is_another_game = (ppu.gpr[11] == 27);
+
+	Emu.CallFromMainThread([is_real_reboot, is_another_game, argv = std::move(argv), envp = std::move(envp), data = std::move(data)]() mutable
 	{
 		sys_process.success("Process finished -> %s", argv[0]);
 
@@ -456,24 +459,27 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 			ensure(g_fxo->init<lv2_memory_container>(std::min(old_size - total_size, sdk_suggested_mem) + total_size));
 		};
 
-		Emu.after_kill_callback = [func = std::move(func), argv = std::move(argv), envp = std::move(envp), data = std::move(data),
+		Emu.after_kill_callback = [is_another_game, func = std::move(func), argv = std::move(argv), envp = std::move(envp), data = std::move(data),
 			disc = std::move(disc), path = std::move(path), hdd1 = std::move(hdd1), old_config = Emu.GetUsedConfig(), klic]() mutable
 		{
-			Emu.argv = std::move(argv);
-			Emu.envp = std::move(envp);
-			Emu.data = std::move(data);
-			Emu.disc = std::move(disc);
-			Emu.hdd1 = std::move(hdd1);
-			Emu.init_mem_containers = std::move(func);
-
-			if (klic)
+			if (!is_another_game)
 			{
-				Emu.klic.emplace_back(klic);
+				Emu.argv = std::move(argv);
+				Emu.envp = std::move(envp);
+				Emu.data = std::move(data);
+				Emu.disc = std::move(disc);
+				Emu.hdd1 = std::move(hdd1);
+				Emu.init_mem_containers = std::move(func);
+
+				if (klic)
+				{
+					Emu.klic.emplace_back(klic);
+				}
 			}
 
 			Emu.SetForceBoot(true);
 
-			auto res = Emu.BootGame(path, "", true, cfg_mode::continuous, old_config);
+			auto res = Emu.BootGame(path, "", true, is_another_game ? cfg_mode::custom : cfg_mode::continuous, is_another_game ? "" : old_config);
 
 			if (res != game_boot_result::no_errors)
 			{
@@ -505,10 +511,42 @@ void sys_process_exit3(ppu_thread& ppu, s32 status)
 	return _sys_process_exit(ppu, status, 0, 0);
 }
 
-error_code sys_process_spawns_a_self2(vm::ptr<u32> pid, u32 primary_prio, u64 flags, vm::ptr<void> stack, u32 stack_size, u32 mem_id, vm::ptr<void> param_sfo, vm::ptr<void> dbg_data)
+error_code sys_process_spawns_a_self2(ppu_thread& ppu, vm::ptr<u32> pid, u32 primary_prio, u64 flags, vm::ptr<spawn_self_stack> stack, u32 stack_size, u32 mem_id, vm::ptr<void> param_sfo, vm::ptr<void> dbg_data)
 {
-	sys_process.todo("sys_process_spawns_a_self2(pid=*0x%x, primary_prio=0x%x, flags=0x%llx, stack=*0x%x, stack_size=0x%x, mem_id=0x%x, param_sfo=*0x%x, dbg_data=*0x%x"
+	ppu.state += cpu_flag::wait;
+
+	sys_process.warning("sys_process_spawns_a_self2(pid=*0x%x, primary_prio=0x%x, flags=0x%llx, stack=*0x%x, stack_size=0x%x, mem_id=0x%x, param_sfo=*0x%x, dbg_data=*0x%x"
 		, pid, primary_prio, flags, stack, stack_size, mem_id, param_sfo, dbg_data);
+
+	if (!g_ps3_process_info.debug_or_root())
+		return CELL_ENOSYS;
+
+	if (!pid || !stack || !param_sfo || !dbg_data)
+		return CELL_EFAULT;
+
+	if (stack_size < sizeof(spawn_self_stack))
+		return CELL_EINVAL;
+
+	std::string_view self_path{stack->self_path, sizeof(stack->self_path)};
+
+	if (const auto trim_start = self_path.find_first_not_of('\0'); trim_start != umax)
+		self_path.remove_prefix(trim_start);
+
+	if (const auto trim_end = self_path.find_first_of('\0'); trim_end != umax)
+		self_path.remove_suffix(self_path.size() - trim_end);
+
+	sys_process.notice("SELF path: %s", self_path);
+
+	if (self_path.ends_with("/USRDIR/EBOOT.BIN"sv)) // Only process game boot currently
+	{
+		std::vector<std::string> argv;
+		std::vector<std::string> envp;
+		std::vector<u8> data;
+
+		argv.emplace_back(self_path);
+
+		lv2_exitspawn(ppu, argv, envp, data);
+	}
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -98,6 +98,12 @@ struct ps3_process_info_t
 
 extern ps3_process_info_t  g_ps3_process_info;
 
+struct spawn_self_stack
+{
+	u8 _x0[0x20];
+	const char self_path[0x30];
+};
+
 // Auxiliary functions
 s32 process_getpid();
 s32 process_get_sdk_version(u32 pid, s32& ver);
@@ -123,4 +129,4 @@ error_code sys_process_detach_child(u64 unk);
 void _sys_process_exit(ppu_thread& ppu, s32 status, u32 arg2, u32 arg3);
 void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> arg, u32 arg_size, u32 arg4);
 void sys_process_exit3(ppu_thread& ppu, s32 status);
-error_code sys_process_spawns_a_self2(vm::ptr<u32> pid, u32 primary_prio, u64 flags, vm::ptr<void> stack, u32 stack_size, u32 mem_id, vm::ptr<void> param_sfo, vm::ptr<void> dbg_data);
+error_code sys_process_spawns_a_self2(ppu_thread& ppu, vm::ptr<u32> pid, u32 primary_prio, u64 flags, vm::ptr<spawn_self_stack> stack, u32 stack_size, u32 mem_id, vm::ptr<void> param_sfo, vm::ptr<void> dbg_data);


### PR DESCRIPTION
This can be a solution for the time being before RPCS3 really supports multi-processing in the future.

Please note that this PR doesn't bring the real in-game XMB, and that this PR just enables you to boot a game from XMB as if you booted a game from the RPCS3 game list.

I tested it with a few games, and it worked very well.