### PR TITLE
Input: Fix multibutton input for mouse interaction

### DIFF
--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -343,6 +343,7 @@ struct Pad
 	bool m_pressure_intensity_button_pressed{}; // Last sensitivity button press state, used for toggle.
 	bool m_pressure_intensity_toggled{}; // Whether the sensitivity is toggled on or off.
 	u8 m_pressure_intensity{127}; // 0-255
+	bool m_adjust_pressure_last{}; // only used in keyboard_pad_handler
 	bool get_pressure_intensity_enabled(bool is_toggle_mode);
 
 	// Cable State:   0 - 1  plugged in ?

--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -286,6 +286,9 @@ struct AnalogStick
 	std::set<u32> m_key_codes_max{};
 	u16 m_value = 128;
 
+	std::map<u32, u16> m_pressed_keys_min{}; // only used in keyboard_pad_handler
+	std::map<u32, u16> m_pressed_keys_max{}; // only used in keyboard_pad_handler
+
 	AnalogStick(u32 offset, std::set<u32> key_codes_min, std::set<u32> key_codes_max)
 		: m_offset(offset)
 		, m_key_codes_min(std::move(key_codes_min))

--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -4,6 +4,7 @@
 #include "util/endian.hpp"
 #include "Emu/Io/pad_config_types.h"
 
+#include <map>
 #include <set>
 #include <vector>
 
@@ -246,10 +247,10 @@ struct Button
 	u16 m_value    = 0;
 	bool m_pressed = false;
 
-	u16 m_actual_value = 0;         // only used in keyboard_pad_handler
-	bool m_analog      = false;     // only used in keyboard_pad_handler
-	bool m_trigger     = false;     // only used in keyboard_pad_handler
-	std::set<u32> m_pressed_keys{}; // only used in keyboard_pad_handler
+	u16 m_actual_value = 0;              // only used in keyboard_pad_handler
+	bool m_analog      = false;          // only used in keyboard_pad_handler
+	bool m_trigger     = false;          // only used in keyboard_pad_handler
+	std::map<u32, u16> m_pressed_keys{}; // only used in keyboard_pad_handler
 
 	Button(u32 offset, std::set<u32> key_codes, u32 outKeyCode)
 		: m_offset(offset)

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -6,9 +6,6 @@
 
 #include <QApplication>
 
-inline std::string sstr(const QString& _in) { return _in.toStdString(); }
-constexpr auto qstr = QString::fromStdString;
-
 bool keyboard_pad_handler::Init()
 {
 	const steady_clock::time_point now = steady_clock::now();
@@ -281,7 +278,7 @@ void keyboard_pad_handler::processKeyEvent(QKeyEvent* event, bool pressed)
 		if (is_num_key)
 			list.removeAll("Num");
 
-		const QString name = qstr(GetKeyName(event));
+		const QString name = QString::fromStdString(GetKeyName(event));
 
 		// TODO: Edge case: switching numlock keeps numpad keys pressed due to now different modifier
 
@@ -642,7 +639,7 @@ QStringList keyboard_pad_handler::GetKeyNames(const QKeyEvent* keyEvent)
 	// Handle special cases
 	if (const std::string name = native_scan_code_to_string(keyEvent->nativeScanCode()); !name.empty())
 	{
-		list.append(qstr(name));
+		list.append(QString::fromStdString(name));
 	}
 
 	switch (keyEvent->key())
@@ -692,7 +689,7 @@ std::string keyboard_pad_handler::GetKeyName(const QKeyEvent* keyEvent)
 	case Qt::Key_Meta:
 		return "Meta";
 	case Qt::Key_NumLock:
-		return sstr(QKeySequence(keyEvent->key()).toString(QKeySequence::NativeText));
+		return QKeySequence(keyEvent->key()).toString(QKeySequence::NativeText).toStdString();
 #ifdef __APPLE__
 	// On macOS, the arrow keys are considered to be part of the keypad;
 	// since most Mac keyboards lack a keypad to begin with,
@@ -709,12 +706,12 @@ std::string keyboard_pad_handler::GetKeyName(const QKeyEvent* keyEvent)
 	default:
 		break;
 	}
-	return sstr(QKeySequence(keyEvent->key() | keyEvent->modifiers()).toString(QKeySequence::NativeText));
+	return QKeySequence(keyEvent->key() | keyEvent->modifiers()).toString(QKeySequence::NativeText).toStdString();
 }
 
 std::string keyboard_pad_handler::GetKeyName(const u32& keyCode)
 {
-	return sstr(QKeySequence(keyCode).toString(QKeySequence::NativeText));
+	return QKeySequence(keyCode).toString(QKeySequence::NativeText).toStdString();
 }
 
 std::set<u32> keyboard_pad_handler::GetKeyCodes(const cfg::string& cfg_string)
