### PR TITLE
Qt: rename pad profiles to input config files

### DIFF
--- a/rpcs3/Emu/Io/pad_config.cpp
+++ b/rpcs3/Emu/Io/pad_config.cpp
@@ -4,7 +4,7 @@
 
 LOG_CHANNEL(input_log, "Input");
 
-extern std::string g_pad_profile_override;
+extern std::string g_input_config_override;
 
 std::vector<std::string> cfg_pad::get_buttons(const std::string& str)
 {
@@ -26,16 +26,16 @@ std::string cfg_pad::get_buttons(std::vector<std::string> vec)
 	return fmt::merge(vec, ",");
 }
 
-bool cfg_input::load(const std::string& title_id, const std::string& profile, bool strict)
+bool cfg_input::load(const std::string& title_id, const std::string& config_file, bool strict)
 {
-	input_log.notice("Loading pad config (title_id='%s', profile='%s', strict=%d)", title_id, profile, strict);
+	input_log.notice("Loading pad config (title_id='%s', config_file='%s', strict=%d)", title_id, config_file, strict);
 
 	std::string cfg_name;
 
-	// Check profile override first
-	if (!strict && !g_pad_profile_override.empty())
+	// Check configuration override first
+	if (!strict && !g_input_config_override.empty())
 	{
-		cfg_name = rpcs3::utils::get_input_config_dir() + g_pad_profile_override + ".yml";
+		cfg_name = rpcs3::utils::get_input_config_dir() + g_input_config_override + ".yml";
 	}
 
 	// Check custom config next
@@ -44,23 +44,23 @@ bool cfg_input::load(const std::string& title_id, const std::string& profile, bo
 		cfg_name = rpcs3::utils::get_custom_input_config_path(title_id);
 	}
 
-	// Check active global profile next
-	if ((title_id.empty() || !strict) && !profile.empty() && !fs::is_file(cfg_name))
+	// Check active global configuration next
+	if ((title_id.empty() || !strict) && !config_file.empty() && !fs::is_file(cfg_name))
 	{
-		cfg_name = rpcs3::utils::get_input_config_dir() + profile + ".yml";
+		cfg_name = rpcs3::utils::get_input_config_dir() + config_file + ".yml";
 	}
 
-	// Fallback to default profile
+	// Fallback to default configuration
 	if (!strict && !fs::is_file(cfg_name))
 	{
-		cfg_name = rpcs3::utils::get_input_config_dir() + g_cfg_profile.default_profile + ".yml";
+		cfg_name = rpcs3::utils::get_input_config_dir() + g_cfg_input_configs.default_config + ".yml";
 	}
 
 	from_default();
 
 	if (fs::file cfg_file{ cfg_name, fs::read })
 	{
-		input_log.notice("Loading pad profile: '%s'", cfg_name);
+		input_log.notice("Loading input configuration: '%s'", cfg_name);
 
 		if (std::string content = cfg_file.to_string(); !content.empty())
 		{
@@ -69,7 +69,7 @@ bool cfg_input::load(const std::string& title_id, const std::string& profile, bo
 	}
 
 	// Add keyboard by default
-	input_log.notice("Pad profile empty. Adding default keyboard pad handler");
+	input_log.notice("Input configuration empty. Adding default keyboard pad handler");
 	player[0]->handler.from_string(fmt::format("%s", pad_handler::keyboard));
 	player[0]->device.from_string(pad::keyboard_device_name.data());
 	player[0]->buddy_device.from_string(""sv);
@@ -77,14 +77,14 @@ bool cfg_input::load(const std::string& title_id, const std::string& profile, bo
 	return false;
 }
 
-void cfg_input::save(const std::string& title_id, const std::string& profile) const
+void cfg_input::save(const std::string& title_id, const std::string& config_file) const
 {
 	std::string cfg_name;
 
 	if (title_id.empty())
 	{
-		cfg_name = rpcs3::utils::get_input_config_dir() + profile + ".yml";
-		input_log.notice("Saving pad config profile '%s' to '%s'", profile, cfg_name);
+		cfg_name = rpcs3::utils::get_input_config_dir() + config_file + ".yml";
+		input_log.notice("Saving input configuration '%s' to '%s'", config_file, cfg_name);
 	}
 	else
 	{
@@ -105,12 +105,12 @@ void cfg_input::save(const std::string& title_id, const std::string& profile) co
 	}
 }
 
-cfg_profile::cfg_profile()
-	: path(rpcs3::utils::get_input_config_root() + "/active_profiles.yml")
+cfg_input_configurations::cfg_input_configurations()
+	: path(rpcs3::utils::get_input_config_root() + "/active_input_configurations.yml")
 {
 }
 
-bool cfg_profile::load()
+bool cfg_input_configurations::load()
 {
 	if (fs::file cfg_file{ path, fs::read })
 	{
@@ -121,14 +121,14 @@ bool cfg_profile::load()
 	return false;
 }
 
-void cfg_profile::save() const
+void cfg_input_configurations::save() const
 {
-	input_log.notice("Saving pad profile config to '%s'", path);
+	input_log.notice("Saving input configurations config to '%s'", path);
 
 	fs::pending_file cfg_file(path);
 
 	if (!cfg_file.file || (cfg_file.file.write(to_string()), !cfg_file.commit()))
 	{
-		input_log.error("Failed to save pad profile config to '%s' (error=%s)", path, fs::g_tls_error);
+		input_log.error("Failed to save input configurations config to '%s' (error=%s)", path, fs::g_tls_error);
 	}
 }

--- a/rpcs3/Emu/Io/pad_config.h
+++ b/rpcs3/Emu/Io/pad_config.h
@@ -131,18 +131,18 @@ struct cfg_input final : cfg::node
 	void save(const std::string& title_id, const std::string& profile = "") const;
 };
 
-struct cfg_profile final : cfg::node
+struct cfg_input_configurations final : cfg::node
 {
-	cfg_profile();
+	cfg_input_configurations();
 	bool load();
 	void save() const;
 
 	const std::string path;
 	const std::string global_key = "global";
-	const std::string default_profile = "Default";
+	const std::string default_config = "Default";
 
-	cfg::map_entry active_profiles{ this, "Active Profiles" };
+	cfg::map_entry active_configs{ this, "Active Configurations" };
 };
 
 extern cfg_input g_cfg_input;
-extern cfg_profile g_cfg_profile;
+extern cfg_input_configurations g_cfg_input_configs;

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -379,6 +379,6 @@ namespace rpcs3::utils
 	std::string get_custom_input_config_path(const std::string& title_id)
 	{
 		if (title_id.empty()) return "";
-		return get_input_config_dir(title_id) + g_cfg_profile.default_profile + ".yml";
+		return get_input_config_dir(title_id) + g_cfg_input_configs.default_config + ".yml";
 	}
 }

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -27,7 +27,7 @@
 LOG_CHANNEL(sys_log, "SYS");
 
 extern bool is_input_allowed();
-extern std::string g_pad_profile_override;
+extern std::string g_input_config_override;
 
 namespace pad
 {
@@ -100,19 +100,19 @@ void pad_thread::Init()
 
 	handlers.clear();
 
-	g_cfg_profile.load();
+	g_cfg_input_configs.load();
 
-	std::string active_profile = g_cfg_profile.active_profiles.get_value(pad::g_title_id);
+	std::string active_config = g_cfg_input_configs.active_configs.get_value(pad::g_title_id);
 
-	if (active_profile.empty())
+	if (active_config.empty())
 	{
-		active_profile = g_cfg_profile.active_profiles.get_value(g_cfg_profile.global_key);
+		active_config = g_cfg_input_configs.active_configs.get_value(g_cfg_input_configs.global_key);
 	}
 
-	input_log.notice("Using pad profile: '%s' (override='%s')", active_profile, g_pad_profile_override);
+	input_log.notice("Using input configuration: '%s' (override='%s')", active_config, g_input_config_override);
 
 	// Load in order to get the pad handlers
-	if (!g_cfg_input.load(pad::g_title_id, active_profile))
+	if (!g_cfg_input.load(pad::g_title_id, active_config))
 	{
 		input_log.notice("Loaded empty pad config");
 	}
@@ -125,7 +125,7 @@ void pad_thread::Init()
 	}
 
 	// Reload with proper defaults
-	if (!g_cfg_input.load(pad::g_title_id, active_profile))
+	if (!g_cfg_input.load(pad::g_title_id, active_config))
 	{
 		input_log.notice("Reloaded empty pad config");
 	}

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -88,7 +88,7 @@ static atomic_t<bool> s_headless = false;
 static atomic_t<bool> s_no_gui = false;
 static atomic_t<char*> s_argv0;
 
-std::string g_pad_profile_override;
+std::string g_input_config_override;
 
 extern thread_local std::string(*g_tls_log_prefix)();
 extern thread_local std::string_view g_tls_serialize_name;
@@ -291,7 +291,7 @@ constexpr auto arg_styles       = "styles";
 constexpr auto arg_style        = "style";
 constexpr auto arg_stylesheet   = "stylesheet";
 constexpr auto arg_config       = "config";
-constexpr auto arg_pad_profile  = "pad-profile"; // only useful with no-gui
+constexpr auto arg_input_config = "input-config"; // only useful with no-gui
 constexpr auto arg_q_debug      = "qDebug";
 constexpr auto arg_error        = "error";
 constexpr auto arg_updating     = "updating";
@@ -652,8 +652,8 @@ int main(int argc, char** argv)
 	parser.addOption(QCommandLineOption(arg_stylesheet, "Loads a custom stylesheet.", "path", ""));
 	const QCommandLineOption config_option(arg_config, "Forces the emulator to use this configuration file for CLI-booted game.", "path", "");
 	parser.addOption(config_option);
-	const QCommandLineOption pad_profile_option(arg_pad_profile, "Forces the emulator to use this pad profile file for CLI-booted game.", "name", "");
-	parser.addOption(pad_profile_option);
+	const QCommandLineOption input_config_option(arg_input_config, "Forces the emulator to use this input config file for CLI-booted game.", "name", "");
+	parser.addOption(input_config_option);
 	const QCommandLineOption installfw_option(arg_installfw, "Forces the emulator to install this firmware file.", "path", "");
 	parser.addOption(installfw_option);
 	const QCommandLineOption installpkg_option(arg_installpkg, "Forces the emulator to install this pkg file.", "path", "");
@@ -1289,18 +1289,18 @@ int main(int argc, char** argv)
 			}
 		}
 
