### PR TITLE
Input: Fix "," key in keyboard pad handler

### DIFF
--- a/rpcs3/Emu/Io/pad_config.cpp
+++ b/rpcs3/Emu/Io/pad_config.cpp
@@ -8,7 +8,13 @@ extern std::string g_input_config_override;
 
 std::vector<std::string> cfg_pad::get_buttons(const std::string& str)
 {
-	std::vector<std::string> vec = fmt::split(str, {","});;
+	std::vector<std::string> vec = fmt::split(str, {","});
+
+	// Handle special case: string contains separator itself as configured value
+	if (str == "," || str.find(",,") != umax)
+	{
+		vec.push_back(",");
+	}
 
 	// Remove duplicates
 	std::sort(vec.begin(), vec.end());

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -213,13 +213,13 @@ bool emu_settings::ValidateSettings(bool cleanup)
 			}
 			else
 			{
-				const auto get_full_key = [&keys](const std::string& seperator) -> std::string
+				const auto get_full_key = [&keys](const std::string& separator) -> std::string
 				{
 					std::string full_key;
 					for (usz i = 0; i < keys.size(); i++)
 					{
 						full_key += keys[i];
-						if (i < keys.size() - 1) full_key += seperator;
+						if (i < keys.size() - 1) full_key += separator;
 					}
 					return full_key;
 				};


### PR DESCRIPTION
The "," (or comma) key wasn't working in the keyboard pad handler, since "," is also the separator for multi-assignments.
- Check if the config is solely "," and assign it properly
- Check if the config contains a sequence of multiple "," which most likely means that it was assigned in a multi-assignment.
The alternative would be user error or a Qt bug I guess.