### PR TITLE
vk: Fix detection of RADV on get_driver_vendor()

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -255,6 +255,11 @@ namespace vk
 		{
 			const auto gpu_name = get_name();
 
+			if (gpu_name.find("RADV") != umax)
+			{
+				return driver_vendor::RADV;
+			}
+
 			if (gpu_name.find("Radeon") != umax)
 			{
 				return driver_vendor::AMD;
@@ -263,11 +268,6 @@ namespace vk
 			if (gpu_name.find("NVIDIA") != umax || gpu_name.find("GeForce") != umax || gpu_name.find("Quadro") != umax)
 			{
 				return driver_vendor::NVIDIA;
-			}
-
-			if (gpu_name.find("RADV") != umax)
-			{
-				return driver_vendor::RADV;
 			}
 
 			if (gpu_name.find("Intel") != umax)


### PR DESCRIPTION
Since **Mesa 22.2.0 (2022-09-21)**, commit [f06da59fd75d7ce7708d159753fcdbc11de16f9e](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/11027/diffs?commit_id=f06da59fd75d7ce7708d159753fcdbc11de16f9e), the deviceName property has included the name of the GPU, thus invalidating our previous method of detecting RADV as a driver vendor.

Because the AMD check looks for "Radeon" and comes before the RADV one, RADV drivers started wrongly being detected as AMD proprietary. The fix is to simply do the RADV check before the AMD one.

Examples:

Before: "AMD RADV NAVY_FLOUNDER"
After: "AMD Radeon RX 6700M (RADV NAVI22)"

Before: "AMD RADV RENOIR"
After: "AMD Radeon Graphics (RADV RENOIR)"