### PR TITLE
cellRec: Remove outdated frame size check

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellRec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRec.cpp
@@ -312,7 +312,7 @@ struct rec_info
 void rec_info::set_video_params(s32 video_format)
 {
 	const s32 video_type = video_format & 0xf000;
-	const s32 video_quality = video_format  & 0xf00;
+	const s32 video_quality = video_format & 0xf00;
 
 	switch (video_format)
 	{
@@ -688,8 +688,6 @@ void rec_info::start_video_provider()
 
 				if (const s64 pts = encoder->get_pts(frame.timestamp_ms); pts > last_video_pts && !frame.data.empty())
 				{
-					ensure(frame.data.size() == frame_size);
-
 					if (use_ring_buffer)
 					{
 						// The video frames originate from our render pipeline and are stored in a ringbuffer.

--- a/rpcs3/rpcs3qt/screenshot_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/screenshot_manager_dialog.cpp
@@ -127,7 +127,7 @@ void screenshot_manager_dialog::showEvent(QShowEvent* event)
 
 bool screenshot_manager_dialog::eventFilter(QObject* watched, QEvent* event)
 {
-	if (event && event->type() == QEvent::MouseButtonDblClick)
+	if (event && event->type() == QEvent::MouseButtonDblClick && static_cast<QMouseEvent*>(event)->button() == Qt::LeftButton)
 	{
 		if (screenshot_item* item = static_cast<screenshot_item*>(watched))
 		{

--- a/rpcs3/rpcs3qt/screenshot_preview.cpp
+++ b/rpcs3/rpcs3qt/screenshot_preview.cpp
@@ -29,7 +29,7 @@ screenshot_preview::screenshot_preview(const QString& filepath, QWidget* parent)
 	connect(this, &screenshot_preview::customContextMenuRequested, this, &screenshot_preview::show_context_menu);
 }
 
-void screenshot_preview::show_context_menu(const QPoint & pos)
+void screenshot_preview::show_context_menu(const QPoint& pos)
 {
 	QMenu* menu = new QMenu();
 	menu->addAction(tr("&Copy"), [this]() { QGuiApplication::clipboard()->setImage(m_image); });


### PR DESCRIPTION
- cellRec: Remove outdated frame size check
We are rescaling the images to the desired output format in the encoder.
The frames themselves are not a fixed container anymore.
- Qt: only allow double leftclick in screenshot manager.
You could click any mouse button before, which was weird.

fixes #14871