### PR TITLE
SPU LLVM: Precompilation Improvements and misc fixes

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1303,12 +1303,12 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 
 				DWORD nwritten = 0;
 				OVERLAPPED ovl{};
-				const u64 pos = m_pos;
+				const u64 pos = m_pos.fetch_add(size);
 				ovl.Offset = DWORD(pos);
 				ovl.OffsetHigh = DWORD(pos >> 32);
 				ensure(WriteFile(m_handle, data, size, &nwritten, &ovl)); // "file::write"
+				ensure(nwritten == size);
 				nwritten_sum += nwritten;
-				m_pos += nwritten;
 
 				if (nwritten < size)
 				{

--- a/Utilities/lockless.h
+++ b/Utilities/lockless.h
@@ -270,6 +270,30 @@ public:
 		return {};
 	}
 
+	const T& operator[](usz index) const noexcept
+	{
+		lf_queue_iterator<T> result = begin();
+
+		while (--index != umax)
+		{
+			result++;
+		}
+
+		return *result;
+	}
+
+	T& operator[](usz index) noexcept
+	{
+		lf_queue_iterator<T> result = begin();
+
+		while (--index != umax)
+		{
+			result++;
+		}
+
+		return *result;
+	}
+
 	lf_queue_slice& pop_front()
 	{
 		delete std::exchange(m_head, std::exchange(m_head->m_link, nullptr));
@@ -314,6 +338,23 @@ class lf_queue final
 
 public:
 	constexpr lf_queue() = default;
+
+	lf_queue(lf_queue&& other) noexcept
+	{
+		m_head.release(other.m_head.exchange(0));
+	}
+
+	lf_queue& operator=(lf_queue&& other) noexcept
+	{
+		if (this == std::addressof(other))
+		{
+			return *this;
+		}
+
+		delete load(m_head);
+		m_head.release(other.m_head.exchange(0));
+		return *this;
+	}
 
 	~lf_queue()
 	{

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -1397,7 +1397,7 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 				}
 				else if (type & ppu_itype::trap)
 				{
-					if (op.bo != 31)
+					if (op.opcode != ppu_instructions::TRAP())
 					{
 						add_block(_ptr.addr());
 					}

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3681,7 +3681,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 			}
 
 			// Check ELF filename
-			if ((entry.name == "EBOOT.BIN" || upper.ends_with(".ELF") || upper.ends_with(".SELF")) && Emu.GetBoot() != dir_queue[i] + entry.name)
+			if ((upper.ends_with(".ELF") || upper.ends_with(".SELF")) && Emu.GetBoot() != dir_queue[i] + entry.name)
 			{
 				// Get full path
 				file_queue.emplace_back(dir_queue[i] + entry.name,  0);

--- a/rpcs3/Emu/Cell/SPUAnalyser.h
+++ b/rpcs3/Emu/Cell/SPUAnalyser.h
@@ -14,12 +14,13 @@ struct spu_itype
 	static constexpr struct floating_tag{} floating{}; // Floating-Point Instructions
 	static constexpr struct quadrop_tag{} _quadrop{}; // 4-op Instructions
 	static constexpr struct xfloat_tag{} xfloat{}; // Instructions producing xfloat values
+	static constexpr struct zregmod_tag{} zregmod{}; // Instructions not modifying any GPR
 
 	enum type : unsigned char
 	{
 		UNK = 0,
 
-		HEQ,
+		HEQ, // zregmod_tag first
 		HEQI,
 		HGT,
 		HGTI,
@@ -36,11 +37,21 @@ struct spu_itype
 		NOP,
 		SYNC,
 		DSYNC,
-		MFSPR,
 		MTSPR,
+		WRCH,
+
+		STQD, // memory_tag first
+		STQX,
+		STQA,
+		STQR, // zregmod_tag last
+		LQD,
+		LQX,
+		LQA,
+		LQR, // memory_tag last
+
+		MFSPR,
 		RDCH,
 		RCHCNT,
-		WRCH,
 
 		BR, // branch_tag first
 		BRA,
@@ -58,15 +69,6 @@ struct spu_itype
 		BINZ,
 		BIHZ,
 		BIHNZ, // branch_tag last
-
-		LQD, // memory_tag first
-		LQX,
-		LQA,
-		LQR,
-		STQD,
-		STQX,
-		STQA,
-		STQR, // memory_tag last
 
 		ILH, // constant_tag_first
 		ILHU,
@@ -267,7 +269,7 @@ struct spu_itype
 	// Test for memory instruction
 	friend constexpr bool operator &(type value, memory_tag)
 	{
-		return value >= LQD && value <= STQR;
+		return value >= STQD && value <= LQR;
 	}
 
 	// Test for compare instruction
@@ -292,6 +294,12 @@ struct spu_itype
 	friend constexpr bool operator &(type value, constant_tag)
 	{
 		return value >= ILH && value <= FSMBI;
+	}
+
+	// Test for non register-modifying instruction
+	friend constexpr bool operator &(type value, zregmod_tag)
+	{
+		return value >= HEQ && value <= STQR;
 	}
 };
 

--- a/rpcs3/Emu/Cell/SPUDisAsm.h
+++ b/rpcs3/Emu/Cell/SPUDisAsm.h
@@ -851,6 +851,13 @@ public:
 	}
 	void BR(spu_opcode_t op)
 	{
+		if (op.rt && op.rt != 127u)
+		{
+			// Valid but makes no sense
+			DisAsm("br??", DisAsmBranchTarget(op.i16));
+			return;
+		}
+
 		DisAsm("br", DisAsmBranchTarget(op.i16));
 	}
 	void FSMBI(spu_opcode_t op)

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -588,9 +588,12 @@ std::deque<spu_program> spu_cache::get()
 			break;
 		}
 
