### PR TITLE
Recording: optimize access to video recorder

### DIFF
--- a/rpcs3/Emu/Audio/audio_resampler.cpp
+++ b/rpcs3/Emu/Audio/audio_resampler.cpp
@@ -33,7 +33,10 @@ void audio_resampler::put_samples(const f32* buf, u32 sample_cnt)
 
 std::pair<f32* /* buffer */, u32 /* samples */> audio_resampler::get_samples(u32 sample_cnt)
 {
-	return std::make_pair(resampler.bufBegin(), resampler.receiveSamples(sample_cnt));
+	// NOTE: Make sure to get the buffer first because receiveSamples advances its position internally
+	//       and std::make_pair evaluates the second parameter first...
+	f32 *const buf = resampler.bufBegin();
+	return std::make_pair(buf, resampler.receiveSamples(sample_cnt));
 }
 
 u32 audio_resampler::samples_available() const

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -11,6 +11,8 @@
 
 LOG_CHANNEL(cellAudio);
 
+extern atomic_t<recording_mode> g_recording_mode;
+
 extern void lv2_sleep(u64 timeout, ppu_thread* ppu = nullptr);
 
 vm::gvar<char, AUDIO_PORT_OFFSET * AUDIO_PORT_COUNT> g_audio_buffer;
@@ -290,8 +292,9 @@ void audio_ringbuffer::commit_data(f32* buf, u32 sample_cnt)
 	m_dump.WriteData(buf, sample_cnt_in * static_cast<u32>(AudioSampleSize::FLOAT));
 
 	// Record audio if enabled
