### PR TITLE
PPU Loader: Fix main()'s envp, move process arguments to stack

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -2307,33 +2307,6 @@ bool ppu_load_exec(const ppu_exec_object& elf, bool virtual_load, const std::str
 		}
 	}
 
-	// Initialize process arguments
-	auto args = vm::ptr<u64>::make(vm::alloc(u32{sizeof(u64)} * (::size32(Emu.argv) + ::size32(Emu.envp) + 2), vm::main));
-	auto argv = args;
-
-	for (const auto& arg : Emu.argv)
-	{
-		const u32 arg_size = ::size32(arg) + 1;
-		const u32 arg_addr = vm::alloc(arg_size, vm::main);
-
-		std::memcpy(vm::base(arg_addr), arg.data(), arg_size);
-
-		*args++ = arg_addr;
-	}
-
-	*args++ = 0;
-	auto envp = args;
-
-	for (const auto& arg : Emu.envp)
-	{
-		const u32 arg_size = ::size32(arg) + 1;
-		const u32 arg_addr = vm::alloc(arg_size, vm::main);
-
-		std::memcpy(vm::base(arg_addr), arg.data(), arg_size);
-
-		*args++ = arg_addr;
-	}
-
 	// Fix primary stack size
 	switch (u32 sz = primary_stacksize)
 	{
@@ -2366,6 +2339,61 @@ bool ppu_load_exec(const ppu_exec_object& elf, bool virtual_load, const std::str
 		std::memcpy(vm::base(ppu->stack_addr + ppu->stack_size - ::size32(Emu.data)), Emu.data.data(), Emu.data.size());
 		ppu->gpr[1] -= Emu.data.size();
 	}
+
+	// Initialize process arguments
+
+	// Calculate storage requirements on the stack
+	const u32 pointers_storage_size = u32{sizeof(u64)} * (::size32(Emu.envp) + ::size32(Emu.argv) + 3);
+
+	u32 stack_alloc_size = pointers_storage_size;
+
+	for (const auto& arg : Emu.argv)
+	{
+		stack_alloc_size += utils::align<u32>(::size32(arg) + 1, 0x10);
+	}
+
+	for (const auto& arg : Emu.envp)
+	{
+		stack_alloc_size += utils::align<u32>(::size32(arg) + 1, 0x10);
+	}
+
+	ensure(ppu->stack_size > stack_alloc_size);
+
+	vm::ptr<u64> args = vm::cast(static_cast<u32>(ppu->stack_addr + ppu->stack_size - stack_alloc_size - utils::align<u32>(Emu.data.size(), 0x10)));
+	vm::ptr<u8> args_data = vm::cast(args.addr() + pointers_storage_size);
+
+	const vm::ptr<u64> argv = args;
+
+	for (const auto& arg : Emu.argv)
+	{
+		const u32 arg_size = ::size32(arg) + 1;
+
+		std::memcpy(args_data.get_ptr(), arg.data(), arg_size);
+
+		*args++ = args_data.addr();
+		args_data = vm::cast(args_data.addr() + utils::align<u32>(arg_size, 0x10));
+	}
+
+	*args++ = 0;
+
+	const vm::ptr<u64> envp = vm::cast(utils::align<u32>(args.addr(), 8));
+	args = envp;
+
+	for (const auto& arg : Emu.envp)
+	{
+		const u32 arg_size = ::size32(arg) + 1;
+
+		std::memcpy(args_data.get_ptr(), arg.data(), arg_size);
+
+		*args++ = args_data.addr();
+		args_data = vm::cast(args_data.addr() + utils::align<u32>(arg_size, 0x10));
+	}
+
+	*args++ = 0;
+
+	*args++ = 0; // Unknown
+
+	ppu->gpr[1] -= stack_alloc_size;
 
 	ensure(g_fxo->get<lv2_memory_container>().take(primary_stacksize));
 
@@ -2400,7 +2428,7 @@ bool ppu_load_exec(const ppu_exec_object& elf, bool virtual_load, const std::str
 	// Set command line arguments, run entry function
 	ppu->cmd_list
 	({
-		{ ppu_cmd::set_args, 8 }, u64{Emu.argv.size()}, u64{argv.addr()}, u64{envp.addr()}, u64{0}, u64{ppu->id}, u64{tls_vaddr}, u64{tls_fsize}, u64{tls_vsize},
+		{ ppu_cmd::set_args, 8 }, u64{Emu.argv.size()}, u64{argv.addr()}, u64{envp.addr()}, u64{Emu.envp.size()}, u64{ppu->id}, u64{tls_vaddr}, u64{tls_fsize}, u64{tls_vsize},
 		{ ppu_cmd::set_gpr, 11 }, u64{elf.header.e_entry},
 		{ ppu_cmd::set_gpr, 12 }, u64{malloc_pagesize},
 		{ ppu_cmd::entry_call, 0 },


### PR DESCRIPTION
This originally came from that I knew for a while that R1 of main thread is not accurate to realh unlike in other threads, I did not fix it originally when discovered because I was not sure why R1 changes sometimes.
Today it hitted me that it may because the argv and envp are passed on the stack and their size may differ when using different arguments.
So I tested it on realhw, fixing it by moving `argv` and `envp` to stack instead of dynamic memory. Saving a whopping 128KB of RAM as a side effect ;)
But this was not playing nice with `envp`, after some reversing it turned out we were emulating `envp` wrong.
Originally, the `argv` and `envp` pointer arrays are 64-bit arrays because CELL is natively a 64-bit processor, but games use 32-bit pointers exclusively. So the workaround embedded in all EBOOT.BIN is to convert the 64-bit array into 32-bit array. This functionality needs to know how many arguments are in each array in total. Total amount of `envp` arguments is passed in the R6 register to the program but we were always initializaing it with 0 so it could not fix the `envp` array resutling in crashes (because it always pointed to 32-bit nullptr) when dereferencing it!

Hwtest: https://github.com/elad335/myps3tests/commit/173d34698f18cb7a0b42690b08a929eb0522de68

Fixes #13014 as it turns out :)