### PR TITLE
SPU LLVM: Fix for AVX-512 CFLTU path

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -9882,7 +9882,7 @@ public:
 
 			if (m_use_avx512)
 			{
-				const auto sc = clamp_smax(a);
+				const auto sc = eval(bitcast<f32[4]>(max(bitcast<s32[4]>(a),splat<s32[4]>(0x0))));
 				r.value = m_ir->CreateFPToUI(sc.value, get_type<s32[4]>());
 				set_vr(op.rt, r);
 				return;


### PR DESCRIPTION
vcvvtps2udq doesn't turn negative numbers into 0, fix by using signed integer max with 0 instead of vrangeps

fixes: https://github.com/RPCS3/rpcs3/issues/14462