### PR TITLE
rsx: Maintenance improvements

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -197,7 +197,7 @@ void GLFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	m_shader_props.low_precision_tests = ::gl::get_driver_caps().vendor_NVIDIA && !(m_prog.ctrl & RSX_SHADER_CONTROL_ATTRIBUTE_INTERPOLATION);
 	m_shader_props.disable_early_discard = !::gl::get_driver_caps().vendor_NVIDIA;
 	m_shader_props.supports_native_fp16 = device_props.has_native_half_support;
-	m_shader_props.ROP_output_rounding = ::gl::get_driver_caps().vendor_NVIDIA;
+	m_shader_props.ROP_output_rounding = g_cfg.video.shader_precision != gpu_preset_level::low;
 	m_shader_props.require_tex1D_ops = properties.has_tex1D;
 	m_shader_props.require_tex2D_ops = properties.has_tex2D;
 	m_shader_props.require_tex3D_ops = properties.has_tex3D;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -330,16 +330,16 @@ void GLGSRender::on_init_thread()
 		sampler.bind(image_unit++);
 	}
 
-	for (auto &sampler : m_fs_sampler_mirror_states)
-	{
-		sampler.create();
-		sampler.apply_defaults();
-		sampler.bind(image_unit++);
-	}
-
 	for (auto &sampler : m_vs_sampler_states)
 	{
 		sampler.create();
+		sampler.bind(image_unit++);
+	}
+
+	for (auto& sampler : m_fs_sampler_mirror_states)
+	{
+		sampler.create();
+		sampler.apply_defaults();
 		sampler.bind(image_unit++);
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -249,7 +249,7 @@ void VKFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	m_shader_props.low_precision_tests = device_props.has_low_precision_rounding && !(m_prog.ctrl & RSX_SHADER_CONTROL_ATTRIBUTE_INTERPOLATION);
 	m_shader_props.disable_early_discard = vk::get_driver_vendor() != vk::driver_vendor::NVIDIA;
 	m_shader_props.supports_native_fp16 = device_props.has_native_half_support;
-	m_shader_props.ROP_output_rounding = vk::get_driver_vendor() == vk::driver_vendor::NVIDIA;
+	m_shader_props.ROP_output_rounding = g_cfg.video.shader_precision != gpu_preset_level::low;
 	m_shader_props.require_tex1D_ops = properties.has_tex1D;
 	m_shader_props.require_tex2D_ops = properties.has_tex2D;
 	m_shader_props.require_tex3D_ops = properties.has_tex3D;


### PR DESCRIPTION
### 1. gl: Fix static sampler bindings
VS states come before FS mirrors. The wrong ordering here meant that non-FS samplers were completely fucked in OpenGL since the refactor that made sampler bindings static. Discovered while debugging an unrelated issue. Likely fixes OpenGL bugs in many games depending on the driver used.

### 2. rsx: Always enable ROP output rounding when shader precision is above low
Force-enables the NVIDIA-specific workaround for all vendors. It appears there is too much variability between hardware vendors to count on a specific behavior.

Fixes https://github.com/RPCS3/rpcs3/issues/14788