### PR TITLE
[Bugfix] USIO: Fixed switch-kind buttons got released when game window lost focus

### DIFF
--- a/rpcs3/Emu/Io/usio.h
+++ b/rpcs3/Emu/Io/usio.h
@@ -19,6 +19,7 @@ private:
 	void translate_input_tekken();
 	void usio_write(u8 channel, u16 reg, std::vector<u8>& data);
 	void usio_read(u8 channel, u16 reg, u16 size);
+	void usio_init(u8 channel, u16 reg, u16 size);
 
 private:
 	bool is_used = false;


### PR DESCRIPTION
Fixed a bug that switch-kind USIO buttons got released when game window lost focus.
Also implemented more USIO commands like ClearSram, so now it's possible to use this feature in game without having to manually edit usiobackup.bin and then manually restart the game.
![SCEEXE000_screenshot_2023_10_20_19_14_03](https://github.com/RPCS3/rpcs3/assets/17809637/da02f75d-6743-4981-bee1-1e1a9eeeb2c0)
