### PR TITLE
Hotfix after #14090

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3084,7 +3084,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 			}
 
 			// Check .self filename
-			if (upper.ends_with(".SELF"))
+			if (upper.ends_with(".SELF") && Emu.GetBoot() != dir_queue[i] + entry.name)
 			{
 				// Get full path
 				file_queue.emplace_back(dir_queue[i] + entry.name,  0);
@@ -3302,14 +3302,15 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 			{
 				while (exec_err == elf_error::ok)
 				{
+					main_ppu_module& _main = g_fxo->get<main_ppu_module>();
+					_main = {};
+
 					if (!ppu_load_exec(obj, true, path))
 					{
 						// Abort
 						exec_err = elf_error::header_type;
 						break;
 					}
-
-					main_ppu_module& _main = g_fxo->get<main_ppu_module>();
 
 					if (!_main.analyse(0, _main.elf_entry, _main.seg0_code_end, _main.applied_pathes, [](){ return Emu.IsStopped(); }))
 					{
@@ -3457,7 +3458,7 @@ extern void ppu_initialize()
 	}
 
 	// Avoid compilation if main's cache exists or it is a standalone SELF with no PARAM.SFO
-	if (compile_main && g_cfg.core.ppu_llvm_precompilation && !Emu.GetTitleID().empty())
+	if (compile_main && g_cfg.core.ppu_llvm_precompilation && !Emu.GetTitleID().empty() && !Emu.IsChildProcess())
 	{
 		// Try to add all related directories
 		const std::set<std::string> dirs = Emu.GetGameDirs();

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2996,10 +2996,6 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 
 	const std::string firmware_sprx_path = vfs::get("/dev_flash/sys/external/");
 
-	// Map fixed address executables area, fake overlay support
-	const bool had_ovl = !vm::map(0x3000'0000, 0x1000'0000, 0x202).operator bool();
-	const u32 ppc_seg = std::exchange(g_ps3_process_info.ppc_seg, 0x3);
-
 	std::vector<std::pair<std::string, u64>> file_queue;
 	file_queue.reserve(2000);
 
@@ -3339,15 +3335,6 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 	});
 
 	exec_worker();
-
-	// Revert changes
-
-	if (!had_ovl)
-	{
-		ensure(vm::unmap(0x3000'0000).second);
-	}
-
-	g_ps3_process_info.ppc_seg = ppc_seg;
 }
 
 extern void ppu_initialize()

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -439,7 +439,7 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 			}
 
 			// Save LV2 memory containers
-			g_fxo->init<id_map<lv2_memory_container>>()->vec = std::move(vec);
+			ensure(g_fxo->init<id_map<lv2_memory_container>>())->vec = std::move(vec);
 
 			// Empty the containers, accumulate their total size
 			u32 total_size = 0;
@@ -453,7 +453,7 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 			// 1. If newer SDK version suggests higher memory capacity - it is ignored
 			// 2. If newer SDK version suggests lower memory capacity - it is lowered
 			// And if 2. happens while user memory containers exist, the left space can be spent on user memory containers
-			g_fxo->init<lv2_memory_container>(std::min(old_size - total_size, sdk_suggested_mem) + total_size);
+			ensure(g_fxo->init<lv2_memory_container>(std::min(old_size - total_size, sdk_suggested_mem) + total_size));
 		};
 
 		Emu.after_kill_callback = [func = std::move(func), argv = std::move(argv), envp = std::move(envp), data = std::move(data),

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2893,8 +2893,9 @@ void Emulator::Kill(bool allow_autoexit, bool savestate)
 
 			if (after_kill_callback)
 			{
-				after_kill_callback();
-				after_kill_callback = nullptr;
+				// Make after_kill_callback empty before call
+				const auto callback = std::move(after_kill_callback);
+				callback();
 			}
 		});
 	}));

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -312,6 +312,11 @@ public:
 		return m_config_path;
 	}
 
+	bool IsChildProcess() const
+	{
+		return m_config_mode == cfg_mode::continuous;
+	}
+
 	game_boot_result BootGame(const std::string& path, const std::string& title_id = "", bool direct = false, cfg_mode config_mode = cfg_mode::custom, const std::string& config_path = "");
 	bool BootRsxCapture(const std::string& path);
 


### PR DESCRIPTION
* init_mem_contianer was called during precompilation of RDR2.self (set up by _sys_process_exit2), this is wrong and fixed.
* Empty after_kill_callback before use to avoid situations in which its called recursively if calling Emu.Stop() inside Emu.Load(), same with init_mem_container but there is just for safety.
* Disable PPU precompilation for child processses (already done in parent process), speeding up boot a little in RDR.

Fixes #14110