### PR TITLE
asm.hpp: fix usage of _mm_prefetch

### DIFF
--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -113,7 +113,7 @@ namespace utils
 		const void* ptr = reinterpret_cast<const void*>(value);
 
 #ifdef _M_X64
-		return _mm_prefetch(static_cast<const char*>(ptr), 2);
+		return _mm_prefetch(static_cast<const char*>(ptr), _MM_HINT_T1);
 #else
 		return __builtin_prefetch(ptr, 0, 2);
 #endif
@@ -128,7 +128,7 @@ namespace utils
 		}
 
 #ifdef _M_X64
-		return _mm_prefetch(static_cast<const char*>(ptr), 3);
+		return _mm_prefetch(static_cast<const char*>(ptr), _MM_HINT_T0);
 #else
 		return __builtin_prefetch(ptr, 0, 3);
 #endif


### PR DESCRIPTION
I'd like to try again to fix usage of `_mm_prefetch`.

`prefetch_exec` has the following comment.
```
	// Try to prefetch to Level 2 cache since it's not split to data/code on most processors
	template <typename T>
	constexpr void prefetch_exec(T func)
```
I changed the argument from `2` to `_MM_HINT_T1`.

```
// MSVC
#define _MM_HINT_T1     2
// GCC/Clang
  _MM_HINT_T1 = 2,
```

As you can see there was no change. T1 is also [correct](https://www.felixcloutier.com/x86/prefetchh):

> T1 (temporal data with respect to first level cache misses)—prefetch data into level 2 cache and higher.

`prefetch_read` has the following comment
```
	// Try to prefetch to Level 1 cache
	constexpr void prefetch_read(const void* ptr)
```
I changed `3` to `_MM_HINT_T0`.

```
// MSVC
#define _MM_HINT_T0     1
// GCC/Clang
  _MM_HINT_T0 = 3,
```

As you can see there is no change on Clang/GCC, but there is a change on MSVC. I think that this is [correct](https://www.felixcloutier.com/x86/prefetchh):

> T0 (temporal data)—prefetch data into all levels of the cache hierarchy.

The way it is now it is prefetched into level 3 and higher on MSVC:
```
#define _MM_HINT_T2     3
```
> T2 (temporal data with respect to second level cache misses)—prefetch data into level 3 cache and higher, or an implementation-specific choice.