### PR TITLE
Qt: Fix saved log filename

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -130,6 +130,7 @@ static fs::error to_error(DWORD e)
 	case ERROR_NOT_READY: return fs::error::noent;
 	case ERROR_FILENAME_EXCED_RANGE: return fs::error::toolong;
 	case ERROR_DISK_FULL: return fs::error::nospace;
+	case ERROR_NOT_SAME_DEVICE: return fs::error::xdev;
 	default: return fs::error::unknown;
 	}
 }
@@ -172,6 +173,7 @@ static fs::error to_error(int e)
 	case EROFS: return fs::error::readonly;
 	case EISDIR: return fs::error::isdir;
 	case ENOSPC: return fs::error::nospace;
+	case EXDEV: return fs::error::xdev;
 	default: return fs::error::unknown;
 	}
 }
@@ -2360,6 +2362,7 @@ void fmt_class_string<fs::error>::format(std::string& out, u64 arg)
 		case fs::error::isdir: return "Is a directory";
 		case fs::error::toolong: return "Path too long";
 		case fs::error::nospace: return "Not enough space on the device";
+		case fs::error::xdev: return "Device mismatch";
 		case fs::error::unknown: return "Unknown system error";
 		}
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -704,6 +704,7 @@ namespace fs
 		isdir,
 		toolong,
 		nospace,
+		xdev,
 		unknown
 	};
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2413,6 +2413,12 @@ void main_window::CreateConnects()
 			// Try to copy it if fails
 			if (fs::copy_file(from, to, true))
 			{
+				if (fs::file sync_fd{to, fs::write})
+				{
+					// Prevent data loss (expensive)
+					sync_fd.sync();
+				}
+
 				fs::remove_file(from);
 				return true;
 			}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2376,9 +2376,14 @@ void main_window::CreateConnects()
 		}
 
 		// Get new filename from title and title ID but simplified
-		std::string log_filename = Emu.GetTitleID().empty() ? "RPCS3" : Emu.GetTitleAndTitleID();
-		log_filename.erase(std::remove_if(log_filename.begin(), log_filename.end(), [](u8 c){ return !std::isalnum(c) && c != ' ' && c != '[' && ']'; }), log_filename.end());
-		fmt::trim_back(log_filename);
+		QString log_filename_q = qstr(Emu.GetTitleID().empty() ? "RPCS3" : Emu.GetTitleAndTitleID());
+		ensure(!log_filename_q.isEmpty());
+
+		// Replace unfitting characters
+		std::replace_if(log_filename_q.begin(), log_filename_q.end(), [](QChar c){ return !c.isLetterOrNumber() && c != QChar::Space && c != '[' && c != ']'; }, QChar::Space);
+		log_filename_q = log_filename_q.simplified();
+
+		const std::string log_filename = log_filename_q.toStdString();
 
 		QString path_last_log = m_gui_settings->GetValue(gui::fd_save_log).toString();
 
@@ -2432,6 +2437,7 @@ void main_window::CreateConnects()
 			{
 				m_gui_settings->SetValue(gui::fd_save_log, dir_path);
 				gui_log.success("Moved log file to '%s'!", dest_archived_path);
+				gui::utils::open_dir(dest_archived_path);
 				return;
 			}
 
@@ -2454,6 +2460,7 @@ void main_window::CreateConnects()
 		{
 			m_gui_settings->SetValue(gui::fd_save_log, dir_path);
 			gui_log.success("Moved log file to '%s'!", dest_raw_file_path);
+			gui::utils::open_dir(dest_raw_file_path);
 			return;
 		}
 


### PR DESCRIPTION
* Allow non-english leetters.
* Fix missing ']'.
* Deduplicate spaces.
* Show log directory on success to further simplify log finding.