### PR TITLE
rename fs::stat to fs::get_stat

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -502,7 +502,7 @@ std::string_view fs::get_parent_dir_view(std::string_view path, u32 parent_level
 	return result;
 }
 
-bool fs::stat(const std::string& path, stat_t& info)
+bool fs::get_stat(const std::string& path, stat_t& info)
 {
 	// Ensure consistent information on failure
 	info = {};
@@ -618,13 +618,13 @@ bool fs::stat(const std::string& path, stat_t& info)
 bool fs::exists(const std::string& path)
 {
 	fs::stat_t info{};
-	return fs::stat(path, info);
+	return fs::get_stat(path, info);
 }
 
 bool fs::is_file(const std::string& path)
 {
 	fs::stat_t info{};
-	if (!fs::stat(path, info))
+	if (!fs::get_stat(path, info))
 	{
 		return false;
 	}
@@ -641,7 +641,7 @@ bool fs::is_file(const std::string& path)
 bool fs::is_dir(const std::string& path)
 {
 	fs::stat_t info{};
-	if (!fs::stat(path, info))
+	if (!fs::get_stat(path, info))
 	{
 		return false;
 	}

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -186,7 +186,7 @@ namespace fs
 	}
 
 	// Get file information
-	bool stat(const std::string& path, stat_t& info);
+	bool get_stat(const std::string& path, stat_t& info);
 
 	// Check whether a file or a directory exists (not recommended, use is_file() or is_dir() instead)
 	bool exists(const std::string& path);

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -726,7 +726,7 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 		break;
 	default:
 	{
-		const u32 offset = get_yaml_node_value<u32>(addr_node, error_message);
+		get_yaml_node_value<u32>(addr_node, error_message);
 		if (!error_message.empty())
 		{
 			error_message = fmt::format("Skipping patch data entry: [ %s, 0x%.8x, %s ] (key: %s, location: %s) Invalid patch offset '%s' (not a valid u32 or overflow)",

--- a/rpcs3/Emu/Cell/Modules/cellPhotoImport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoImport.cpp
@@ -155,7 +155,7 @@ error_code select_photo(std::string dst_dir)
 				{
 					fs::stat_t f_info{};
 
-					if (!fs::stat(info.path, f_info) || f_info.is_directory)
+					if (!fs::get_stat(info.path, f_info) || f_info.is_directory)
 					{
 						cellPhotoImportUtil.error("Path does not belong to a valid file: '%s'", info.path);
 						result = CELL_PHOTO_IMPORT_ERROR_ACCESS_ERROR; // TODO: is this correct ?

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1397,7 +1397,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 		}
 
 		fs::stat_t dir_info{};
-		if (!fs::stat(dir_path, dir_info))
+		if (!fs::get_stat(dir_path, dir_info))
 		{
 			// funcStat is called even if the directory doesn't exist.
 		}
@@ -2099,7 +2099,7 @@ static NEVER_INLINE error_code savedata_get_list_item(vm::cptr<char> dirName, vm
 	if (dir)
 	{
 		fs::stat_t dir_info{};
-		if (!fs::stat(save_path, dir_info))
+		if (!fs::get_stat(save_path, dir_info))
 		{
 			return CELL_SAVEDATA_ERROR_INTERNAL;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1488,7 +1488,7 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 
 	fs::stat_t info{};
 
-	if (!fs::stat(local_path, info))
+	if (!fs::get_stat(local_path, info))
 	{
 		switch (auto error = fs::g_tls_error)
 		{
@@ -1499,7 +1499,7 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 
 			for (u32 i = 66601; i <= 66699; i++)
 			{
-				if (fs::stat(fmt::format("%s.%u", local_path, i), info) && !info.is_directory)
+				if (fs::get_stat(fmt::format("%s.%u", local_path, i), info) && !info.is_directory)
 				{
 					total_size += info.size;
 				}
@@ -1510,7 +1510,7 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 			}
 
 			// Use attributes from the first fragment (consistently with sys_fs_open+fstat)
-			if (fs::stat(local_path + ".66600", info) && !info.is_directory)
+			if (fs::get_stat(local_path + ".66600", info) && !info.is_directory)
 			{
 				// Success
 				info.size += total_size;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -296,12 +296,12 @@ namespace rsx
 
 			// Writeback to cache either if file does not exist or it is invalid (unexpected size)
 			// Note: fs::write_file is not atomic, if the process is terminated in the middle an empty file is created
-			if (fs::stat_t s{}; !fs::stat(fp_name, s) || s.size != fp.ucode_length)
+			if (fs::stat_t s{}; !fs::get_stat(fp_name, s) || s.size != fp.ucode_length)
 			{
 				fs::write_file(fp_name, fs::rewrite, fp.get_data(), fp.ucode_length);
 			}
 
-			if (fs::stat_t s{}; !fs::stat(vp_name, s) || s.size != vp.data.size() * sizeof(u32))
+			if (fs::stat_t s{}; !fs::get_stat(vp_name, s) || s.size != vp.data.size() * sizeof(u32))
 			{
 				fs::write_file(vp_name, fs::rewrite, vp.data);
 			}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -277,7 +277,7 @@ void Emulator::Init()
 	const std::string cfg_path = fs::get_config_dir() + "/config.yml";
 
 	// Save new global config if it doesn't exist or is empty
-	if (fs::stat_t info{}; !fs::stat(cfg_path, info) || info.size == 0)
+	if (fs::stat_t info{}; !fs::get_stat(cfg_path, info) || info.size == 0)
 	{
 		Emulator::SaveSettings(g_cfg_defaults, {});
 	}

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -263,7 +263,7 @@ std::vector<u8> tar_object::save_directory(const std::string& src_dir, std::vect
 	const std::string& target_path = full_path.empty() ? src_dir : full_path;
 
 	fs::stat_t stat{};
-	if (!fs::stat(target_path, stat))
+	if (!fs::get_stat(target_path, stat))
 	{
 		return std::move(init);
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2384,7 +2384,7 @@ void main_window::CreateConnects()
 		fs::stat_t raw_stat{};
 		fs::stat_t archived_stat{};
 
-		if ((!fs::stat(raw_file_path, raw_stat) || raw_stat.is_directory) || (!fs::stat(archived_path, archived_stat) || archived_stat.is_directory) || (raw_stat.size == 0 && archived_stat.size == 0))
+		if ((!fs::get_stat(raw_file_path, raw_stat) || raw_stat.is_directory) || (!fs::get_stat(archived_path, archived_stat) || archived_stat.is_directory) || (raw_stat.size == 0 && archived_stat.size == 0))
 		{
 			QMessageBox::warning(this, tr("Failed to locate log"), tr("Failed to locate log files.\nMake sure that RPCS3.log and RPCS3.log.gz are writable and can be created without permission issues."));
 			return;


### PR DESCRIPTION
GCC on Windows broke because `stat` is macro in mingw-w64 headers. I have renamed `fs::stat` to `fs::get_stat` just like I did in my other PR.