### PR TITLE
Fix current date format

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -422,7 +422,7 @@ template <>
 void fmt_class_string<std::chrono::sys_time<typename std::chrono::system_clock::duration>>::format(std::string& out, u64 arg)
 {
 	const std::time_t dateTime = std::chrono::system_clock::to_time_t(get_object(arg));
- 	out += date_time::fmt_time("%Y-%m-%eT%H:%M:%S", dateTime);
+ 	out += date_time::fmt_time("%Y-%m-%dT%H:%M:%S", dateTime);
 }
 
 void run_platform_sanity_checks()


### PR DESCRIPTION
The "Current date" information that's printed at start of log file was missing leading zero if current time is only one digit number.

```
Current Time: 2023-08- 4T10:23:29
```

With this change the leading zero is added and the timestamp is ISO 8601 compliant

```
Current Time: 2023-08-04T11:17:10
```