### PR TITLE
opengl: fix Qt warnings

### DIFF
--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -32,6 +32,7 @@ draw_context_t gl_gs_frame::make_context()
 	{
 		auto surface = new QOffscreenSurface();
 		surface->setFormat(m_format);
+		// Workaround for the Qt warning: "Attempting to create QWindow-based QOffscreenSurface outside the gui thread. Expect failures."
 		Emu.BlockingCallFromMainThread([&]()
 		{
 			surface->create();

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -2,7 +2,6 @@
 
 #include "Emu/System.h"
 #include "Emu/system_config.h"
-#include "util/atomic.hpp"
 
 #include <QOpenGLContext>
 #include <QOffscreenSurface>
@@ -31,16 +30,16 @@ draw_context_t gl_gs_frame::make_context()
 
 	if (m_primary_context)
 	{
-		atomic_t<QOffscreenSurface*> surface = new QOffscreenSurface();
-		surface.load()->setFormat(m_format);
+		auto surface = new QOffscreenSurface();
+		surface->setFormat(m_format);
 		Emu.BlockingCallFromMainThread([&]()
 		{
-			surface.load()->create();
+			surface->create();
 		});
 
 		// Share resources with the first created context
 		context->handle->setShareContext(m_primary_context->handle);
-		context->surface = surface.load();
+		context->surface = surface;
 		context->owner = true;
 	}
 	else

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -52,7 +52,7 @@ namespace utils
 #ifdef MAP_NORESERVE
 	constexpr int c_map_noreserve = MAP_NORESERVE;
 #else
-	constexpr int c_map_noreserve = 0;
+	[[maybe_unused]] constexpr int c_map_noreserve = 0;
 #endif
 
 #ifdef MADV_FREE
@@ -66,7 +66,7 @@ namespace utils
 #ifdef MADV_HUGEPAGE
 	constexpr int c_madv_hugepage = MADV_HUGEPAGE;
 #else
-	constexpr int c_madv_hugepage = 0;
+	[[maybe_unused]] constexpr int c_madv_hugepage = 0;
 #endif
 
 #if defined(MADV_DONTDUMP) && defined(MADV_DODUMP)
@@ -76,8 +76,8 @@ namespace utils
 	constexpr int c_madv_no_dump = MADV_NOCORE;
 	constexpr int c_madv_dump = MADV_CORE;
 #else
-	constexpr int c_madv_no_dump = 0;
-	constexpr int c_madv_dump = 0;
+	[[maybe_unused]] constexpr int c_madv_no_dump = 0;
+	[[maybe_unused]] constexpr int c_madv_dump = 0;
 #endif
 
 #if defined(MFD_HUGETLB) && defined(MFD_HUGE_2MB)


### PR DESCRIPTION
I tried fixing the Qt warnings that are printed when you compile RPCS3 in debug mode.

```
warning: QOpenGLContext::swapBuffers() called with non-exposed window, behavior is undefined
```
```
warning: Attempting to create QWindow-based QOffscreenSurface outside the gui thread. Expect failures.
```