### PR TITLE
cellPad: fix custom controller status

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -71,9 +71,9 @@ void pad_info::save(utils::serial& ar)
 	sys_io_serialize(ar);
 }
 
-extern void send_sys_io_connect_event(u32 index, u32 state);
+extern void send_sys_io_connect_event(usz index, u32 state);
 
-void cellPad_NotifyStateChange(u32 index, u32 state)
+void cellPad_NotifyStateChange(usz index, u32 state)
 {
 	auto info = g_fxo->try_get<pad_info>();
 
@@ -84,7 +84,7 @@ void cellPad_NotifyStateChange(u32 index, u32 state)
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
-	if (!info->max_connect)
+	if (index >= info->get_max_connect())
 	{
 		return;
 	}
@@ -148,7 +148,7 @@ void cellPad_NotifyStateChange(u32 index, u32 state)
 	}
 }
 
-extern void pad_state_notify_state_change(u32 index, u32 state)
+extern void pad_state_notify_state_change(usz index, u32 state)
 {
 	cellPad_NotifyStateChange(index, state);
 }
@@ -179,7 +179,7 @@ error_code cellPadInit(ppu_thread& ppu, u32 max_connect)
 
 	const auto& pads = handler->GetPads();
 
-	for (u32 i = 0; i < statuses.size(); ++i)
+	for (usz i = 0; i < statuses.size(); ++i)
 	{
 		if (i >= config.get_max_connect())
 			break;

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -617,19 +617,22 @@ error_code cellPadPeriphGetInfo(vm::ptr<CellPadPeriphInfo> info)
 		if (i >= config.get_max_connect())
 			break;
 
-		info->port_status[i] = config.reported_info[i].port_status;
-		config.reported_info[i].port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES;
+		pad_data_internal& reported_info = config.reported_info[i];
+
+		info->port_status[i] = reported_info.port_status;
 		info->port_setting[i] = config.port_setting[i];
 
-		if (~config.reported_info[i].port_status & CELL_PAD_STATUS_CONNECTED)
+		reported_info.port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES;
+
+		if (~reported_info.port_status & CELL_PAD_STATUS_CONNECTED)
 		{
 			continue;
 		}
 
-		info->device_capability[i] = config.reported_info[i].device_capability;
-		info->device_type[i] = config.reported_info[i].device_type;
-		info->pclass_type[i] = config.reported_info[i].pclass_type;
-		info->pclass_profile[i] = config.reported_info[i].pclass_profile;
+		info->device_capability[i] = reported_info.device_capability;
+		info->device_type[i] = reported_info.device_type;
+		info->pclass_type[i] = reported_info.pclass_type;
+		info->pclass_profile[i] = reported_info.pclass_profile;
 
 		now_connect++;
 	}
@@ -804,16 +807,18 @@ error_code cellPadGetInfo(vm::ptr<CellPadInfo> info)
 		if (i >= config.get_max_connect())
 			break;
 
-		config.reported_info[i].port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES; // TODO: should ASSIGN flags be cleared here?
-		info->status[i] = config.reported_info[i].port_status;
+		pad_data_internal& reported_info = config.reported_info[i];
+		reported_info.port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES; // TODO: should ASSIGN flags be cleared here?
 
-		if (~config.reported_info[i].port_status & CELL_PAD_STATUS_CONNECTED)
+		info->status[i] = reported_info.port_status;
+
+		if (~reported_info.port_status & CELL_PAD_STATUS_CONNECTED)
 		{
 			continue;
 		}
 
-		info->vendor_id[i] = config.reported_info[i].vendor_id;
-		info->product_id[i] = config.reported_info[i].product_id;
+		info->vendor_id[i] = reported_info.vendor_id;
+		info->product_id[i] = reported_info.product_id;
 
 		now_connect++;
 	}
@@ -853,11 +858,14 @@ error_code cellPadGetInfo2(vm::ptr<CellPadInfo2> info)
 		if (i >= config.get_max_connect())
 			break;
 
-		info->port_status[i] = config.reported_info[i].port_status;
-		config.reported_info[i].port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES;
+		pad_data_internal& reported_info = config.reported_info[i];
+
+		info->port_status[i] = reported_info.port_status;
 		info->port_setting[i] = config.port_setting[i];
 
-		if (~config.reported_info[i].port_status & CELL_PAD_STATUS_CONNECTED)
+		reported_info.port_status &= ~CELL_PAD_STATUS_ASSIGN_CHANGES;
+
+		if (~reported_info.port_status & CELL_PAD_STATUS_CONNECTED)
 		{
 			continue;
 		}

--- a/rpcs3/Emu/Cell/Modules/sys_io_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_io_.cpp
@@ -36,7 +36,7 @@ extern void sys_io_serialize(utils::serial& ar)
 	g_fxo->get<libio_sys_config>().save_or_load(ar);
 }
 
-extern void cellPad_NotifyStateChange(u32 index, u32 state);
+extern void cellPad_NotifyStateChange(usz index, u32 state);
 
 void config_event_entry(ppu_thread& ppu)
 {
@@ -101,7 +101,7 @@ std::unique_lock<shared_mutex> lock_lv2_mutex_alike(shared_mutex& mtx, ppu_threa
 	return lock;
 }
 
-extern void send_sys_io_connect_event(u32 index, u32 state)
+extern void send_sys_io_connect_event(usz index, u32 state)
 {
 	auto& cfg = g_fxo->get<libio_sys_config>();
 

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -7,7 +7,7 @@
 
 cfg_input g_cfg_input;
 
-extern void pad_state_notify_state_change(u32 index, u32 state);
+extern void pad_state_notify_state_change(usz index, u32 state);
 
 PadHandlerBase::PadHandlerBase(pad_handler type) : m_type(type)
 {

--- a/rpcs3/Emu/Io/RB3MidiGuitar.h
+++ b/rpcs3/Emu/Io/RB3MidiGuitar.h
@@ -7,7 +7,7 @@
 class usb_device_rb3_midi_guitar : public usb_device_emulated
 {
 private:
-	u32 response_pos = 0;
+	usz response_pos = 0;
 	bool buttons_enabled = false;
 	RtMidiInPtr midi_in{};
 

--- a/rpcs3/Emu/Io/RB3MidiKeyboard.h
+++ b/rpcs3/Emu/Io/RB3MidiKeyboard.h
@@ -7,7 +7,7 @@
 class usb_device_rb3_midi_keyboard : public usb_device_emulated
 {
 private:
-	u32 response_pos = 0;
+	usz response_pos = 0;
 	bool buttons_enabled = false;
 	RtMidiInPtr midi_in{};
 


### PR DESCRIPTION
- CELL_PAD_STATUS_CUSTOM_CONTROLLER was lost in cellPad_NotifyStateChange. Use the whole status instead.
I don't know what config_event_entry usually sets. If it only sets the connection, I can update the code to work with the old param.
- Fixes a potential out of bounds read in cellPad_NotifyStateChange (max_connect vs. get_max_connect())
- Fixes some u32 warning in Midi code
- Improves readability a bit by using some local references

Probably fixes #14493