### PR TITLE
rsx: Fix index vertex array range with modulo calculation

### DIFF
--- a/rpcs3/Emu/RSX/Core/RSXVertexTypes.h
+++ b/rpcs3/Emu/RSX/Core/RSXVertexTypes.h
@@ -62,11 +62,12 @@ namespace rsx
 		u32  real_offset_address = 0;
 		u8   memory_location = 0;
 		u8   attribute_stride = 0;
+		std::pair<u32, u32> vertex_range{};
 
 		rsx::simple_array<interleaved_attribute_t> locations;
 
 		// Check if we need to upload a full unoptimized range, i.e [0-max_index]
-		std::pair<u32, u32> calculate_required_range(u32 first, u32 count) const;
+		std::pair<u32, u32> calculate_required_range(u32 first, u32 count);
 	};
 
 	enum attribute_buffer_placement : u8
@@ -100,6 +101,7 @@ namespace rsx
 			result->single_vertex = false;
 			result->locations.clear();
 			result->interleaved = true;
+			result->vertex_range.second = 0;
 			return result;
 		}
 


### PR DESCRIPTION
In #9055, modulo op with frequency was used on vertex indices wiuth some values already surpoassing frequency divider value. We incorrectly assumed that this means that the upper bound of vertex data memory data is the frequency divider in this case, but actually we still need to check for each element max_index = max(index % frequency, max_index). This is also true for min_index.
This re-iteration over all indices can be quite expensive for this exceptionally rare case, so do it if an access violation is guarenteed due to unallocated memory access. I think this can be optimized in the future for single frequency across the entire vertex arrays but I won't do it in this pr.

Fixes #9055 