### PR TITLE
sys_fs: Fixed up sys_fs_fcntl(0xc0000007, 0xc0000015, and 0xc000001c) according to real hardware testing

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -2181,39 +2181,37 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 			break;
 		}
 
-		std::string_view vpath{arg->name.get_ptr(), arg->name_size};
+		std::string_view vpath{arg->path.get_ptr(), arg->path_size};
+
+		if (vpath.size() == 0)
+			return CELL_ENOMEM;
 
 		// Trim trailing '\0'
 		if (const auto trim_pos = vpath.find('\0'); trim_pos != umax)
 			vpath.remove_suffix(vpath.size() - trim_pos);
 
-		if (vfs::get(vpath).empty())
+		arg->out_code = CELL_ENOTMOUNTED; // arg->out_code is set to CELL_ENOTMOUNTED on real hardware when the device doesn't exist or when the device isn't USB
+
+		if (!vfs::get(vpath).empty())
 		{
-			arg->out_code = CELL_ENOTMOUNTED;
-			return {CELL_ENOTMOUNTED, vpath};
+			if (const auto& mp = g_fxo->get<lv2_fs_mount_info_map>().lookup(vpath, true); mp == &g_mp_sys_dev_usb)
+			{
+				const cfg::device_info device = g_cfg_vfs.get_device(g_cfg_vfs.dev_usb, fmt::format("%s%s", mp->root, mp.device.substr(mp->device.size())));
+				const auto usb_ids = device.get_usb_ids();
+				std::tie(arg->vendorID, arg->productID) = usb_ids;
+
+				if (with_serial)
+				{
+					const auto arg_c000001c = vm::static_ptr_cast<lv2_file_c000001c>(_arg);
+					const std::u16string serial = utf8_to_utf16(device.serial); // Serial needs to be encoded to utf-16 BE
+					std::copy_n(serial.begin(), std::min(serial.size(), sizeof(arg_c000001c->serial) / sizeof(u16)), arg_c000001c->serial);
+				}
+
+				arg->out_code = CELL_OK;
+				sys_fs.trace("sys_fs_fcntl(0x%08x): found device \"%s\" (vid=0x%04x, pid=0x%04x, serial=\"%s\")", op, mp.device, usb_ids.first, usb_ids.second, device.serial);
+			}
 		}
 
-		const auto& mp = g_fxo->get<lv2_fs_mount_info_map>().lookup(vpath, true);
-
-		if (mp != &g_mp_sys_dev_usb)
-		{
-			arg->out_code = CELL_ENOTSUP;
-			return {CELL_ENOTSUP, vpath};
-		}
-
-		const cfg::device_info device = g_cfg_vfs.get_device(g_cfg_vfs.dev_usb, fmt::format("%s%s", mp->root, mp.device.substr(mp->device.size())));
-		std::tie(arg->vendorID, arg->productID) = device.get_usb_ids();
-
-		if (with_serial)
-		{
-			const auto arg_c000001c = vm::static_ptr_cast<lv2_file_c000001c>(_arg);
-			const std::u16string serial = utf8_to_utf16(device.serial); // Serial needs to be encoded to utf-16 BE
-			std::copy_n(serial.begin(), std::min(serial.size(), sizeof(arg_c000001c->serial) / sizeof(u16)), arg_c000001c->serial);
-		}
-
-		arg->out_code = CELL_OK;
-
-		sys_fs.trace("sys_fs_fcntl(0x%08x): found device \"%s\" (vid=0x%04x, pid=0x%04x, serial=\"%s\")", op, mp.device, arg->vendorID, arg->productID, device.serial);
 		return CELL_OK;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -529,8 +529,8 @@ CHECK_SIZE(lv2_file_c0000006, 0x20);
 // sys_fs_fcntl: cellFsArcadeHddSerialNumber
 struct lv2_file_c0000007 : lv2_file_op
 {
-	be_t<u32> out_code;
-	vm::bcptr<char> device;
+	be_t<u32> out_code; // set to 0
+	vm::bcptr<char> device; // CELL_FS_IOS:ATA_HDD
 	be_t<u32> device_size;  // 0x14
 	vm::bptr<char> model;
 	be_t<u32> model_size; // 0x29

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -562,8 +562,8 @@ struct lv2_file_c0000015 : lv2_file_op
 	be_t<u32> size; // 0x20
 	be_t<u32> _x4;  // 0x10
 	be_t<u32> _x8;  // 0x18 - offset of out_code
-	be_t<u32> name_size;
-	vm::bcptr<char> name;
+	be_t<u32> path_size;
+	vm::bcptr<char> path;
 	be_t<u32> _x14; //
 	be_t<u16> vendorID;
 	be_t<u16> productID;
@@ -590,8 +590,8 @@ struct lv2_file_c000001c : lv2_file_op
 	be_t<u32> size; // 0x60
 	be_t<u32> _x4;  // 0x10
 	be_t<u32> _x8;  // 0x18 - offset of out_code
-	be_t<u32> name_size;
-	vm::bcptr<char> name;
+	be_t<u32> path_size;
+	vm::bcptr<char> path;
 	be_t<u32> unk1;
 	be_t<u16> vendorID;
 	be_t<u16> productID;

--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -334,7 +334,7 @@ void usb_device_usio::translate_input_tekken()
 					}
 					break;
 				case usio_btn::down:
-					if ( pressed)
+					if (pressed)
 					{
 						digital_input |= 0x100000ULL << shift;
 						if (player == 0)


### PR DESCRIPTION
I tested `sys_fs_fcntl(0xc0000007)` aka `cellFsArcadeHddSerialNumber` on my real hardware, validated the result, and compared the output values with the ones obtained from some other methods on my PC.
It turned out that padding and alignment (model: left, serial: right) are used by `sys_fs_fcntl(0xc0000007)` to compose the output.

Following is the information of my HDD obtained through `sys_fs_fcntl(0xc0000007)` for example:
```
Model Name: "TOSHIBA MK3265GSX H                     "
Serial Number: "           0A1B2C3D4"
```
Also, it seems like the syscall doesn't care about the device name in the arguments, though it's supposed to be "CELL_FS_IOS:ATA_HDD".


I also tested `sys_fs_fcntl(0xc0000015&0xc000001c)` on my real hardware, and it turned out the error handling was a little bit different.
Following is the testing result on the real hardware:
```
path="/dev_usb000": return: CELL_OK, arg->out_code: CELL_OK
path="/dev_hdd0": return: CELL_OK, arg->out_code: CELL_ENOTMOUNTED
path="/": return: CELL_OK, arg->out_code: CELL_ENOTMOUNTED
path="": return: CELL_ENOMEM, arg->out_code: CELL_OK
```