### PR TITLE
Only silence logging during gameplay

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -791,6 +791,9 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 		return game_boot_result::still_running;
 	}
 
+	// Enable logging
+	rpcs3::utils::configure_logs(true);
+
 	m_ar.reset();
 
 	{
@@ -2502,6 +2505,9 @@ extern bool try_lock_spu_threads_in_a_state_compatible_with_savestates(bool reve
 
 void Emulator::Kill(bool allow_autoexit, bool savestate)
 {
+	// Enable logging
+	rpcs3::utils::configure_logs(true);
+
 	if (!IsStopped() && savestate && !try_lock_spu_threads_in_a_state_compatible_with_savestates())
 	{
 		sys_log.error("Failed to savestate: failed to lock SPU threads execution.");

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -38,17 +38,17 @@ namespace rpcs3::utils
 		return thread_count;
 	}
 
-	void configure_logs()
+	void configure_logs(bool force_enable)
 	{
 		static bool was_silenced = false;
 
-		const bool silenced = g_cfg.misc.silence_all_logs.get();
+		const bool silenced = g_cfg.misc.silence_all_logs.get() && !force_enable;
 
 		if (silenced)
 		{
 			if (!was_silenced)
 			{
-				sys_log.success("Disabling logging! Do not create issues on GitHub or on the forums while logging is disabled.");
+				sys_log.always()("Disabling logging! Do not create issues on GitHub or on the forums while logging is disabled.");
 			}
 
 			logs::silence();

--- a/rpcs3/Emu/system_utils.hpp
+++ b/rpcs3/Emu/system_utils.hpp
@@ -7,7 +7,7 @@ namespace rpcs3::utils
 {
 	u32 get_max_threads();
 
-	void configure_logs();
+	void configure_logs(bool force_enable = false);
 
 	u32 check_user(const std::string& user);
 

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -79,10 +79,11 @@ void main_application::OnEmuSettingsChange()
 		}
 	}
 
-	rpcs3::utils::configure_logs();
-
 	if (!Emu.IsStopped())
 	{
+		// Change logging (only allowed during gameplay)
+		rpcs3::utils::configure_logs();
+
 		// Force audio provider
 		g_cfg.audio.provider.set(Emu.IsVsh() ? audio_provider::rsxaudio : audio_provider::cell_audio);
 	}


### PR DESCRIPTION
Turns out disabling the log at all times is a bit counter productive. 