### PR TITLE
PPU Analyzer/Savestates: Usability improvements, Reduce LLVM compilation of garbage data

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -67,6 +67,8 @@ void pad_info::save(utils::serial& ar)
 	USING_SERIALIZATION_VERSION(sys_io);
 
 	ar(max_connect, port_setting);
+
+	sys_io_serialize(ar);
 }
 
 extern void send_sys_io_connect_event(u32 index, u32 state);

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -53,14 +53,19 @@ void fmt_class_string<CellPadFilterError>::format(std::string& out, u64 arg)
 	});
 }
 
+extern void sys_io_serialize(utils::serial& ar);
+
 pad_info::pad_info(utils::serial& ar)
 	: max_connect(ar)
 	, port_setting(ar)
 {
+	sys_io_serialize(ar);
 }
 
 void pad_info::save(utils::serial& ar)
 {
+	USING_SERIALIZATION_VERSION(sys_io);
+
 	ar(max_connect, port_setting);
 }
 

--- a/rpcs3/Emu/Cell/Modules/sys_io_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_io_.cpp
@@ -23,7 +23,18 @@ struct libio_sys_config
 	~libio_sys_config() noexcept
 	{
 	}
+
+	void save_or_load(utils::serial& ar)
+	{
+		ar(init_ctr, ppu_id, queue_id);
+	}
 };
+
+extern void sys_io_serialize(utils::serial& ar)
+{
+	// Do not assign a serialization tag for now, call it from cellPad serialization
+	g_fxo->get<libio_sys_config>().save_or_load(ar);
+}
 
 extern void cellPad_NotifyStateChange(u32 index, u32 state);
 
@@ -31,8 +42,11 @@ void config_event_entry(ppu_thread& ppu)
 {
 	auto& cfg = g_fxo->get<libio_sys_config>();
 
-	// Ensure awake
-	ppu.check_state();
+	if (!ppu.loaded_from_savestate)
+	{
+		// Ensure awake
+		ppu.check_state();
+	}
 
 	while (!sys_event_queue_receive(ppu, cfg.queue_id, vm::null, 0))
 	{

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -263,6 +263,7 @@ struct ppu_pattern_matrix
 struct ppu_itype
 {
 	static constexpr struct branch_tag{} branch{}; // Branch Instructions
+	static constexpr struct trap_tag{} trap{}; // Branch Instructions
 
 	enum type
 	{
@@ -425,8 +426,6 @@ struct ppu_itype
 		VUPKLSB,
 		VUPKLSH,
 		VXOR,
-		TDI,
-		TWI,
 		MULLI,
 		SUBFIC,
 		CMPLI,
@@ -461,7 +460,6 @@ struct ppu_itype
 		RLDCL,
 		RLDCR,
 		CMP,
-		TW,
 		LVSL,
 		LVEBX,
 		SUBFC,
@@ -488,7 +486,6 @@ struct ppu_itype
 		LWZUX,
 		CNTLZD,
 		ANDC,
-		TD,
 		LVEWX,
 		MULHD,
 		MULHW,
@@ -784,6 +781,11 @@ struct ppu_itype
 		BC,
 		BCLR,
 		BCCTR, // branch_tag last
+
+		TD, // trap_tag first
+		TW,
+		TDI,
+		TWI, // trap_tag last
 	};
 
 	// Enable address-of operator for ppu_decoder<>
@@ -795,6 +797,11 @@ struct ppu_itype
 	friend constexpr bool operator &(type value, branch_tag)
 	{
 		return value >= B && value <= BCCTR;
+	}
+
+	friend constexpr bool operator &(type value, trap_tag)
+	{
+		return value >= TD && value <= TWI;
 	}
 };
 

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -18,7 +18,7 @@ struct serial_ver_t
 	std::set<s32> compatible_versions;
 };
 
-static std::array<serial_ver_t, 23> s_serial_versions;
+static std::array<serial_ver_t, 26> s_serial_versions;
 
 #define SERIALIZATION_VER(name, identifier, ...) \
 \
@@ -35,7 +35,7 @@ static std::array<serial_ver_t, 23> s_serial_versions;
 		return ::s_serial_versions[identifier].current_version;\
 	}
 
-SERIALIZATION_VER(global_version, 0,                            13) // For stuff not listed here
+SERIALIZATION_VER(global_version, 0,                            14) // For stuff not listed here
 SERIALIZATION_VER(ppu, 1,                                       1)
 SERIALIZATION_VER(spu, 2,                                       1)
 SERIALIZATION_VER(lv2_sync, 3,                                  1)
@@ -73,6 +73,11 @@ SERIALIZATION_VER(cellGcm, 19,                                  1)
 SERIALIZATION_VER(sysPrxForUser, 20,                            1)
 SERIALIZATION_VER(cellSaveData, 21,                             1)
 SERIALIZATION_VER(cellAudioOut, 22,                             1)
+SERIALIZATION_VER(sys_io, 23,                                   1)
+
+// Misc versions for HLE/LLE not included so main version would not invalidated
+SERIALIZATION_VER(LLE, 24,                                      1)
+SERIALIZATION_VER(HLE, 25,                                      1)
 
 std::vector<std::pair<u16, u16>> get_savestate_versioning_data(const fs::file& file)
 {


### PR DESCRIPTION
Previously, savestates 99% of the time caused a second, and much longer (!) PPU LLVM compilation in addition to the already existing cache because it is scanning the whole segment 0. This was done in order to support analysis of patches applied within the savestate file on instructions located outside of registered code regions in executable.
Now, why savestates do not simply allow patches to be reused and re-register them instead? because applying patches after boot (on savestates for example) and before boot (normal patches) is not the same operation and may have different and unexpected consequences on farther execution.

The idea here is simply to avoid this and compile segment 0 at all times, so there won't be a second compilation for savestates. In order to avoid compiling garbage data, I added some more constraints in PPU Analayzer.

~~Please test if PPU LLVM compilation is being signficantly prolonged by this pr and remove previous PPU cache before testing.~~
I improved constrainsts further and made the "anti-optimization" affect only when patches are applied.
So in turn it may actually improve PPU LLVM compilation time when patches are not applied. 