### PR TITLE
Hotfix SPU Cache Spam For Game Collections

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1073,6 +1073,8 @@ static void ppu_check_patch_spu_images(const ppu_module& mod, const ppu_segment&
 
 	const bool is_firmware = mod.path.starts_with(vfs::get("/dev_flash/"));
 
+	const auto _main = g_fxo->try_get<main_ppu_module>();
+
 	const std::string_view seg_view{ensure(mod.get_ptr<char>(seg.addr)), seg.size};
 
 	auto find_first_of_multiple = [](std::string_view data, std::initializer_list<std::string_view> values, usz index)
@@ -1231,7 +1233,7 @@ static void ppu_check_patch_spu_images(const ppu_module& mod, const ppu_segment&
 
 					ppu_log.success("Found valid roaming SPU code at 0x%x..0x%x (guessed_ls_addr=0x%x)", seg.addr + begin, seg.addr + end, guessed_ls_addr);
 
-					if (!is_firmware)
+					if (!is_firmware && _main == &mod)
 					{
 						// Siginify that the base address is unknown by passing 0
 						utilize_spu_data_segment(guessed_ls_addr ? guessed_ls_addr : 0x4000, seg_view.data() + begin, end - begin);
@@ -1282,7 +1284,7 @@ static void ppu_check_patch_spu_images(const ppu_module& mod, const ppu_segment&
 
 			if (prog.p_type == 0x1u /* LOAD */ && prog.p_filesz > 0u)
 			{
-				if (prog.p_vaddr && !is_firmware)
+				if (prog.p_vaddr && !is_firmware && _main == &mod)
 				{
 					extern void utilize_spu_data_segment(u32 vaddr, const void* ls_data_vaddr, u32 size);
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3667,8 +3667,8 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				return g_prx_list.count(entry.name) && ::at32(g_prx_list, entry.name) != 0;
 			};
 
-			// Check .sprx filename
-			if (upper.ends_with(".SPRX") && entry.name != "libfs_utility_init.sprx"sv)
+			// Check PRX filename
+			if (upper.ends_with(".PRX") || (upper.ends_with(".SPRX") && entry.name != "libfs_utility_init.sprx"sv))
 			{
 				if (is_ignored(0))
 				{
@@ -3680,8 +3680,8 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				continue;
 			}
 
-			// Check .self filename
-			if (upper.ends_with(".SELF") && Emu.GetBoot() != dir_queue[i] + entry.name)
+			// Check ELF filename
+			if ((entry.name == "EBOOT.BIN" || upper.ends_with(".ELF") || upper.ends_with(".SELF")) && Emu.GetBoot() != dir_queue[i] + entry.name)
 			{
 				// Get full path
 				file_queue.emplace_back(dir_queue[i] + entry.name,  0);


### PR DESCRIPTION
Ideally we should track a list of referenced PRX/OVL paths in main executable and only if existing, precompile their SPU code.

In addition: Add ".PRX" and ".ELF" extensions to precompiled PPU LLVM files, seen "PRX" extension instead of "SPRX" in some games. (although they are really all encrypted, real sys_prx load does not accept files not starting with SCE prefix)