### PR TITLE
Qt: Exit And Save Log - toolbar action

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -135,6 +135,7 @@ namespace gui
 	const gui_save fd_insert_disc  = gui_save(main_window, "lastExplorePathDISC", "");
 	const gui_save fd_cfg_check    = gui_save(main_window, "lastExplorePathCfgChk", "");
 	const gui_save fd_save_elf     = gui_save(main_window, "lastExplorePathSaveElf", "");
+	const gui_save fd_save_log     = gui_save(main_window, "lastExplorePathSaveLog", "");
 
 	const gui_save mw_debugger         = gui_save(main_window, "debuggerVisible",  false);
 	const gui_save mw_logger           = gui_save(main_window, "loggerVisible",    true);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3373,6 +3373,11 @@ Check data for valid file types and cache their paths if necessary
 */
 main_window::drop_type main_window::IsValidFile(const QMimeData& md, QStringList* drop_paths)
 {
+	if (drop_paths)
+	{
+		drop_paths->clear();
+	}
+
 	drop_type type = drop_type::drop_error;
 
 	QList<QUrl> list = md.urls(); // get list of all the dropped file urls
@@ -3380,6 +3385,14 @@ main_window::drop_type main_window::IsValidFile(const QMimeData& md, QStringList
 	// Try to cache the data for half a second
 	if (m_drop_file_timestamp != umax && m_drop_file_url_list == list && get_system_time() - m_drop_file_timestamp < 500'000)
 	{
+		if (drop_paths)
+		{
+			for (auto&& url : m_drop_file_url_list)
+			{
+				drop_paths->append(url.toLocalFile());
+			}
+		}
+
 		return m_drop_file_cached_drop_type;
 	}
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2398,12 +2398,22 @@ void main_window::CreateConnects()
 
 		if (archived_stat.size)
 		{
-			const std::string dest_archived_path = fs::get_cache_dir() + log_filename + ".log.gz";
+			std::string dest_archived_path = fs::get_cache_dir() + log_filename + ".log.gz";
 
-			if (!Emu.GetTitleID().empty() && rename_log(archived_path, dest_archived_path))
+			const QString file_path = QFileDialog::getOpenFileName(this, tr("Save RPCS3's log file"), qstr(dest_archived_path), tr("RPCS3 Archived Log File (*.log.gz);;All files (*.*)"));
+
+			if (file_path.isEmpty())
+			{
+				// Aborted - view the current location
+				gui::utils::open_dir(archived_path);
+				return;
+			}
+
+			dest_archived_path = file_path.toStdString();
+
+			if (!Emu.GetTitleID().empty() && !dest_archived_path.empty() && rename_log(archived_path, dest_archived_path))
 			{
 				gui_log.success("Moved log file to '%s'!", dest_archived_path);
-				gui::utils::open_dir(dest_archived_path);
 				return;
 			}
 
@@ -2411,22 +2421,32 @@ void main_window::CreateConnects()
 			return;
 		}
 
-		const std::string dest_raw_file_path = fs::get_cache_dir() + log_filename + ".log";
+		std::string dest_raw_file_path = fs::get_cache_dir() + log_filename + ".log";
 
-		if (!Emu.GetTitleID().empty() && rename_log(raw_file_path, dest_raw_file_path))
+		const QString file_path = QFileDialog::getOpenFileName(this, tr("Save RPCS3's log file"), qstr(dest_raw_file_path), tr("RPCS3 Non-Archived Log File (*.log);;All files (*.*)"));
+
+		if (file_path.isEmpty())
+		{
+			// Aborted - view the current location
+			gui::utils::open_dir(raw_file_path);
+			return;
+		}
+
+		dest_raw_file_path = file_path.toStdString();
+
+		if (!Emu.GetTitleID().empty() && !dest_raw_file_path.empty() && rename_log(raw_file_path, dest_raw_file_path))
 		{
 			gui_log.success("Moved log file to '%s'!", dest_raw_file_path);
-			gui::utils::open_dir(dest_raw_file_path);
 			return;
 		}
 
 		gui::utils::open_dir(raw_file_path);
 	});
 
-	connect(ui->exitAnchorAndLocateLogAct, &QAction::triggered, this, [this]()
+	connect(ui->exitAndSaveLogAct, &QAction::triggered, this, [this]()
 	{
 		m_requested_show_logs_on_exit = true;
-		QWidget::close();
+		close();
 	});
 	connect(ui->exitAct, &QAction::triggered, this, &QWidget::close);
 

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -50,6 +50,7 @@ class main_window : public QMainWindow
 
 	bool m_is_list_mode = true;
 	bool m_save_slider_pos = false;
+	bool m_requested_show_logs_on_exit = false;
 	int m_other_slider_pos = 0;
 
 	QIcon m_app_icon;
@@ -95,6 +96,7 @@ Q_SIGNALS:
 	void RequestGlobalStylesheetChange();
 	void RequestTrophyManagerRepaint();
 	void NotifyEmuSettingsChange();
+	void NotifyWindowCloseEvent(bool closed);
 
 public Q_SLOTS:
 	void OnEmuStop();

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -213,7 +213,7 @@
     <addaction name="menuBatch"/>
     <addaction name="menuFirmware"/>
     <addaction name="separator"/>
-    <addaction name="exitAndLocateLogAct"/>
+    <addaction name="exitAnchorAndLocateLogAct"/>
     <addaction name="exitAct"/>
    </widget>
    <widget class="QMenu" name="menuEmulation">
@@ -589,12 +589,12 @@
     <string>Configure Auto Pause</string>
    </property>
   </action>
-  <action name="exitAndLocateLogAct">
+  <action name="exitAnchorAndLocateLogAct">
    <property name="text">
-    <string>Exit And Locate Log</string>
+    <string>Exit, Locate And Anchor Log</string>
    </property>
    <property name="toolTip">
-    <string>Exit RPCS3 and locate RPCS3.log.gz</string>
+    <string>Exit RPCS3, anchor the file log it and locate it</string>
    </property>
    <property name="statusTip">
     <string>Exit the application and locate the log</string>

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -213,6 +213,7 @@
     <addaction name="menuBatch"/>
     <addaction name="menuFirmware"/>
     <addaction name="separator"/>
+    <addaction name="exitAndLocateLogAct"/>
     <addaction name="exitAct"/>
    </widget>
    <widget class="QMenu" name="menuEmulation">
@@ -586,6 +587,17 @@
    </property>
    <property name="toolTip">
     <string>Configure Auto Pause</string>
+   </property>
+  </action>
+  <action name="exitAndLocateLogAct">
+   <property name="text">
+    <string>Exit And Locate Log</string>
+   </property>
+   <property name="toolTip">
+    <string>Exit RPCS3 and locate RPCS3.log.gz</string>
+   </property>
+   <property name="statusTip">
+    <string>Exit the application and locate the log</string>
    </property>
   </action>
   <action name="exitAct">

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -213,7 +213,7 @@
     <addaction name="menuBatch"/>
     <addaction name="menuFirmware"/>
     <addaction name="separator"/>
-    <addaction name="exitAnchorAndLocateLogAct"/>
+    <addaction name="exitAndSaveLogAct"/>
     <addaction name="exitAct"/>
    </widget>
    <widget class="QMenu" name="menuEmulation">
@@ -589,15 +589,15 @@
     <string>Configure Auto Pause</string>
    </property>
   </action>
-  <action name="exitAnchorAndLocateLogAct">
+  <action name="exitAndSaveLogAct">
    <property name="text">
-    <string>Exit, Locate And Anchor Log</string>
+    <string>Exit And Save Log</string>
    </property>
    <property name="toolTip">
-    <string>Exit RPCS3, anchor the file log it and locate it</string>
+    <string>Exit RPCS3, move the log file to a custom location</string>
    </property>
    <property name="statusTip">
-    <string>Exit the application and locate the log</string>
+    <string>Exit the application and save the log to a user-defined location</string>
    </property>
   </action>
   <action name="exitAct">

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -107,6 +107,9 @@ namespace logs
 
 		// Ensure written to disk
 		void sync();
+
+		// Close file handle after flushing to disk
+		void close_prematurely();
 	};
 
 	struct file_listener final : file_writer, public listener
@@ -120,6 +123,11 @@ namespace logs
 		void sync() override
 		{
 			file_writer::sync();
+		}
+
+		void close_prematurely() override
+		{
+			file_writer::close_prematurely();
 		}
 	};
 
