### PR TITLE
timerslack improvements for linux and usermode waiting 

### DIFF
--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -2041,8 +2041,6 @@ bool lv2_obj::wait_timeout(u64 usec, ppu_thread* cpu, bool scale, bool is_usleep
 	return true;
 }
 
-
-
 void lv2_obj::prepare_for_sleep(cpu_thread& cpu)
 {
 	vm::temporary_unlock(cpu);

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -53,6 +53,17 @@
 #include <optional>
 #include <deque>
 #include "util/tsc.hpp"
+#include "util/sysinfo.hpp"
+
+#if defined(ARCH_X64)
+#ifdef _MSC_VER
+#include <intrin.h>
+#include <immintrin.h>
+#else
+#include <x86intrin.h>
+#endif
+#endif
+
 
 extern std::string ppu_get_syscall_name(u64 code);
 
@@ -1880,6 +1891,35 @@ void lv2_obj::set_yield_frequency(u64 freq, u64 max_allowed_tsc)
 	g_lv2_preempts_taken.release(0);
 }
 
+#if defined(_MSC_VER)
+#define mwaitx_func
+#define waitpkg_func
+#else
+#define mwaitx_func __attribute__((__target__("mwaitx")))
+#define waitpkg_func __attribute__((__target__("waitpkg")))
+#endif
+
+#if defined(ARCH_X64)
+// Waits for a number of TSC clock cycles in power optimized state
+// Cstate is represented in bits [7:4]+1 cstate. So C0 requires bits [7:4] to be set to 0xf, C1 requires bits [7:4] to be set to 0.
+mwaitx_func static void __mwaitx(u32 cycles, u32 cstate)
+{
+	constexpr u32 timer_enable = 0x2;
+
+	// monitorx will wake if the cache line is written to. We don't want this, so place the monitor value on it's own cache line.
+	alignas(64) u64 monitor_var{};
+	_mm_monitorx(&monitor_var, 0, 0);
+	_mm_mwaitx(timer_enable, cstate, cycles);
+}
+
+// First bit indicates cstate, 0x0 for C.02 state (lower power) or 0x1 for C.01 state (higher power)
+waitpkg_func static void __tpause(u32 cycles, u32 cstate)
+{
+	const u64 tsc = utils::get_tsc() + cycles;
+	_tpause(cstate, tsc);
+}
+#endif
+
 bool lv2_obj::wait_timeout(u64 usec, ppu_thread* cpu, bool scale, bool is_usleep)
 {
 	static_assert(u64{umax} / max_timeout >= 100, "max timeout is not valid for scaling");
@@ -1947,8 +1987,7 @@ bool lv2_obj::wait_timeout(u64 usec, ppu_thread* cpu, bool scale, bool is_usleep
 
 		u64 remaining = usec - passed;
 #ifdef __linux__
-		// NOTE: Assumption that timer initialization has succeeded
-		u64 host_min_quantum = is_usleep && remaining <= 1000 ? 10 : 50;
+		constexpr u64 host_min_quantum = 10;
 #else
 		// Host scheduler quantum for windows (worst case)
 		// NOTE: On ps3 this function has very high accuracy
@@ -1965,14 +2004,29 @@ bool lv2_obj::wait_timeout(u64 usec, ppu_thread* cpu, bool scale, bool is_usleep
 			if (remaining > host_min_quantum)
 			{
 #ifdef __linux__
-				// Do not wait for the last quantum to avoid loss of accuracy
-				wait_for(remaining - ((remaining % host_min_quantum) + host_min_quantum));
+				// With timerslack set low, Linux is precise for all values above 10us
+				wait_for(remaining);
 #else
 				// Wait on multiple of min quantum for large durations to avoid overloading low thread cpus
 				wait_for(remaining - (remaining % host_min_quantum));
 #endif
 			}
 			// TODO: Determine best value for yield delay
+#if defined(ARCH_X64)
+			else if (utils::has_appropriate_um_wait())
+			{
+				u32 us_in_tsc_clocks = remaining * (utils::get_tsc_freq() / 1000000);
+
+				if (utils::has_waitpkg())
+				{
+					__tpause(us_in_tsc_clocks, 0x1);
+				}
+				else
+				{
+					__mwaitx(us_in_tsc_clocks, 0xf0);
+				}
+			}
+#endif
 			else
 			{
 				// Try yielding. May cause long wake latency but helps weaker CPUs a lot by alleviating resource pressure
@@ -1985,6 +2039,8 @@ bool lv2_obj::wait_timeout(u64 usec, ppu_thread* cpu, bool scale, bool is_usleep
 
 	return true;
 }
+
+
 
 void lv2_obj::prepare_for_sleep(cpu_thread& cpu)
 {

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -55,6 +55,7 @@ DYNAMIC_IMPORT("ntdll.dll", NtSetTimerResolution, NTSTATUS(ULONG DesiredResoluti
 #ifdef __linux__
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/prctl.h>
 #endif
 
 #if defined(__APPLE__)
@@ -1042,6 +1043,10 @@ int main(int argc, char** argv)
 			}
 		}
 	}
+
+#ifdef __linux__
+	prctl(PR_SET_TIMERSLACK, 1, 0, 0, 0);
+#endif
 
 #ifdef _WIN32
 	// Create dummy permanent low resolution timer to workaround messing with system timer resolution

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -1044,6 +1044,7 @@ int main(int argc, char** argv)
 		}
 	}
 
+// Set timerslack value for Linux. The default value is 50,000ns. Change this to just 1 since we value precise timers.
 #ifdef __linux__
 	prctl(PR_SET_TIMERSLACK, 1, 0, 0, 0);
 #endif

--- a/rpcs3/util/sysinfo.hpp
+++ b/rpcs3/util/sysinfo.hpp
@@ -53,6 +53,12 @@ namespace utils
 
 	bool has_fsrm();
 
+	bool has_waitx();
+
+	bool has_waitpkg();
+
+	bool has_appropriate_um_wait();
+
 	std::string get_cpu_brand();
 
 	std::string get_system_info();


### PR DESCRIPTION
Uses user mode wait instructions when available, and an appropriate number of threads on the machine are detected.

Should improve power efficiency on windows particularly for users with Ryzen and at least 12 threads, or users with 12th gen intel and at least 12 threads.

Also has some improvements for linux timers, thanks to the ability to set the timerslack.