### PR TITLE
Home menu: settings improvements

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
@@ -66,7 +66,7 @@ namespace rsx
 			add_dropdown(&g_cfg.core.sleep_timers_accuracy, "Sleep Timers Accuracy");
 
 			add_unsigned_slider(&g_cfg.video.driver_wakeup_delay, "Driver Wake-Up Delay", " µs", 20, g_cfg.video.driver_wakeup_delay.min, 800);
-			add_signed_slider(&g_cfg.video.vblank_rate, "VBlank Frequency", " Hz", 1);
+			add_signed_slider(&g_cfg.video.vblank_rate, "VBlank Frequency", " Hz", 30);
 			add_checkbox(&g_cfg.video.vblank_ntsc, "VBlank NTSC Fixup");
 
 			apply_layout();

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
@@ -43,7 +43,7 @@ namespace rsx
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_VIDEO))
 		{
 			add_dropdown(&g_cfg.video.frame_limit, "Frame Limit");
-			add_unsigned_slider(&g_cfg.video.anisotropic_level_override, "Anisotropic Filter Override", "", 2, {{0, "Auto"}});
+			add_unsigned_slider(&g_cfg.video.anisotropic_level_override, "Anisotropic Filter Override", "x", 2, {{0, "Auto"}});
 
 			add_dropdown(&g_cfg.video.output_scaling, "Output Scaling");
 			if (g_cfg.video.renderer == video_renderer::vulkan && g_cfg.video.output_scaling == output_scaling_mode::fsr)

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
@@ -43,7 +43,7 @@ namespace rsx
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_VIDEO))
 		{
 			add_dropdown(&g_cfg.video.frame_limit, "Frame Limit");
-			add_unsigned_slider(&g_cfg.video.anisotropic_level_override, "Anisotropic Filter Override", "", 2);
+			add_unsigned_slider(&g_cfg.video.anisotropic_level_override, "Anisotropic Filter Override", "", 2, {{0, "Auto"}});
 
 			add_dropdown(&g_cfg.video.output_scaling, "Output Scaling");
 			if (g_cfg.video.renderer == video_renderer::vulkan && g_cfg.video.output_scaling == output_scaling_mode::fsr)
@@ -65,7 +65,7 @@ namespace rsx
 			add_checkbox(&g_cfg.core.rsx_accurate_res_access, "Accurate RSX reservation access");
 			add_dropdown(&g_cfg.core.sleep_timers_accuracy, "Sleep Timers Accuracy");
 
-			add_unsigned_slider(&g_cfg.video.driver_wakeup_delay, "Driver Wake-Up Delay", " µs", 20, g_cfg.video.driver_wakeup_delay.min, 800);
+			add_unsigned_slider(&g_cfg.video.driver_wakeup_delay, "Driver Wake-Up Delay", " µs", 20, {}, g_cfg.video.driver_wakeup_delay.min, 800);
 			add_signed_slider(&g_cfg.video.vblank_rate, "VBlank Frequency", " Hz", 30);
 			add_checkbox(&g_cfg.video.vblank_ntsc, "VBlank NTSC Fixup");
 

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
@@ -53,10 +53,6 @@ namespace rsx
 
 			add_checkbox(&g_cfg.video.stretch_to_display_area, "Stretch To Display Area");
 
-			add_unsigned_slider(&g_cfg.video.driver_wakeup_delay, "Driver Wake-Up Delay", " µs", 20, g_cfg.video.driver_wakeup_delay.min, 800);
-			add_signed_slider(&g_cfg.video.vblank_rate, "VBlank Frequency", " Hz", 1);
-			add_checkbox(&g_cfg.video.vblank_ntsc, "VBlank NTSC Fixup");
-
 			apply_layout();
 		}
 
@@ -68,6 +64,10 @@ namespace rsx
 			add_unsigned_slider(&g_cfg.core.max_cpu_preempt_count_per_frame, "Max Power Saving CPU-Preemptions", "", 1);
 			add_checkbox(&g_cfg.core.rsx_accurate_res_access, "Accurate RSX reservation access");
 			add_dropdown(&g_cfg.core.sleep_timers_accuracy, "Sleep Timers Accuracy");
