### PR TITLE
Patches: Add savable breakpoints patch type

### DIFF
--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -52,6 +52,7 @@ enum class patch_type
 	bd64, // be64 with data hint (non-code)
 	bef32,
 	bef64,
+	bp_exec, // Execution Breakpoint 
 	utf8, // Text of string (not null-terminated automatically)
 	c_utf8, // Text of string (null-terminated automatically)
 	move_file, // Move file

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -91,6 +91,7 @@ struct EmuCallbacks
 	std::string(*resolve_path)(std::string_view) = [](std::string_view arg){ return std::string{arg}; }; // Resolve path using Qt
 	std::function<std::vector<std::string>()> get_font_dirs;
 	std::function<bool(const std::vector<std::string>&)> on_install_pkgs;
+	std::function<void(u32)> add_breakpoint;
 };
 
 namespace utils

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -159,6 +159,7 @@ void headless_application::InitializeCallbacks()
 	callbacks.get_localized_u32string = [](localized_string_id, const char*) -> std::u32string { return {}; };
 
 	callbacks.play_sound = [](const std::string&){};
+	callbacks.add_breakpoint = [](u32 /*addr*/){};
 
 	Emu.SetCallbacks(std::move(callbacks));
 }

--- a/rpcs3/rpcs3qt/breakpoint_list.cpp
+++ b/rpcs3/rpcs3qt/breakpoint_list.cpp
@@ -100,7 +100,7 @@ bool breakpoint_list::AddBreakpoint(u32 pc)
 /**
 * If breakpoint exists, we remove it, else add new one.  Yeah, it'd be nicer from a code logic to have it be set/reset.  But, that logic has to happen somewhere anyhow.
 */
-void breakpoint_list::HandleBreakpointRequest(u32 loc)
+void breakpoint_list::HandleBreakpointRequest(u32 loc, bool only_add)
 {
 	if (!m_cpu || m_cpu->state & cpu_flag::exit)
 	{
@@ -167,7 +167,10 @@ void breakpoint_list::HandleBreakpointRequest(u32 loc)
 
 	if (m_ppu_breakpoint_handler->HasBreakpoint(loc))
 	{
-		RemoveBreakpoint(loc);
+		if (!only_add)
+		{
+			RemoveBreakpoint(loc);
+		}
 	}
 	else
 	{

--- a/rpcs3/rpcs3qt/breakpoint_list.h
+++ b/rpcs3/rpcs3qt/breakpoint_list.h
@@ -24,7 +24,7 @@ public:
 Q_SIGNALS:
 	void RequestShowAddress(u32 addr, bool select_addr = true, bool force = false);
 public Q_SLOTS:
-	void HandleBreakpointRequest(u32 loc);
+	void HandleBreakpointRequest(u32 loc, bool add_only);
 private Q_SLOTS:
 	void OnBreakpointListDoubleClicked();
 	void OnBreakpointListRightClicked(const QPoint &pos);

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1250,6 +1250,11 @@ void debugger_frame::PerformGoToRequest(const QString& text_argument)
 	}
 }
 
+void debugger_frame::PerformAddBreakpointRequest(u32 addr)
+{
+	m_debugger_list->BreakpointRequested(addr, true);
+}
+
 u64 debugger_frame::EvaluateExpression(const QString& expression)
 {
 	bool ok = false;

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1250,6 +1250,29 @@ void debugger_frame::PerformGoToRequest(const QString& text_argument)
 	}
 }
 
