### PR TITLE
Fix initialization order for network_thread

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
@@ -83,6 +83,12 @@ void need_network()
 	initialize_tcp_timeout_monitor();
 }
 
+network_thread::network_thread()
+{
+	// Ensures IDM for lv2_socket is always valid when the thread is running
+	g_fxo->init<id_manager::id_map<lv2_socket>>();
+}
+
 void network_thread::bind_sce_np_port()
 {
 	std::lock_guard list_lock(list_p2p_ports_mutex);

--- a/rpcs3/Emu/Cell/lv2/sys_net/network_context.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/network_context.h
@@ -17,6 +17,7 @@ struct network_thread
 
 	static constexpr auto thread_name = "Network Thread";
 
+	network_thread();
 	void bind_sce_np_port();
 	void operator()();
 };


### PR DESCRIPTION
Fixes crashes when restarting a game that had active sockets.