### PR TITLE
sys_fs: use path instead of u8path

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -251,7 +251,7 @@ bool lv2_fs_mount_info_map::vfs_unmount(std::string_view vpath, bool remove_from
 
 std::string lv2_fs_object::get_normalized_path(std::string_view path)
 {
-	std::string normalized_path = std::filesystem::u8path(path).lexically_normal().string();
+	std::string normalized_path = std::filesystem::path(path).lexically_normal().string();
 
 #ifdef _WIN32
 	std::replace(normalized_path.begin(), normalized_path.end(), '\\', '/');


### PR DESCRIPTION
Japanese PS3 games often use unicode paths which hard crash the std::filesystem::string() method.
wstring() would work in these cases, but I guess we can just use path() instead of u8path().
No idea why it was proposed by @Nekotekina .

Fixes #14135 (probably)

For reference, this code will reproduce the crash:

```cpp
sysutil_register_cb([](ppu_thread& cb_ppu) -> s32
{
	vm::var<char[]> str = vm::make_str("/dev_bdvd/PS3_GAME/USRDIR/DATA/SOUND/VOICE/OBLIVION.ESM/イン/M/GENERIC_POWERATTACK_000C454A_1.MP3");
	auto [err, vpath] = translate_to_sv(str);
	cellOskDialog.error("translate_to_sv(str=%s, vpath=%s)", str.get_ptr(), vpath);

	std::string path;
	std::string local_path = vfs::get(vpath, nullptr, &path);
	cellOskDialog.error("get(path=%s, local_path=%s)", path, local_path);

	const lv2_fs_mount_info& info = g_fxo->get<lv2_fs_mount_info_map>().lookup(vpath);
	cellOskDialog.error("info: mp=%d, device=%s, fs=%s, read_only=%d", !!info.mp, info.device, info.file_system, info.read_only);

	return 0;
});
```