### PR TITLE
Bump MoltenVK to 1.2.6 (Vulkan 1.3.268)

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -12,7 +12,7 @@ arch -x86_64 /usr/local/bin/brew install llvm@16 glew cmake sdl2 vulkan-headers 
 arch -x86_64 /usr/local/bin/brew link -f llvm@16
 
 # moltenvk based on commit for 1.2.5 release
-wget https://raw.githubusercontent.com/Homebrew/homebrew-core/b0bba05b617ef0fd796b3727be46addfd098a491/Formula/m/molten-vk.rb
+wget https://raw.githubusercontent.com/Homebrew/homebrew-core/4ac0cfaca4c2505abe2fcbcc0ce5816572103a6c/Formula/m/molten-vk.rb
 arch -x86_64 /usr/local/bin/brew install -f --overwrite ./molten-vk.rb
 #export MACOSX_DEPLOYMENT_TARGET=12.0
 export CXX=clang++

--- a/3rdparty/MoltenVK/CMakeLists.txt
+++ b/3rdparty/MoltenVK/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(moltenvk
 	GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-	GIT_TAG 02a8c01
+	GIT_TAG 9e4ee9e
 	BUILD_IN_SOURCE 1
 	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK
 	CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK/fetchDependencies" --macos


### PR DESCRIPTION
New [MoltenVK 1.2.6 release](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.2.6) 

New features or changes include:

- Add support for extensions:
    - `VK_KHR_synchronization2`
    - `VK_EXT_extended_dynamic_state` (requires Metal 3.1 for `VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE`)
    - `VK_EXT_extended_dynamic_state2`
- Fix rare case where vertex attribute buffers are not bound to Metal when no other bindings change between pipelines.
- Ensure objects retained for life of `MTLCommandBuffer` during `vkCmdBlitImage()` & `vkQueuePresentKHR()`.
- Fix case where a `CAMetalDrawable` with invalid pixel format causes onscreen flickering.
- Fix deadlock when reporting debug message on `MVKInstance` destruction.
- Fix MSL code used in `vkCmdBlitImage()` on depth-stencil formats.
- Improve behavior of swapchain image presentation stalls caused by Metal regression.
- `VkPhysicalDeviceLimits::timestampPeriod` set to 1.0 on Apple GPUs, and calculated dynamically on non-Apple GPUs.
- Add `MVKConfiguration::timestampPeriodLowPassAlpha` and environment variable `MVK_CONFIG_TIMESTAMP_PERIOD_LOWPASS_ALPHA`, to add a configurable lowpass filter for varying `VkPhysicalDeviceLimits::timestampPeriod` on non-Apple GPUs.
- Add several additional performance trackers, available via logging, or the `mvk_private_api.h` API.
- Deprecate `MVK_DEBUG` env var, and add `MVK_CONFIG_DEBUG` env var to replace it.
- Update `MVK_CONFIGURATION_API_VERSION` and `MVK_PRIVATE_API_VERSION` to 38.
- Update dependency libraries to match Vulkan SDK 1.3.268.
- Update to latest SPIRV-Cross:
    - MSL: Workaround Metal 3.1 regression bug on recursive input structs.
    - MSL: fix extraction of global variables, in case of atomics.
    - MSL: Workaround bizarre crash on macOS.
    - MSL: runtime array over argument buffers.
    - MSL: Make rw texture fences optional.
    - MSL: Prevent RAW hazards on read_write textures.