-	if (utils::video_provider& provider = g_fxo->get<utils::video_provider>(); provider.can_consume_sample())
+	if (g_recording_mode != recording_mode::stopped)
 	{
+		utils::video_provider& provider = g_fxo->get<utils::video_provider>();
 		provider.present_samples(reinterpret_cast<u8*>(buf), sample_cnt, static_cast<u32>(cfg.audio_channels));
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellRec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRec.cpp
@@ -176,8 +176,7 @@ public:
 	{
 		cellRec.notice("Stopping video sink. flush=%d", flush);
 
-		std::lock_guard lock_video(m_video_mtx);
-		std::lock_guard lock_audio(m_audio_mtx);
+		std::scoped_lock lock(m_video_mtx, m_audio_mtx);
 		m_flush = flush;
 		m_paused = false;
 		m_frames_to_encode.clear();
@@ -189,8 +188,7 @@ public:
 	{
 		cellRec.notice("Pausing video sink. flush=%d", flush);
 
-		std::lock_guard lock_video(m_video_mtx);
-		std::lock_guard lock_audio(m_audio_mtx);
+		std::scoped_lock lock(m_video_mtx, m_audio_mtx);
 		m_flush = flush;
 		m_paused = true;
 	}
@@ -199,8 +197,7 @@ public:
 	{
 		cellRec.notice("Resuming video sink");
 
-		std::lock_guard lock_video(m_video_mtx);
-		std::lock_guard lock_audio(m_audio_mtx);
+		std::scoped_lock lock(m_video_mtx, m_audio_mtx);
 		m_flush = false;
 		m_paused = false;
 	}

--- a/rpcs3/Emu/Cell/Modules/cellRec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRec.cpp
@@ -176,7 +176,8 @@ public:
 	{
 		cellRec.notice("Stopping video sink. flush=%d", flush);
 
-		std::lock_guard lock(m_mtx);
+		std::lock_guard lock_video(m_video_mtx);
+		std::lock_guard lock_audio(m_audio_mtx);
 		m_flush = flush;
 		m_paused = false;
 		m_frames_to_encode.clear();
@@ -188,7 +189,8 @@ public:
 	{
 		cellRec.notice("Pausing video sink. flush=%d", flush);
 
-		std::lock_guard lock(m_mtx);
+		std::lock_guard lock_video(m_video_mtx);
+		std::lock_guard lock_audio(m_audio_mtx);
 		m_flush = flush;
 		m_paused = true;
 	}
@@ -197,14 +199,15 @@ public:
 	{
 		cellRec.notice("Resuming video sink");
 
-		std::lock_guard lock(m_mtx);
+		std::lock_guard lock_video(m_video_mtx);
+		std::lock_guard lock_audio(m_audio_mtx);
 		m_flush = false;
 		m_paused = false;
 	}
 
 	encoder_frame get_frame()
 	{
-		std::lock_guard lock(m_mtx);
+		std::lock_guard lock_video(m_video_mtx);
 
 		if (!m_frames_to_encode.empty())
 		{
@@ -218,7 +221,7 @@ public:
 
 	encoder_sample get_sample()
 	{
-		std::lock_guard lock(m_mtx);
+		std::lock_guard lock(m_audio_mtx);
 
 		if (!m_samples_to_encode.empty())
 		{

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -781,8 +781,7 @@ namespace utils
 			m_thread.reset();
 		}
 
-		std::lock_guard lock_video(m_video_mtx);
-		std::lock_guard lock_audio(m_audio_mtx);
+		std::scoped_lock lock(m_video_mtx, m_audio_mtx);
 		m_frames_to_encode.clear();
 		m_samples_to_encode.clear();
 		has_error = false;

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -781,7 +781,8 @@ namespace utils
 			m_thread.reset();
 		}
 
-		std::lock_guard lock(m_mtx);
+		std::lock_guard lock_video(m_video_mtx);
+		std::lock_guard lock_audio(m_audio_mtx);
 		m_frames_to_encode.clear();
 		m_samples_to_encode.clear();
 		has_error = false;
@@ -1288,17 +1289,17 @@ namespace utils
 				encoder_frame frame_data;
 				bool got_frame = false;
 				{
-					m_mtx.lock();
+					m_video_mtx.lock();
 
 					if (m_frames_to_encode.empty())
 					{
-						m_mtx.unlock();
+						m_video_mtx.unlock();
 					}
 					else
 					{
 						frame_data = std::move(m_frames_to_encode.front());
 						m_frames_to_encode.pop_front();
-						m_mtx.unlock();
+						m_video_mtx.unlock();
 
 						got_frame = true;
 

--- a/rpcs3/util/video_provider.cpp
+++ b/rpcs3/util/video_provider.cpp
@@ -45,8 +45,7 @@ namespace utils
 			return false;
 		}
 
-		std::lock_guard lock_video(m_video_mutex);
-		std::lock_guard lock_audio(m_audio_mutex);
+		std::scoped_lock lock(m_video_mutex, m_audio_mutex);
 
 		if (m_video_sink)
 		{
@@ -80,9 +79,7 @@ namespace utils
 
 	void video_provider::set_pause_time_us(usz pause_time_us)
 	{
-		std::lock_guard lock_video(m_video_mutex);
-		std::lock_guard lock_audio(m_audio_mutex);
-
+		std::scoped_lock lock(m_video_mutex, m_audio_mutex);
 		m_pause_time_us = pause_time_us;
 	}
 

--- a/rpcs3/util/video_provider.h
+++ b/rpcs3/util/video_provider.h
@@ -23,7 +23,6 @@ namespace utils
 		bool can_consume_frame();
 		void present_frame(std::vector<u8>& data, u32 pitch, u32 width, u32 height, bool is_bgra);
 
-		bool can_consume_sample();
 		void present_samples(u8* buf, u32 sample_count, u16 channels);
 
 	private:
@@ -31,11 +30,10 @@ namespace utils
 
 		recording_mode m_type = recording_mode::stopped;
 		std::shared_ptr<video_sink> m_video_sink;
-		shared_mutex m_mutex{};
+		shared_mutex m_video_mutex{};
+		shared_mutex m_audio_mutex{};
 		atomic_t<bool> m_active{false};
-		atomic_t<usz> m_current_encoder_frame{0};
-		atomic_t<usz> m_current_encoder_sample{0};
-		steady_clock::time_point m_encoder_start{};
+		atomic_t<usz> m_start_time_us{umax};
 		s64 m_last_video_pts_incoming = -1;
 		s64 m_last_audio_pts_incoming = -1;
 		usz m_pause_time_us = 0;

--- a/rpcs3/util/video_sink.h
+++ b/rpcs3/util/video_sink.h
@@ -24,7 +24,7 @@ namespace utils
 			if (m_flush || m_paused)
 				return false;
 
-			std::lock_guard lock(m_mtx);
+			std::lock_guard lock(m_video_mtx);
 			m_frames_to_encode.emplace_back(timestamp_ms, pitch, width, height, pixel_format, std::move(frame));
 			return true;
 		}
@@ -102,7 +102,7 @@ namespace utils
 		bool use_internal_video = false; // True if we want to fetch frames from rsx
 
 	protected:
-		shared_mutex m_mtx;
+		shared_mutex m_video_mtx;
 		std::deque<encoder_frame> m_frames_to_encode;
 		shared_mutex m_audio_mtx;
 		std::deque<encoder_sample> m_samples_to_encode;


### PR DESCRIPTION
Bugfix:
- Fix time stretching facepalm regression

Recording:
- Use separate locks for audio and video. This should reduce possible audio/video stutter during recording.
- Fix audio mutex usage in cellRec. This was a typo and should've caused audio issues in recordings of games like Just Cause 2.
- Removes can_consume_sample, since we don't do any processing between can_consume_sample and present_samples.
- Use get_system_time in video_provider for consistency.
- Move video_provider pts reset to set_video_sink, which basically acts like a start/stop function.
- Make video_provider start time atomic to ensure only one track can initialize it. (We need to initialize it when we get the first input, not any earlier)
- Remove frame and sample counts. These were only needed for the start time initialization
- Use active state for early out in order to reduce more expensive checks and mutex locks.
- Do not try to present samples if the recording mode is stopped anyway.
- Only access global video provider in cellRec if needed.

Fixes #14850