### PR TITLE
Disable RTMidi linking to jack

### DIFF
--- a/3rdparty/rtmidi/CMakeLists.txt
+++ b/3rdparty/rtmidi/CMakeLists.txt
@@ -1,1 +1,2 @@
+option(RTMIDI_API_JACK "Compile with JACK support." OFF)
 add_subdirectory(rtmidi EXCLUDE_FROM_ALL)


### PR DESCRIPTION
RTMidi links to libjack which makes the appimage unusable when jack is not installed.
