### PR TITLE
cellGame/sceNpDrm/Loader: Few fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -703,7 +703,7 @@ error_code cellGameBootCheck(vm::ptr<u32> type, vm::ptr<u32> attributes, vm::ptr
 
 	auto& perm = g_fxo->get<content_permission>();
 
-	lv2_sleep(5000);
+	lv2_sleep(500);
 
 	const auto init = perm.init.init();
 
@@ -831,8 +831,6 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 
 	const std::string dir = type == CELL_GAME_GAMETYPE_DISC ? "/dev_bdvd/PS3_GAME"s : "/dev_hdd0/game/" + name;
 
-	lv2_sleep(5000);
-
 	// TODO: not sure what should be checked there
 
 	auto& perm = g_fxo->get<content_permission>();
@@ -841,8 +839,13 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 
 	if (!init)
 	{
+		lv2_sleep(300);
 		return CELL_GAME_ERROR_BUSY;
 	}
+
+	// This function is incredibly slow, slower for DISC type and even if the game/disc data does not exist
+	// Null size does not change it
+	lv2_sleep(type == CELL_GAME_GAMETYPE_DISC ? 300000 : 120000);
 
 	auto [sfo, psf_error] = psf::load(vfs::get(dir + "/PARAM.SFO"));
 
@@ -870,7 +873,7 @@ error_code cellGameDataCheck(u32 type, vm::cptr<char> dirName, vm::ptr<CellGameC
 		size->hddFreeSizeKB = 40 * 1024 * 1024 - 1; // Read explanation in cellHddGameCheck
 
 		// TODO: Calculate data size for game data, if necessary.
-		size->sizeKB = CELL_GAME_SIZEKB_NOTCALC;
+		size->sizeKB = sfo.empty() ? 0 : CELL_GAME_SIZEKB_NOTCALC;
 		size->sysSizeKB = 0; // TODO
 	}
 

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -699,6 +699,11 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 	// Find OPD section
 	for (const auto& sec : secs)
 	{
+		if (sec.size % 8)
+		{
+			continue;
+		}
+
 		vm::cptr<void> sec_end = vm::cast(sec.addr + sec.size);
 
 		// Probe
@@ -785,6 +790,11 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 	// Find .eh_frame section
 	for (const auto& sec : secs)
 	{
+		if (sec.size % 4)
+		{
+			continue;
+		}
+
 		vm::cptr<void> sec_end = vm::cast(sec.addr + sec.size);
 
 		// Probe


### PR DESCRIPTION
* Slow down sceNpDrmIsAvailable, this function takes about 80 to 120ms on PS3.
* Slow down cellGameDataCheck, this function is incredibly slow. Takes around 80ms to 150ms with non-existant GAMEDATA. and 280ms to 300ms with DISC type even if /dev_bdvd is not mounted.
* Fix PPU Analyzer crashes with unaligned sections.

Fixes [SingStar](https://forums.rpcs3.net/thread-201485.html) PSN version loading.
Fixes [SingStar: Back to the 80s](https://forums.rpcs3.net/thread-186971.html) booting.