### PR TITLE
rsx: Let 308a::color have a synchronization side-effect in strict mode

### DIFF
--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1054,6 +1054,13 @@ namespace rsx
 				// Skip "handled methods"
 				rsx->fifo_ctrl->skip_methods(count - 1);
 
+				// 308A::COLOR can be used to create custom sync primitives.
+				// Hide this behind strict mode due to the potential performance implications.
+				if (count == 1 && !g_cfg.video.relaxed_zcull_sync && g_cfg.video.strict_rendering_mode)
+				{
+					rsx->sync();
+				}
+
 				switch (*method_registers.blit_engine_nv3062_color_format())
 				{
 				case blit_engine::transfer_destination_format::a8r8g8b8:

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1056,7 +1056,7 @@ namespace rsx
 
 				// 308A::COLOR can be used to create custom sync primitives.
 				// Hide this behind strict mode due to the potential performance implications.
-				if (count == 1 && !g_cfg.video.relaxed_zcull_sync && g_cfg.video.strict_rendering_mode)
+				if (count == 1 && g_cfg.video.strict_rendering_mode && !g_cfg.video.relaxed_zcull_sync)
 				{
 					rsx->sync();
 				}


### PR DESCRIPTION
Some games use 308a::color to implement custom sync primitives (ETQW). When the color data is written, the engine assumes all occlusion reports are ready which can cause severe flickering if we don't flush the pipeline.

Fixes https://github.com/RPCS3/rpcs3/issues/12425