### PR TITLE
Utils: Add initial AVX10 support

### DIFF
--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -177,6 +177,71 @@ bool utils::has_avx512_vnni()
 #endif
 }
 
+bool utils::has_avx10()
+{
+#if defined(ARCH_X64)
+	// Implies support for most AVX-512 instructions
+	static const bool g_value = get_cpuid(0, 0)[0] >= 0x7 && get_cpuid(7, 1)[3] & 0x80000;
+	return g_value;
+#else
+	return false;
+#endif
+}
+
+bool utils::has_avx10_512()
+{
+#if defined(ARCH_X64)
+	// AVX10 with 512 wide vectors
+	static const bool g_value = has_avx10() && get_cpuid(24, 0)[2] & 0x40000;
+	return g_value;
+#else
+	return false;
+#endif
+}
+
+u32 utils::avx10_isa_version()
+{
+#if defined(ARCH_X64)
+	// 8bit value
+	static const u32 g_value = []()
+	{
+		u32 isa_version = 0;
+		if (has_avx10())
+		{
+			isa_version = get_cpuid(24, 0)[2] & 0x000ff;
+		}
+
+		return isa_version;
+	}();
+
+	return g_value;
+#else
+	return 0;
+#endif
+}
+
+bool utils::has_avx512_256()
+{
+#if defined(ARCH_X64)
+	// Either AVX10 or AVX512 implies support for 256-bit length AVX-512 SKL-X tier instructions
+	static const bool g_value = (has_avx512() || has_avx10());
+	return g_value;
+#else
+	return false;
+#endif
+}
+
+bool utils::has_avx512_icl_256()
+{
+#if defined(ARCH_X64)
+	// Check for AVX512_ICL or check for AVX10, together with GFNI, VAES, and VPCLMULQDQ, implies support for the same instructions that AVX-512_icl does at 256 bit length
+	static const bool g_value = (has_avx512_icl() || (has_avx10() && get_cpuid(7, 0)[2] & 0x00000700));
+	return g_value;
+#else
+	return false;
+#endif
+}
+
 bool utils::has_xop()
 {
 #if defined(ARCH_X64)
@@ -335,7 +400,21 @@ std::string utils::get_system_info()
 	{
 		result += " | AVX";
 
-		if (has_avx512())
+		if (has_avx10())
+		{
+			const u32 avx10_version = avx10_isa_version();
+			fmt::append(result, "10.%d", avx10_version);
+
+			if (has_avx10_512())
+			{
+				result += "-512";
+			}
+			else
+			{
+				result += "-256";
+			}
+		}
+		else if (has_avx512())
 		{
 			result += "-512";
 

--- a/rpcs3/util/sysinfo.hpp
+++ b/rpcs3/util/sysinfo.hpp
@@ -27,6 +27,16 @@ namespace utils
 
 	bool has_avx512_vnni();
 
+	bool has_avx10();
+
+	bool has_avx10_512();
+
+	u32 avx10_isa_version();
+
+	bool has_avx512_256();
+
+	bool has_avx512_icl_256();
+
 	bool has_xop();
 
 	bool has_clwb();


### PR DESCRIPTION
Adds detection for new AVX10 features: https://cdrdv2.intel.com/v1/dl/getContent/784267

In short, AVX10 is AVX-512 with optionality to not implement 512-wide vectors. Since much of the code in RPCS3 that uses AVX-512 doesn't use 512-wide vectors, we need new bools to guard 128/256 wide code that's using AVX-512 instructions, since both AVX-512 and AVX10 processors can execute these paths.

![image](https://github.com/RPCS3/rpcs3/assets/26352541/d4086911-fa26-4711-91e5-bb94657b9f3f)


