### PR TITLE
sys_fs: Optimize concurrent file reads

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1854,8 +1854,9 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			}
 
 			const auto file = std::as_const(all_files).find(file_path);
+			const u64 pos = fileSet->fileOffset;
 
-			if (file == all_files.cend() || file->second.size() <= fileSet->fileOffset)
+			if (file == all_files.cend() || file->second.size() <= pos)
 			{
 				cellSaveData.error("Failed to open file %s%s (size=%d, fileOffset=%d)", dir_path, file_path, file == all_files.cend() ? -1 : file->second.size(), fileSet->fileOffset);
 				savedata_result = CELL_SAVEDATA_ERROR_FAILURE;
@@ -1863,8 +1864,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			}
 
 			// Read from memory file to vm
-			file->second.seek(fileSet->fileOffset);
-			const u64 rr = lv2_file::op_read(file->second, fileSet->fileBuf, fileSet->fileSize);
+			const u64 rr = lv2_file::op_read(file->second, fileSet->fileBuf, fileSet->fileSize, pos);
 			fileGet->excSize = ::narrow<u32>(rr);
 			break;
 		}

--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -568,7 +568,7 @@ error_code sceNpDrmIsAvailable(ppu_thread& ppu, vm::cptr<u8> k_licensee_addr, vm
 	lv2_obj::sleep(ppu);
 
 	const auto ret = npDrmIsAvailable(k_licensee_addr, drm_path);
-	lv2_sleep(100000, &ppu);
+	lv2_sleep(50'000, &ppu);
 
 	return ret;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -157,7 +157,7 @@ struct lv2_fs_mount_point
 	const bs_t<lv2_mp_flag> flags{};
 	lv2_fs_mount_point* const next = nullptr;
 
-	mutable std::recursive_mutex mutex;
+	mutable shared_mutex mutex;
 };
 
 extern lv2_fs_mount_point g_mp_sys_dev_hdd0;
@@ -340,11 +340,11 @@ struct lv2_file final : lv2_fs_object
 	static open_result_t open(std::string_view vpath, s32 flags, s32 mode, const void* arg = {}, u64 size = 0);
 
 	// File reading with intermediate buffer
-	static u64 op_read(const fs::file& file, vm::ptr<void> buf, u64 size);
+	static u64 op_read(const fs::file& file, vm::ptr<void> buf, u64 size, u64 opt_pos = umax);
 
-	u64 op_read(vm::ptr<void> buf, u64 size) const
+	u64 op_read(vm::ptr<void> buf, u64 size, u64 opt_pos = umax) const
 	{
-		return op_read(file, buf, size);
+		return op_read(file, buf, size, opt_pos);
 	}
 
 	// File writing with intermediate buffer


### PR DESCRIPTION
Make use of file::read_at to allow concurrent fixed file reads.