### PR TITLE
rsx: Vertex program analyser improvements

### DIFF
--- a/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.cpp
@@ -445,7 +445,7 @@ std::string VertexProgramDecompiler::Decompile()
 	const auto& data = m_prog.data;
 	m_instr_count = data.size() / 4;
 
-	bool is_has_BRA = false;
+	bool has_BRA = false;
 	bool program_end = false;
 	u32 i = 1;
 	u32 last_label_addr = 0;
@@ -527,7 +527,7 @@ std::string VertexProgramDecompiler::Decompile()
 		}
 	};
 
-	if (is_has_BRA || !m_prog.jump_table.empty())
+	if (has_BRA || !m_prog.jump_table.empty())
 	{
 		m_cur_instr = &m_instructions[0];
 
@@ -573,7 +573,7 @@ std::string VertexProgramDecompiler::Decompile()
 		{
 			//TODO: Subroutines can also have arbitrary jumps!
 			u32 jump_position = find_jump_lvl(i);
-			if (is_has_BRA || jump_position != umax)
+			if (has_BRA || jump_position != umax)
 			{
 				m_cur_instr->close_scopes++;
 				AddCode("}");
@@ -782,7 +782,7 @@ std::string VertexProgramDecompiler::Decompile()
 		}
 	}
 
-	if (is_has_BRA || !m_prog.jump_table.empty())
+	if (has_BRA || !m_prog.jump_table.empty())
 	{
 		m_cur_instr = &m_instructions[m_instr_count - 1];
 		m_cur_instr->close_scopes++;


### PR DESCRIPTION
- Fixes a bug when the program entry is at the end of an ubershader block. In this scenario, the entry is the dispatch block and the subroutines sit above it which could cause a crash if there is padding in the structure.
- More aggressive DCE. In case a loop is detected, we don't need to walk the loop again as it will always end the same way. Previously, we walked over the blocks and consumed the tail sections which could add hundreds of instructions of unreachable code at the end of ubershaders.

Closes https://github.com/RPCS3/rpcs3/issues/13443