### PR TITLE
Crypto: Fix endianess, avoid crashing on invalid values

### DIFF
--- a/rpcs3/Crypto/utils.h
+++ b/rpcs3/Crypto/utils.h
@@ -5,38 +5,11 @@
 // http://www.gnu.org/licenses/gpl-2.0.txt
 
 #include "util/types.hpp"
+#include "util/asm.hpp"
 
 #include <stdlib.h>
 
 enum { CRYPTO_MAX_PATH = 4096 };
-
-// Auxiliary functions (endian swap, xor, and file name).
-inline u16 swap16(u16 i)
-{
-#if defined(__GNUG__)
-	return __builtin_bswap16(i);
-#else
-	return _byteswap_ushort(i);
-#endif
-}
-
-inline u32 swap32(u32 i)
-{
-#if defined(__GNUG__)
-	return __builtin_bswap32(i);
-#else
-	return _byteswap_ulong(i);
-#endif
-}
-
-inline u64 swap64(u64 i)
-{
-#if defined(__GNUG__)
-	return __builtin_bswap64(i);
-#else
-	return _byteswap_uint64(i);
-#endif
-}
 
 char* extract_file_name(const char* file_path, char real_file_name[CRYPTO_MAX_PATH]);
 


### PR DESCRIPTION
Encountered a crash when experimenting with stuff on SCE decrypter because SCE prefix is used not only for executables.
Also fixed endiness swapping - does not fit big endian architectures like ARM so it may improve compatibility there.