### PR TITLE
Utilities/Thread.cpp: Fix threads memory leak

### DIFF
--- a/rpcs3/Emu/Cell/MFC.h
+++ b/rpcs3/Emu/Cell/MFC.h
@@ -98,9 +98,11 @@ struct alignas(16) spu_mfc_cmd
 	u32 eah;
 };
 
+enum class spu_block_hash : u64;
+
 struct mfc_cmd_dump
 {
 	spu_mfc_cmd cmd;
-
+	u64 block_hash;
 	alignas(16) u8 data[128];
 };

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -617,6 +617,8 @@ enum class spu_debugger_mode : u32
 	max_mode,
 };
 
+enum class spu_block_hash : u64 {};
+
 class spu_thread : public cpu_thread
 {
 public:

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -506,7 +506,7 @@ void debugger_frame::keyPressEvent(QKeyEvent* event)
 					auto& dump = *it;
 
 					const u32 pc = std::exchange(dump.cmd.eah, 0);
-					fmt::append(ret, "\n(%d) PC 0x%05x: [%s]", i, pc, dump.cmd);
+					fmt::append(ret, "\n(%d) PC 0x%05x: [%s] (%s)", i, pc, dump.cmd, spu_block_hash{dump.block_hash});
 
 					if (dump.cmd.cmd == MFC_PUTLLC_CMD)
 					{


### PR DESCRIPTION
Fix memory leak in Thread.cpp due to not exiting threads.

Fixes #14764 