### PR TITLE
cellAudio: Move and partially fix _mxr000 hack

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -349,7 +349,7 @@ void disc_change_manager::insert_disc(u32 disc_type, std::string title_id)
 	});
 }
 
-void lv2_sleep(u64 timeout, ppu_thread* ppu = nullptr)
+extern void lv2_sleep(u64 timeout, ppu_thread* ppu = nullptr)
 {
 	if (!ppu)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -591,32 +591,6 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 	{
 		thread->cmd_notify++;
 		thread->cmd_notify.notify_one();
-
-		// Dirty hack for sound: confirm the creation of _mxr000 event queue
-		if (*thread->ppu_tname.load() == "_cellsurMixerMain"sv)
-		{
-			ppu.check_state();
-			lv2_obj::sleep(ppu);
-
-			while (!idm::select<lv2_obj, lv2_event_queue>([](u32, lv2_event_queue& eq)
-			{
-				//some games do not set event queue name, though key seems constant for them
-				return (eq.name == "_mxr000\0"_u64) || (eq.key == 0x8000cafe02460300);
-			}))
-			{
-				if (ppu.is_stopped())
-				{
-					return {};
-				}
-
-				thread_ctrl::wait_for(50000);
-			}
-
-			if (ppu.test_stopped())
-			{
-				return 0;
-			}
-		}
 	}
 
 	return CELL_OK;


### PR DESCRIPTION
cellAudioSetNotifyEventQueue waits for VSH threads to respond for port creation and connection to the event queue key provided. I believe this delay is what caused the need for the hack in sys_ppu_thread_start. I added the delay to cellAudioSetNotifyEventQueue for any key and added a long loop (but not infinite as before) waiting for _mxr000 to be created.

Edit: the delay is actually due to cellAudioPortOpen.