### PR TITLE
Debugger/PPU: Superior Callstack Detection

### DIFF
--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -262,6 +262,8 @@ struct ppu_pattern_matrix
 // PPU Instruction Type
 struct ppu_itype
 {
+	static constexpr struct branch_tag{} branch{}; // Branch Instructions
+
 	enum type
 	{
 		UNK = 0,
@@ -432,11 +434,8 @@ struct ppu_itype
 		ADDIC,
 		ADDI,
 		ADDIS,
-		BC,
 		SC,
-		B,
 		MCRF,
-		BCLR,
 		CRNOR,
 		CRANDC,
 		ISYNC,
@@ -446,7 +445,6 @@ struct ppu_itype
 		CREQV,
 		CRORC,
 		CROR,
-		BCCTR,
 		RLWIMI,
 		RLWINM,
 		RLWNM,
@@ -781,12 +779,22 @@ struct ppu_itype
 		FCTID_,
 		FCTIDZ_,
 		FCFID_,
+
+		B, // branch_tag first
+		BC,
+		BCLR,
+		BCCTR, // branch_tag last
 	};
 
 	// Enable address-of operator for ppu_decoder<>
 	friend constexpr type operator &(type value)
 	{
 		return value;
+	}
+
+	friend constexpr bool operator &(type value, branch_tag)
+	{
+		return value >= B && value <= BCCTR;
 	}
 };
 

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -106,12 +106,7 @@ std::pair<PPUDisAsm::const_op, u64> PPUDisAsm::try_get_const_op_gpr_value(u32 re
 
 		const auto type = s_ppu_itype.decode(opcode);
 
-		auto is_branch = [](enum ppu_itype::type itype)
-		{
-			return itype == ppu_itype::BC || itype == ppu_itype::B || itype == ppu_itype::BCLR || itype == ppu_itype::BCCTR;
-		};
-
-		if (is_branch(type) || type == ppu_itype::UNK)
+		if (type & ppu_itype::branch || type == ppu_itype::UNK)
 		{
 			// TODO: Detect calls, ignore them if reg is a non-volatile register
 			return {};

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1330,7 +1330,7 @@ void debugger_frame::DoStep(bool step_over)
 					ppu_opcode_t ppu_op{result};
 					const ppu_itype::type itype = g_ppu_itype.decode(ppu_op.opcode);
 
-					should_step_over = (itype == ppu_itype::BC || itype == ppu_itype::B || itype == ppu_itype::BCCTR || itype == ppu_itype::BCLR) && ppu_op.lk;
+					should_step_over = (itype & ppu_itype::branch && ppu_op.lk);
 				}
 			}
 


### PR DESCRIPTION
Make call stack smooth - no distinguishes between leaf function vs non-leaf function, start function or the the end of the function.
The most simple callstack as possible from user POV like x86 by analysing instructions, this has been partially implemented on SPU side already. (TODO there)