### PR TITLE
Create New Paths for Dev_USB and mms

### DIFF
--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -122,12 +122,10 @@ void usb_device_usio::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue
 	transfer->fake = true;
 
 	// Control transfers are nearly instant
-	switch (bmRequestType)
+	if (true) // always true
 	{
-	default:
 		// Follow to default emulated handler
 		usb_device_emulated::control_transfer(bmRequestType, bRequest, wValue, wIndex, wLength, buf_size, buf, transfer);
-		break;
 	}
 }
 

--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -122,10 +122,12 @@ void usb_device_usio::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue
 	transfer->fake = true;
 
 	// Control transfers are nearly instant
-	if (true) // always true
+	//switch (bmRequestType)
 	{
+	//default:
 		// Follow to default emulated handler
 		usb_device_emulated::control_transfer(bmRequestType, bRequest, wValue, wIndex, wLength, buf_size, buf, transfer);
+		//break;
 	}
 }
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -434,7 +434,6 @@ void Emulator::Init()
 			make_path_verbose(dev_usb + "PS3/SAVEDATA", false);
 			make_path_verbose(dev_usb + "PS3/THEME", false);
 			make_path_verbose(dev_usb + "PS3/UPDATE", false);
-			
 		}
 
 		if (make_path_verbose(dev_hdd1, true))

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -466,6 +466,13 @@ void Emulator::Init()
 			make_path_verbose(dev_hdd0 + "music/", false);
 			make_path_verbose(dev_hdd0 + "theme/", false);
 			make_path_verbose(dev_hdd0 + "video/", false);
+			make_path_verbose(dev_hdd0 + "drm/", false);
+			make_path_verbose(dev_hdd0 + "vsh/", false);
+			make_path_verbose(dev_hdd0 + "crash_report/", false);
+			make_path_verbose(dev_hdd0 + "tmp/", false);
+			make_path_verbose(dev_hdd0 + "mms/", false); //multimedia server for vsh, created from rebuilding the database
+			make_path_verbose(dev_hdd0 + "data/", false);
+			make_path_verbose(dev_hdd0 + "vm/", false);
 		}
 
 		const std::string games_common_dir = g_cfg_vfs.get(g_cfg_vfs.games_dir, emu_dir);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -424,7 +424,18 @@ void Emulator::Init()
 		make_path_verbose(dev_flash, true);
 		make_path_verbose(dev_flash2, true);
 		make_path_verbose(dev_flash3, true);
-		make_path_verbose(dev_usb, true);
+		
+		if (make_path_verbose(dev_usb, true))
+		{
+			make_path_verbose(dev_usb + "MUSIC/", false);
+			make_path_verbose(dev_usb + "VIDEO/", false);
+			make_path_verbose(dev_usb + "PICTURE/", false);
+			make_path_verbose(dev_usb + "PS3/EXPORT/PSV/", false); // PS1 and PS2 Saves go here
+			make_path_verbose(dev_usb + "PS3/SAVEDATA", false);
+			make_path_verbose(dev_usb + "PS3/THEME", false);
+			make_path_verbose(dev_usb + "PS3/UPDATE", false);
+			
+		}
 
 		if (make_path_verbose(dev_hdd1, true))
 		{
@@ -453,6 +464,9 @@ void Emulator::Init()
 			make_path_verbose(dev_hdd0 + "savedata/", false);
 			make_path_verbose(dev_hdd0 + "savedata/vmc/", false);
 			make_path_verbose(dev_hdd0 + "photo/", false);
+			make_path_verbose(dev_hdd0 + "music/", false);
+			make_path_verbose(dev_hdd0 + "theme/", false);
+			make_path_verbose(dev_hdd0 + "video/", false);
 		}
 
 		const std::string games_common_dir = g_cfg_vfs.get(g_cfg_vfs.games_dir, emu_dir);

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #ifdef _WIN32
-#include <QWinTHumbnailToolbar>
-#include <QWinTHumbnailToolbutton>
+#include <QWinThumbnailToolBar>
+#include <QWinThumbnailToolButton>
 #endif
 
 #include <QActionGroup>

--- a/rpcs3/util/dyn_lib.hpp
+++ b/rpcs3/util/dyn_lib.hpp
@@ -14,7 +14,7 @@ namespace utils
 
 		dynamic_library(const dynamic_library&) = delete;
 
-		dynamic_library(dynamic_library&& other)
+		dynamic_library(dynamic_library&& other) noexcept
 			: m_handle(other.m_handle)
 		{
 			other.m_handle = nullptr;
@@ -22,7 +22,7 @@ namespace utils
 
 		dynamic_library& operator=(const dynamic_library&) = delete;
 
-		dynamic_library& operator=(dynamic_library&& other)
+		dynamic_library& operator=(dynamic_library&& other) noexcept
 		{
 			std::swap(m_handle, other.m_handle);
 			return *this;


### PR DESCRIPTION
I noticed that RPCS3 could use some more PS3 file structures.
Main intention is to aid converting savedata for usb users of Apollo Save Tool [NP0APOLLO]