### PR TITLE
Qt: add trophy count column to trophy manager game list

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -95,6 +95,8 @@ namespace gui
 			return "trophy_game_column_name";
 		case trophy_game_list_columns::progress:
 			return "trophy_game_column_progress";
+		case trophy_game_list_columns::trophies:
+			return "trophy_game_column_trophies";
 		case trophy_game_list_columns::count:
 			return "";
 		}

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -58,6 +58,7 @@ namespace gui
 		icon = 0,
 		name = 1,
 		progress = 2,
+		trophies = 3,
 
 		count
 	};

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2251,7 +2251,7 @@ void main_window::RepaintGui()
 	RepaintToolBarIcons();
 	RepaintThumbnailIcons();
 
-	Q_EMIT RequestTrophyManagerRepaint();
+	Q_EMIT RequestDialogRepaint();
 }
 
 void main_window::RetranslateUI(const QStringList& language_codes, const QString& language)
@@ -2667,14 +2667,14 @@ void main_window::CreateConnects()
 	connect(ui->confSavedataManagerAct, &QAction::triggered, this, [this]
 	{
 		save_manager_dialog* save_manager = new save_manager_dialog(m_gui_settings, m_persistent_settings);
-		connect(this, &main_window::RequestTrophyManagerRepaint, save_manager, &save_manager_dialog::HandleRepaintUiRequest);
+		connect(this, &main_window::RequestDialogRepaint, save_manager, &save_manager_dialog::HandleRepaintUiRequest);
 		save_manager->show();
 	});
 
 	connect(ui->actionManage_Trophy_Data, &QAction::triggered, this, [this]
 	{
 		trophy_manager_dialog* trop_manager = new trophy_manager_dialog(m_gui_settings);
-		connect(this, &main_window::RequestTrophyManagerRepaint, trop_manager, &trophy_manager_dialog::HandleRepaintUiRequest);
+		connect(this, &main_window::RequestDialogRepaint, trop_manager, &trophy_manager_dialog::HandleRepaintUiRequest);
 		trop_manager->show();
 	});
 

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -94,7 +94,7 @@ public:
 Q_SIGNALS:
 	void RequestLanguageChange(const QString& language);
 	void RequestGlobalStylesheetChange();
-	void RequestTrophyManagerRepaint();
+	void RequestDialogRepaint();
 	void NotifyEmuSettingsChange();
 	void NotifyWindowCloseEvent(bool closed);
 

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -113,6 +113,7 @@ trophy_manager_dialog::trophy_manager_dialog(std::shared_ptr<gui_settings> gui_s
 	add_game_column(gui::trophy_game_list_columns::icon,     tr("Icon"),     tr("Show Icons"));
 	add_game_column(gui::trophy_game_list_columns::name,     tr("Game"),     tr("Show Games"));
 	add_game_column(gui::trophy_game_list_columns::progress, tr("Progress"), tr("Show Progress"));
+	add_game_column(gui::trophy_game_list_columns::trophies, tr("Trophies"), tr("Show Trophies"));
 
 	// Trophy Table
 	m_trophy_table = new game_list();
@@ -1004,6 +1005,7 @@ void trophy_manager_dialog::PopulateGameTable()
 		m_game_table->setItem(i, static_cast<int>(gui::trophy_game_list_columns::icon), icon_item);
 		m_game_table->setItem(i, static_cast<int>(gui::trophy_game_list_columns::name), new custom_table_widget_item(name));
 		m_game_table->setItem(i, static_cast<int>(gui::trophy_game_list_columns::progress), new custom_table_widget_item(progress, Qt::UserRole, percentage));
+		m_game_table->setItem(i, static_cast<int>(gui::trophy_game_list_columns::trophies), new custom_table_widget_item(QString::number(all_trophies), Qt::UserRole, all_trophies));
 
 		m_game_combo->addItem(name, i);
 	}


### PR DESCRIPTION
- Adds a trophy count column to trophy manager game list which allows you to sort the games by trophy count

![image](https://github.com/RPCS3/rpcs3/assets/23019877/e93487f1-caae-4f3a-a695-e556010b6a60)
