### PR TITLE
LV2/Loader: Fix kernel regions addresses

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1864,7 +1864,7 @@ std::vector<std::pair<u32, u32>> ppu_thread::dump_callstack_list() const
 				}
 			}
 
-			const context_t& res = workload[start];
+			const context_t& res = workload[std::min<usz>(start, workload.size() - 1)];
 
 			if (res.maybe_leaf && !res.non_leaf)
 			{

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -85,6 +85,12 @@ struct sys_memory_address_table
 	}
 };
 
+std::shared_ptr<vm::block_t> reserve_map(u32 alloc_size, u32 align)
+{
+	return vm::reserve_map(align == 0x10000 ? vm::user64k : vm::user1m, 0, align == 0x10000 ? 0x20000000 : utils::align(alloc_size, 0x10000000)
+		, align == 0x10000 ? (vm::page_size_64k | vm::bf0_0x1) : (vm::page_size_1m | vm::bf0_0x1));
+}
+
 // Todo: fix order of error checks
 
 error_code sys_memory_allocate(cpu_thread& cpu, u32 size, u64 flags, vm::ptr<u32> alloc_addr)
@@ -123,7 +129,7 @@ error_code sys_memory_allocate(cpu_thread& cpu, u32 size, u64 flags, vm::ptr<u32
 		return CELL_ENOMEM;
 	}
 
-	if (const auto area = vm::reserve_map(align == 0x10000 ? vm::user64k : vm::user1m, 0, utils::align(size, 0x10000000), 0x401))
+	if (const auto area = reserve_map(size, align))
 	{
 		if (const u32 addr = area->alloc(size, nullptr, align))
 		{
@@ -197,7 +203,7 @@ error_code sys_memory_allocate_from_container(cpu_thread& cpu, u32 size, u32 cid
 		return ct.ret;
 	}
 
-	if (const auto area = vm::reserve_map(align == 0x10000 ? vm::user64k : vm::user1m, 0, utils::align(size, 0x10000000), 0x401))
+	if (const auto area = reserve_map(size, align))
 	{
 		if (const u32 addr = area->alloc(size))
 		{

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1803,12 +1803,12 @@ namespace vm
 	{
 		const u32 max = (0xC0000000 - size) & (0 - align);
 
-		if (size > 0xC0000000 - 0x20000000 || max < 0x20000000)
+		if (size > 0xC0000000 - 0x10000000 || max < 0x10000000)
 		{
 			return nullptr;
 		}
 
-		for (u32 addr = utils::align<u32>(0x20000000, align);; addr += align)
+		for (u32 addr = utils::align<u32>(0x10000000, align);; addr += align)
 		{
 			if (_test_map(addr, size))
 			{
@@ -2131,8 +2131,8 @@ namespace vm
 
 			g_locations =
 			{
-				std::make_shared<block_t>(0x00010000, 0x1FFF0000, page_size_64k | preallocated), // main
-				std::make_shared<block_t>(0x20000000, 0x10000000, page_size_64k | bf0_0x1),		 // user 64k pages
+				std::make_shared<block_t>(0x00010000, 0x0FFF0000, page_size_64k | preallocated), // main
+				nullptr,		                                                                 // user 64k pages
 				nullptr,                                                                         // user 1m pages
 				nullptr,                                                                         // rsx context
 				std::make_shared<block_t>(0xC0000000, 0x10000000, page_size_64k | preallocated), // video


### PR DESCRIPTION
For a while I knew memory area addresses are inaccurate.
From what has been tested: if .ppu_private segment exists, it allocates its own 256MB block of 64k pages. If .rsx_image segment it allocates its own 256MB block of 1M pages. This seems to make sense because access rights (PPU/SPU/RSX flags) are block wide and not allocation specific.
At first, user64k is placed at `0x10000000` if no such special allocfation is made and user1m on `0x30000000`. Adding ppu private and rsx image segment to the ELF causes this addresses to become `0x30000000` and `0x50000000` respectively.

In #4522, the game tries to access a region of memory by mistake that would already be allocated on PS3 but not RPCS3 hence it crashes.
By fixing those addresses the game can be played and not crash anymore.
Fixes #4522.
This also fixes some games broken with Debug Console Mode because now `user4k` region is 512MB long as opposed to 256MB. (because debug console has additional memory, some games use it on `user64k`)
