### PR TITLE
Savestates: Fix compressed serialization handler deadlock

### DIFF
--- a/rpcs3/util/serialization_ext.cpp
+++ b/rpcs3/util/serialization_ext.cpp
@@ -288,7 +288,7 @@ bool compressed_serialization_file_handler::handle_file_op(utils::serial& ar, us
 				{
 					v &= ~(1ull << 63);
 
-					if (v + ar.data.size() > 0x400'0000)
+					if (v > 0x400'0000)
 					{
 						v |= 1ull << 63;
 					}


### PR DESCRIPTION
Should test the current state rather then the future state, otherwise the thread may wait for its own byte to process even though it did not commit anything.