### PR TITLE
don't need to clone llvm submodule if BUILD_LLVM=OFF

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -326,7 +326,9 @@ endif()
 
 
 # LLVM
-add_subdirectory(llvm EXCLUDE_FROM_ALL)
+if(BUILD_LLVM)
+	add_subdirectory(llvm EXCLUDE_FROM_ALL)
+endif()
 
 # WOLFSSL
 add_subdirectory(wolfssl EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Fix #14227 