### PR TITLE
cellMic: Improve cellMicGetDeviceAttr for channel volume

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -861,19 +861,18 @@ error_code cellMicGetDeviceAttr(s32 dev_num, CellMicDeviceAttr deviceAttributes,
 	{
 		switch (deviceAttributes)
 		{
+		case CELLMIC_DEVATTR_CHANVOL:
+			if (*arg1 > 2 || !arg2)
+				return CELL_MICIN_ERROR_PARAM;
+			*arg2 = ::at32(device.attr_chanvol, *arg1);
+			 break;
 		case CELLMIC_DEVATTR_LED: *arg1 = device.attr_led; break;
 		case CELLMIC_DEVATTR_GAIN: *arg1 = device.attr_gain; break;
 		case CELLMIC_DEVATTR_VOLUME: *arg1 = device.attr_volume; break;
 		case CELLMIC_DEVATTR_AGC: *arg1 = device.attr_agc; break;
-		case CELLMIC_DEVATTR_CHANVOL: *arg1 = device.attr_volume; break;
 		case CELLMIC_DEVATTR_DSPTYPE: *arg1 = device.attr_dsptype; break;
 		default: return CELL_MICIN_ERROR_PARAM;
 		}
-	}
-
-	if (arg2)
-	{
-		// TODO
 	}
 
 	return CELL_OK;

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -307,10 +307,10 @@ public:
 	u32 read_dsp(u8* buf, u32 size) { return rbuf_dsp.read_bytes(buf, size); }
 
 	// Microphone attributes
-	u32 attr_gain       = 3;
-	u32 attr_volume     = 145;
-	u32 attr_agc        = 0;
-	std::array<u32, 2> attr_chanvol = {145, 145};
+	u32 attr_gain       = 3;                      // 0 to 5.   Default is 3.
+	u32 attr_volume     = 145;                    // 0 to 241. Default is 145.
+	u32 attr_agc        = 0;                      // 0 to 241. Default is 0.
+	std::array<u32, 2> attr_chanvol = {100, 100}; // 0 to 100. Default is ?.
 	u32 attr_led        = 0;
 	u32 attr_dsptype    = 0;
 


### PR DESCRIPTION
- Changes the default channel volume from 145 to 100, since apparently that's the max.
- Returns the proper channel volume the same way it's set in cellMicSetDeviceAttr.
We always wrote the wrong volume to the index argument, leaving the value argument untouched.

Maybe helps with #14639