### PR TITLE
LV2/cellPad: Implement priority-based connection updates

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -6,8 +6,8 @@
 #include "Emu/Io/KeyboardHandler.h"
 #include "cellKb.h"
 
-extern void libio_sys_config_init();
-extern void libio_sys_config_end();
+error_code sys_config_start(ppu_thread& ppu);
+error_code sys_config_stop(ppu_thread& ppu);
 
 extern bool is_input_allowed();
 
@@ -61,7 +61,7 @@ void KeyboardHandlerBase::save(utils::serial& ar)
 	ar(inited ? m_info.max_connect : 0);
 }
 
-error_code cellKbInit(u32 max_connect)
+error_code cellKbInit(ppu_thread& ppu, u32 max_connect)
 {
 	sys_io.warning("cellKbInit(max_connect=%d)", max_connect);
 
@@ -78,13 +78,13 @@ error_code cellKbInit(u32 max_connect)
 		return CELL_KB_ERROR_INVALID_PARAMETER;
 	}
 
-	libio_sys_config_init();
+	sys_config_start(ppu);
 	handler.Init(std::min(max_connect, 7u));
 
 	return CELL_OK;
 }
 
-error_code cellKbEnd()
+error_code cellKbEnd(ppu_thread& ppu)
 {
 	sys_io.notice("cellKbEnd()");
 
@@ -96,7 +96,7 @@ error_code cellKbEnd()
 		return CELL_KB_ERROR_UNINITIALIZED;
 
 	// TODO
-	libio_sys_config_end();
+	sys_config_stop(ppu);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -7,8 +7,8 @@
 
 #include "cellMouse.h"
 
-extern void libio_sys_config_init();
-extern void libio_sys_config_end();
+error_code sys_config_start(ppu_thread& ppu);
+error_code sys_config_stop(ppu_thread& ppu);
 
 extern bool is_input_allowed();
 
@@ -61,7 +61,7 @@ void MouseHandlerBase::save(utils::serial& ar)
 	ar(inited ? m_info.max_connect : 0);
 }
 
-error_code cellMouseInit(u32 max_connect)
+error_code cellMouseInit(ppu_thread& ppu, u32 max_connect)
 {
 	sys_io.notice("cellMouseInit(max_connect=%d)", max_connect);
 
@@ -78,7 +78,7 @@ error_code cellMouseInit(u32 max_connect)
 		return CELL_MOUSE_ERROR_INVALID_PARAMETER;
 	}
 
-	libio_sys_config_init();
+	sys_config_start(ppu);
 	handler.Init(std::min(max_connect, 7u));
 
 	return CELL_OK;
@@ -121,7 +121,7 @@ error_code cellMouseClearBuf(u32 port_no)
 	return CELL_OK;
 }
 
-error_code cellMouseEnd()
+error_code cellMouseEnd(ppu_thread& ppu)
 {
 	sys_io.notice("cellMouseEnd()");
 
@@ -133,7 +133,7 @@ error_code cellMouseEnd()
 		return CELL_MOUSE_ERROR_UNINITIALIZED;
 
 	// TODO
-	libio_sys_config_end();
+	sys_config_stop(ppu);
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -79,7 +79,7 @@ error_code cellPadInit(u32 max_connect)
 		return CELL_PAD_ERROR_INVALID_PARAMETER;
 
 	libio_sys_config_init();
-	config.max_connect = std::min<u32>(max_connect, CELL_PAD_MAX_PORT_NUM);
+	config.max_connect = max_connect;
 	config.port_setting.fill(CELL_PAD_SETTING_PRESS_OFF | CELL_PAD_SETTING_SENSOR_OFF);
 	return CELL_OK;
 }
@@ -138,7 +138,7 @@ error_code cellPadClearBuf(u32 port_no)
 
 	const auto& pads = handler->GetPads();
 
-	if (port_no >= config.max_connect)
+	if (port_no >= config.get_max_connect())
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto& pad = pads[port_no];
@@ -171,7 +171,7 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 
 	const auto& pads = handler->GetPads();
 
