### PR TITLE
3rdParty: Bump MoltenVK to 1.2.5 - Vulkan SDK 1.3.261

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -9,8 +9,8 @@ arch -x86_64 /usr/local/bin/brew update
 arch -x86_64 /usr/local/bin/brew install -f --overwrite llvm@16 glew cmake sdl2 vulkan-headers ffmpeg
 arch -x86_64 /usr/local/bin/brew link -f llvm@16
 
-# moltenvk based on commit for 1.2.4 release
-wget https://raw.githubusercontent.com/Homebrew/homebrew-core/b233d4f9f40f26d81da11140defbfd578cfe4a69/Formula/molten-vk.rb
+# moltenvk based on commit for 1.2.5 release
+wget https://raw.githubusercontent.com/Homebrew/homebrew-core/055ae78415b61ecf1fa3de32b76b8a149855f903/Formula/m/molten-vk.rb
 arch -x86_64 /usr/local/bin/brew install -f --overwrite ./molten-vk.rb
 #export MACOSX_DEPLOYMENT_TARGET=12.0
 export CXX=clang++

--- a/3rdparty/MoltenVK/CMakeLists.txt
+++ b/3rdparty/MoltenVK/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(moltenvk
 	GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-	GIT_TAG 4c6bfbe
+	GIT_TAG b3c9f86
 	BUILD_IN_SOURCE 1
 	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK
 	CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK/fetchDependencies" --macos


### PR DESCRIPTION
Bumps MoltenVK to 1.2.5 matching Vulkan SDK 1.3.261

[Changelog](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.5): 

- Add support for extensions:
  - VK_KHR_incremental_present
  - VK_KHR_shader_non_semantic_info
  - VK_EXT_4444_formats
  - VK_EXT_calibrated_timestamps
  - VK_EXT_pipeline_creation_feedback
  - VK_EXT_shader_demote_to_helper_invocation
  - VK_EXT_shader_subgroup_ballot
  - VK_EXT_shader_subgroup_vote
- Add support for VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN.
- Support building MoltenVK for visionOS.
- Ensure non-dispatch compute commands don't interfere with compute encoding state used by dispatch commands.
- Support maximizing the concurrent executing compilation tasks via - MVKConfiguration::shouldMaximizeConcurrentCompilation
- Support VK_PRESENT_MODE_IMMEDIATE_KHR if VkPresentTimeGOOGLE::desiredPresentTime is zero.
- Add support for VK_PRESENT_MODE_IMMEDIATE_KHR to macOS Cube demo.
- Allow both renderPass and VkPipelineRenderingCreateInfo to be missing.
- Fix sync delay between calls to vkQueueSubmit() on non-Apple-Silicon devices.
- Ensure Xcode simulator always uses 256B buffer alignment.
- Don't attempt to force the window system to use the same high-power GPU as the app, on every swapchain creation.
- Log more info about SPIR-V to MSL conversion errors.
- Implement Deferred Host Operations.
- Support MSL Version 3.1.
- Drop official support for using Xcode 11 to build MoltenVK.
- To allow building MoltenVK without an internet connection, don't fetch a submodule if the commit is already known.
- Update dependency libraries to match Vulkan SDK 1.3.261.
- Update to latest SPIRV-Cross:
  - MSL: Fix argument buffer padding when content includes arrays.
  - MSL: ray-query intersection params
  - MSL: Support SPV_KHR_shader_ballot and SPV_KHR_subgroup_vote.
  - Skip line directives when emitting loop condition blocks.
  - MSL: Consider changed array types for array-of-constant-bool in struct.
  - MSL: Consider bool-short remapping for constant expressions as well.
  - Minor cleanup in constant_expression().
  - MSL: Add test for bool-in-struct edge cases.
  - MSL: Handle more complex array copy scenarios with bool <-> short.
  - MSL: Handle stores to struct bool[].
  - MSL: Consider bool/short remapping when dealing with composites.
  - MSL: fix function constant deduplication misfire