-		func.resize(size);
+		if (utils::add_saturate<u32>(addr, utils::mul_saturate<u32>(size, 4)) > SPU_LS_SIZE)
+		{
+			break;
+		}
 
-		if (m_file.read(func.data(), func.size() * 4) != func.size() * 4)
+		if (!m_file.read(func, size))
 		{
 			break;
 		}

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -35,6 +35,17 @@ public:
 	void add(const struct spu_program& func);
 
 	static void initialize(bool build_existing_cache = true);
+
+	struct precompile_data_t
+	{
+		u32 vaddr;
+		std::basic_string<u32> inst_data;
+		std::vector<u32> funcs;
+	};
+
+	bool collect_funcs_to_precompile = true;
+
+	lf_queue<precompile_data_t> precompile_funcs;
 };
 
 struct spu_program

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4034,10 +4034,10 @@ bool spu_thread::is_exec_code(u32 addr, std::span<const u8> ls_ptr, u32 base_add
 		}
 
 		const u32 addr0 = spu_branch_target(addr);
-		const u32 op = read_from_ptr<be_t<u32>>(ls_ptr, addr0 - base_addr);
-		const auto type = s_spu_itype.decode(op);
+		const spu_opcode_t op{read_from_ptr<be_t<u32>>(ls_ptr, addr0 - base_addr)};
+		const auto type = s_spu_itype.decode(op.opcode);
 
-		if (type == spu_itype::UNK || !op)
+		if (type == spu_itype::UNK || !op.opcode)
 		{
 			return false;
 		}
@@ -4054,11 +4054,30 @@ bool spu_thread::is_exec_code(u32 addr, std::span<const u8> ls_ptr, u32 base_add
 				return false;
 			}
 
-			const auto results = op_branch_targets(addr, spu_opcode_t{op});
+			auto results = op_branch_targets(addr, op);
 
 			if (results[0] == umax)
 			{
-				break;
+				switch (type)
+				{
+				case spu_itype::BIZ:
+				case spu_itype::BINZ:
+				case spu_itype::BIHZ:
+				case spu_itype::BIHNZ:
+				{
+					results[0] = addr + 4;
+					break;
+				}
+				default:
+				{
+					break;
+				}
+				}
+
+				if (results[0] == umax)
+				{
+					break;
+				}
 			}
 
 			for (usz res_i = 1; res_i < results.size(); res_i++)

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4042,8 +4042,18 @@ bool spu_thread::is_exec_code(u32 addr, std::span<const u8> ls_ptr, u32 base_add
 			return false;
 		}
 
