### PR TITLE
Qt: Post Game-Installation Assistant

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3717,8 +3717,9 @@ game_boot_result Emulator::AddGameToYml(const std::string& path)
 bool Emulator::IsPathInsideDir(std::string_view path, std::string_view dir) const
 {
 	const std::string dir_path = GetCallbacks().resolve_path(dir);
+	const std::string resolved_path = GetCallbacks().resolve_path(path);
 
-	return !dir_path.empty() && (GetCallbacks().resolve_path(path) + '/').starts_with((dir_path.back() == '/') ? dir_path : (dir_path + '/'));
+	return !dir_path.empty() && !resolved_path.empty() && (resolved_path + '/').starts_with((dir_path.back() == '/') ? dir_path : (dir_path + '/'));
 }
 
 game_boot_result Emulator::VerifyPathCasing(

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -150,6 +150,7 @@ private:
 	void CreateDockWindows();
 	void EnableMenus(bool enabled) const;
 	void ShowTitleBars(bool show) const;
+	void ShowOptionalGamePreparations(const QString& title, const QString& message, std::map<std::string, QString> game_path);
 
 	static bool InstallFileInExData(const std::string& extension, const QString& path, const std::string& filename);
 
@@ -165,7 +166,7 @@ private:
 	u64 m_drop_file_timestamp = umax;
 	drop_type m_drop_file_cached_drop_type = drop_type::drop_error;
 	drop_type IsValidFile(const QMimeData& md, QStringList* drop_paths = nullptr);
-	static void AddGamesFromDir(const QString& path);
+	void AddGamesFromDirs(const QStringList& paths);
 
 	QAction* CreateRecentAction(const q_string_pair& entry, const uint& sc_idx);
 	void BootRecentAction(const QAction* act);


### PR DESCRIPTION
## New Features
* "Add Games" would now prompt the post-install assistant, which was previously only done when installing game packages.
* I added the option to precompile CPU caches right after installation for your convenience. Preventing the wait on boot before first boot when you actually want to play the game!

![image](https://github.com/RPCS3/rpcs3/assets/18193363/59f2d184-a21b-42db-94d4-30eedb0f009c)