### PR TITLE
Qt: Cache drag-and-drop result when moving it

### DIFF
--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -8,6 +8,8 @@
 #include <QActionGroup>
 #include <QMainWindow>
 #include <QIcon>
+#include <QList>
+#include <QUrl>
 #include <QMimeData>
 
 #include "update_manager.h"
@@ -156,7 +158,10 @@ private:
 	void ExtractTar();
 	void ExtractMSELF();
 
-	static drop_type IsValidFile(const QMimeData& md, QStringList* drop_paths = nullptr);
+	QList<QUrl> m_drop_file_url_list;
+	u64 m_drop_file_timestamp = umax;
+	drop_type m_drop_file_cached_drop_type = drop_type::drop_error;
+	drop_type IsValidFile(const QMimeData& md, QStringList* drop_paths = nullptr);
 	static void AddGamesFromDir(const QString& path);
 
 	QAction* CreateRecentAction(const q_string_pair& entry, const uint& sc_idx);


### PR DESCRIPTION
Before it used to check file attributes of dropped file list every time the mouse pointer changed its location on the screen even by a pixel, this is not very useful and only spams the disk. Instead, cache the information for half a second before re-evaluating it.