-		if (parser.isSet(arg_pad_profile))
+		if (parser.isSet(arg_input_config))
 		{
 			if (!s_no_gui)
 			{
-				report_fatal_error(fmt::format("The option '%s' can only be used in combination with '%s'.", arg_pad_profile, arg_no_gui));
+				report_fatal_error(fmt::format("The option '%s' can only be used in combination with '%s'.", arg_input_config, arg_no_gui));
 			}
 
-			g_pad_profile_override = parser.value(pad_profile_option).toStdString();
+			g_input_config_override = parser.value(input_config_option).toStdString();
 
-			if (g_pad_profile_override.empty())
+			if (g_input_config_override.empty())
 			{
-				report_fatal_error(fmt::format("Pad profile name is empty"));
+				report_fatal_error(fmt::format("Input config file name is empty"));
 			}
 		}
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1684,10 +1684,10 @@ bool game_list_frame::RemoveCustomPadConfiguration(const std::string& title_id, 
 		: tr("Remove custom pad configuration?")) != QMessageBox::Yes)
 		return true;
 
-	g_cfg_profile.load();
-	g_cfg_profile.active_profiles.erase(title_id);
-	g_cfg_profile.save();
-	game_list_log.notice("Removed active pad profile entry for key '%s'", title_id);
+	g_cfg_input_configs.load();
+	g_cfg_input_configs.active_configs.erase(title_id);
+	g_cfg_input_configs.save();
+	game_list_log.notice("Removed active input configuration entry for key '%s'", title_id);
 
 	if (QDir(qstr(config_dir)).removeRecursively())
 	{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -72,7 +72,7 @@ class pad_settings_dialog : public QDialog
 		id_reset_parameters,
 		id_blacklist,
 		id_refresh,
-		id_add_profile,
+		id_add_config_file,
 		id_ok,
 		id_cancel
 	};
