### PR TITLE
rsx: Rewrite image merging routines

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -11,8 +11,7 @@ namespace rsx
 	enum surface_transform : u32
 	{
 		identity = 0,                // Nothing
-		argb_to_bgra = 1,            // Swap ARGB to BGRA (endian swap)
-		coordinate_transform = 2     // Incoming source coordinates may generated based on the format of the secondary (dest) surface. Recalculate them before use.
+		coordinate_transform = 1     // Incoming source coordinates may generated based on the format of the secondary (dest) surface. Recalculate them before use.
 	};
 
 	template<typename image_resource_type>

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
@@ -193,7 +193,9 @@ namespace gl
 		for (const auto &slice : sources)
 		{
 			if (!slice.src)
+			{
 				continue;
+			}
 
 			const bool typeless = !formats_are_bitcast_compatible(slice.src, dst_image);
 			ensure(typeless || dst_aspect == slice.src->aspect());
@@ -262,19 +264,14 @@ namespace gl
 				const areai src_rect = { src_x, src_y, src_x + src_w, src_y + src_h };
 				const areai dst_rect = { slice.dst_x, slice.dst_y, slice.dst_x + slice.dst_w, slice.dst_y + slice.dst_h };
 
-				gl::texture* _dst;
-				if (src_image->get_internal_format() == dst_image->get_internal_format() && slice.level == 0 && slice.dst_z == 0)
-				{
-					_dst = dst_image;
-				}
-				else
+				gl::texture* _dst = dst_image;
+				if (src_image->get_internal_format() != dst_image->get_internal_format() || slice.level != 0 || slice.dst_z != 0) [[ unlikely ]]
 				{
 					tmp = std::make_unique<texture>(GL_TEXTURE_2D, dst_rect.x2, dst_rect.y2, 1, 1, static_cast<GLenum>(slice.src->get_internal_format()));
 					_dst = tmp.get();
 				}
 
-				_blitter->scale_image(cmd, src_image, _dst,
-					src_rect, dst_rect, false, {});
+				_blitter->scale_image(cmd, src_image, _dst, src_rect, dst_rect, false, {});
 
 				if (_dst != dst_image)
 				{

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
@@ -258,14 +258,12 @@ namespace gl
 			}
 			else
 			{
-				ensure(dst_image->get_target() == gl::texture::target::texture2D);
-
 				auto _blitter = gl::g_hw_blitter;
 				const areai src_rect = { src_x, src_y, src_x + src_w, src_y + src_h };
 				const areai dst_rect = { slice.dst_x, slice.dst_y, slice.dst_x + slice.dst_w, slice.dst_y + slice.dst_h };
 
 				gl::texture* _dst;
-				if (src_image->get_internal_format() == dst_image->get_internal_format() && slice.level == 0)
+				if (src_image->get_internal_format() == dst_image->get_internal_format() && slice.level == 0 && slice.dst_z == 0)
 				{
 					_dst = dst_image;
 				}


### PR DESCRIPTION
Now supports writing scaled output to 3D and CUBE targets.

Fixes https://github.com/RPCS3/rpcs3/issues/14410
Fixes https://github.com/RPCS3/rpcs3/issues/14184
Fixes https://github.com/RPCS3/rpcs3/issues/13277