### PR TITLE
rsx: Discard color mask writes with reserved bits

### DIFF
--- a/rpcs3/Emu/RSX/RSXDisAsm.cpp
+++ b/rpcs3/Emu/RSX/RSXDisAsm.cpp
@@ -167,7 +167,11 @@ void RSXDisAsm::Write(std::string_view str, s32 count, bool is_non_inc, u32 id)
 	{
 		last_opcode.clear();
 
-		if (count >= 0)
+		if (count == 1 && !is_non_inc)
+		{
+			fmt::append(last_opcode, "[%08x] ( )", dump_pc);
+		}
+		else if (count >= 0)
 		{
 			fmt::append(last_opcode, "[%08x] (%s%u)", dump_pc, is_non_inc ? "+" : "", count);
 		}

--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -1592,7 +1592,7 @@ struct registers_decoder<NV4097_SET_SURFACE_ZETA_OFFSET>
 
 	static void dump(std::string& out, const decoded_type& decoded)
 	{
-		fmt::append(out, "Surface: Z offset: %u", decoded.surface_z_offset());
+		fmt::append(out, "Surface: Z offset: 0x%x", decoded.surface_z_offset());
 	}
 };
 
@@ -3040,10 +3040,21 @@ struct registers_decoder<NV4097_SET_COLOR_MASK>
 		{
 			return value != 0;
 		}
+
+		u32 is_invalid() const
+		{
+			return (value & 0xfefefefe) ? value : 0;
+		}
 	};
 
 	static void dump(std::string& out, const decoded_type& decoded)
 	{
+		if (u32 invalid_value = decoded.is_invalid())
+		{
+			fmt::append(out, "Surface: color mask: invalid = 0x%08x", invalid_value);
+			return;
+		}
+
 		fmt::append(out, "Surface: color mask A = %s R = %s G = %s B = %s"
 			, print_boolean(decoded.color_a()), print_boolean(decoded.color_r()), print_boolean(decoded.color_g()), print_boolean(decoded.color_b()));
 	}

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -849,6 +849,23 @@ namespace rsx
 			}
 		}
 
+		void set_color_mask(thread* rsx, u32 reg, u32 arg)
+		{
+			if (arg == method_registers.register_previous_value)
+			{
+				return;
+			}
+
+			if (method_registers.decode<NV4097_SET_COLOR_MASK>(arg).is_invalid()) [[ unlikely ]]
+			{
+				method_registers.decode(reg, method_registers.register_previous_value);
+			}
+			else
+			{
+				set_surface_options_dirty_bit(rsx, reg, arg);
+			}
+		}
+
 		void set_stencil_op(thread* rsx, u32 reg, u32 arg)
 		{
 			if (arg == method_registers.register_previous_value)
@@ -3550,7 +3567,7 @@ namespace rsx
 		bind(NV4097_SET_DEPTH_TEST_ENABLE, nv4097::set_surface_options_dirty_bit);
 		bind(NV4097_SET_DEPTH_FUNC, nv4097::set_surface_options_dirty_bit);
 		bind(NV4097_SET_DEPTH_MASK, nv4097::set_surface_options_dirty_bit);
-		bind(NV4097_SET_COLOR_MASK, nv4097::set_surface_options_dirty_bit);
+		bind(NV4097_SET_COLOR_MASK, nv4097::set_color_mask);
 		bind(NV4097_SET_COLOR_MASK_MRT, nv4097::set_surface_options_dirty_bit);
 		bind(NV4097_SET_TWO_SIDED_STENCIL_TEST_ENABLE, nv4097::set_surface_options_dirty_bit);
 		bind(NV4097_SET_STENCIL_TEST_ENABLE, nv4097::set_surface_options_dirty_bit);

--- a/rpcs3/rpcs3qt/syntax_highlighter.cpp
+++ b/rpcs3/rpcs3qt/syntax_highlighter.cpp
@@ -67,7 +67,7 @@ LogHighlighter::LogHighlighter(QTextDocument* parent) : Highlighter(parent)
 
 AsmHighlighter::AsmHighlighter(QTextDocument *parent) : Highlighter(parent)
 {
-	addRule("^\b[A-Z0-9]+\b",         Qt::darkBlue);    // Instructions
+	addRule("^\\b[A-Z0-9]+\\b",       Qt::darkBlue);    // Instructions
 	addRule("-?R\\d[^,;\\s]*",        Qt::darkRed);     // -R0.*
 	addRule("-?H\\d[^,;\\s]*",        Qt::red);         // -H1.*
 	addRule("-?v\\[\\d\\]*[^,;\\s]*", Qt::darkCyan);    // -v[xyz].*


### PR DESCRIPTION
Testcase https://github.com/elad335/myps3tests/tree/master/rsx_tests/write%20output%20mask
This testcase tests what happens on a write to ones to reserved of color mask register
It does this by iterating and ORis valid masks with a single reserved bit at a time, for completeness it also tests it with valid bit masks as well and examines buffer state.
Results: writes with reserved bits set are being ignored by RSX.

Fixes the colors in #13101.
Fixes #10530 

![image](https://github.com/RPCS3/rpcs3/assets/18193363/fab6c269-3410-45c1-8439-3d5e8ebbeabb)
