### PR TITLE
CELL: Selective and postponed address notifications

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -262,6 +262,7 @@ public:
 	u64 rtime{0};
 	alignas(64) std::byte rdata[128]{}; // Reservation data
 	bool use_full_rdata{};
+	u32 res_notify{};
 
 	union ppu_prio_t
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -465,7 +465,8 @@ public:
 
 				// While IDM mutex is still locked (this function assumes so) check if the notification is still needed
 				// Pending flag is meant for forced notification (if the CPU really has pending work it can restore the flag in theory)
-				if (cpu != &g_to_notify && static_cast<const decltype(cpu_thread::state)*>(cpu)->none_of(cpu_flag::signal + cpu_flag::pending))
+				// Disabled to allow reservation notifications from here
+				if (false && cpu != &g_to_notify && static_cast<const decltype(cpu_thread::state)*>(cpu)->none_of(cpu_flag::signal + cpu_flag::pending))
 				{
 					// Omit it (this is a void pointer, it can hold anything)
 					cpu = &g_to_notify;

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -358,6 +358,13 @@ bool utils::has_appropriate_um_wait()
 #endif
 }
 
+// Similar to the above function but allow execution if alternatives such as yield are not wanted
+bool utils::has_um_wait()
+{
+	static const bool g_value = (has_waitx() || has_waitpkg()) && get_tsc_freq();
+	return g_value;
+}
+
 u32 utils::get_rep_movsb_threshold()
 {
 	static const u32 g_value = []()

--- a/rpcs3/util/sysinfo.hpp
+++ b/rpcs3/util/sysinfo.hpp
@@ -59,6 +59,8 @@ namespace utils
 
 	bool has_appropriate_um_wait();
 
+	bool has_um_wait();
+
 	std::string get_cpu_brand();
 
 	std::string get_system_info();


### PR DESCRIPTION
* Try to postpone address notification to when PPU is asleep or join notifications on the same address. This also optimizes a mutex - won't notify after lock is aqcuired (prolonging the critical section duration), only notifies on unlock
* Use usermode waiting for supported CPUs on detection GETLLAR busy-waiting loop in order to reduce power consumtion and improve performance

Please compare:

1. Framerate.
2. SPU usage.
3. PPU usage.

Note: Make sure that you are using the default setting for "Maximum Number Of SPURS Threads" and "Preferred SPU Threads".