### PR TITLE
Qt/Patches: Improve patch validation and patch creator

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -251,6 +251,13 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 			// Each key in "Patches" is also the patch description
 			const std::string& description = patches_entry.first.Scalar();
 
+			if (description.empty())
+			{
+				append_log_message(log_messages, fmt::format("Error: Empty patch name (key: %s, location: %s, file: %s)", main_key, get_yaml_node_location(patches_entry.first), path), &patch_log.error);
+				is_valid = false;
+				continue;
+			}
+
 			// Compile patch information
 
 			if (const auto yml_type = patches_entry.second.Type(); yml_type != YAML::NodeType::Map)

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -218,18 +218,18 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 	// Go through each main key in the file
 	for (auto pair : root)
 	{
-		const auto& main_key = pair.first.Scalar();
+		const std::string& main_key = pair.first.Scalar();
 
-		if (const auto yml_type = pair.second.Type(); yml_type != YAML::NodeType::Map)
+		if (main_key.empty())
 		{
-			append_log_message(log_messages, fmt::format("Error: Skipping key %s: expected Map, found %s (location: %s, file: %s)", main_key, yml_type, get_yaml_node_location(pair.second), path), &patch_log.error);
+			append_log_message(log_messages, fmt::format("Error: Skipping empty key (location: %s, file: %s)", get_yaml_node_location(pair.first), path), &patch_log.error);
 			is_valid = false;
 			continue;
 		}
 
-		if (main_key.empty())
+		if (const auto yml_type = pair.second.Type(); yml_type != YAML::NodeType::Map)
 		{
-			append_log_message(log_messages, fmt::format("Error: Skipping empty key (location: %s, file: %s)", get_yaml_node_location(pair.second), path), &patch_log.error);
+			append_log_message(log_messages, fmt::format("Error: Skipping key %s: expected Map, found %s (location: %s, file: %s)", main_key, yml_type, get_yaml_node_location(pair.second), path), &patch_log.error);
 			is_valid = false;
 			continue;
 		}
@@ -241,7 +241,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 		}
 
 		// Find or create an entry matching the key/hash in our map
-		auto& container = patches_map[main_key];
+		patch_container& container = patches_map[main_key];
 		container.hash    = main_key;
 		container.version = version;
 
@@ -336,7 +336,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 							continue;
 						}
 
-						patch_engine::patch_app_versions app_versions;
+						patch_app_versions app_versions;
 
 						for (const auto version : serial_node.second)
 						{
@@ -585,6 +585,14 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 			{
 				if (!read_patch_node(info, patch_node, root, log_messages))
 				{
+					for (const auto& it : patches_entry.second)
+					{
+						if (it.first.Scalar() == patch_key::patch)
+						{
+							append_log_message(log_messages, fmt::format("Skipping invalid patch node %s: (key: %s, location: %s)", info.description, main_key, get_yaml_node_location(it.first)), &patch_log.error);
+							break;
+						}
+					}
 					is_valid = false;
 				}
 			}
@@ -1299,9 +1307,9 @@ std::basic_string<u32> patch_engine::apply(const std::string& name, std::functio
 	}
 
 	std::basic_string<u32> applied_total;
-	const auto& container = ::at32(m_map, name);
-	const auto& serial = Emu.GetTitleID();
-	const auto& app_version = Emu.GetAppVersion();
+	const patch_container& container = ::at32(m_map, name);
+	const std::string& serial = Emu.GetTitleID();
+	const std::string& app_version = Emu.GetAppVersion();
 
 	// Different containers in order to seperate the patches
 	std::vector<std::shared_ptr<patch_info>> patches_for_this_serial_and_this_version;
@@ -1335,7 +1343,7 @@ std::basic_string<u32> patch_engine::apply(const std::string& name, std::functio
 				continue;
 			}
 
-			const auto& app_versions = ::at32(serials, found_serial);
+			const patch_app_versions& app_versions = ::at32(serials, found_serial);
 			std::string found_app_version;
 
 			if (app_versions.contains(app_version))
@@ -1453,11 +1461,11 @@ void patch_engine::unload(const std::string& name)
 		return;
 	}
 
