### PR TITLE
rsx: Preserve the texcoord transform around destructive modifications

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2416,6 +2416,12 @@ namespace rsx
 					result.external_subresource_desc = { 0, deferred_request_command::mipmap_gather, attributes, {}, tex.decoded_remap() };
 					result.format_class = rsx::classify_format(attributes.gcm_format);
 
+					if (result.texcoord_xform.clamp)
+					{
+						// Revert clamp configuration
+						result.pop_texcoord_xform();
+					}
+
 					if (use_upscaling)
 					{
 						// Grab the correct image dimensions from the base mipmap level

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -3264,7 +3264,13 @@ namespace rsx
 						else
 						{
 							// Unlikely situation, but the only one which would allow re-upload from CPU to overlap this section.
-							ensure(!found->is_flushable());
+							if (found->is_flushable())
+							{
+								// Technically this is possible in games that may change surface pitch at random (insomniac engine)
+								// FIXME: A proper fix includes pitch conversion and surface inheritance chains between surface targets and blit targets (unified cache) which is a very long-term thing.
+								const auto range = found->get_section_range();
+								rsx_log.error("[Pitch Mismatch] GPU-resident data at 0x%x->0x%x is discarded due to surface cache data clobbering it.", range.start, range.end);
+							}
 							found->discard(true);
 						}
 					}

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -514,6 +514,9 @@ namespace rsx
 			const size2i& desired_dimensions,
 			const size2i& actual_dimensions)
 		{
+			// Back up the transformation before we destructively modify it.
+			desc.push_texcoord_xform();
+
 			desc.texcoord_xform.scale[0] *= f32(desired_dimensions.width) / actual_dimensions.width;
 			desc.texcoord_xform.scale[1] *= f32(desired_dimensions.height) / actual_dimensions.height;
 			desc.texcoord_xform.bias[0] += f32(offset.x) / actual_dimensions.width;

--- a/rpcs3/Emu/RSX/GL/glutils/sampler.h
+++ b/rpcs3/Emu/RSX/GL/glutils/sampler.h
@@ -6,7 +6,7 @@ namespace rsx
 {
 	class fragment_texture;
 	class vertex_texture;
-	struct sampled_image_descriptor_base;
+	class sampled_image_descriptor_base;
 }
 
 namespace gl

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -138,7 +138,7 @@ namespace rsx
 		bool supports_normalized_barycentrics; // Basically all GPUs except NVIDIA have properly normalized barycentrics
 	};
 
-	struct sampled_image_descriptor_base;
+	class sampled_image_descriptor_base;
 
 	struct desync_fifo_cmd_info
 	{


### PR DESCRIPTION
Adds a transformation stack to the texture references. The subimage transform is destructive and we may decide to roll back later.
Also lowers a fatal assert into a logged error message.

Fixes https://github.com/RPCS3/rpcs3/issues/14176
Fixes https://github.com/RPCS3/rpcs3/issues/14103