### PR TITLE
Actually fix build id issue

### DIFF
--- a/Utilities/git-version-gen.cmd
+++ b/Utilities/git-version-gen.cmd
@@ -91,7 +91,7 @@ for /F %%I IN ('call %GIT% rev-list HEAD --count') do set COMMIT_COUNT=%%I
 
 rem // Check if the current build system sets the git branch and version.
 rem // The name is misleading. This is also used for master builds.
-if defined SYSTEM_PULLREQUEST_SOURCEBRANCH (
+if defined BUILD_SOURCEBRANCHNAME (
 
 	rem // This must be a CI build
 
@@ -125,6 +125,7 @@ if defined SYSTEM_PULLREQUEST_SOURCEBRANCH (
 		for /F %%I IN ('call %GIT% rev-parse --short^=8 HEAD') do set GIT_VERSION=%COMMIT_COUNT%-%%I
 		for /F %%I IN ('call %GIT% rev-parse --abbrev-ref HEAD') do set GIT_BRANCH=%%I
 
+		set GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%
 	) else (
 		rem // This must be a pull request or a build from a fork.
 		echo Assuming pull request build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,6 @@ pr:
   branches:
     include:
       - master
-variables:
-  BUILD_REPOSITORY_NAME: $(Build.Repository.Name)
-  SYSTEM_PULLREQUEST_SOURCEBRANCH: $(System.PullRequest.SourceBranch)
-  SYSTEM_PULLREQUEST_PULLREQUESTID: $(System.PullRequest.PullRequestId)
-  BUILD_SOURCEVERSION: $(Build.SourceVersion)
-  BUILD_SOURCEBRANCHNAME: $(Build.SourceBranchName)
 jobs:
 - job: Linux_Build
   strategy:


### PR DESCRIPTION
Seems like Azure changed how it's SYSTEM_PULLREQUEST_SOURCEBRANCH works, and now is undefined if it's not a PR build.