### PR TITLE
SPU LLVM: AVX-512 optimization for CFLTU

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9871,6 +9871,15 @@ public:
 				a = eval(a * s);
 
 			value_t<s32[4]> r;
+
+			if (m_use_avx512)
+			{
+				const auto sc = clamp_smax(a);
+				r.value = m_ir->CreateFPToUI(sc.value, get_type<s32[4]>());
+				set_vr(op.rt, r);
+				return;
+			}
+
 			r.value = m_ir->CreateFPToUI(a.value, get_type<s32[4]>());
 			set_vr(op.rt, select(bitcast<s32[4]>(a) > splat<s32[4]>(((32 + 127) << 23) - 1), splat<s32[4]>(-1), r & ~(bitcast<s32[4]>(a) >> 31)));
 		}


### PR DESCRIPTION
- Takes advantage of vrangeps and the new float to uint instructions from AVX-512
- Down from 6 to 3 instructions

<Details>
<summary> Before </summary>

![image](https://github.com/RPCS3/rpcs3/assets/26352541/311dcd57-bfb3-44db-8388-4b4b5a1dac4b)

</Details>

<Details>
<summary> After </summary>

![image](https://github.com/RPCS3/rpcs3/assets/26352541/aff37c6b-5a83-4717-9f43-ed9912a43e38)


</Details>