### PR TITLE
SPU/PPU LLVM: Fixups and minor optimizations

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1745,6 +1745,28 @@ static LONG exception_handler(PEXCEPTION_POINTERS pExp) noexcept
 		}
 	}
 
+	switch (pExp->ExceptionRecord->ExceptionCode)
+	{
+	case EXCEPTION_ACCESS_VIOLATION:
+	case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+	case EXCEPTION_DATATYPE_MISALIGNMENT:
+	case EXCEPTION_ILLEGAL_INSTRUCTION:
+	case EXCEPTION_IN_PAGE_ERROR:
+	case EXCEPTION_INT_DIVIDE_BY_ZERO:
+	case EXCEPTION_NONCONTINUABLE_EXCEPTION:
+	case EXCEPTION_PRIV_INSTRUCTION:
+	//case EXCEPTION_STACK_OVERFLOW:
+	{
+		sys_log.notice("\n%s", dump_useful_thread_info());
+		logs::listener::sync_all();
+		break;
+	}
+	default:
+	{
+		break;
+	}
+	}
+
 	return EXCEPTION_CONTINUE_SEARCH;
 }
 
@@ -1826,6 +1848,9 @@ static LONG exception_filter(PEXCEPTION_POINTERS pExp) noexcept
 	fmt::append(msg, "RPCS3 image base: %p.\n", GetModuleHandle(NULL));
 
 	// TODO: print registers and the callstack
+
+	sys_log.fatal("\n%s", msg);
+	logs::listener::sync_all();
 
 	thread_ctrl::emergency_exit(msg);
 }
@@ -1912,12 +1937,12 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 
 	append_thread_name(msg);
 
+	sys_log.fatal("\n%s", msg);
+	sys_log.notice("\n%s", dump_useful_thread_info());
+	logs::listener::sync_all();
+
 	if (IsDebuggerPresent())
 	{
-		sys_log.fatal("\n%s", msg);
-
-		sys_log.notice("\n%s", dump_useful_thread_info());
-
 		// Convert to SIGTRAP
 		raise(SIGTRAP);
 		return;
@@ -1932,12 +1957,12 @@ static void sigill_handler(int /*sig*/, siginfo_t* info, void* /*uct*/) noexcept
 
 	append_thread_name(msg);
 
+	sys_log.fatal("\n%s", msg);
+	sys_log.notice("\n%s", dump_useful_thread_info());
+	logs::listener::sync_all();
+
 	if (IsDebuggerPresent())
 	{
-		sys_log.fatal("\n%s", msg);
-
-		sys_log.notice("\n%s", dump_useful_thread_info());
-
 		// Convert to SIGTRAP
 		raise(SIGTRAP);
 		return;

--- a/rpcs3/Emu/Cell/SPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/SPUDisAsm.cpp
@@ -104,8 +104,7 @@ std::pair<bool, v128> SPUDisAsm::try_get_const_value(u32 reg, u32 pc, u32 TTL) c
 
 		//const auto flag = g_spu_iflag.decode(opcode);
 
-		// TODO: It detects spurious register modifications
-		if (u32 dst = type & spu_itype::_quadrop ? +op0.rt4 : +op0.rt; dst == reg)
+		if (u32 dst = type & spu_itype::_quadrop ? +op0.rt4 : +op0.rt; dst == reg && !(type & spu_itype::zregmod))
 		{
 			// Note: It's not 100% reliable because it won't detect branch targets within [i, dump_pc] range (e.g. if-else statement for command's value)
 			switch (type)
@@ -182,15 +181,6 @@ std::pair<bool, v128> SPUDisAsm::try_get_const_value(u32 reg, u32 pc, u32 TTL) c
 				GET_CONST_REG(reg_val, op0.rt);
 
 				return { true, reg_val | v128::from32p(op0.i16) };
-			}
-			case spu_itype::STQA:
-			case spu_itype::STQD:
-			case spu_itype::STQR:
-			case spu_itype::STQX:
-			case spu_itype::WRCH:
-			{
-				// Do not modify RT
-				break;
 			}
 			case spu_itype::SHLQBYI:
 			{

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -326,7 +326,7 @@ public:
 	static void old_interpreter(spu_thread&, void* ls, u8*);
 
 	// Get the function data at specified address
-	spu_program analyse(const be_t<u32>* ls, u32 entry_point);
+	spu_program analyse(const be_t<u32>* ls, u32 entry_point, std::map<u32, std::basic_string<u32>>* out_target_list = nullptr);
 
 	// Print analyser internal state
 	void dump(const spu_program& result, std::string& out);
@@ -340,11 +340,6 @@ public:
 		}
 
 		return *m_spurt;
-	}
-
-	const auto& get_targets() const
-	{
-		return m_targets;
 	}
 
 	// Create recompiler instance (ASMJIT)


### PR DESCRIPTION
* Fix greedy PPU instruction search, there was a typo there and it was not considering BCLR and BCCTR.
* Add an optimization for PPU LLVM whener there are direct-unconditional branches following one another or ending up in an empty function (BLR).
* Add an optimization regarding PPU traps conditions, detect "always trap" forms and detect possible but theorectical simple "inequality" trap form. (either when both signed greater/lower or unsigned greater/lower are set).
* Improve SPU LLVM precompilation a bit.
* PPU LLVM: Patch unregistered BLRs.

May fix #14555
May fix #14600
May fix #14613 