### PR TITLE
Savestates: Implement initial RAM ventilation system

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -2255,8 +2255,22 @@ fs::file fs::make_gather(std::vector<fs::file> files)
 	return result;
 }
 
-fs::pending_file::pending_file(std::string_view path)
+bool fs::pending_file::open(std::string_view path)
 {
+	file.close();
+
+	if (!m_path.empty())
+	{
+		fs::remove_file(m_path);
+	}
+
+	if (path.empty())
+	{
+		fs::g_tls_error = fs::error::noent;
+		m_dest.clear();
+		return false;
+	}
+
 	do
 	{
 		m_path = fmt::format(u8"%s/＄%s.%s.tmp", get_parent_dir(path), path.substr(path.find_last_of(fs::delim) + 1), fmt::base57(utils::get_unique_tsc()));
@@ -2270,6 +2284,8 @@ fs::pending_file::pending_file(std::string_view path)
 		m_path.clear();
 	}
 	while (fs::g_tls_error == fs::error::exist); // Only retry if failed due to existing file
+
+	return file.operator bool();
 }
 
 fs::pending_file::~pending_file()
@@ -2284,7 +2300,7 @@ fs::pending_file::~pending_file()
 
 bool fs::pending_file::commit(bool overwrite)
 {
-	if (!file || m_path.empty())
+	if (m_path.empty())
 	{
 		fs::g_tls_error = fs::error::noent;
 		return false;
@@ -2292,7 +2308,11 @@ bool fs::pending_file::commit(bool overwrite)
 
 	// The temporary file's contents must be on disk before rename
 #ifndef _WIN32
-	file.sync();
+	if (file)
+	{
+		file.sync();
+	}
+
 #endif
 	file.close();
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -674,11 +674,23 @@ namespace fs
 
 		// This is meant to modify files atomically, overwriting is likely
 		bool commit(bool overwrite = true);
+		bool open(std::string_view path);
 
-		pending_file(std::string_view path);
+		pending_file() noexcept = default;
+
+		pending_file(std::string_view path) noexcept
+		{
+			open(path);
+		}
+
 		pending_file(const pending_file&) = delete;
 		pending_file& operator=(const pending_file&) = delete;
 		~pending_file();
+
+		const std::string& get_temp_path() const
+		{
+			return m_path;
+		}
 
 	private:
 		std::string m_path{}; // Pending file path

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -351,10 +351,10 @@ void MetadataInfo::Show() const
 	std::string iv_pad_str;
 	for (int i = 0; i < 0x10; i++)
 	{
-		key_str += fmt::format("%02x", key[i]);
-		key_pad_str += fmt::format("%02x", key_pad[i]);
-		iv_str += fmt::format("%02x", iv[i]);
-		iv_pad_str += fmt::format("%02x", iv_pad[i]);
+		fmt::append(key_str, "%02x", key[i]);
+		fmt::append(key_pad_str, "%02x", key_pad[i]);
+		fmt::append(iv_str, "%02x", iv[i]);
+		fmt::append(iv_pad_str, "%02x", iv_pad[i]);
 	}
 
 	self_log.notice("Key: %s", key_str.c_str());

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -68,7 +68,7 @@ static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vp
 	return CELL_OK;
 }
 
-fs::file make_file_view(fs::file&&, u64);
+fs::file make_file_view(fs::file&& file, u64 offset, u64 size);
 
 std::shared_ptr<void> lv2_overlay::load(utils::serial& ar)
 {
@@ -82,7 +82,7 @@ std::shared_ptr<void> lv2_overlay::load(utils::serial& ar)
 	if (file)
 	{
 		u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
-		file = make_file_view(std::move(file), offset);
+		file = make_file_view(std::move(file), offset, umax);
 		ovlm = ppu_load_overlay(ppu_exec_object{ decrypt_self(std::move(file), reinterpret_cast<u8*>(&klic)) }, false, path, 0, &ar).first;
 		ensure(ovlm);
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -286,7 +286,7 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 	return not_an_error(idm::last_id());
 }
 
-fs::file make_file_view(fs::file&& _file, u64 offset);
+fs::file make_file_view(fs::file&& file, u64 offset, u64 size);
 
 std::shared_ptr<void> lv2_prx::load(utils::serial& ar)
 {
@@ -319,7 +319,7 @@ std::shared_ptr<void> lv2_prx::load(utils::serial& ar)
 		if (file)
 		{
 			u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
-			file = make_file_view(std::move(file), offset);
+			file = make_file_view(std::move(file), offset, umax);
 			prx = ppu_load_prx(ppu_prx_object{ decrypt_self(std::move(file), reinterpret_cast<u8*>(&klic)) }, false, path, 0, &ar);
 			prx->m_loaded_flags = std::move(loaded_flags);
 			prx->m_external_loaded_flags = std::move(external_flags);

--- a/rpcs3/Emu/NP/np_structs_extra.cpp
+++ b/rpcs3/Emu/NP/np_structs_extra.cpp
@@ -27,14 +27,15 @@ namespace extra_nps
 
 	void print_bin_attr(const SceNpMatching2BinAttr* bin)
 	{
-		sceNp2.warning("Id: %d, Size: %d, ptr: 0x%x", bin->id, bin->size, bin->ptr);
+		const auto ptr = +bin->ptr;
+		const u32 size = bin->size;
 
-		std::string dadata{};
-		for (u32 i = 0; i < bin->size; i++)
+		sceNp2.warning("Id: %d, Size: %d, ptr: 0x%x", bin->id, size, ptr);
+
+		if (ptr && size)
 		{
-			dadata = fmt::format("%s %02X", dadata, bin->ptr[i]);
+			sceNp2.warning("Data: %s", std::basic_string_view<u8>{ptr.get_ptr(), size});
 		}
-		sceNp2.warning("Data: %s", dadata);
 	}
 
 	void print_bin_attr_internal(const SceNpMatching2RoomBinAttrInternal* bin)
@@ -51,12 +52,7 @@ namespace extra_nps
 
 	void print_presence_data(const SceNpMatching2PresenceOptionData* opt)
 	{
-		std::string dadata{};
-		for (int i = 0; i < 16; i++)
-		{
-			dadata = fmt::format("%s %02X", dadata, opt->data[i]);
-		}
-		sceNp2.warning("Data: %s", dadata);
+		sceNp2.warning("Data: %s", std::basic_string_view<u8>{std::data(opt->data), std::size(opt->data)});
 	}
 
 	void print_range(const SceNpMatching2Range* range)

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -537,19 +537,19 @@ namespace rsx
 				}
 				case detail_level::minimal:
 				{
-					perf_text += fmt::format("FPS : %05.2f", m_fps);
+					fmt::append(perf_text, "FPS : %05.2f", m_fps);
 					break;
 				}
 				case detail_level::low:
 				{
-					perf_text += fmt::format("FPS : %05.2f\n"
+					fmt::append(perf_text, "FPS : %05.2f\n"
 					                         "CPU : %04.1f %%",
 					    m_fps, m_cpu_usage);
 					break;
 				}
 				case detail_level::medium:
 				{
-					perf_text += fmt::format("FPS : %05.2f\n\n"
+					fmt::append(perf_text, "FPS : %05.2f\n\n"
 					                         "%s\n"
 					                         " PPU   : %04.1f %%\n"
 					                         " SPU   : %04.1f %%\n"
@@ -560,7 +560,7 @@ namespace rsx
 				}
 				case detail_level::high:
 				{
-					perf_text += fmt::format("FPS : %05.2f (%03.1fms)\n\n"
+					fmt::append(perf_text, "FPS : %05.2f (%03.1fms)\n\n"
 					                         "%s\n"
 					                         " PPU   : %04.1f %% (%2u)\n"
 					                         " SPU   : %04.1f %% (%2u)\n"

--- a/rpcs3/Emu/RSX/Program/CgBinaryFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/Program/CgBinaryFragmentProgram.cpp
@@ -12,13 +12,13 @@ void CgBinaryDisasm::AddCodeAsm(const std::string& code)
 
 	if (dst.dest_reg == 63)
 	{
-		m_dst_reg_name = fmt::format("RC%s, ", GetMask().c_str());
+		m_dst_reg_name = fmt::format("RC%s, ", GetMask());
 		op_name = rsx_fp_op_names[m_opcode] + "XC";
 	}
 
 	else
 	{
-		m_dst_reg_name = fmt::format("%s%d%s, ", dst.fp16 ? "H" : "R", dst.dest_reg, GetMask().c_str());
+		m_dst_reg_name = fmt::format("%s%d%s, ", dst.fp16 ? "H" : "R", dst.dest_reg, GetMask());
 		op_name = rsx_fp_op_names[m_opcode] + std::string(dst.fp16 ? "H" : "R");
 	}
 
@@ -181,7 +181,7 @@ template<typename T> std::string CgBinaryDisasm::GetSrcDisAsm(T src)
 			{
 				const std::string perspective_correction = src2.perspective_corr ? "g" : "f";
 				const std::string input_attr_reg         = reg_table[dst.src_attr_reg_num];
-				ret += fmt::format("%s[%s]", perspective_correction.c_str(), input_attr_reg.c_str());
+				fmt::append(ret, "%s[%s]", perspective_correction, input_attr_reg);
 			}
 			else
 			{

--- a/rpcs3/Emu/RSX/Program/CgBinaryProgram.h
+++ b/rpcs3/Emu/RSX/Program/CgBinaryProgram.h
@@ -193,7 +193,7 @@ public:
 		m_buffer_size = f.size();
 		m_buffer = new u8[m_buffer_size];
 		f.read(m_buffer, m_buffer_size);
-		m_arb_shader += fmt::format("Loading... [%s]\n", path.c_str());
+		fmt::append(m_arb_shader, "Loading... [%s]\n", path.c_str());
 	}
 
 	~CgBinaryDisasm()
@@ -243,7 +243,7 @@ public:
 		offset += 6;
 		while (offset < end_offset)
 		{
-			offsets += fmt::format(" %d,", m_buffer[offset] << 8 | m_buffer[offset + 1]);
+			fmt::append(offsets, " %d,", m_buffer[offset] << 8 | m_buffer[offset + 1]);
 			offset += 4;
 			num++;
 		}
@@ -322,12 +322,12 @@ public:
 		{
 			auto& fprog = GetCgRef<CgBinaryFragmentProgram>(prog.program);
 			m_arb_shader += "\n";
-			m_arb_shader += fmt::format("# binaryFormatRevision 0x%x\n", prog.binaryFormatRevision);
-			m_arb_shader += fmt::format("# profile sce_fp_rsx\n");
-			m_arb_shader += fmt::format("# parameterCount %d\n", prog.parameterCount);
-			m_arb_shader += fmt::format("# instructionCount %d\n", fprog.instructionCount);
-			m_arb_shader += fmt::format("# attributeInputMask 0x%x\n", fprog.attributeInputMask);
-			m_arb_shader += fmt::format("# registerCount %d\n\n", fprog.registerCount);
+			fmt::append(m_arb_shader, "# binaryFormatRevision 0x%x\n", prog.binaryFormatRevision);
+			fmt::append(m_arb_shader, "# profile sce_fp_rsx\n");
+			fmt::append(m_arb_shader, "# parameterCount %d\n", prog.parameterCount);
+			fmt::append(m_arb_shader, "# instructionCount %d\n", fprog.instructionCount);
+			fmt::append(m_arb_shader, "# attributeInputMask 0x%x\n", fprog.attributeInputMask);
+			fmt::append(m_arb_shader, "# registerCount %d\n\n", fprog.registerCount);
 
 			CgBinaryParameterOffset offset = prog.parameterArray;
 			for (u32 i = 0; i < prog.parameterCount; i++)
@@ -340,7 +340,7 @@ public:
 				std::string param_semantic = GetCgParamSemantic(fparam.semantic) + " ";
 				std::string param_const = GetCgParamValue(fparam.embeddedConst, fparam.name);
 
-				m_arb_shader += fmt::format("#%d ", i) + param_type + param_name + param_semantic + param_const + "\n";
+				fmt::append(m_arb_shader, "#%d%s%s%s%s\n", i, param_type, param_name, param_semantic, param_const);
 
 				offset += u32{sizeof(CgBinaryParameter)};
 			}
@@ -375,13 +375,13 @@ public:
 		{
 			const auto& vprog = GetCgRef<CgBinaryVertexProgram>(prog.program);
 			m_arb_shader += "\n";
-			m_arb_shader += fmt::format("# binaryFormatRevision 0x%x\n", prog.binaryFormatRevision);
-			m_arb_shader += fmt::format("# profile sce_vp_rsx\n");
-			m_arb_shader += fmt::format("# parameterCount %d\n", prog.parameterCount);
-			m_arb_shader += fmt::format("# instructionCount %d\n", vprog.instructionCount);
-			m_arb_shader += fmt::format("# registerCount %d\n", vprog.registerCount);
-			m_arb_shader += fmt::format("# attributeInputMask 0x%x\n", vprog.attributeInputMask);
-			m_arb_shader += fmt::format("# attributeOutputMask 0x%x\n\n", vprog.attributeOutputMask);
+			fmt::append(m_arb_shader, "# binaryFormatRevision 0x%x\n", prog.binaryFormatRevision);
+			fmt::append(m_arb_shader, "# profile sce_vp_rsx\n");
+			fmt::append(m_arb_shader, "# parameterCount %d\n", prog.parameterCount);
+			fmt::append(m_arb_shader, "# instructionCount %d\n", vprog.instructionCount);
+			fmt::append(m_arb_shader, "# registerCount %d\n", vprog.registerCount);
+			fmt::append(m_arb_shader, "# attributeInputMask 0x%x\n", vprog.attributeInputMask);
+			fmt::append(m_arb_shader, "# attributeOutputMask 0x%x\n\n", vprog.attributeOutputMask);
 
 			CgBinaryParameterOffset offset = prog.parameterArray;
 			for (u32 i = 0; i < prog.parameterCount; i++)
@@ -394,7 +394,7 @@ public:
 				std::string param_semantic = GetCgParamSemantic(vparam.semantic) + " ";
 				std::string param_const = GetCgParamValue(vparam.embeddedConst, vparam.name);
 
-				m_arb_shader += fmt::format("#%d ", i) + param_type + param_name + param_semantic + param_const + "\n";
+				fmt::append(m_arb_shader, "#%d%s%s%s%s\n", i, param_type, param_name, param_semantic, param_const);
 
 				offset += u32{sizeof(CgBinaryParameter)};
 			}

--- a/rpcs3/Emu/savestate_utils.hpp
+++ b/rpcs3/Emu/savestate_utils.hpp
@@ -1,0 +1,45 @@
+#include "util/serialization.hpp"
+
+namespace fs
+{
+	class file;
+}
+
+// Uncompressed file serialization handler
+struct uncompressed_serialization_file_handler : utils::serialization_file_handler
+{
+	const std::unique_ptr<fs::file> m_file_storage;
+	const std::add_pointer_t<const fs::file> m_file;
+
+	explicit uncompressed_serialization_file_handler(fs::file&& file) noexcept
+		: utils::serialization_file_handler()
+		, m_file_storage(std::make_unique<fs::file>(std::move(file)))
+		, m_file(m_file_storage.get())
+	{
+	}
+
+	explicit uncompressed_serialization_file_handler(const fs::file& file) noexcept
+		: utils::serialization_file_handler()
+		, m_file_storage(nullptr)
+		, m_file(std::addressof(file))
+	{
+	}
+
+	// Handle file read and write requests
+	bool handle_file_op(utils::serial& ar, usz pos, usz size, const void* data) override;
+
+	// Get available memory or file size
+	// Preferably memory size if is already greater/equal to recommended to avoid additional file ops
+	usz get_size(const utils::serial& ar, usz recommended) const override;
+};
+
+inline std::unique_ptr<uncompressed_serialization_file_handler> make_uncompressed_serialization_file_handler(fs::file&& file)
+{
+	return std::make_unique<uncompressed_serialization_file_handler>(std::move(file));
+}
+
+inline std::unique_ptr<uncompressed_serialization_file_handler> make_uncompressed_serialization_file_handler(const fs::file& file)
+{
+	return std::make_unique<uncompressed_serialization_file_handler>(file);
+}
+

--- a/rpcs3/Loader/TAR.h
+++ b/rpcs3/Loader/TAR.h
@@ -22,6 +22,11 @@ namespace fs
 	class file;
 }
 
+namespace utils
+{
+	struct serial;
+}
+
 class tar_object
 {
 	const fs::file& m_file;
@@ -38,13 +43,13 @@ public:
 
 	fs::file get_file(const std::string& path);
 
-	using process_func = std::function<bool(const fs::file&, std::string&, std::vector<u8>&&)>;
+	using process_func = std::function<bool(const fs::file&, std::string&, utils::serial&)>;
 
 	// Extract all files in archive to destination (as VFS if is_vfs is true)
 	// Allow to optionally specify explicit mount point (which may be directory meant for extraction)
 	bool extract(std::string prefix_path = {}, bool is_vfs = false);
 
-	static std::vector<u8> save_directory(const std::string& src_dir, std::vector<u8>&& init = std::vector<u8>{}, const process_func& func = {}, std::string append_path = {});
+	static void save_directory(const std::string& src_dir, utils::serial& ar, const process_func& func = {}, std::string append_path = {});
 };
 
 bool extract_tar(const std::string& file_path, const std::string& dir_path, fs::file file = {});

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -607,6 +607,7 @@
     <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.h" />
     <ClInclude Include="Emu\RSX\RSXDisAsm.h" />
     <ClInclude Include="Emu\RSX\RSXZCULL.h" />
+    <ClInclude Include="Emu\savestate_utils.hpp" />
     <ClInclude Include="Emu\system_progress.hpp" />
     <ClInclude Include="Emu\system_utils.hpp" />
     <ClInclude Include="Emu\title.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2389,6 +2389,9 @@
     <ClInclude Include="Crypto\unzip.h">
       <Filter>Crypto</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\savestate_utils.hpp">
+      <Filter>Emu</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Emu\RSX\Program\GLSLSnippets\GPUDeswizzle.glsl">

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1078,7 +1078,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 		});
 	}
 
-	extern bool is_savestate_compatible(const fs::file& file);
+	extern bool is_savestate_compatible(fs::file&& file);
 
 	if (const std::string sstate = get_savestate_file(current_game.serial, current_game.path, 0, 0); is_savestate_compatible(fs::file(sstate)))
 	{

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -251,6 +251,12 @@ namespace stx
 					*m_order++ = data;
 					*m_info++ = &type;
 					m_init[id] = true;
+
+					if (ar)
+					{
+						extern void serial_breathe(utils::serial& ar);
+						serial_breathe(*ar);
+					}
 				}
 			}
 
@@ -310,7 +316,8 @@ namespace stx
 			}
 		}
 
-		void save(utils::serial& ar)
+		template <typename T> requires (std::is_same_v<T&, utils::serial&>)
+		void save(T& ar)
 		{
 			if (!is_init())
 			{
@@ -332,7 +339,11 @@ namespace stx
 			// Save data in forward order
 			for (u32 i = _max; i; i--)
 			{
-				if (auto save = (*std::prev(m_info, i))->save) save(*std::prev(m_order, i), ar);
+				if (auto save = (*std::prev(m_info, i))->save)
+				{
+					save(*std::prev(m_order, i), ar);
+					ar.breathe();
+				}
 			}
 		}
 


### PR DESCRIPTION
Savestates may weigh anywhere from few hundreds of MB to few GBs if not more. Until now, the entire file contents were kept in RAM. This applies to both reading and writing of savestates.
Implement "breathing" points where the file contents may or may move from RAM to disk when writing savestates, or simply discarding data when reading savestates. This depends on the size of contents accumulated, because frequent disk accesses have negative impacts on performance as well.
This prevents RAM shortages by reducing total memory consumption.
This pull request also affects RSX captures loading and saving in a similar manner.