+void debugger_frame::PerformGoToThreadRequest(const QString& text_argument)
+{
+	const u64 thread_id = EvaluateExpression(text_argument);
+
+	if (thread_id != umax)
+	{
+		for (int i = 0; i < m_choice_units->count(); i++)
+		{
+			QVariant cpu = m_choice_units->itemData(i);
+
+			if (cpu.canConvert<data_type>())
+			{
+				if (cpu_thread* ptr = cpu.value<data_type>()(); ptr && ptr->id == thread_id)
+				{
+					// Success
+					m_choice_units->setCurrentIndex(i);
+					return;
+				}
+			}
+		}
+	}
+}
+
 void debugger_frame::PerformAddBreakpointRequest(u32 addr)
 {
 	m_debugger_list->BreakpointRequested(addr, true);

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -95,6 +95,7 @@ public:
 	void EnableButtons(bool enable);
 	void ShowGotoAddressDialog();
 	void PerformGoToRequest(const QString& text_argument);
+	void PerformAddBreakpointRequest(u32 addr);
 	u64 EvaluateExpression(const QString& expression);
 	void ClearBreakpoints() const; // Fallthrough method into breakpoint_list.
 	void ClearCallStack();

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -95,6 +95,7 @@ public:
 	void EnableButtons(bool enable);
 	void ShowGotoAddressDialog();
 	void PerformGoToRequest(const QString& text_argument);
+	void PerformGoToThreadRequest(const QString& text_argument);
 	void PerformAddBreakpointRequest(u32 addr);
 	u64 EvaluateExpression(const QString& expression);
 	void ClearBreakpoints() const; // Fallthrough method into breakpoint_list.

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -30,7 +30,7 @@ public:
 	QColor m_text_color_pc;
 
 Q_SIGNALS:
-	void BreakpointRequested(u32 loc);
+	void BreakpointRequested(u32 loc, bool only_add = false);
 public:
 	debugger_list(QWidget* parent, std::shared_ptr<gui_settings> settings, breakpoint_handler* handler);
 	void UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm);

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -638,6 +638,14 @@ void gui_application::InitializeCallbacks()
 		});
 	};
 
+	callbacks.add_breakpoint = [this](u32 addr)
+	{
+		Emu.BlockingCallFromMainThread([this, addr]()
+		{
+			m_main_window->OnAddBreakpoint(addr);
+		});
+	};
+
 	Emu.SetCallbacks(std::move(callbacks));
 }
 

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -252,7 +252,14 @@ void log_frame::CreateAndConnectActions()
 	connect(m_perform_goto_on_debugger, &QAction::triggered, [this]()
 	{
 		QPlainTextEdit* pte = (m_tabWidget->currentIndex() == 1 ? m_tty : m_log);
-		Q_EMIT PerformGoToOnDebugger(pte->textCursor().selectedText());
+		Q_EMIT PerformGoToOnDebugger(pte->textCursor().selectedText(), true);
+	});
+
+	m_perform_goto_thread_on_debugger = new QAction(tr("Show Thread On The Debugger"), this);
+	connect(m_perform_goto_thread_on_debugger, &QAction::triggered, [this]()
+	{
+		QPlainTextEdit* pte = (m_tabWidget->currentIndex() == 1 ? m_tty : m_log);
+		Q_EMIT PerformGoToOnDebugger(pte->textCursor().selectedText(), false);
 	});
 
 	m_stack_act_tty = new QAction(tr("Stack Mode (TTY)"), this);
@@ -351,11 +358,14 @@ void log_frame::CreateAndConnectActions()
 		QMenu* menu = m_log->createStandardContextMenu();
 		menu->addAction(m_clear_act);
 		menu->addAction(m_perform_goto_on_debugger);
+		menu->addAction(m_perform_goto_thread_on_debugger);
 
 		std::shared_ptr<bool> goto_signal_accepted = std::make_shared<bool>(false);
-		Q_EMIT PerformGoToOnDebugger("", true, goto_signal_accepted);
+		Q_EMIT PerformGoToOnDebugger("", true, true, goto_signal_accepted);
 		m_perform_goto_on_debugger->setEnabled(m_log->textCursor().hasSelection() && *goto_signal_accepted);
+		m_perform_goto_thread_on_debugger->setEnabled(m_log->textCursor().hasSelection() && *goto_signal_accepted);
 		m_perform_goto_on_debugger->setToolTip(tr("Jump to the selected hexadecimal address from the log text on the debugger."));
+		m_perform_goto_thread_on_debugger->setToolTip(tr("Show the thread that corresponds to the thread ID from lthe log text on the debugger."));
 
 		menu->addSeparator();
 		menu->addActions(m_log_level_acts->actions());
