### PR TITLE
[HOTFIX] Do not wait for progress dialog cleanup for SPU Precompilation

### DIFF
--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -559,7 +559,7 @@ private:
 	}
 };
 
-fs::file decrypt_self(fs::file elf_or_self, u8* klic_key = nullptr, SelfAdditionalInfo* additional_info = nullptr);
+fs::file decrypt_self(fs::file elf_or_self, u8* klic_key = nullptr, SelfAdditionalInfo* additional_info = nullptr, bool require_encrypted = false);
 bool verify_npdrm_self_headers(const fs::file& self, u8* klic_key = nullptr, NPD_HEADER* npd_out = nullptr);
 bool get_npdrm_self_header(const fs::file& self, NPD_HEADER& npd);
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3890,7 +3890,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 			}
 
 			// Some files may fail to decrypt due to the lack of klic
-			src = decrypt_self(std::move(src));
+			src = decrypt_self(std::move(src), nullptr, nullptr, true);
 
 			if (!src)
 			{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3749,7 +3749,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 		// Set low priority
 		thread_ctrl::scoped_priority low_prio(-1);
 
-		for (usz func_i = fnext++; func_i < file_queue.size(); func_i = fnext++, g_progr_fdone++)
+		for (usz func_i = fnext++, inc_fdone = 1; func_i < file_queue.size(); func_i = fnext++, g_progr_fdone += std::exchange(inc_fdone, 1))
 		{
 			if (Emu.IsStopped())
 			{
@@ -3843,7 +3843,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 
 			ppu_log.notice("Failed to precompile '%s' (prx: %s, ovl: %s): Attempting tratment as executable file", path, prx_err, ovl_err);
 			possible_exec_file_paths.push(path);
-			continue;
+			inc_fdone = 0;
 		}
 	});
 
@@ -3869,8 +3869,6 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 
 		for (; slice; slice.pop_front(), g_progr_fdone++)
 		{
-			g_progr_ftotal++;
-
 			if (Emu.IsStopped())
 			{
 				continue;
@@ -3947,7 +3945,6 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 			}
 
 			ppu_log.notice("Failed to precompile '%s' as executable (%s)", path, exec_err);
-			continue;
 		}
 
 		g_fxo->get<main_ppu_module>() = std::move(main_module);

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -2270,7 +2270,7 @@ std::vector<u32> spu_thread::discover_functions(u32 base_addr, std::span<const u
 		// Search for AI R1, +x or OR R3/4, Rx, 0
 		// Reasoning: AI R1, +x means stack pointer restoration, branch after that is likely a tail call
 		// R3 and R4 are common function arguments because they are the first two
-		for (u32 back = addr - 4, it = 5; it && back >= base_addr; back -= 4)
+		for (u32 back = addr - 4, it = 10; it && back >= base_addr && back < std::min<u32>(base_addr + ls.size(), 0x3FFF0); it--, back -= 4)
 		{
 			const spu_opcode_t test_op{read_from_ptr<be_t<u32>>(ls, back - base_addr)};
 			const auto type = g_spu_itype.decode(test_op.opcode);

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -764,8 +764,9 @@ void spu_cache::initialize(bool build_existing_cache)
 		// Initialize progress dialog (wait for previous progress done)
 		while (u32 v = g_progr_ptotal)
 		{
-			if (Emu.IsStopped())
+			if (Emu.IsStopped() || !build_existing_cache)
 			{
+				// Workaround: disable progress dialog updates in the case of sole SPU precompilation
 				break;
 			}
 
@@ -776,7 +777,7 @@ void spu_cache::initialize(bool build_existing_cache)
 
 		if (add_count)
 		{
-			g_progr_ptotal += add_count;
+			g_progr_ptotal += build_existing_cache ? add_count : 0;
 			progr.emplace("Building SPU cache...");
 		}
 
@@ -812,7 +813,7 @@ void spu_cache::initialize(bool build_existing_cache)
 		std::vector<be_t<u32>> ls(0x10000);
 
 		// Build functions
-		for (usz func_i = fnext++; func_i < func_list.size(); func_i = fnext++, g_progr_pdone++)
+		for (usz func_i = fnext++; func_i < func_list.size(); func_i = fnext++, g_progr_pdone += build_existing_cache ? 1 : 0)
 		{
 			const spu_program& func = std::as_const(func_list)[func_i];
 
@@ -875,7 +876,7 @@ void spu_cache::initialize(bool build_existing_cache)
 
 		u32 last_sec_idx = umax;
 
-		for (usz func_i = data_indexer++;; func_i = data_indexer++, g_progr_pdone++)
+		for (usz func_i = data_indexer++;; func_i = data_indexer++, g_progr_pdone += build_existing_cache ? 1 : 0)
 		{
 			u32 passed_count = 0;
 			u32 func_addr = 0;

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -36,7 +36,7 @@ static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vp
 
 	u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 
-	ppu_exec_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic));
+	ppu_exec_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic), nullptr, true);
 
 	if (obj != elf_error::ok)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -263,11 +263,11 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 
-	ppu_prx_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic));
+	ppu_prx_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic), nullptr, true);
 
 	if (obj != elf_error::ok)
 	{
-		return CELL_PRX_ERROR_ILLEGAL_LIBRARY;
+		return CELL_PRX_ERROR_UNSUPPORTED_PRX_TYPE;
 	}
 
 	const auto prx = ppu_load_prx(obj, false, path, file_offset);


### PR DESCRIPTION
spu_cache::initialize can now be called inside PPU precompilation which creates a deadlock. Avoid the use of progress dialog updates forr SPU Precompilation inside PPU precompilation for now (TODO).