-	if (port_no >= config.max_connect)
+	if (port_no >= config.get_max_connect())
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto& pad = pads[port_no];
@@ -413,7 +413,7 @@ error_code cellPadPeriphGetInfo(vm::ptr<CellPadPeriphInfo> info)
 
 	for (u32 i = 0; i < CELL_PAD_MAX_PORT_NUM; ++i)
 	{
-		if (i >= config.max_connect)
+		if (i >= config.get_max_connect())
 			break;
 
 		info->port_status[i] = pads[i]->m_port_status;
@@ -447,7 +447,7 @@ error_code cellPadPeriphGetData(u32 port_no, vm::ptr<CellPadPeriphData> data)
 
 	const auto& pads = handler->GetPads();
 
-	if (port_no >= config.max_connect)
+	if (port_no >= config.get_max_connect())
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto& pad = pads[port_no];
@@ -482,7 +482,7 @@ error_code cellPadGetRawData(u32 port_no, vm::ptr<CellPadData> data)
 
 	const auto& pads = handler->GetPads();
 
-	if (port_no >= config.max_connect)
+	if (port_no >= config.get_max_connect())
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto& pad = pads[port_no];
@@ -548,7 +548,7 @@ error_code cellPadSetActDirect(u32 port_no, vm::ptr<CellPadActParam> param)
 
 	const auto& pads = handler->GetPads();
 
-	if (port_no >= config.max_connect)
+	if (port_no >= config.get_max_connect())
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto& pad = pads[port_no];
@@ -592,7 +592,7 @@ error_code cellPadGetInfo(vm::ptr<CellPadInfo> info)
 
 	for (u32 i = 0; i < CELL_MAX_PADS; ++i)
 	{
-		if (i >= config.max_connect)
+		if (i >= config.get_max_connect())
 			break;
 
 		pads[i]->m_port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES; // TODO: should ASSIGN flags be cleared here?
@@ -657,7 +657,7 @@ error_code cellPadGetInfo2(vm::ptr<CellPadInfo2> info)
 	std::memset(info.get_ptr(), 0, sizeof(CellPadInfo2));
 
 	const PadInfo& rinfo = handler->GetInfo();
-	info->max_connect = config.max_connect;
+	info->max_connect = config.get_max_connect(); // Here it is forcibly clamped
 	info->now_connect = rinfo.now_connect;
 	info->system_info = rinfo.system_info;
 
@@ -665,7 +665,7 @@ error_code cellPadGetInfo2(vm::ptr<CellPadInfo2> info)
 
 	for (u32 i = 0; i < CELL_PAD_MAX_PORT_NUM; ++i)
 	{
-		if (i >= config.max_connect)
+		if (i >= config.get_max_connect())
 			break;
 
 		info->port_status[i] = pads[i]->m_port_status;
@@ -696,7 +696,7 @@ error_code cellPadGetCapabilityInfo(u32 port_no, vm::ptr<CellPadCapabilityInfo> 
 
 	const auto& pads = handler->GetPads();
 
-	if (port_no >= config.max_connect)
+	if (port_no >= config.get_max_connect())
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto& pad = pads[port_no];
@@ -754,7 +754,7 @@ error_code cellPadInfoPressMode(u32 port_no)
 
 	const auto& pads = handler->GetPads();
 
-	if (port_no >= config.max_connect)
+	if (port_no >= config.get_max_connect())
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto& pad = pads[port_no];
@@ -783,7 +783,7 @@ error_code cellPadInfoSensorMode(u32 port_no)
 
 	const auto& pads = handler->GetPads();
 
-	if (port_no >= config.max_connect)
+	if (port_no >= config.get_max_connect())
 		return CELL_PAD_ERROR_NO_DEVICE;
 
 	const auto& pad = pads[port_no];

--- a/rpcs3/Emu/Cell/Modules/cellPad.h
+++ b/rpcs3/Emu/Cell/Modules/cellPad.h
@@ -198,6 +198,11 @@ struct pad_info
 	pad_info() = default;
 	pad_info(utils::serial& ar);
 	void save(utils::serial& ar);
+
+	u32 get_max_connect() const
+	{
+		return std::min<u32>(max_connect, CELL_PAD_MAX_PORT_NUM);
+	}
 };
 
 error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data);

--- a/rpcs3/Emu/Cell/Modules/sys_io_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_io_.cpp
@@ -3,6 +3,10 @@
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUModule.h"
 
+#include "Emu/Cell/lv2/sys_event.h"
+#include "Emu/Cell/lv2/sys_ppu_thread.h"
+#include "Emu/Cell/Modules/sysPrxForUser.h"
+
 LOG_CHANNEL(sys_io);
 
 extern void cellPad_init();
@@ -13,53 +17,114 @@ struct libio_sys_config
 {
 	shared_mutex mtx;
 	s32 init_ctr = 0;
-	u32 stack_addr = 0;
+	u32 ppu_id = 0;
+	u32 queue_id = 0;
 
 	~libio_sys_config() noexcept
 	{
-		if (stack_addr)
-		{
-			ensure(vm::dealloc(stack_addr, vm::stack));
-		}
 	}
 };
 
-// Only exists internally (has no name)
-extern void libio_sys_config_init()
+extern void cellPad_NotifyStateChange(u32 index, u32 state);
+
+void config_event_entry(ppu_thread& ppu)
 {
+	auto& cfg = g_fxo->get<libio_sys_config>();
+
+	// Ensure awake
+	ppu.check_state();
+
+	while (!sys_event_queue_receive(ppu, cfg.queue_id, vm::null, 0))
+	{
+		if (ppu.is_stopped())
+		{
+			return;
+		}
+
+		// Some delay
+		thread_ctrl::wait_for(10000);
+
+		// Wakeup
+		ppu.check_state();
+
+		const u64 arg1 = ppu.gpr[5];
+		const u64 arg2 = ppu.gpr[6];
+		const u64 arg3 = ppu.gpr[7];
+
+		// TODO: Reverse-engineer proper event system
+
+		if (arg1 == 1)
+		{
+			cellPad_NotifyStateChange(arg2, arg3);
+		}
+	}
+
+	ppu_execute<&sys_ppu_thread_exit>(ppu, 0);
+}
+
+extern void send_sys_io_connect_event(u32 index, u32 state)
+{
+	auto& cfg = g_fxo->get<libio_sys_config>();
+
+	std::lock_guard lock(cfg.mtx);
+
+	if (cfg.init_ctr)
+	{
+		if (auto port = idm::get<lv2_obj, lv2_event_queue>(cfg.queue_id))
+		{
+			port->send(0, 1, index, state);
+		}
+	}
+}
+
+error_code sys_config_start(ppu_thread& ppu)
+{
+	sys_io.warning("sys_config_start()");
+
 	auto& cfg = g_fxo->get<libio_sys_config>();
 
 	std::lock_guard lock(cfg.mtx);
 
 	if (cfg.init_ctr++ == 0)
 	{
-		// Belongs to "_cfg_evt_hndlr" thread (8k stack)
-		cfg.stack_addr = ensure(vm::alloc(0x2000, vm::stack, 4096));
+		// Run thread
+		vm::var<u64> _tid;
+		vm::var<u32> queue_id;
+		vm::var<char[]> _name = vm::make_str("_cfg_evt_hndlr");
+
+		vm::var<sys_event_queue_attribute_t> attr;
+		attr->protocol = SYS_SYNC_PRIORITY;
+		attr->type = SYS_PPU_QUEUE;
+		attr->name_u64 = 0;
+
+		ensure(CELL_OK == sys_event_queue_create(ppu, queue_id, attr, 0, 0x20));
+		ensure(CELL_OK == ppu_execute<&sys_ppu_thread_create>(ppu, +_tid, g_fxo->get<ppu_function_manager>().func_addr(FIND_FUNC(config_event_entry)), 0, 512, 0x2000, SYS_PPU_THREAD_CREATE_JOINABLE, +_name));
+
+		cfg.ppu_id = static_cast<u32>(*_tid);
+		cfg.queue_id = *queue_id;
 	}
-}
-
-extern void libio_sys_config_end()
-{
-	auto& cfg = g_fxo->get<libio_sys_config>();
-
-	std::lock_guard lock(cfg.mtx);
-
-	if (cfg.init_ctr-- == 1)
-	{
-		ensure(vm::dealloc(std::exchange(cfg.stack_addr, 0), vm::stack));
-	}
-}
-
-error_code sys_config_start()
-{
-	sys_io.todo("sys_config_start()");
 
 	return CELL_OK;
 }
 
-error_code sys_config_stop()
+error_code sys_config_stop(ppu_thread& ppu)
 {
-	sys_io.todo("sys_config_stop()");
+	sys_io.warning("sys_config_stop()");
+
+	auto& cfg = g_fxo->get<libio_sys_config>();
+
+	std::lock_guard lock(cfg.mtx);
+
+	if (cfg.init_ctr && cfg.init_ctr-- == 1)
+	{
+		ensure(CELL_OK == sys_event_queue_destroy(ppu, cfg.queue_id, SYS_EVENT_QUEUE_DESTROY_FORCE));
+		ensure(CELL_OK == sys_ppu_thread_join(ppu, cfg.ppu_id, +vm::var<u64>{}));
+	}
+	else
+	{
+		// TODO: Unknown error
+	}
+
 	return CELL_OK;
 }
 
@@ -114,4 +179,6 @@ DECLARE(ppu_module_manager::sys_io)("sys_io", []()
 	REG_FUNC(sys_io, sys_config_register_service);
 	REG_FUNC(sys_io, sys_config_unregister_io_error_handler);
 	REG_FUNC(sys_io, sys_config_unregister_service);
+
+	REG_HIDDEN_FUNC(config_event_entry);
 });

--- a/rpcs3/Emu/Cell/lv2/sys_hid.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_hid.cpp
@@ -12,7 +12,7 @@
 
 LOG_CHANNEL(sys_hid);
 
-error_code sys_hid_manager_open(u64 device_type, u64 port_no, vm::ptr<u32> handle)
+error_code sys_hid_manager_open(ppu_thread& ppu, u64 device_type, u64 port_no, vm::ptr<u32> handle)
 {
 	sys_hid.todo("sys_hid_manager_open(device_type=0x%llx, port_no=0x%llx, handle=*0x%llx)", device_type, port_no, handle);
 
@@ -34,7 +34,7 @@ error_code sys_hid_manager_open(u64 device_type, u64 port_no, vm::ptr<u32> handl
 
 	if (device_type == 1)
 	{
-		cellPadInit(7);
+		cellPadInit(ppu, 7);
 		cellPadSetPortSetting(::narrow<u32>(port_no) /* 0 */, CELL_PAD_SETTING_LDD | CELL_PAD_SETTING_PRESS_ON | CELL_PAD_SETTING_SENSOR_ON);
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_hid.h
+++ b/rpcs3/Emu/Cell/lv2/sys_hid.h
@@ -34,7 +34,7 @@ struct sys_hid_manager_514_pkg_d
 
 // SysCalls
 
-error_code sys_hid_manager_open(u64 device_type, u64 port_no, vm::ptr<u32> handle);
+error_code sys_hid_manager_open(ppu_thread& ppu, u64 device_type, u64 port_no, vm::ptr<u32> handle);
 error_code sys_hid_manager_ioctl(u32 hid_handle, u32 pkg_id, vm::ptr<void> buf, u64 buf_size);
 error_code sys_hid_manager_add_hot_key_observer(u32 event_queue, vm::ptr<u32> unk);
 error_code sys_hid_manager_check_focus();

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -7,6 +7,8 @@
 
 cfg_input g_cfg_input;
 
+extern void pad_state_notify_state_change(u32 index, u32 state);
+
 PadHandlerBase::PadHandlerBase(pad_handler type) : m_type(type)
 {
 }
@@ -701,8 +703,10 @@ void PadHandlerBase::process()
 			if (!last_connection_status[i])
 			{
 				input_log.success("%s device %d connected", m_type, i);
-				pad->m_port_status |= CELL_PAD_STATUS_CONNECTED;
-				pad->m_port_status |= CELL_PAD_STATUS_ASSIGN_CHANGES;
+
+				pad->m_port_status |= CELL_PAD_STATUS_CONNECTED + CELL_PAD_STATUS_ASSIGN_CHANGES;
+				pad_state_notify_state_change(i, CELL_PAD_STATUS_CONNECTED);
+
 				last_connection_status[i] = true;
 				connected_devices++;
 			}
@@ -723,8 +727,10 @@ void PadHandlerBase::process()
 				if (!last_connection_status[i])
 				{
 					input_log.success("%s device %d connected by force", m_type, i);
-					pad->m_port_status |= CELL_PAD_STATUS_CONNECTED;
-					pad->m_port_status |= CELL_PAD_STATUS_ASSIGN_CHANGES;
+
+					pad->m_port_status |= CELL_PAD_STATUS_CONNECTED + CELL_PAD_STATUS_ASSIGN_CHANGES;
+					pad_state_notify_state_change(i, CELL_PAD_STATUS_CONNECTED);
+
 					last_connection_status[i] = true;
 					connected_devices++;
 				}
@@ -734,8 +740,12 @@ void PadHandlerBase::process()
 			if (last_connection_status[i])
 			{
 				input_log.error("%s device %d disconnected", m_type, i);
+
 				pad->m_port_status &= ~CELL_PAD_STATUS_CONNECTED;
 				pad->m_port_status |= CELL_PAD_STATUS_ASSIGN_CHANGES;
+
+				pad_state_notify_state_change(i, CELL_PAD_STATUS_DISCONNECTED);
+
 				last_connection_status[i] = false;
 				connected_devices--;
 			}


### PR DESCRIPTION
* Fix max_connect value in cellPadGetInfo, this value is the unmodified one from cellPadInit.
* cellPadGetInfo does not execute even a single syscall to read controller state, it relies on data updates from the _cfg_ev_hndlr input thread. This thread has a priority of 512 and most of the threads in The Simposns Game have priority of 256 including the main thread which calls the cellPad functions. This means, that in order for a connection to be registered the IO thread (_cfg_ev_hndlr) needs to able to run first which means it is dependant on the LV2 schedular to allow it. ~~I went along and implemented this functionality HLE style for LV2, I think this probably has more uses.~~ Written in LLE style with event queue in the end.

This fixes input in The Simpsons Game which expects controller readings to report disconnected at first then connected.
Fixes #6093 