### PR TITLE
SPU LLVM: Optimize spu_idisable

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -2607,6 +2607,12 @@ void spu_recompiler::BI(spu_opcode_t op)
 	{
 		spu_log.error("[0x%x] BI: no targets", m_pos);
 	}
+	else if (op.d && found->second.size() == 1 && found->second[0] == spu_branch_target(m_pos, 1))
+	{
+		// Interrupts-disable pattern
+		c->mov(SPU_OFF_8(interrupts_enabled), 0);
+		return;
+	}
 
 	c->mov(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, 3));
 	c->and_(*addr, 0x3fffc);


### PR DESCRIPTION
Do not break blocks on interrupt-disabling branch-to-next. Maybe improves performance in TLoU and some other Sony's exclusives.

Example:
![image](https://github.com/RPCS3/rpcs3/assets/18193363/e2e05a4d-0570-4d1a-b848-db7982fdab84)