+		if (type == spu_itype::STOP && op.rb)
+		{
+			return false;
+		}
+
 		if (type & spu_itype::branch)
 		{
+			if (type == spu_itype::BR && op.rt && op.rt != 127u)
+			{
+				return false;
+			}
+
 			const auto results = op_branch_targets(addr, spu_opcode_t{op});
 
 			if (results[0] == umax)

--- a/rpcs3/Emu/RSX/RSXDisAsm.cpp
+++ b/rpcs3/Emu/RSX/RSXDisAsm.cpp
@@ -43,6 +43,11 @@ u32 RSXDisAsm::disasm(u32 pc)
 
 	if (m_op & RSX_METHOD_NON_METHOD_CMD_MASK)
 	{
+		if (m_mode == cpu_disasm_mode::survey_cmd_size)
+		{
+			return 4;
+		}
+
 		if ((m_op & RSX_METHOD_OLD_JUMP_CMD_MASK) == RSX_METHOD_OLD_JUMP_CMD)
 		{
 			u32 jumpAddr = m_op & RSX_METHOD_OLD_JUMP_OFFSET_MASK;
@@ -86,10 +91,13 @@ u32 RSXDisAsm::disasm(u32 pc)
 			}
 		}
 
-		if (i == 1)
-			Write("nop", 0);
-		else
-			Write(fmt::format("nop x%u", i), 0);
+		if (m_mode != cpu_disasm_mode::survey_cmd_size)
+		{
+			if (i == 1)
+				Write("nop", 0);
+			else
+				Write(fmt::format("nop x%u", i), 0);
+		}
 
 		return i * 4;
 	}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -219,7 +219,7 @@ namespace rsx
 		void flush_fifo();
 
 		// Returns [count of found commands, PC of their start]
-		std::pair<u32, u32> try_get_pc_of_x_cmds_backwards(u32 count, u32 get) const;
+		std::pair<u32, u32> try_get_pc_of_x_cmds_backwards(s32 count, u32 get) const;
 
 		void recover_fifo(u32 line = __builtin_LINE(),
 			u32 col = __builtin_COLUMN(),

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -328,8 +328,8 @@ void debugger_list::keyPressEvent(QKeyEvent* event)
 	{
 	case Qt::Key_PageUp:   scroll(0 - m_item_count); return;
 	case Qt::Key_PageDown: scroll(m_item_count); return;
-	case Qt::Key_Up:       scroll(1); return;
-	case Qt::Key_Down:     scroll(-1); return;
+	case Qt::Key_Up:       scroll(-1); return;
+	case Qt::Key_Down:     scroll(1); return;
 	case Qt::Key_I:
 	{
 		if (event->isAutoRepeat())

--- a/rpcs3/util/simd.hpp
+++ b/rpcs3/util/simd.hpp
@@ -2988,6 +2988,24 @@ inline v128 gv_rol32(const v128& a, const v128& b)
 #endif
 }
 
+// For each 32-bit element, r = rotate a by count
+inline v128 gv_rol32(const v128& a, u32 count)
+{
+	count %= 32;
+#if defined(ARCH_X64)
+	return _mm_or_epi32(_mm_srli_epi32(a, 32 - count), _mm_slli_epi32(a, count));
+#elif defined(ARCH_ARM64)
+	const auto amt1 = vdupq_n_s32(count);
+	const auto amt2 = vdupq_n_s32(count - 32);
+	return vorrq_u32(vshlq_u32(a, amt1), vshlq_u32(a, amt2));
+#else
+	v128 r;
+	for (u32 i = 0; i < 4; i++)
+		r._u32[i] = utils::rol32(a._u32[i], count);
+	return r;
+#endif
+}
+
 // For each 8-bit element, r = (a << (c & 7)) | (b >> (~c & 7) >> 1)
 template <typename A, typename B, typename C>
 inline auto gv_fshl8(A&& a, B&& b, C&& c)


### PR DESCRIPTION
* A fix for SPU fdunction discovery, do not count non-r0 link branches and branch-to-self or branch-to-next. A bit sad but this cuts found functions in TLoU from around 22xx to exacly 1800.
* Fix GOTO in the debugger in some conditions.
* Fix instriuction scrolling direction with the arrow keys in the debugger.
* Add CRC check to prevent use of invalid cache entries. (not perfect of-course)
* Add minimal discovery of tail-calls for precompilation.
* Revert a PPU Analyzer change, may address #14600.