### PR TITLE
Progress dialog: Fix remaining time

### DIFF
--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -160,8 +160,8 @@ void progress_dialog_server::operator()()
 
 		u32 ftotal = 0;
 		u32 fdone = 0;
-		u32 fknown_bits = 0;
-		u32 ftotal_bits = 0;
+		u64 fknown_bits = 0;
+		u64 ftotal_bits = 0;
 		u32 ptotal = 0;
 		u32 pdone = 0;
 		const char* text1 = nullptr;
@@ -236,9 +236,10 @@ void progress_dialog_server::operator()()
 						const u64 passed = (get_system_time() - start_time);
 						const u64 seconds_passed = passed / 1'000'000;
 						const u64 seconds_total = (passed / 1'000'000 * 100 / value);
-						const u64 seconds = seconds_total % 60;
-						const u64 minutes = (seconds_total / 60) % 60;
-						const u64 hours = (seconds_total / 3600);
+						const u64 seconds_remaining = seconds_total - seconds_passed;
+						const u64 seconds = seconds_remaining % 60;
+						const u64 minutes = (seconds_remaining / 60) % 60;
+						const u64 hours = (seconds_remaining / 3600);
 
 						if (seconds_passed < 4)
 						{
@@ -251,6 +252,10 @@ void progress_dialog_server::operator()()
 						else if (minutes >= 2)
 						{
 							fmt::append(progr, " (%um remaining)", minutes);
+						}
+						else if (minutes == 0)
+						{
+							fmt::append(progr, " (%02us remaining)", seconds);
 						}
 						else
 						{

--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -315,6 +315,14 @@ namespace utils
 		return r;
 	}
 
+#ifdef _MSC_VER
+	inline u128 operator/(u128 lhs, u64 rhs)
+	{
+		u64 rem = 0;
+		return _udiv128(lhs.hi, lhs.lo, rhs, &rem);
+	}
+#endif
+
 	constexpr u32 ctz128(u128 arg)
 	{
 #ifdef _MSC_VER
@@ -403,7 +411,7 @@ namespace utils
 
 		if constexpr (sizeof(T) <= sizeof(u128) / 2)
 		{
-			return static_cast<T>(value * u128{numerator} / u128{denominator});
+			return static_cast<T>(value * u128{numerator} / u64{denominator});
 		}
 
 		return static_cast<T>(value / denominator * numerator + (value % denominator) * numerator / denominator);


### PR DESCRIPTION
It was showing the total time.
Also removes the 00m if the time is less than 60 seconds.

(Ignore the first commit, it's a rebase)