### PR TITLE
Auto-dump binaries (PPU Debug), reduce ELF loader RAM usage

### DIFF
--- a/rpcs3/Crypto/decrypt_binaries.h
+++ b/rpcs3/Crypto/decrypt_binaries.h
@@ -16,7 +16,7 @@ public:
 
     bool done() const
     {
-        return m_index >= m_klics.size();
+        return m_index >= m_modules.size();
     }
 
     const std::string& operator[](usz index) const

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -2783,7 +2783,7 @@ bool ppu_load_rel_exec(const ppu_rel_object& elf)
 			_sec.addr = addr;
 			relm.secs.emplace_back(_sec);
 
-			std::memcpy(vm::base(addr), s.bin.data(), size);
+			std::memcpy(vm::base(addr), s.get_bin().data(), size);
 			addr = utils::align<u32>(addr + size, 128);
 		}
 	}

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -410,7 +410,7 @@ void spu_load_rel_exec(const spu_rel_object& elf)
 	{
 		if (shdr.sh_type == sec_type::sht_progbits && shdr.sh_flags().all_of(sh_flag::shf_alloc))
 		{
-			std::memcpy(spu->_ptr<void>(offs), shdr.bin.data(), shdr.sh_size);
+			std::memcpy(spu->_ptr<void>(offs), shdr.get_bin().data(), shdr.sh_size);
 			offs = utils::align<u32>(offs + shdr.sh_size, 4);
 		}
 	}


### PR DESCRIPTION
* Fix regression with manual-KLIC-required files from #13990 
* Dump PPU executables (currently not PRX or OVL) when enabling PPU debug when booting games or on process exitspawn.
* Optimize memory usage of ELF loader, found by accident when testing the PR.

![image](https://github.com/RPCS3/rpcs3/assets/18193363/3a8bd014-2161-4fbc-a3a3-1f0049912cbf)

This was the difference in file size when using this dumping code and the decryption tool because elf_object::open/save were not optimized to include inner sections.
