### PR TITLE
workaround for Clang crash

### DIFF
--- a/Utilities/lockless.h
+++ b/Utilities/lockless.h
@@ -2,7 +2,7 @@
 
 #include "util/types.hpp"
 #include "util/atomic.hpp"
-#include "util/asm.hpp"
+#include "util/bless.hpp"
 
 //! Simple unshrinkable array base for concurrent access. Only growths automatically.
 //! There is no way to know the current size. The smaller index is, the faster it's accessed.

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -611,6 +611,7 @@
     <ClInclude Include="Loader\mself.hpp" />
     <ClInclude Include="io_buffer.h" />
     <ClInclude Include="util\atomic.hpp" />
+    <ClInclude Include="util\bless.hpp" />
     <ClInclude Include="util\image_sink.h" />
     <ClInclude Include="util\video_provider.h" />
     <ClInclude Include="util\media_utils.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2371,6 +2371,9 @@
     <ClInclude Include="Emu\RSX\Common\unordered_map.hpp">
       <Filter>Emu\GPU\RSX\Common</Filter>
     </ClInclude>
+    <ClInclude Include="util\bless.hpp">
+      <Filter>Utilities</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Emu\RSX\Program\GLSLSnippets\GPUDeswizzle.glsl">

--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -410,23 +410,6 @@ namespace utils
 		return factor1 > 0 && T{umax} / factor1 < factor2 ? T{umax} : static_cast<T>(factor1 * factor2);
 	}
 
-	// Hack. Pointer cast util to workaround UB. Use with extreme care.
-	template <typename T, typename U>
-	[[nodiscard]] T* bless(U* ptr)
-	{
-#ifdef _MSC_VER
-		return (T*)ptr;
-#elif defined(ARCH_X64)
-		T* result;
-		__asm__("movq %1, %0;" : "=r" (result) : "r" (ptr) : "memory");
-		return result;
-#elif defined(ARCH_ARM64)
-		T* result;
-		__asm__("mov %0, %1" : "=r" (result) : "r" (ptr) : "memory");
-		return result;
-#endif
-	}
-
 	inline void trap()
 	{
 #ifdef _M_X64

--- a/rpcs3/util/bless.hpp
+++ b/rpcs3/util/bless.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace utils
+{
+	// Hack. Pointer cast util to workaround UB. Use with extreme care.
+	template <typename T, typename U>
+	[[nodiscard]] T* bless(U* ptr)
+	{
+#ifdef _MSC_VER
+		return (T*)ptr;
+#elif defined(ARCH_X64)
+		T* result;
+		__asm__("movq %1, %0;" : "=r" (result) : "r" (ptr) : "memory");
+		return result;
+#elif defined(ARCH_ARM64)
+		T* result;
+		__asm__("mov %0, %1" : "=r" (result) : "r" (ptr) : "memory");
+		return result;
+#endif
+	}
+}

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <memory>
 #include "atomic.hpp"
-#include "asm.hpp"
+#include "bless.hpp"
 
 namespace stx
 {


### PR DESCRIPTION
This is a workaround for a Clang 16.0.5 crash which I reported [here](https://github.com/llvm/llvm-project/issues/64450).