### PR TITLE
input/evdev: handle flatness deadzone value

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -208,10 +208,10 @@ protected:
 	static s32 MultipliedInput(s32 raw_value, s32 multiplier);
 
 	// Get new scaled value between 0 and 255 based on its minimum and maximum
-	static f32 ScaledInput(s32 raw_value, int minimum, int maximum, f32 range = 255.0f);
+	static f32 ScaledInput(f32 raw_value, f32 minimum, f32 maximum, f32 deadzone, f32 range = 255.0f);
 
 	// Get new scaled value between -255 and 255 based on its minimum and maximum
-	static f32 ScaledInput2(s32 raw_value, int minimum, int maximum, f32 range = 255.0f);
+	static f32 ScaledAxisInput(f32 raw_value, f32 minimum, f32 maximum, f32 deadzone, f32 range = 255.0f);
 
 	// Get normalized trigger value based on the range defined by a threshold
 	u16 NormalizeTriggerInput(u16 value, int threshold) const;

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -371,6 +371,7 @@ class evdev_joystick_handler final : public PadHandlerBase
 		bool is_trigger{};
 		int min{};
 		int max{};
+		int flat{};
 	};
 
 	struct EvdevDevice : public PadDevice

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -420,7 +420,8 @@ std::unordered_map<u64, u16> mm_joystick_handler::GetButtonValues(const JOYINFOE
 
 	auto add_axis_value = [&](DWORD axis, UINT min, UINT max, u64 pos, u64 neg)
 	{
-		const float val = ScaledInput2(axis, min, max);
+		constexpr int deadzone = 0;
+		const float val = ScaledAxisInput(axis, min, max, deadzone);
 		if (val < 0)
 		{
 			button_values.emplace(pos, 0);


### PR DESCRIPTION
- input/evdev: handle flatness deadzone value:
This may fix issues with sticky axis on evdev, especially if you are not using any of the usual sticks or triggers whose deadzones can be configured.
The flatness of an axis seems to be a suggested deadzone. I could not find any mention of it being filtered pre-event, so we most likely are supposed to do this on our own.
I took the opportunity to refactor some partially redundant axis scaling functions and re-use the same function more often.

- rsxaudio: fix ensure order and remove some unnecessary scoping.

fixes #14886