### PR TITLE
SPU: Fix static interpreter requirement with interrupts

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -2666,7 +2666,6 @@ void PPUTranslator::DCBST(ppu_opcode_t)
 void PPUTranslator::LWZUX(ppu_opcode_t op)
 {
 	m_may_be_mmio &= (op.ra != 1u && op.ra != 13u && op.rb != 1u && op.rb != 13u); // Stack register and TLS address register are unlikely to be used in MMIO address calculation
-	m_may_be_mmio &= op.simm16 == 0 || spu_thread::test_is_problem_state_register_offset(op.uimm16, true, false); // Either exact MMIO address or MMIO base with completing s16 address offset
 
 	const auto addr = m_ir->CreateAdd(GetGpr(op.ra), GetGpr(op.rb));
 	SetGpr(op.rd, ReadMemory(addr, GetType<u32>()));

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4612,9 +4612,9 @@ void spu_thread::set_interrupt_status(bool enable)
 		// Detect enabling interrupts with events masked
 		if (auto mask = ch_events.load().mask; mask & SPU_EVENT_INTR_BUSY_CHECK)
 		{
-			if (g_cfg.core.spu_decoder != spu_decoder_type::_static)
+			if (g_cfg.core.spu_decoder != spu_decoder_type::_static && g_cfg.core.spu_decoder != spu_decoder_type::dynamic)
 			{
-				fmt::throw_exception("SPU Interrupts not implemented (mask=0x%x): Use static interpreter", mask);
+				fmt::throw_exception("SPU Interrupts not implemented (mask=0x%x): Use [%s] SPU decoder", mask, spu_decoder_type::dynamic);
 			}
 
 			spu_log.trace("SPU Interrupts (mask=0x%x) are using CPU busy checking mode", mask);


### PR DESCRIPTION
The dynamic interpreter is also allowed in this case.
Fixes it for games such as FIFA Street 3 which use the decrementer event interrupt.