### PR TITLE
Force sending a FIN packet on rpcn disconnect

### DIFF
--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -673,8 +673,10 @@ namespace rpcn
 		if (sockfd)
 		{
 #ifdef _WIN32
+			::shutdown(sockfd, SD_BOTH);
 			::closesocket(sockfd);
 #else
+			::shutdown(sockfd, SHUT_RDWR);
 			::close(sockfd);
 #endif
 			sockfd = 0;


### PR DESCRIPTION
Should fix most issues with getting already logged in error when trying to reconnect.