### PR TITLE
USIO: Added support for Tekken Tag Tournament 2 and Dragon Ball: Zenkai Battle

### DIFF
--- a/rpcs3/Emu/Io/usio.h
+++ b/rpcs3/Emu/Io/usio.h
@@ -15,7 +15,8 @@ public:
 private:
 	void load_backup();
 	void save_backup();
-	void translate_input();
+	void translate_input_taiko();
+	void translate_input_tekken();
 	void usio_write(u8 channel, u16 reg, std::vector<u8>& data);
 	void usio_read(u8 channel, u16 reg, u16 size);
 

--- a/rpcs3/Emu/Io/usio_config.h
+++ b/rpcs3/Emu/Io/usio_config.h
@@ -8,18 +8,21 @@ enum class usio_btn
 {
 	test,
 	coin,
+	service,
 	enter,
 	up,
 	down,
-	service,
-	strong_hit_side_left,
-	strong_hit_side_right,
-	strong_hit_center_left,
-	strong_hit_center_right,
-	small_hit_side_left,
-	small_hit_side_right,
-	small_hit_center_left,
-	small_hit_center_right,
+	left,
+	right,
+	taiko_hit_side_left,
+	taiko_hit_side_right,
+	taiko_hit_center_left,
+	taiko_hit_center_right,
+	tekken_button1,
+	tekken_button2,
+	tekken_button3,
+	tekken_button4,
+	tekken_button5,
 
 	count
 };
@@ -29,19 +32,22 @@ struct cfg_usio final : public emulated_pad_config<usio_btn>
 	cfg_usio(node* owner, const std::string& name) : emulated_pad_config(owner, name) {}
 
 	cfg_pad_btn<usio_btn> test{ this, "Test", usio_btn::test, pad_button::select };
-	cfg_pad_btn<usio_btn> coin{ this, "Coin", usio_btn::coin, pad_button::dpad_left };
-	cfg_pad_btn<usio_btn> enter{ this, "Enter", usio_btn::enter, pad_button::start };
+	cfg_pad_btn<usio_btn> coin{ this, "Coin", usio_btn::coin, pad_button::L3 };
+	cfg_pad_btn<usio_btn> service{this, "Service", usio_btn::service, pad_button::R3};
+	cfg_pad_btn<usio_btn> enter{ this, "Enter/Start", usio_btn::enter, pad_button::start };
 	cfg_pad_btn<usio_btn> up{ this, "Up", usio_btn::up, pad_button::dpad_up };
 	cfg_pad_btn<usio_btn> down{ this, "Down", usio_btn::down, pad_button::dpad_down };
-	cfg_pad_btn<usio_btn> service{ this, "Service", usio_btn::service, pad_button::dpad_right };
-	cfg_pad_btn<usio_btn> strong_hit_side_left{ this, "Strong Hit Side Left", usio_btn::strong_hit_side_left, pad_button::square };
-	cfg_pad_btn<usio_btn> strong_hit_side_right{ this, "Strong Hit Side Right", usio_btn::strong_hit_side_right, pad_button::circle };
-	cfg_pad_btn<usio_btn> strong_hit_center_left{ this, "Strong Hit Center Left", usio_btn::strong_hit_center_left, pad_button::triangle };
-	cfg_pad_btn<usio_btn> strong_hit_center_right{ this, "Strong Hit Center Right", usio_btn::strong_hit_center_right, pad_button::cross };
-	cfg_pad_btn<usio_btn> small_hit_side_left{ this, "Small Hit Side Left", usio_btn::small_hit_side_left, pad_button::L2 };
-	cfg_pad_btn<usio_btn> small_hit_side_right{ this, "Small Hit Side Right", usio_btn::small_hit_side_right, pad_button::R2 };
-	cfg_pad_btn<usio_btn> small_hit_center_left{ this, "Small Hit Center Left", usio_btn::small_hit_center_left, pad_button::L1 };
-	cfg_pad_btn<usio_btn> small_hit_center_right{ this, "Small Hit Center Right", usio_btn::small_hit_center_right, pad_button::R1 };
+	cfg_pad_btn<usio_btn> left{this, "Left", usio_btn::left, pad_button::dpad_left};
+	cfg_pad_btn<usio_btn> right{this, "Right", usio_btn::right, pad_button::dpad_right};
+	cfg_pad_btn<usio_btn> taiko_hit_side_left{ this, "Taiko Hit Side Left", usio_btn::taiko_hit_side_left, pad_button::square };
+	cfg_pad_btn<usio_btn> taiko_hit_side_right{ this, "Taiko Hit Side Right", usio_btn::taiko_hit_side_right, pad_button::circle };
+	cfg_pad_btn<usio_btn> taiko_hit_center_left{ this, "Taiko Hit Center Left", usio_btn::taiko_hit_center_left, pad_button::triangle };
+	cfg_pad_btn<usio_btn> taiko_hit_center_right{ this, "Taiko Hit Center Right", usio_btn::taiko_hit_center_right, pad_button::cross };
+	cfg_pad_btn<usio_btn> tekken_button1{this, "Tekken Button 1", usio_btn::tekken_button1, pad_button::square};
+	cfg_pad_btn<usio_btn> tekken_button2{this, "Tekken Button 2", usio_btn::tekken_button2, pad_button::triangle};
+	cfg_pad_btn<usio_btn> tekken_button3{this, "Tekken Button 3", usio_btn::tekken_button3, pad_button::cross};
+	cfg_pad_btn<usio_btn> tekken_button4{this, "Tekken Button 4", usio_btn::tekken_button4, pad_button::circle};
+	cfg_pad_btn<usio_btn> tekken_button5{this, "Tekken Button 5", usio_btn::tekken_button5, pad_button::R1};
 };
 
 struct cfg_usios final : public emulated_pads_config<cfg_usio, 2>


### PR DESCRIPTION
Added support for Tekken Tag Tournament 2.
![2023-07-23](https://github.com/RPCS3/rpcs3/assets/17809637/821f1dd4-eb61-482f-9df0-154327d1a44c)
![SCEEXE000_screenshot_2023_07_23](https://github.com/RPCS3/rpcs3/assets/17809637/3a15b098-c77d-4007-9792-b33230ae42d3)
![SCEEXE000_screenshot_2023_07_23_1](https://github.com/RPCS3/rpcs3/assets/17809637/8e24a24f-7bc7-4041-a692-1e40572fd6a2)

Support Dragon Ball: Zenkai Battle by the same function as well.
![SCEEXE000_screenshot_2023_07_23_2](https://github.com/RPCS3/rpcs3/assets/17809637/9b6cd58c-4d75-46dc-a1cc-93623e03e108)

With this PR merged, the following 3 System 357/369 arcade games are fully supported by RPCS3:
 - Taiko no Tatsujin series
 - Tekken Tag Tournament 2 (Unlimited)
 - Dragon Ball: Zenkai Battle

By the way, in my opinion, there's no any point keeping the small drum hits for Taiko, so I removed them to make the configuration tidy. It's not by accident.