### PR TITLE
PPU LLVM: Improve precompilation time

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3479,6 +3479,12 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 
 					if (error)
 					{
+						if (error == CELL_CANCEL + 0u)
+						{
+							// Emulation stopped
+							break;
+						}
+
 						// Abort
 						ovl_err = elf_error::header_type;
 						break;

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -49,6 +49,12 @@ static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vp
 
 	if (error)
 	{
+		if (error == CELL_CANCEL + 0u)
+		{
+			// Emulation stopped
+			return {};
+		}
+
 		return error;
 	}
 


### PR DESCRIPTION
* Drop PPU linking stage from precompilation, this does not affect EBOOT.BIN compilation when booting games of course but affects the precompilation of SELF, MSELF and SPRX.
* Fixes a tiny race when stopping emulation which could resulted in PPU attempting to execute LLVM compiled code but no function pointers have been written yet.