@@ -373,7 +383,7 @@ void log_frame::CreateAndConnectActions()
 		menu->addAction(m_perform_goto_on_debugger);
 
 		std::shared_ptr<bool> goto_signal_accepted = std::make_shared<bool>(false);
-		Q_EMIT PerformGoToOnDebugger("", true, goto_signal_accepted);
+		Q_EMIT PerformGoToOnDebugger("", false, true, goto_signal_accepted);
 		m_perform_goto_on_debugger->setEnabled(m_tty->textCursor().hasSelection() && *goto_signal_accepted);
 		m_perform_goto_on_debugger->setToolTip(tr("Jump to the selected hexadecimal address from the TTY text on the debugger."));
 

--- a/rpcs3/rpcs3qt/log_frame.h
+++ b/rpcs3/rpcs3qt/log_frame.h
@@ -30,7 +30,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void LogFrameClosed();
-	void PerformGoToOnDebugger(const QString& text_argument, bool test_only = false, std::shared_ptr<bool> signal_accepted = nullptr);
+	void PerformGoToOnDebugger(const QString& text_argument, bool is_address, bool test_only = false, std::shared_ptr<bool> signal_accepted = nullptr);
 protected:
 	/** Override inherited method from Qt to allow signalling when close happened.*/
 	void closeEvent(QCloseEvent* event) override;
@@ -73,6 +73,7 @@ private:
 	QAction* m_clear_act = nullptr;
 	QAction* m_clear_tty_act = nullptr;
 	QAction* m_perform_goto_on_debugger = nullptr;
+	QAction* m_perform_goto_thread_on_debugger = nullptr;
 
 	QActionGroup* m_log_level_acts = nullptr;
 	QAction* m_nothing_act = nullptr;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2007,6 +2007,14 @@ void main_window::EnableMenus(bool enabled) const
 	ui->actionCreate_Savestate->setEnabled(enabled);
 }
 
+void main_window::OnAddBreakpoint(u32 addr) const
+{
+	if (m_debugger_frame)
+	{
+		m_debugger_frame->PerformAddBreakpointRequest(addr);
+	}
+}
+
 void main_window::OnEnableDiscEject(bool enabled) const
 {
 	ui->ejectDiscAct->setEnabled(enabled);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3071,7 +3071,7 @@ void main_window::CreateDockWindows()
 		}
 	});
 
-	connect(m_log_frame, &log_frame::PerformGoToOnDebugger, this, [this](const QString& text_argument, bool test_only, std::shared_ptr<bool> signal_accepted)
+	connect(m_log_frame, &log_frame::PerformGoToOnDebugger, this, [this](const QString& text_argument, bool is_address, bool test_only, std::shared_ptr<bool> signal_accepted)
 	{
 		if (m_debugger_frame && m_debugger_frame->isVisible())
 		{
@@ -3082,7 +3082,14 @@ void main_window::CreateDockWindows()
 
 			if (!test_only)
 			{
-				m_debugger_frame->PerformGoToRequest(text_argument);
+				if (is_address)
+				{
+					m_debugger_frame->PerformGoToRequest(text_argument);
+				}
+				else
+				{
+					m_debugger_frame->PerformGoToThreadRequest(text_argument);
+				}
 			}
 		}
 	});

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -106,6 +106,7 @@ public Q_SLOTS:
 	void OnEmuReady() const;
 	void OnEnableDiscEject(bool enabled) const;
 	void OnEnableDiscInsert(bool enabled) const;
+	void OnAddBreakpoint(u32 addr) const;
 
 	void RepaintGui();
 	void RetranslateUI(const QStringList& language_codes, const QString& language);


### PR DESCRIPTION
* Allow to add savable breakpoints using the patch system with patch type "bpex". Fixes #10059. Although this process need to be done manually.
* Allow to display thread from thread ID text on log.
* Add Got-To from function pointer on log. (PPU addresses starting with asterisk)