### PR TITLE
cellMsgDialogAbort: do not return CELL_MSGDIALOG_ERROR_DIALOG_NOT_OPENED

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAvconfExt.cpp
@@ -202,7 +202,7 @@ error_code cellVideoOutSetupDisplay(u32 videoOut)
 
 error_code cellAudioInGetDeviceInfo(u32 deviceNumber, u32 deviceIndex, vm::ptr<CellAudioInDeviceInfo> info)
 {
-	cellAvconfExt.todo("cellAudioInGetDeviceInfo(deviceNumber=0x%x, deviceIndex=0x%x, info=*0x%x)", deviceNumber, deviceIndex, info);
+	cellAvconfExt.trace("cellAudioInGetDeviceInfo(deviceNumber=0x%x, deviceIndex=0x%x, info=*0x%x)", deviceNumber, deviceIndex, info);
 
 	if (deviceIndex != 0 || !info)
 	{
@@ -277,7 +277,7 @@ error_code cellVideoOutGetGamma(u32 videoOut, vm::ptr<f32> gamma)
 
 error_code cellAudioInGetAvailableDeviceInfo(u32 count, vm::ptr<CellAudioInDeviceInfo> device_info)
 {
-	cellAvconfExt.todo("cellAudioInGetAvailableDeviceInfo(count=%d, info=*0x%x)", count, device_info);
+	cellAvconfExt.trace("cellAudioInGetAvailableDeviceInfo(count=%d, info=*0x%x)", count, device_info);
 
 	if (count > 16 || !device_info)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.cpp
@@ -533,13 +533,15 @@ error_code cellMsgDialogAbort()
 			sysutil_send_system_cmd(CELL_SYSUTIL_DRAWING_END, 0);
 			return CELL_OK;
 		}
+
+		return CELL_OK; // Not CELL_MSGDIALOG_ERROR_DIALOG_NOT_OPENED, tested on HW.
 	}
 
 	const auto dlg = g_fxo->get<msg_info>().get();
 
 	if (!dlg)
 	{
-		return CELL_MSGDIALOG_ERROR_DIALOG_NOT_OPENED;
+		return CELL_OK; // Not CELL_MSGDIALOG_ERROR_DIALOG_NOT_OPENED, tested on HW.
 	}
 
 	if (!dlg->state.compare_and_swap_test(MsgDialogState::Open, MsgDialogState::Abort))


### PR DESCRIPTION
Fixes #13977 (spams cellMsgDialogAbort, ignoring CELL_MSGDIALOG_ERROR_DIALOG_NOT_OPENED)