### PR TITLE
sys_usbd: Implement support for Santroller devices

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -247,6 +247,20 @@ usb_handler_thread::usb_handler_thread()
 		check_device(0x12BA, 0x2430, 0x243F, "Harmonix Button Guitar");
 		check_device(0x12BA, 0x2530, 0x253F, "Harmonix Real Guitar");
 
+		if (desc.idVendor == 0x1209 && desc.idProduct == 0x2882)
+		{
+			sys_usbd.success("Found device: Santroller");
+			// Send the device a specific control transfer so that it jumps to a RPCS3 compatible mode
+			libusb_device_handle* lusb_handle;
+			libusb_open(list[index], &lusb_handle);
+#ifdef __linux__
+			libusb_set_auto_detach_kernel_driver(lusb_handle, true);
+			libusb_claim_interface(lusb_handle, 2);
+#endif
+			libusb_control_transfer(lusb_handle, +LIBUSB_ENDPOINT_IN | +LIBUSB_REQUEST_TYPE_CLASS | +LIBUSB_RECIPIENT_INTERFACE, 0x01, 0x03f2, 2, nullptr, 0, 5000);
+			libusb_close(lusb_handle);
+		}
+
 		// Top Shot Elite controllers
 		check_device(0x12BA, 0x04A0, 0x04A0, "RO Gun Controller");
 		check_device(0x12BA, 0x04A1, 0x04A1, "RO Gun Controller 2012");


### PR DESCRIPTION
I have been working on a microcontroller [firmware](https://github.com/sanjay900/guitar-configurator) for the last few years that is being used by a lot of people playing clone hero, guitar hero, rock band and dj hero. At this point, its being used by most modded guitar hero controllers out there, and a fair amount of Wii extension usb adapters are being sold running it as well.

I have been working on a update to the firmware that can detect what console it is plugged into, and switch to the correct mode for that console. I would like RPCS3 to also trigger this, but unfortunately the requests i look for on a PS3 are never triggered with RPCS3. A simple control request is enough to jump to PS3 mode, and since my controllers automatically install WINUSB drivers, this even works perfectly fine on windows as well. I have specifically had requests from several people who want to use my devices with RPCS3, but my controllers default to XInput as that plays better with games like Clone Hero, but XInput doesn't play so nice with RPCS3 when dealing with instruments.