### PR TITLE
fix Clang warnings

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -31,6 +31,8 @@ std::string wchar_to_utf8(std::wstring_view src)
 #endif
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 std::string utf16_to_utf8(std::u16string_view src)
 {
 	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter{};
@@ -42,6 +44,7 @@ std::u16string utf8_to_utf16(std::string_view src)
 	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter{};
 	return converter.from_bytes(src.data());
 }
+#pragma GCC diagnostic pop
 
 std::wstring utf8_to_wchar(std::string_view src)
 {

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -120,7 +120,7 @@ std::vector<version_entry> get_savestate_versioning_data(fs::file&& file, std::s
 	ar.breathe(true);
 
 	std::vector<version_entry> ver_data = ar.pop<std::vector<version_entry>>();
-	return std::move(ver_data);
+	return ver_data;
 }
 
 bool is_savestate_version_compatible(const std::vector<version_entry>& data, bool is_boot_check)
@@ -183,10 +183,10 @@ std::string get_savestate_file(std::string_view title_id, std::string_view boot_
 
 	if (std::string path_compressed = path + ".gz"; fs::is_file(path_compressed))
 	{
-		return std::move(path_compressed);
+		return path_compressed;
 	}
 
-	return std::move(path);
+	return path;
 }
 
 bool is_savestate_compatible(fs::file&& file, std::string_view filepath)

--- a/rpcs3/util/serialization_ext.cpp
+++ b/rpcs3/util/serialization_ext.cpp
@@ -658,9 +658,6 @@ void compressed_serialization_file_handler::file_writer_thread_op()
 {
 	compressed_stream_data& stream = *m_stream;
 
-	// Data recheck after an abort request is detected so there will not be any missed data
-	bool rechecked = false;
-
 	while (true)
 	{
 		stream.m_queued_data_to_write.wait();


### PR DESCRIPTION
This PR fixes some Clang warnings.

```
[17/410] Building CXX object rpcs3/Emu/CMakeFiles/rpcs3_emu.dir/savestate_utils.cpp.obj
C:/src/rpcs3/rpcs3/Emu/savestate_utils.cpp:123:9: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  123 |         return std::move(ver_data);
      |                ^
C:/src/rpcs3/rpcs3/Emu/savestate_utils.cpp:123:9: note: remove std::move call here
  123 |         return std::move(ver_data);
      |                ^~~~~~~~~~        ~
C:/src/rpcs3/rpcs3/Emu/savestate_utils.cpp:186:10: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  186 |                 return std::move(path_compressed);
      |                        ^
C:/src/rpcs3/rpcs3/Emu/savestate_utils.cpp:186:10: note: remove std::move call here
  186 |                 return std::move(path_compressed);
      |                        ^~~~~~~~~~               ~
C:/src/rpcs3/rpcs3/Emu/savestate_utils.cpp:189:9: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  189 |         return std::move(path);
      |                ^
C:/src/rpcs3/rpcs3/Emu/savestate_utils.cpp:189:9: note: remove std::move call here
  189 |         return std::move(path);
      |                ^~~~~~~~~~    ~
3 warnings generated.
```

```
C:/src/rpcs3/rpcs3/util/serialization_ext.cpp:662:7: warning: unused variable 'rechecked' [-Wunused-variable]
  662 |         bool rechecked = false;
      |              ^~~~~~~~~
```

```
C:/src/rpcs3/Utilities/StrFmt.cpp:36:28: warning: 'codecvt_utf8_utf16<char16_t>' is deprecated [-Wdeprecated-declarations]
   36 |         std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter{};
      |                                   ^
C:/msys64/clang64/include/c++/v1/codecvt:541:28: note: 'codecvt_utf8_utf16<char16_t>' has been explicitly marked deprecated here
  541 | class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16
      |                            ^
C:/msys64/clang64/include/c++/v1/__config:983:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
  983 | #    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
      |                                         ^
C:/msys64/clang64/include/c++/v1/__config:956:49: note: expanded from macro '_LIBCPP_DEPRECATED'
  956 | #      define _LIBCPP_DEPRECATED __attribute__((__deprecated__))
      |                                                 ^
```