+
+			add_unsigned_slider(&g_cfg.video.driver_wakeup_delay, "Driver Wake-Up Delay", " µs", 20, g_cfg.video.driver_wakeup_delay.min, 800);
+			add_signed_slider(&g_cfg.video.vblank_rate, "VBlank Frequency", " Hz", 1);
+			add_checkbox(&g_cfg.video.vblank_ntsc, "VBlank NTSC Fixup");
 
 			apply_layout();
 		}

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.h
@@ -88,10 +88,10 @@ namespace rsx
 			}
 
 			template <s64 Min, s64 Max>
-			void add_signed_slider(cfg::_int<Min, Max>* setting, const std::string& text, const std::string& suffix, s64 step_size, s64 minimum = Min, s64 maximum = Max)
+			void add_signed_slider(cfg::_int<Min, Max>* setting, const std::string& text, const std::string& suffix, s64 step_size, std::map<s64, std::string> special_labels = {}, s64 minimum = Min, s64 maximum = Max)
 			{
 				ensure(setting && setting->get_is_dynamic());
-				std::unique_ptr<overlay_element> elem = std::make_unique<home_menu_signed_slider<Min, Max>>(setting, text, suffix, minimum, maximum);
+				std::unique_ptr<overlay_element> elem = std::make_unique<home_menu_signed_slider<Min, Max>>(setting, text, suffix, special_labels, minimum, maximum);
 
 				add_item(elem, [this, setting, text, step_size, minimum, maximum](pad_button btn) -> page_navigation
 				{
@@ -127,10 +127,10 @@ namespace rsx
 			}
 
 			template <u64 Min, u64 Max>
-			void add_unsigned_slider(cfg::uint<Min, Max>* setting, const std::string& text, const std::string& suffix, u64 step_size, u64 minimum = Min, u64 maximum = Max)
+			void add_unsigned_slider(cfg::uint<Min, Max>* setting, const std::string& text, const std::string& suffix, u64 step_size, std::map<u64, std::string> special_labels = {}, u64 minimum = Min, u64 maximum = Max)
 			{
 				ensure(setting && setting->get_is_dynamic());
-				std::unique_ptr<overlay_element> elem = std::make_unique<home_menu_unsigned_slider<Min, Max>>(setting, text, suffix, minimum, maximum);
+				std::unique_ptr<overlay_element> elem = std::make_unique<home_menu_unsigned_slider<Min, Max>>(setting, text, suffix, special_labels, minimum, maximum);
 
 				add_item(elem, [this, setting, text, step_size, minimum, maximum](pad_button btn) -> page_navigation
 				{
@@ -166,10 +166,10 @@ namespace rsx
 			}
 
 			template <s32 Min, s32 Max>
-			void add_float_slider(cfg::_float<Min, Max>* setting, const std::string& text, const std::string& suffix, f32 step_size, s32 minimum = Min, s32 maximum = Max)
+			void add_float_slider(cfg::_float<Min, Max>* setting, const std::string& text, const std::string& suffix, f32 step_size, std::map<f64, std::string> special_labels = {}, s32 minimum = Min, s32 maximum = Max)
 			{
 				ensure(setting && setting->get_is_dynamic());
-				std::unique_ptr<overlay_element> elem = std::make_unique<home_menu_float_slider<Min, Max>>(setting, text, suffix, minimum, maximum);
+				std::unique_ptr<overlay_element> elem = std::make_unique<home_menu_float_slider<Min, Max>>(setting, text, suffix, special_labels, minimum, maximum);
 
 				add_item(elem, [this, setting, text, step_size, minimum, maximum](pad_button btn) -> page_navigation
 				{


### PR DESCRIPTION
- Move "Driver Wake-Up Delay" to advanced page
- Move "VBlank NTSC Fixup" to advanced page
- Move "VBlank Frequency" to advanced page
- Change "VBlank Frequency" step size to 30
- Add support for value label overrides
- Replace 0 with "Auto" in "Anisotropic Filter Override"
- Add "x" suffix to "Anisotropic Filter Override" (2x,4x,8x vs 2,4,8)