@@ -353,11 +361,23 @@ void logs::listener::sync()
 {
 }
 
+void logs::listener::close_prematurely()
+{
+}
+
 void logs::listener::sync_all()
 {
 	for (listener* lis = get_logger(); lis; lis = lis->m_next)
 	{
 		lis->sync();
+	}
+}
+
+void logs::listener::close_all_prematurely()
+{
+	for (listener* lis = get_logger(); lis; lis = lis->m_next)
+	{
+		lis->close_prematurely();
 	}
 }
 
@@ -535,7 +555,7 @@ logs::file_writer::~file_writer()
 	}
 
 #ifdef _WIN32
-	// Cancel compressed log file autodeletion
+	// Cancel compressed log file auto-deletion
 	FILE_DISPOSITION_INFO disp;
 	disp.DeleteFileW = false;
 	SetFileInformationByHandle(m_fout2.get_handle(), FileDispositionInfo, &disp, sizeof(disp));
@@ -688,6 +708,56 @@ void logs::file_writer::sync()
 	if (m_fout2)
 	{
 		m_fout2.sync();
+	}
+}
+
+void logs::file_writer::close_prematurely()
+{
+	if (!m_fptr)
+	{
+		return;
+	}
+
+	// Ensure written to disk
+	sync();
+
+	std::lock_guard lock(m_m);
+
+	if (m_fout2)
+	{
+		m_zs.avail_in = 0;
+		m_zs.next_in  = nullptr;
+
+		do
+		{
+			m_zs.avail_out = sizeof(m_zout);
+			m_zs.next_out  = m_zout;
+
+			if (deflate(&m_zs, Z_FINISH) == Z_STREAM_ERROR || m_fout2.write(m_zout, sizeof(m_zout) - m_zs.avail_out) != sizeof(m_zout) - m_zs.avail_out)
+			{
+				break;
+			}
+		}
+		while (m_zs.avail_out == 0);
+
+		deflateEnd(&m_zs);
+
+#ifdef _WIN32
+		// Cancel compressed log file auto-deletion
+		FILE_DISPOSITION_INFO disp;
+		disp.DeleteFileW = false;
+		SetFileInformationByHandle(m_fout2.get_handle(), FileDispositionInfo, &disp, sizeof(disp));
+#else
+		// Restore compressed log file permissions
+		::fchmod(m_fout2.get_handle(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+#endif
+
+		m_fout2.close();
+	}
+
+	if (m_fout)
+	{
+		m_fout.close();
 	}
 }
 

--- a/rpcs3/util/logs.hpp
+++ b/rpcs3/util/logs.hpp
@@ -84,6 +84,9 @@ namespace logs
 		// Flush contents (file writer)
 		virtual void sync();
 
+		// Close file handle after flushing to disk (hazardous)
+		virtual void close_prematurely();
+
 		// Add new listener
 		static void add(listener*);
 
@@ -92,6 +95,9 @@ namespace logs
 
 		// Flush log to disk
 		static void sync_all();
+
+		// Close file handle after flushing to disk (hazardous)
+		static void close_all_prematurely();
 	};
 
 	struct alignas(16) channel : private message


### PR DESCRIPTION
Simplifying issue-creation a bit.

This exits RPCS3 and lets tge user choose where to save the log file. 
I made it so it would also rename the log file to "{GAME TITLE} [{TITLE ID}].log" (the last game that was running) in the directory that the user chooses when pressing that button specifically, otherwise it is remained "RPCS3.log".
This also fixes the long lasting issue that RPCS3 erases old log file when it opens (because it only writes to new RPCS3.log, leaving the previous one untouched).

![image](https://github.com/RPCS3/rpcs3/assets/18193363/62ee7117-b6e4-400b-921e-616540ff35c6)
