### PR TITLE
rsx: Rebuild shader texture state if we detect a silent mismatch

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -256,6 +256,7 @@ void VKGSRender::load_texture_env()
 
 		auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
 		const auto& tex = rsx::method_registers.fragment_textures[i];
+		const auto previous_format_class = fs_sampler_state[i]->format_class;
 
 		if (m_samplers_dirty || m_textures_dirty[i] || !check_surface_cache_sampler(sampler_state, tex))
 		{
@@ -274,6 +275,12 @@ void VKGSRender::load_texture_env()
 				if (sampler_state->is_cyclic_reference)
 				{
 					check_for_cyclic_refs |= true;
+				}
+
+				if (!m_textures_dirty[i] && sampler_state->format_class != previous_format_class)
+				{
+					// Host details changed but RSX is not aware
+					m_graphics_state |= rsx::fragment_program_state_dirty;
 				}
 
 				bool replace = !fs_sampler_handles[i];
@@ -403,6 +410,7 @@ void VKGSRender::load_texture_env()
 
 		auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(vs_sampler_state[i].get());
 		const auto& tex = rsx::method_registers.vertex_textures[i];
+		const auto previous_format_class = sampler_state->format_class;
 
 		if (m_samplers_dirty || m_vertex_textures_dirty[i] || !check_surface_cache_sampler(sampler_state, tex))
 		{
@@ -421,6 +429,12 @@ void VKGSRender::load_texture_env()
 				if (sampler_state->is_cyclic_reference || sampler_state->external_subresource_desc.do_not_cache)
 				{
 					check_for_cyclic_refs |= true;
+				}
+
+				if (!m_vertex_textures_dirty[i] && sampler_state->format_class != previous_format_class)
+				{
+					// Host details changed but RSX is not aware
+					m_graphics_state |= rsx::vertex_program_state_dirty;
 				}
 
 				bool replace = !vs_sampler_handles[i];
@@ -1015,10 +1029,17 @@ void VKGSRender::end()
 	// Now bind the shader resources. It is important that this takes place after the barriers so that we don't end up with stale descriptors
 	for (int retry = 0; retry < 3; ++retry)
 	{
-		if (m_samplers_dirty) [[ unlikely ]]
+		if (retry > 0 && m_samplers_dirty) [[ unlikely ]]
 		{
 			// Reload texture env if referenced objects were invalidated during OOM handling.
 			load_texture_env();
+
+			// Do not trust fragment/vertex texture state after a texture state reset.
+			// NOTE: We don't want to change the program - it's too late for that now. We just need to harmonize the state.
+			m_graphics_state |= rsx::vertex_program_state_dirty | rsx::fragment_program_state_dirty;
+			get_current_fragment_program(fs_sampler_state);
+			get_current_vertex_program(vs_sampler_state);
+			m_graphics_state.clear(rsx::pipeline_state::invalidate_pipeline_bits);
 		}
 
 		const bool out_of_memory = m_shader_interpreter.is_interpreter(m_program)


### PR DESCRIPTION
In some cases, we may have to update a texture reference without the RSX state having changed. This can happen for example if the game tries to use a color texture for depth read, so we swap the color texture with a depth one in-place. In this case, we would detect the change and switch the texture, but the shader would still be expecting the original texture because core RSX registers relating to texturing were not changed.
If we trivially detect the format class changed, reload the shader texture state. This isn't sophisticated, but should work for all of cases that would result in a crash.

Fixes https://github.com/RPCS3/rpcs3/issues/14071