### PR TITLE
[UI/UX] Fix Firmware tree checkboxes for Darker Style by TheMitoSan file

### DIFF
--- a/bin/GuiConfigs/Darker Style by TheMitoSan.qss
+++ b/bin/GuiConfigs/Darker Style by TheMitoSan.qss
@@ -58,7 +58,7 @@ QTabBar::tab:hover {
 }
 
 /* Checkboxes */
-QCheckBox::indicator {
+QCheckBox::indicator, QListWidget::indicator, QTreeWidget::indicator {
 	border-radius: 0.125em;
 	border-top-right-radius: 0em;
 	border-bottom-left-radius: 0em;
@@ -67,13 +67,13 @@ QCheckBox::indicator {
 	height: 0.8em;
 	margin-top: 0.0625em;
 }
-QCheckBox::indicator:checked {
+QCheckBox::indicator:checked, QListWidget::indicator::checked, QTreeWidget::indicator::checked {
 	background-color: #FFF; /* White */
 }
-QCheckBox::indicator:unchecked {
+QCheckBox::indicator:unchecked, QListWidget::indicator::unchecked, QTreeWidget::indicator::unchecked {
 	background-color: #000; /* Black */
 }
-QCheckBox::indicator::disabled {
+QCheckBox::indicator::disabled, QListWidget::indicator::disabled, QTreeWidget::indicator::disabled {
 	background-color: #af4949; /* Red */
 }
 
@@ -177,18 +177,6 @@ QMenu::item:selected {
 QMenu::item:disabled {
 	background-color: #313131;
 	color: #888888;
-	border-radius: 0.25em;
-}
-
-/* Libraries list */
-QListWidget::item:selected {
-	background-color: #3d3d3d;
-	color: #ecf0f1;
-	border-radius: 0.125em;
-}
-QListWidget::item:hover {
-	background-color: #4c4b4b;
-	color: #ecf0f1;
 	border-radius: 0.25em;
 }
 


### PR DESCRIPTION
Before
![image](https://github.com/RPCS3/rpcs3/assets/60384196/a29c263c-42b3-4330-9389-6d0724c780e5)
After
![image](https://github.com/RPCS3/rpcs3/assets/60384196/38cc2927-cdfe-404e-bafc-6928152ac3a2)

This isn't my custom stylesheet and may get taken over by a different pull request. But keynotes to look for. 
The box being filled in with white is ticked throughout the entire theme until it comes to the firmware tree. 
So I added QListWidget and QTreeWIdget names to the checkboxes section so as not to mess with any of the colors, borders, margins, padding, or anything else. This enables clear communication to the user what is ticked, unticked, enabled, disabled or anything else by simply keeping a uniform interface for the user to interact with and not just changing the rules when it comes to a specific group/location of the interface.
I notice the checkbox size appears a little big in the after vs before among many other modernizations I'd love to change. Yet this isn't my stylesheet. And I do believe this PR will be edited by maintainers or overruled.