### PR TITLE
macOS CI: use 7-Zip for artifacts

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 export HOMEBREW_NO_AUTO_UPDATE=1
-brew install -f --overwrite nasm ninja git p7zip create-dmg ccache pipenv
+brew install -f --overwrite nasm ninja git p7zip ccache pipenv #create-dmg
 
 #/usr/sbin/softwareupdate --install-rosetta --agree-to-license
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -5,7 +5,7 @@ brew install -f --overwrite nasm ninja git p7zip ccache pipenv #create-dmg
 
 #/usr/sbin/softwareupdate --install-rosetta --agree-to-license
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-arch -x86_64 /usr/local/bin/brew install -f --overwrite python@3.11 || arch -x86_64 /usr/local/bin/brew link --overwrite python@3.11
+arch -x86_64 /usr/local/bin/brew install -f --overwrite python@3.12 || arch -x86_64 /usr/local/bin/brew link --overwrite python@3.12
 arch -x86_64 /usr/local/bin/brew update
 arch -x86_64 /usr/local/bin/brew uninstall -f --ignore-dependencies ffmpeg
 arch -x86_64 /usr/local/bin/brew install -f --build-from-source ffmpeg

--- a/.ci/deploy-mac.sh
+++ b/.ci/deploy-mac.sh
@@ -52,7 +52,7 @@ echo "IconIndex=0" >> Quickstart.url
 #FILESIZE=$(stat -f %z "$DMG_FILEPATH")
 #SHA256SUM=$(shasum -a 256 "$DMG_FILEPATH" | awk '{ print $1 }')
 
-ARCHIVE_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z"
+ARCHIVE_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}_macos.7z"
 "$BREW_X64_PATH/bin/7z" a -mx9 "$ARCHIVE_FILEPATH" RPCS3.app Quickstart.url
 FILESIZE=$(stat -f %z "$ARCHIVE_FILEPATH")
 SHA256SUM=$(shasum -a 256 "$ARCHIVE_FILEPATH" | awk '{ print $1 }')

--- a/.ci/deploy-mac.sh
+++ b/.ci/deploy-mac.sh
@@ -52,10 +52,10 @@ echo "IconIndex=0" >> Quickstart.url
 #FILESIZE=$(stat -f %z "$DMG_FILEPATH")
 #SHA256SUM=$(shasum -a 256 "$DMG_FILEPATH" | awk '{ print $1 }')
 
-7Z_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z"
-"$BREW_X64_PATH/bin/7z" a -mx9 "$7Z_FILEPATH" RPCS3.app Quickstart.url
-FILESIZE=$(stat -f %z "$7Z_FILEPATH")
-SHA256SUM=$(shasum -a 256 "$7Z_FILEPATH" | awk '{ print $1 }')
+ARCHIVE_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z"
+"$BREW_X64_PATH/bin/7z" a -mx9 "$ARCHIVE_FILEPATH" RPCS3.app Quickstart.url
+FILESIZE=$(stat -f %z "$ARCHIVE_FILEPATH")
+SHA256SUM=$(shasum -a 256 "$ARCHIVE_FILEPATH" | awk '{ print $1 }')
 
 cd ..
 echo "${SHA256SUM};${FILESIZE}B" > "$RELEASE_MESSAGE"

--- a/.ci/deploy-mac.sh
+++ b/.ci/deploy-mac.sh
@@ -36,27 +36,27 @@ echo "[InternetShortcut]" > Quickstart.url
 echo "URL=https://rpcs3.net/quickstart" >> Quickstart.url
 echo "IconIndex=0" >> Quickstart.url
 
-DMG_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}_macos.dmg"
+#DMG_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}_macos.dmg"
+#"$BREW_X64_PATH/bin/create-dmg" --volname RPCS3 \
+#--window-size 800 400 \
+#--icon-size 100 \
+#--icon rpcs3.app 200 190 \
+#--add-file Quickstart.url Quickstart.url 400 20 \
+#--hide-extension rpcs3.app \
+#--hide-extension Quickstart.url \
+#--app-drop-link 600 185 \
+#--skip-jenkins \
+#--format ULMO \
+#"$DMG_FILEPATH" \
+#RPCS3.app
+#FILESIZE=$(stat -f %z "$DMG_FILEPATH")
+#SHA256SUM=$(shasum -a 256 "$DMG_FILEPATH" | awk '{ print $1 }')
 
-"$BREW_X64_PATH/bin/create-dmg" --volname RPCS3 \
---window-size 800 400 \
---icon-size 100 \
---icon rpcs3.app 200 190 \
---add-file Quickstart.url Quickstart.url 400 20 \
---hide-extension rpcs3.app \
---hide-extension Quickstart.url \
---app-drop-link 600 185 \
---skip-jenkins \
---format ULMO \
-"$DMG_FILEPATH" \
-RPCS3.app
+7Z_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z"
+"$BREW_X64_PATH/bin/7z" a -mx9 "$7Z_FILEPATH" RPCS3.app Quickstart.url
+FILESIZE=$(stat -f %z "$7Z_FILEPATH")
+SHA256SUM=$(shasum -a 256 "$7Z_FILEPATH" | awk '{ print $1 }')
 
-#"$BREW_X64_PATH/bin/7z" a -mx9 rpcs3-v"${COMM_TAG}"-"${COMM_COUNT}"-"${COMM_HASH}"_macos.7z RPCS3.app
-
-FILESIZE=$(stat -f %z "$DMG_FILEPATH")
-SHA256SUM=$(shasum -a 256 "$DMG_FILEPATH" | awk '{ print $1 }')
 cd ..
 echo "${SHA256SUM};${FILESIZE}B" > "$RELEASE_MESSAGE"
 cd bin
-
-#mv ./rpcs3*_macos.7z "$ARTDIR"


### PR DESCRIPTION
Safer than create-dmg on Ventura
https://github.com/actions/runner-images/issues/7522#issuecomment-1556766641