### PR TITLE
Qt: fix data type of find_dialog text edits

### DIFF
--- a/rpcs3/rpcs3qt/find_dialog.cpp
+++ b/rpcs3/rpcs3qt/find_dialog.cpp
@@ -2,7 +2,7 @@
 
 #include <QVBoxLayout>
 
-find_dialog::find_dialog(QTextEdit* edit, QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f), m_text_edit(edit)
+find_dialog::find_dialog(QPlainTextEdit* edit, QWidget *parent, Qt::WindowFlags f) : QDialog(parent, f), m_text_edit(edit)
 {
 	setWindowTitle(tr("Find string"));
 

--- a/rpcs3/rpcs3qt/find_dialog.h
+++ b/rpcs3/rpcs3qt/find_dialog.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QDialog>
-#include <QTextEdit>
+#include <QPlainTextEdit>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QLabel>
@@ -11,14 +11,14 @@ class find_dialog : public QDialog
 	Q_OBJECT
 
 public:
-	find_dialog(QTextEdit* edit, QWidget *parent = Q_NULLPTR, Qt::WindowFlags f = Qt::WindowFlags());
+	find_dialog(QPlainTextEdit* edit, QWidget *parent = Q_NULLPTR, Qt::WindowFlags f = Qt::WindowFlags());
 
 private:
 	int m_count_lines = 0;
 	int m_count_total = 0;
 	QLabel* m_label_count_lines;
 	QLabel* m_label_count_total;
-	QTextEdit* m_text_edit;
+	QPlainTextEdit* m_text_edit;
 	QLineEdit* m_find_bar;
 	QPushButton* m_find_first;
 	QPushButton* m_find_last;

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -897,7 +897,7 @@ bool log_frame::eventFilter(QObject* object, QEvent* event)
 			if (m_find_dialog && m_find_dialog->isVisible())
 				m_find_dialog->close();
 
-			m_find_dialog.reset(new find_dialog(static_cast<QTextEdit*>(object), this));
+			m_find_dialog.reset(new find_dialog(static_cast<QPlainTextEdit*>(object), this));
 		}
 	}
 

--- a/rpcs3/rpcs3qt/log_viewer.cpp
+++ b/rpcs3/rpcs3qt/log_viewer.cpp
@@ -455,7 +455,7 @@ bool log_viewer::eventFilter(QObject* object, QEvent* event)
 			if (m_find_dialog && m_find_dialog->isVisible())
 				m_find_dialog->close();
 
-			m_find_dialog.reset(new find_dialog(static_cast<QTextEdit*>(object), this));
+			m_find_dialog.reset(new find_dialog(static_cast<QPlainTextEdit*>(object), this));
 		}
 	}
 


### PR DESCRIPTION
find_dialogs were hilariously broken for some time, crashing when m_text_edit was dereferenced.