@@ -734,7 +731,7 @@ u32 keyboard_pad_handler::GetKeyCode(const QString& keyName)
 {
 	if (keyName.isEmpty())
 		return Qt::NoButton;
-	if (const int native_scan_code = native_scan_code_from_string(sstr(keyName)); native_scan_code >= 0)
+	if (const int native_scan_code = native_scan_code_from_string(keyName.toStdString()); native_scan_code >= 0)
 		return Qt::Key_unknown + native_scan_code; // Special cases that can't be expressed with Qt::Key
 	if (keyName == "Alt")
 		return Qt::Key_Alt;

--- a/rpcs3/rpcs3qt/microphone_creator.cpp
+++ b/rpcs3/rpcs3qt/microphone_creator.cpp
@@ -70,8 +70,8 @@ void microphone_creator::parse_devices(const std::string& list)
 {
 	m_sel_list = {};
 
-	const auto devices_list = fmt::split(list, { "@@@" });
-	for (u32 index = 0; index < std::min<u32>(m_sel_list.size(), ::size32(devices_list)); index++)
+	const std::vector<std::string> devices_list = fmt::split(list, { "@@@" });
+	for (usz index = 0; index < std::min(m_sel_list.size(), devices_list.size()); index++)
 	{
 		m_sel_list[index] = devices_list[index];
 	}

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1945,6 +1945,7 @@ void pad_settings_dialog::ResizeDialog()
 
 void pad_settings_dialog::SubscribeTooltip(QObject* object, const QString& tooltip)
 {
+	ensure(!!object);
 	m_descriptions[object] = tooltip;
 	object->installEventFilter(this);
 }
@@ -1967,6 +1968,11 @@ void pad_settings_dialog::SubscribeTooltips()
 	SubscribeTooltip(ui->gb_mouse_accel, tooltips.gamepad_settings.mouse_acceleration);
 	SubscribeTooltip(ui->gb_mouse_dz, tooltips.gamepad_settings.mouse_deadzones);
 	SubscribeTooltip(ui->gb_mouse_movement, tooltips.gamepad_settings.mouse_movement);
+	
+	for (int i = button_ids::id_pad_begin + 1; i < button_ids::id_pad_end; i++)
+	{
+		SubscribeTooltip(m_pad_buttons->button(i), tooltips.gamepad_settings.button_assignment);
+	}
 }
 
 void pad_settings_dialog::start_input_thread()

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -280,6 +280,7 @@ public:
 		const QString mouse_deadzones    = tr("The mouse deadzones represent the games' own deadzones on the x and y axes. Games usually enforce their own deadzones to filter out small unwanted stick movements. In consequence, mouse input feels unintuitive since it relies on immediate responsiveness. You can change these values temporarily during gameplay in order to find out the optimal values for your game (Alt+T and Alt+Y for x, Alt+U and Alt+I for y).");
 		const QString mouse_acceleration = tr("The mouse acceleration can be used to amplify your mouse movements on the x and y axes. Increase these values if your mouse movements feel too slow while playing a game. You can change these values temporarily during gameplay in order to find out the optimal values (Alt+G and Alt+H for x, Alt+J and Alt+K for y). Keep in mind that modern mice usually provide different modes and settings that can be used to change mouse movement speeds as well.");
 		const QString mouse_movement     = tr("The mouse movement mode determines how the mouse movement is translated to pad input.<br>Use the relative mode for traditional mouse movement.<br>Use the absolute mode to use the mouse's distance to the center of the screen as input value.");
+		const QString button_assignment  = tr("Left-click: remap this button.<br>Shift + Left-click: add an addition button mapping.<br>Right-click: clear this button mapping.");
 
 	} gamepad_settings;
 };


### PR DESCRIPTION
- Adds tooltips for button mapping (hover on a button).
- Allows for updates on already pressed keyboard buttons when pressing the pressure sensitivity button.
- Should hopefully fix all issues with multibuttons when using the keyboard.

Previously, the mouse presses, mouse wheel and mouse move would override any other key on the same button.
Additionally, mouse interaction was not working in tandem at all anyway.
Last but not least this should also fix any issues regarding stick or button interpolation with multibuttons on the keyboard.