### PR TITLE
PPU/Debugger: View the currently used CR field content in register panel

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -1093,9 +1093,11 @@ std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu);
 
 void cpu_thread::dump_all(std::string& ret) const
 {
+	std::any func_data;
+
 	ret += dump_misc();
 	ret += '\n';
-	dump_regs(ret);
+	dump_regs(ret, func_data);
 	ret += '\n';
 	ret += dump_callstack();
 	ret += '\n';
@@ -1118,7 +1120,7 @@ void cpu_thread::dump_all(std::string& ret) const
 	}
 }
 
-void cpu_thread::dump_regs(std::string&) const
+void cpu_thread::dump_regs(std::string&, std::any&) const
 {
 }
 

--- a/rpcs3/Emu/CPU/CPUThread.h
+++ b/rpcs3/Emu/CPU/CPUThread.h
@@ -4,6 +4,7 @@
 #include "../Utilities/bit_set.h"
 
 #include <vector>
+#include <any>
 
 template <typename Derived, typename Base>
 concept DerivedFrom = std::is_base_of_v<Base, Derived> &&
@@ -159,7 +160,7 @@ public:
 	virtual void dump_all(std::string&) const;
 
 	// Get CPU register dump
-	virtual void dump_regs(std::string&) const;
+	virtual void dump_regs(std::string& ret, std::any& custom_data) const;
 
 	// Get CPU call stack dump
 	virtual std::string dump_callstack() const;

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -141,7 +141,7 @@ public:
 	static const u32 id_count = 100;
 	static constexpr std::pair<u32, u32> id_invl_range = {12, 12};
 
-	virtual void dump_regs(std::string&) const override;
+	virtual void dump_regs(std::string&, std::any& custom_data) const override;
 	virtual std::string dump_callstack() const override;
 	virtual std::vector<std::pair<u32, u32>> dump_callstack_list() const override;
 	virtual std::string dump_misc() const override;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1017,7 +1017,7 @@ spu_imm_table_t::spu_imm_table_t()
 	}
 }
 
-void spu_thread::dump_regs(std::string& ret) const
+void spu_thread::dump_regs(std::string& ret, std::any& /*custom_data*/) const
 {
 	const system_state emu_state = Emu.GetStatus(false);
 	const bool is_stopped_or_frozen = state & cpu_flag::exit || emu_state == system_state::frozen || emu_state <= system_state::stopping;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -620,7 +620,7 @@ enum class spu_debugger_mode : u32
 class spu_thread : public cpu_thread
 {
 public:
-	virtual void dump_regs(std::string&) const override;
+	virtual void dump_regs(std::string&, std::any& custom_data) const override;
 	virtual std::string dump_callstack() const override;
 	virtual std::vector<std::pair<u32, u32>> dump_callstack_list() const override;
 	virtual std::string dump_misc() const override;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -3164,7 +3164,7 @@ namespace rsx
 
 	void invalid_method(thread*, u32, u32);
 
-	void thread::dump_regs(std::string& result) const
+	void thread::dump_regs(std::string& result, std::any& /*custom_data*/) const
 	{
 		if (ctrl)
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -228,7 +228,7 @@ namespace rsx
 		static void fifo_wake_delay(u64 div = 1);
 		u32 get_fifo_cmd() const;
 
-		void dump_regs(std::string&) const override;
+		void dump_regs(std::string&, std::any& custom_data) const override;
 		void cpu_wait(bs_t<cpu_flag> old) override;
 
 		static constexpr u32 id_base = 0x5555'5555; // See get_current_cpu_thread()

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1155,7 +1155,7 @@ void debugger_frame::WritePanels()
 	hloc = m_regs->horizontalScrollBar()->value();
 	m_regs->clear();
 	m_last_reg_state.clear();
-	cpu->dump_regs(m_last_reg_state);
+	cpu->dump_regs(m_last_reg_state, m_dump_reg_func_data);
 	m_regs->setText(qstr(m_last_reg_state));
 	m_regs->verticalScrollBar()->setValue(loc);
 	m_regs->horizontalScrollBar()->setValue(hloc);

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <vector>
+#include <any>
 
 class CPUDisAsm;
 class cpu_thread;
@@ -58,6 +59,7 @@ class debugger_frame : public custom_dock_widget
 	u32 m_last_pc = -1;
 	std::vector<char> m_last_query_state;
 	std::string m_last_reg_state;
+	std::any m_dump_reg_func_data;
 	u32 m_last_step_over_breakpoint = -1;
 	u64 m_ui_update_ctr = 0;
 	u64 m_ui_fast_update_permission_deadline = 0;


### PR DESCRIPTION
CR register is composed of 8 different fields which are 32 bits in total, it's not easy to track and intuitively understand its relavant bits to the current code and how they affect the current thread code and being affected by it.
So this pull requests aims to predict what is the most relavant CR field to the current code and display it in an intuitive manner.

There is a specialization for STDCX and STWCX. (but other CR0 modifing instructions are currently not being detected)

Example: detected used CR4 field in context.

![image](https://github.com/RPCS3/rpcs3/assets/18193363/2245d775-9294-4845-935b-803cd68d7ba0)

But when I keep stepping in this code and encounter an instruction using CR7:

![image](https://github.com/RPCS3/rpcs3/assets/18193363/9ab03bfc-df89-4542-98d8-6f7ec329bf17)
