### PR TITLE
Welcome Dialog: Add ability to set Dark Theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,10 @@ rpcs3/rpcs3_autogen/*
 CMakeLists.txt.user
 *.autosave
 
+# Sublime Text
+*.sublime-project
+*.sublime-workspace
+
 # CLion
 /.idea/*
 /cmake-build-*/

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -1833,7 +1833,7 @@ bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::b
 
 					if (type == ppu_itype::B || type == ppu_itype::BC)
 					{
-						if (type == ppu_itype::BC && (op.bo & 0x14) == 0x14 && op.bo & 0xd)
+						if (type == ppu_itype::BC && (op.bo & 0x14) == 0x14 && op.bo & 0xB)
 						{
 							// Invalid form
 							is_good = false;

--- a/rpcs3/Emu/Cell/PPUDisAsm.cpp
+++ b/rpcs3/Emu/Cell/PPUDisAsm.cpp
@@ -1342,7 +1342,7 @@ void PPUDisAsm::BC(ppu_opcode_t op)
 
 	if (!inst)
 	{
-		fmt::append(last_opcode, "bc 0x%x, 0x%x, 0x%x, %d, %d", bo, bi, bd, aa, lk);
+		fmt::append(last_opcode, "%-*s 0x%x, 0x%x, 0x%x, %d, %d", PadOp(), "bc", bo, bi, bd, aa, lk);
 		return;
 	}
 

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -135,10 +135,19 @@ bool gui_application::Init()
 	// Create connects to propagate events throughout Gui.
 	InitializeConnects();
 
+	bool set_dark_theme = false;
+
 	if (m_gui_settings->GetValue(gui::ib_show_welcome).toBool())
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, false);
 		welcome->exec();
+
+		if (welcome->does_user_want_dark_theme())
+		{
+			m_gui_settings->SetValue(gui::m_currentStylesheet, "Darker Style by TheMitoSan");
+		}
+
+		m_gui_settings->sync();
 	}
 
 	// Check maxfiles

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -48,6 +48,7 @@
 #include <QFontDatabase>
 #include <QBuffer>
 #include <QTemporaryFile>
+#include <QDesktopServices>
 
 #include "rpcs3_version.h"
 #include "Emu/IdManager.h"
@@ -2923,6 +2924,11 @@ void main_window::CreateConnects()
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);
 		welcome->open();
+	});
+
+	connect(ui->supportAct, &QAction::triggered, this, [this]
+	{
+		QDesktopServices::openUrl(QUrl("https://www.patreon.com/Nekotekina"));
 	});
 
 	connect(ui->aboutAct, &QAction::triggered, this, [this]

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -371,6 +371,8 @@
     <addaction name="separator"/>
     <addaction name="languageMenu"/>
     <addaction name="separator"/>
+    <addaction name="supportAct"/>
+    <addaction name="separator"/>
     <addaction name="aboutAct"/>
     <addaction name="aboutQtAct"/>
    </widget>
@@ -707,6 +709,14 @@
    </property>
    <property name="text">
     <string>Show Log/TTY</string>
+   </property>
+  </action>
+  <action name="supportAct">
+   <property name="text">
+    <string>Support Us</string>
+   </property>
+   <property name="toolTip">
+    <string>To ensure continued improvements of RPCS3, become a part of our Patreon group!</string>
    </property>
   </action>
   <action name="aboutAct">

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -10,6 +10,13 @@
 #include <QPushButton>
 #include <QCheckBox>
 #include <QSvgWidget>
+#include <QStyleHints>
+#include <QGuiApplication>
+
+static bool recommend_dark_theme()
+{
+	return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+}
 
 welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool is_manual_show, QWidget* parent)
 	: QDialog(parent)
@@ -26,6 +33,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->i_have_read->setEnabled(!is_manual_show);
 	ui->do_not_show->setEnabled(!is_manual_show);
 	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
+	ui->use_dark_theme->setChecked(recommend_dark_theme());
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));
 	ui->label_3->setText(tr(
 		R"(
@@ -85,6 +93,8 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 		{
 			gui::utils::create_shortcut("RPCS3", "", "RPCS3", ":/rpcs3.svg", fs::get_temp_dir(), gui::utils::shortcut_location::applications);
 		}
+
+		m_user_wants_dark_theme = ui->use_dark_theme->isChecked();
 	});
 }
 

--- a/rpcs3/rpcs3qt/welcome_dialog.h
+++ b/rpcs3/rpcs3qt/welcome_dialog.h
@@ -17,7 +17,12 @@ public:
 	explicit welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool is_manual_show, QWidget* parent = nullptr);
 	~welcome_dialog();
 
+	bool does_user_want_dark_theme() const
+	{
+		return m_user_wants_dark_theme;
+	}
 private:
 	std::unique_ptr<Ui::welcome_dialog> ui;
 	std::shared_ptr<gui_settings> m_gui_settings;
+	bool m_user_wants_dark_theme = false;
 };

--- a/rpcs3/rpcs3qt/welcome_dialog.ui
+++ b/rpcs3/rpcs3qt/welcome_dialog.ui
@@ -199,6 +199,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="use_dark_theme">
+       <property name="text">
+        <string>Use Dark Theme (Can Be Configured Later)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Add the ability to set dark theme in the welcome dialog, set dark by default if the system-wide theme is already dark.
Probably the most important PR in RPCS3 history.

![image](https://github.com/RPCS3/rpcs3/assets/18193363/e02f62a0-f3a0-4dea-bf87-64b6aabe3474)