-	const auto& container = ::at32(m_map, name);
+	const patch_container& container = ::at32(m_map, name);
 
 	for (const auto& [description, patch] : container.patch_info_map)
 	{
-		for (auto& entry : patch.data_list)
+		for (const patch_data& entry : patch.data_list)
 		{
 			// Deallocate used memory
 			if (u32 addr = std::exchange(entry.alloc_addr, 0))
@@ -1585,7 +1593,7 @@ static void append_patches(patch_engine::patch_map& existing_patches, const patc
 			continue;
 		}
 
-		auto& container = existing_patches[hash];
+		patch_engine::patch_container& container = existing_patches[hash];
 
 		for (const auto& [description, new_info] : new_container.patch_info_map)
 		{
@@ -1596,7 +1604,7 @@ static void append_patches(patch_engine::patch_map& existing_patches, const patc
 				continue;
 			}
 
-			auto& info = container.patch_info_map[description];
+			patch_engine::patch_info& info = container.patch_info_map[description];
 
 			bool ok;
 			const bool version_is_bigger = utils::compare_versions(new_info.patch_version, info.patch_version, ok) > 0;
@@ -1759,7 +1767,7 @@ bool patch_engine::save_patches(const patch_map& patches, const std::string& pat
 
 bool patch_engine::import_patches(const patch_engine::patch_map& patches, const std::string& path, usz& count, usz& total, std::stringstream* log_messages)
 {
-	patch_engine::patch_map existing_patches;
+	patch_map existing_patches;
 
 	if (load(existing_patches, path, "", true, log_messages))
 	{
@@ -1772,13 +1780,13 @@ bool patch_engine::import_patches(const patch_engine::patch_map& patches, const 
 
 bool patch_engine::remove_patch(const patch_info& info)
 {
-	patch_engine::patch_map patches;
+	patch_map patches;
 
 	if (load(patches, info.source_path))
 	{
 		if (patches.contains(info.hash))
 		{
-			auto& container = patches[info.hash];
+			patch_container& container = patches[info.hash];
 
 			if (container.patch_info_map.contains(info.description))
 			{

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -435,7 +435,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 				dlg.set_input_font(mono, false);
 				dlg.set_clear_button_enabled(false);
 				dlg.set_button_enabled(QDialogButtonBox::StandardButton::Ok, false);
-				dlg.set_validator(new QRegularExpressionValidator(QRegularExpression("^[1-9][0-9]*$")));
+				dlg.set_validator(new QRegularExpressionValidator(QRegularExpression("^[1-9][0-9]*$"), &dlg));
 
 				u32 max = 0;
 
@@ -1188,11 +1188,11 @@ void debugger_frame::ShowGotoAddressDialog()
 
 	if (const auto thread = get_cpu(); !thread || thread->id_type() != 2)
 	{
-		expression_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$")));
+		expression_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$"), this));
 	}
 	else
 	{
-		expression_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,5}$")));
+		expression_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,5}$"), this));
 	}
 
 	// Ok/Cancel

--- a/rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp
+++ b/rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp
@@ -34,13 +34,13 @@ elf_memory_dumping_dialog::elf_memory_dumping_dialog(u32 ppu_debugger_addr, std:
 	m_seg_list->setMinimumWidth(gui::utils::get_label_width(tr("PPU Address: 0x00000000, LS Address: 0x00000, Segment Size: 0x00000, Flags: 0x0")));
 
 	// Address expression input
-	auto make_hex_edit = [mono](u32 max_digits)
+	auto make_hex_edit = [this, mono](u32 max_digits)
 	{
 		QLineEdit* le = new QLineEdit();
 		le->setFont(mono);
 		le->setMaxLength(max_digits + 2);
 		le->setPlaceholderText("0x" + QStringLiteral("0").repeated(max_digits));
-		le->setValidator(new QRegularExpressionValidator(QRegularExpression(QStringLiteral("^(0[xX])?0*[a-fA-F0-9]{0,%1}$").arg(max_digits))));
+		le->setValidator(new QRegularExpressionValidator(QRegularExpression(QStringLiteral("^(0[xX])?0*[a-fA-F0-9]{0,%1}$").arg(max_digits)), this));
 		return le;
 	};
 

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -679,7 +679,7 @@ void log_frame::UpdateUI()
 
 	const auto font_start_tag = [](const QColor& color) -> const QString { return QStringLiteral("<font color = \"") % color.name() % QStringLiteral("\">"); };
 	const QString font_start_tag_stack = "<font color = \"" % m_color_stack.name() % "\">";
-	const QString font_end_tag = QStringLiteral("</font>");
+	static const QString font_end_tag = QStringLiteral("</font>");
 
 	static constexpr auto escaped = [](const QString& text)
 	{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1633,7 +1633,7 @@ void main_window::DecryptSPRXLibraries()
 		dlg->set_input_font(mono, true, '0');
 		dlg->set_clear_button_enabled(false);
 		dlg->set_button_enabled(QDialogButtonBox::StandardButton::Ok, false);
-		dlg->set_validator(new QRegularExpressionValidator(QRegularExpression("^((((((K?L)?I)?C)?=)?0)?x)?[a-fA-F0-9]{0,32}$"))); // HEX only (with additional KLIC=0x prefix for convenience)
+		dlg->set_validator(new QRegularExpressionValidator(QRegularExpression("^((((((K?L)?I)?C)?=)?0)?x)?[a-fA-F0-9]{0,32}$"), this)); // HEX only (with additional KLIC=0x prefix for convenience)
 		dlg->setAttribute(Qt::WA_DeleteOnClose);
 
 		connect(dlg, &input_dialog::text_changed, dlg, [dlg](const QString& text)

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -92,7 +92,7 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, std::shared_ptr<CPUDis
 	m_addr_line->setMaxLength(18);
 	m_addr_line->setFixedWidth(75);
 	m_addr_line->setFocus();
-	m_addr_line->setValidator(new QRegularExpressionValidator(QRegularExpression(m_type == thread_type::spu ? "^(0[xX])?0*[a-fA-F0-9]{0,5}$" : "^(0[xX])?0*[a-fA-F0-9]{0,8}$")));
+	m_addr_line->setValidator(new QRegularExpressionValidator(QRegularExpression(m_type == thread_type::spu ? "^(0[xX])?0*[a-fA-F0-9]{0,5}$" : "^(0[xX])?0*[a-fA-F0-9]{0,8}$"), this));
 	hbox_tools_mem_addr->addWidget(m_addr_line);
 	tools_mem_addr->setLayout(hbox_tools_mem_addr);
 

--- a/rpcs3/rpcs3qt/patch_creator_dialog.h
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.h
@@ -45,7 +45,7 @@ private:
 
 private Q_SLOTS:
 	void show_table_menu(const QPoint& pos);
-	void validate();
+	void validate(const QString& patch);
 	void generate_yml(const QString& text = {});
 	void export_patch();
 

--- a/rpcs3/rpcs3qt/patch_creator_dialog.h
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.h
@@ -25,6 +25,7 @@ private:
 	QColor mValidColor;
 	QColor mInvalidColor;
 	bool m_valid = true; // Will be invalidated immediately
+	QRegularExpressionValidator* m_offset_validator = nullptr;
 
 	enum class move_direction
 	{
@@ -39,6 +40,8 @@ private:
 
 	static void init_patch_type_bombo_box(QComboBox* combo_box, patch_type set_type, bool searchable);
 	QComboBox* create_patch_type_bombo_box(patch_type set_type);
+
+	void update_validator(int index, QComboBox* combo_box, QLineEdit* line_edit);
 
 private Q_SLOTS:
 	void show_table_menu(const QPoint& pos);

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -166,7 +166,7 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 	tex_idx_line->setMaxLength(18);
 	tex_idx_line->setFixedWidth(75);
 	tex_idx_line->setFocus();
-	tex_idx_line->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$")));
+	tex_idx_line->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$"), this));
 
 	QLineEdit* tex_fmt_override_line = new QLineEdit(this);
 	tex_fmt_override_line->setPlaceholderText("00");
@@ -174,7 +174,7 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 	tex_fmt_override_line->setMaxLength(18);
 	tex_fmt_override_line->setFixedWidth(75);
 	tex_fmt_override_line->setFocus();
-	tex_fmt_override_line->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,2}$")));
+	tex_fmt_override_line->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,2}$"), this));
 
 	hbox_idx_line->addWidget(tex_idx_line);
 	hbox_idx_line->addWidget(tex_fmt_override_line);

--- a/rpcs3/rpcs3qt/system_cmd_dialog.cpp
+++ b/rpcs3/rpcs3qt/system_cmd_dialog.cpp
@@ -33,13 +33,13 @@ system_cmd_dialog::system_cmd_dialog(QWidget* parent)
 	m_value_input = new QLineEdit();
 	m_value_input->setFont(mono);
 	m_value_input->setMaxLength(18);
-	m_value_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$")));
+	m_value_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$"), this));
 	m_value_input->setPlaceholderText(QString("0x%1").arg(0, 16, 16, QChar('0')));
 
 	m_custom_command_input = new QLineEdit();
 	m_custom_command_input->setFont(mono);
 	m_custom_command_input->setMaxLength(18);
-	m_custom_command_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$")));
+	m_custom_command_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$"), this));
 	m_custom_command_input->setPlaceholderText(QString("0x%1").arg(0, 16, 16, QChar('0')));
 
 	m_command_box = new QComboBox();

--- a/rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp
@@ -58,12 +58,12 @@ vfs_dialog_usb_input::vfs_dialog_usb_input(const QString& name, const cfg::devic
 
 	m_vid_edit = new QLineEdit;
 	m_vid_edit->setMaxLength(4);
-	m_vid_edit->setValidator(new QRegularExpressionValidator(QRegularExpression("^[a-fA-F0-9]*$"))); // HEX only
+	m_vid_edit->setValidator(new QRegularExpressionValidator(QRegularExpression("^[a-fA-F0-9]*$"), this)); // HEX only
 	m_vid_edit->setText(QString::fromStdString(info->vid));
 
 	m_pid_edit = new QLineEdit;
 	m_pid_edit->setMaxLength(4);
-	m_pid_edit->setValidator(new QRegularExpressionValidator(QRegularExpression("^[a-fA-F0-9]*$"))); // HEX only
+	m_pid_edit->setValidator(new QRegularExpressionValidator(QRegularExpression("^[a-fA-F0-9]*$"), this)); // HEX only
 	m_pid_edit->setText(QString::fromStdString(info->pid));
 
 	m_serial_edit = new QLineEdit;

--- a/rpcs3/util/yaml.cpp
+++ b/rpcs3/util/yaml.cpp
@@ -76,6 +76,11 @@ std::string get_yaml_node_location(YAML::Node node)
 	}
 }
 
+std::string get_yaml_node_location(const YAML::detail::iterator_value& it)
+{
+	return get_yaml_node_location(it.first);
+}
+
 template u32 get_yaml_node_value<u32>(YAML::Node, std::string&);
 template u64 get_yaml_node_value<u64>(YAML::Node, std::string&);
 template s64 get_yaml_node_value<s64>(YAML::Node, std::string&);

--- a/rpcs3/util/yaml.hpp
+++ b/rpcs3/util/yaml.hpp
@@ -28,3 +28,4 @@ T get_yaml_node_value(YAML::Node node, std::string& error_message);
 
 // Get the location of the node in the document
 std::string get_yaml_node_location(YAML::Node node);
+std::string get_yaml_node_location(const YAML::detail::iterator_value& it);


### PR DESCRIPTION
Backend:
- Validate yml patch offset values (prevent overflow)
- Do not allow empty patch names
- Fix logging for locations of node iterators (previously "location: invalid node")
- Improve location logging of some other invalid patch nodes

Frontend:
- Add validator to patch creator bottom offset line edit (updates depending on patch type)
- Add clear buttons to patch creator bottom line edits
- Highlight faulty lines in patch creator
- Fix some memory leaks regarding QValidators

Caveats:
- The table itself doesn't validate the offset input, but at least you now get better feedback in general.

fixes #14169