### PR TITLE
Qt: fix pressure intensity deadzone enabled state

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -623,7 +623,7 @@ void PadHandlerBase::get_mapping(const pad_ensemble& binding)
 	s32 stick_val[4]{};
 
 	// Translate any corresponding keycodes to our two sticks. (ignoring thresholds for now)
-	for (int i = 0; i < static_cast<int>(pad->m_sticks.size()); i++)
+	for (usz i = 0; i < pad->m_sticks.size(); i++)
 	{
 		bool pressed{};
 		u16 val_min{};

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -956,14 +956,12 @@ int dualsense_pad_handler::send_output_report(DualSenseDevice* device)
 
 		return hid_write(device->hidDevice, &report.report_id, DUALSENSE_BLUETOOTH_REPORT_SIZE);
 	}
-	else
-	{
-		output_report_usb report{};
-		report.report_id = 0x02; // report id for usb
-		report.common    = common;
 
-		return hid_write(device->hidDevice, &report.report_id, DUALSENSE_USB_REPORT_SIZE);
-	}
+	output_report_usb report{};
+	report.report_id = 0x02; // report id for usb
+	report.common    = common;
+
+	return hid_write(device->hidDevice, &report.report_id, DUALSENSE_USB_REPORT_SIZE);
 }
 
 void dualsense_pad_handler::apply_pad_data(const pad_ensemble& binding)

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -1062,7 +1062,7 @@ void keyboard_pad_handler::process()
 		{
 			if (update_sticks)
 			{
-				for (int j = 0; j < static_cast<int>(pad.m_sticks.size()); j++)
+				for (usz j = 0; j < pad.m_sticks.size(); j++)
 				{
 					const f32 stick_lerp_factor = (j < 2) ? m_l_stick_lerp_factor : m_r_stick_lerp_factor;
 

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -125,9 +125,9 @@ private:
 	f32 m_r_stick_lerp_factor = 1.0f;
 	u32 m_l_stick_multiplier = 100;
 	u32 m_r_stick_multiplier = 100;
-	u8 m_stick_min[4] = { 0, 0, 0, 0 };
-	u8 m_stick_max[4] = { 128, 128, 128, 128 };
-	u8 m_stick_val[4] = { 128, 128, 128, 128 };
+	std::array<u8, 4> m_stick_min{ 0, 0, 0, 0 };
+	std::array<u8, 4> m_stick_max{ 128, 128, 128, 128 };
+	std::array<u8, 4> m_stick_val{ 128, 128, 128, 128 };
 
 	// Mouse Movements
 	steady_clock::time_point m_last_mouse_move_left;

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1221,6 +1221,7 @@ void pad_settings_dialog::SwitchButtons(bool is_enabled)
 	ui->kb_stick_multi_right->setEnabled(is_enabled);
 	ui->squircle_left->setEnabled(is_enabled);
 	ui->squircle_right->setEnabled(is_enabled);
+	ui->gb_pressure_intensity_deadzone->setEnabled(is_enabled);
 	ui->gb_pressure_intensity->setEnabled(is_enabled && m_enable_pressure_intensity_button);
 	ui->gb_vibration->setEnabled(is_enabled && m_enable_rumble);
 	ui->gb_motion_controls->setEnabled(is_enabled && m_enable_motion);


### PR DESCRIPTION
The slider could be used when it shouldn't.