@@ -97,10 +97,10 @@ private Q_SLOTS:
 	void OnTabChanged(int index);
 	void RefreshHandlers();
 	void ChangeHandler();
-	void ChangeProfile(const QString& profile);
+	void ChangeConfig(const QString& config_file);
 	void ChangeDevice(int index);
 	void HandleDeviceClassChange(u32 class_id) const;
-	void AddProfile();
+	void AddConfigFile();
 	/** Update the current player config with the GUI values. */
 	void ApplyCurrentPlayerConfig(int new_player_id);
 	void RefreshPads();
@@ -147,7 +147,7 @@ private:
 	std::mutex m_handler_mutex;
 	std::string m_device_name;
 	std::string m_buddy_device_name;
-	std::string m_profile;
+	std::string m_config_file;
 	QTimer m_timer_pad_refresh;
 	int m_last_player_id = 0;
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -147,11 +147,11 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="gb_profiles">
+           <widget class="QGroupBox" name="gb_config_files">
             <property name="title">
-             <string>Profiles</string>
+             <string>Configuration Files</string>
             </property>
-            <layout class="QHBoxLayout" name="gb_profiles_layout">
+            <layout class="QHBoxLayout" name="gb_config_files_layout">
              <property name="leftMargin">
               <number>5</number>
              </property>
@@ -165,12 +165,12 @@
               <number>5</number>
              </property>
              <item>
-              <widget class="QComboBox" name="chooseProfile"/>
+              <widget class="QComboBox" name="chooseConfig"/>
              </item>
              <item>
-              <widget class="QPushButton" name="b_addProfile">
+              <widget class="QPushButton" name="b_addConfig">
                <property name="text">
-                <string>Add Profile</string>
+                <string>Add Configuration</string>
                </property>
                <property name="autoDefault">
                 <bool>false</bool>


### PR DESCRIPTION
It became clear that the pad profiles aren't really what you would interpret as pad profiles in other emulators, but rather entire input config files.
This confused several users, so I decided to rename everything related to pad profiles to make this clear in the codebase.

- Renames all occurences of pad profiles to input configs or similar
- Renames active_profiles.yml file to active_input_configurations.yml
(sorry, but I think this is necessary. you can just copy the contents of the old one if necessary and rename "Active Profiles" to "Active Configurations")
- Renames the pad-profile cli arg to input-config (same reason)