### PR TITLE
Make experimental build warning modal

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -73,6 +73,7 @@ bool gui_application::Init()
 		gui_log.warning("Experimental Build Warning! Build origin: %s", branch_name);
 
 		QMessageBox msg;
+		msg.setWindowModality(Qt::WindowModal);
 		msg.setWindowTitle(tr("Experimental Build Warning"));
 		msg.setIcon(QMessageBox::Critical);
 		msg.setTextFormat(Qt::RichText);


### PR DESCRIPTION
Fixes an issue that prevents unofficial builds from working correctly (at least on macOS) since the switch to Qt 6.

Specifically, the game window does not open (but the game still runs in the background and audio can be heard), and right clicking on the log window does not show the context menu even though the cursor changes.
Setting the warning window to "modal" (as it seemingly was before switching to Qt 6) fixes this.

Changes this:
![Screenshot 2023-08-01 alle 18 36 38](https://github.com/RPCS3/rpcs3/assets/7950891/f3c6322a-fdc2-4e7e-a238-db2d392c2fdb)
To this:
![Screenshot 2023-08-05 alle 11 20 56](https://github.com/RPCS3/rpcs3/assets/7950891/f96f89c1-4da9-48cb-80dd-09fdec1a186b)

I'm not sure if the cause is a Qt bug, or just the way Qt handles non-modal windows with no parent on macOS.