### PR TITLE
Util/fixed_typemap.hpp: Fixes

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2040,6 +2040,12 @@ DECLARE(thread_ctrl::g_native_core_layout) { native_core_arrangement::undefined 
 
 void thread_base::start()
 {
+	m_sync.atomic_op([&](u32& v)
+	{
+		v &= ~static_cast<u32>(thread_state::mask);
+		v |= static_cast<u32>(thread_state::created);
+	});
+
 #ifdef _WIN32
 	m_thread = ::_beginthreadex(nullptr, 0, entry_point, this, CREATE_SUSPENDED, nullptr);
 	ensure(m_thread);

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -509,7 +509,7 @@ int check_data(unsigned char *key, EDAT_HEADER *edat, NPD_HEADER *npd, const fs:
 			// Setup signature hash.
 			if ((edat->flags & EDAT_FLAG_0x20) != 0) //Sony failed again, they used buffer from 0x100 with half size of real metadata.
 			{
-				int metadata_buf_size = block_num * 0x10;
+				const usz metadata_buf_size = block_num * 0x10;
 				std::unique_ptr<u8[]> metadata_buf(new u8[metadata_buf_size]);
 				f->seek(file_offset + metadata_offset);
 				f->read(metadata_buf.get(), metadata_buf_size);
@@ -941,7 +941,7 @@ bool EDATADecrypter::ReadHeader()
 	}*/
 
 	file_size = edatHeader.file_size;
-	total_blocks = utils::aligned_div(edatHeader.file_size, edatHeader.block_size);
+	total_blocks = ::narrow<u32>(utils::aligned_div(edatHeader.file_size, edatHeader.block_size));
 
 	// Try decrypting the first block instead
 	u8 data_sample[1];

--- a/rpcs3/Crypto/utils.cpp
+++ b/rpcs3/Crypto/utils.cpp
@@ -66,7 +66,7 @@ void hex_to_bytes(unsigned char* data, const char* hex_str, unsigned int str_len
 
 
 // Crypto functions (AES128-CBC, AES128-ECB, SHA1-HMAC and AES-CMAC).
-void aescbc128_decrypt(unsigned char *key, unsigned char *iv, unsigned char *in, unsigned char *out, int len)
+void aescbc128_decrypt(unsigned char *key, unsigned char *iv, unsigned char *in, unsigned char *out, usz len)
 {
 	aes_context ctx;
 	aes_setkey_dec(&ctx, key, 128);
@@ -76,7 +76,7 @@ void aescbc128_decrypt(unsigned char *key, unsigned char *iv, unsigned char *in,
 	memset(iv, 0, 0x10);
 }
 
-void aescbc128_encrypt(unsigned char *key, unsigned char *iv, unsigned char *in, unsigned char *out, int len)
+void aescbc128_encrypt(unsigned char *key, unsigned char *iv, unsigned char *in, unsigned char *out, usz len)
 {
 	aes_context ctx;
 	aes_setkey_enc(&ctx, key, 128);
@@ -93,7 +93,7 @@ void aesecb128_encrypt(unsigned char *key, unsigned char *in, unsigned char *out
 	aes_crypt_ecb(&ctx, AES_ENCRYPT, in, out);
 }
 
-bool hmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash, int hash_len)
+bool hmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, usz in_len, unsigned char *hash, usz hash_len)
 {
 	const std::unique_ptr<u8[]> out(new u8[key_len]);
 
@@ -102,12 +102,12 @@ bool hmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, int i
 	return std::memcmp(out.get(), hash, hash_len) == 0;
 }
 
-void hmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash)
+void hmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, usz in_len, unsigned char *hash)
 {
 	sha1_hmac(key, key_len, in, in_len, hash);
 }
 
-bool cmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash, int hash_len)
+bool cmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, usz in_len, unsigned char *hash, usz hash_len)
 {
 	const std::unique_ptr<u8[]> out(new u8[key_len]);
 
@@ -118,7 +118,7 @@ bool cmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, int i
 	return std::memcmp(out.get(), hash, hash_len) == 0;
 }
 
-void cmac_hash_forge(unsigned char *key, int /*key_len*/, unsigned char *in, int in_len, unsigned char *hash)
+void cmac_hash_forge(unsigned char *key, int /*key_len*/, unsigned char *in, usz in_len, unsigned char *hash)
 {
 	aes_context ctx;
 	aes_setkey_enc(&ctx, key, 128);

--- a/rpcs3/Crypto/utils.h
+++ b/rpcs3/Crypto/utils.h
@@ -20,13 +20,13 @@ u64 hex_to_u64(const char* hex_str);
 void hex_to_bytes(unsigned char *data, const char *hex_str, unsigned int str_length);
 
 // Crypto functions (AES128-CBC, AES128-ECB, SHA1-HMAC and AES-CMAC).
-void aescbc128_decrypt(unsigned char *key, unsigned char *iv, unsigned char *in, unsigned char *out, int len);
-void aescbc128_encrypt(unsigned char *key, unsigned char *iv, unsigned char *in, unsigned char *out, int len);
+void aescbc128_decrypt(unsigned char *key, unsigned char *iv, unsigned char *in, unsigned char *out, usz len);
+void aescbc128_encrypt(unsigned char *key, unsigned char *iv, unsigned char *in, unsigned char *out, usz len);
 void aesecb128_encrypt(unsigned char *key, unsigned char *in, unsigned char *out);
-bool hmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash, int hash_len);
-void hmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash);
-bool cmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash, int hash_len);
-void cmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, int in_len, unsigned char *hash);
+bool hmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, usz in_len, unsigned char *hash, usz hash_len);
+void hmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, usz in_len, unsigned char *hash);
+bool cmac_hash_compare(unsigned char *key, int key_len, unsigned char *in, usz in_len, unsigned char *hash, usz hash_len);
+void cmac_hash_forge(unsigned char *key, int key_len, unsigned char *in, usz in_len, unsigned char *hash);
 void mbedtls_zeroize(void *v, size_t n);
 
 // SC passphrase crypto

--- a/rpcs3/Emu/Cell/Modules/cellRec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRec.cpp
@@ -1377,7 +1377,6 @@ error_code cellRecClose(s32 isDiscard)
 				cellRec.error("cellRecClose: Unexpected recording mode %s found while stopping video capture.", old_mode);
 			}
 
-			g_fxo->need<utils::video_provider>();
 			utils::video_provider& video_provider = g_fxo->get<utils::video_provider>();
 
 			if (!video_provider.set_video_sink(nullptr, recording_mode::cell))
@@ -1465,7 +1464,6 @@ error_code cellRecStart()
 		// Setup a video sink if it is needed
 		if (rec.param.use_internal_video() || rec.param.use_internal_audio())
 		{
-			g_fxo->need<utils::video_provider>();
 			utils::video_provider& video_provider = g_fxo->get<utils::video_provider>();
 
 			if (rec.sink && !video_provider.set_video_sink(rec.sink, recording_mode::cell))

--- a/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_lwcond_.cpp
@@ -195,7 +195,12 @@ error_code sys_lwcond_signal_to(ppu_thread& ppu, vm::ptr<sys_lwcond_t> lwcond, u
 
 	if (g_cfg.core.hle_lwmutex)
 	{
-		return sys_cond_signal_to(ppu, lwcond->lwcond_queue, ppu_thread_id);
+		if (ppu_thread_id == u32{umax})
+		{
+			return sys_cond_signal(ppu, lwcond->lwcond_queue);
+		}
+
+		return sys_cond_signal_to(ppu, lwcond->lwcond_queue, static_cast<u32>(ppu_thread_id));
 	}
 
 	const vm::ptr<sys_lwmutex_t> lwmutex = lwcond->lwmutex;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
@@ -179,11 +179,6 @@ private:
 	std::unordered_map<s32, rtt_info> rtts; // (sock_id, rtt)
 };
 
-void initialize_tcp_timeout_monitor()
-{
-	g_fxo->need<named_thread<tcp_timeout_monitor>>();
-}
-
 u16 u2s_tcp_checksum(const le_t<u16>* buffer, usz size)
 {
 	u32 cksum = 0;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
@@ -74,6 +74,12 @@ public:
 		while (thread_ctrl::state() != thread_state::aborting)
 		{
 			std::unique_lock<std::mutex> lock(data_mutex);
+
+			if (thread_ctrl::state() == thread_state::aborting)
+			{
+				break;
+			}
+
 			if (msgs.size())
 				wakey.wait_until(lock, msgs.begin()->first);
 			else
@@ -150,6 +156,8 @@ public:
 
 	tcp_timeout_monitor& operator=(thread_state)
 	{
+		data_mutex.lock();
+		data_mutex.unlock();
 		wakey.notify_one();
 		return *this;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
@@ -50,7 +50,6 @@ enum p2ps_tcp_flags : u8
 	CWR = (1 << 7),
 };
 
-void initialize_tcp_timeout_monitor();
 u16 u2s_tcp_checksum(const le_t<u16>* buffer, usz size);
 std::vector<u8> generate_u2s_packet(const p2ps_encapsulated_tcp& header, const u8* data, const u32 datasize);
 

--- a/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
@@ -77,16 +77,14 @@ std::vector<signaling_message> get_sign_msgs()
 	return msgs;
 }
 
-void need_network()
+namespace np
 {
-	g_fxo->need<network_context>();
-	initialize_tcp_timeout_monitor();
+	void init_np_handler_dependencies();
 }
 
 network_thread::network_thread()
 {
-	// Ensures IDM for lv2_socket is always valid when the thread is running
-	g_fxo->init<id_manager::id_map<lv2_socket>>();
+	np::init_np_handler_dependencies();
 }
 
 void network_thread::bind_sce_np_port()

--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -219,65 +219,27 @@ namespace vm
 		return vm::addr_t{static_cast<u32>(uptr(ptr))};
 	}
 
-	template<typename T>
-	struct cast_impl
-	{
-		static_assert(std::is_same<T, u32>::value, "vm::cast() error: unsupported type");
-	};
-
-	template<>
-	struct cast_impl<u32>
-	{
-		static vm::addr_t cast(u32 addr,
-			u32,
-			u32,
-			const char*,
-			const char*)
-		{
-			return static_cast<vm::addr_t>(addr);
-		}
-	};
-
-	template<>
-	struct cast_impl<u64>
-	{
-		static vm::addr_t cast(u64 addr,
-			u32 line,
-			u32 col,
-			const char* file,
-			const char* func)
-		{
-			return static_cast<vm::addr_t>(::narrow<u32>(addr, line, col, file, func));
-		}
-	};
-
-	template<typename T, bool Se>
-	struct cast_impl<se_t<T, Se>>
-	{
-		static vm::addr_t cast(const se_t<T, Se>& addr,
-			u32 line,
-			u32 col,
-			const char* file,
-			const char* func)
-		{
-			return cast_impl<T>::cast(addr, line, col, file, func);
-		}
-	};
-
-	template<typename T>
+	template<typename T> requires (std::is_integral_v<decltype(+T{})> && (sizeof(+T{}) > 4 || std::is_signed_v<decltype(+T{})>))
 	vm::addr_t cast(const T& addr,
 		u32 line = __builtin_LINE(),
 		u32 col = __builtin_COLUMN(),
 		const char* file = __builtin_FILE(),
 		const char* func = __builtin_FUNCTION())
 	{
-		return cast_impl<T>::cast(addr, line, col, file, func);
+		return vm::addr_t{::narrow<u32>(+addr, line, col, file, func)};
+	}
+
+	template<typename T> requires (std::is_integral_v<decltype(+T{})> && (sizeof(+T{}) <= 4 && !std::is_signed_v<decltype(+T{})>))
+	vm::addr_t cast(const T& addr, u32 = 0, u32 = 0, const char* = nullptr, const char* = nullptr)
+	{
+		return vm::addr_t{static_cast<u32>(+addr)};
 	}
 
 	// Convert specified PS3/PSV virtual memory address to a pointer for common access
-	inline void* base(u32 addr)
+	template <typename T> requires (std::is_integral_v<decltype(+T{})>)
+	inline void* base(T addr)
 	{
-		return g_base_addr + addr;
+		return g_base_addr + static_cast<u32>(vm::cast(addr));
 	}
 
 	inline const u8& read8(u32 addr)
@@ -296,15 +258,15 @@ namespace vm
 	inline namespace ps3_
 	{
 		// Convert specified PS3 address to a pointer of specified (possibly converted to BE) type
-		template<typename T> inline to_be_t<T>* _ptr(u32 addr)
+		template <typename T, typename U> inline to_be_t<T>* _ptr(const U& addr)
 		{
 			return static_cast<to_be_t<T>*>(base(addr));
 		}
 
 		// Convert specified PS3 address to a reference of specified (possibly converted to BE) type
-		template<typename T> inline to_be_t<T>& _ref(u32 addr)
+		template <typename T, typename U> inline to_be_t<T>& _ref(const U& addr)
 		{
-			return *_ptr<T>(addr);
+			return *static_cast<to_be_t<T>*>(base(addr));
 		}
 
 		// Access memory bypassing memory protection

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -76,6 +76,7 @@ namespace np
 		np_handler(utils::serial& ar);
 		void save(utils::serial& ar);
 
+		void init_np_handler_dependencies();
 		const std::array<u8, 6>& get_ether_addr() const;
 		const std::string& get_hostname() const;
 		u32 get_local_ip_addr() const;
@@ -304,6 +305,8 @@ namespace np
 
 		shared_mutex mutex_queue_basic_events;
 		std::queue<basic_event> queue_basic_events;
+
+		bool m_inited_np_handler_dependencies = false;
 
 	private:
 		bool is_connected  = false;

--- a/rpcs3/Emu/NP/signaling_handler.cpp
+++ b/rpcs3/Emu/NP/signaling_handler.cpp
@@ -17,7 +17,6 @@
 
 LOG_CHANNEL(sign_log, "Signaling");
 
-void need_network();
 
 template <>
 void fmt_class_string<SignalingCommand>::format(std::string& out, u64 arg)
@@ -41,7 +40,6 @@ void fmt_class_string<SignalingCommand>::format(std::string& out, u64 arg)
 
 signaling_handler::signaling_handler()
 {
-	need_network();
 }
 
 /////////////////////////////

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2875,9 +2875,9 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 	for (const auto& [type, data] : *g_fxo)
 	{
-		if (type.stop)
+		if (type.thread_op)
 		{
-			type.stop(data, thread_state::aborting);
+			type.thread_op(data, thread_state::aborting);
 		}
 	}
 
@@ -2928,9 +2928,9 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 		// Join threads
 		for (const auto& [type, data] : *g_fxo)
 		{
-			if (type.stop)
+			if (type.thread_op)
 			{
-				type.stop(data, thread_state::finished);
+				type.thread_op(data, thread_state::finished);
 			}
 		}
 

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -144,8 +144,10 @@ bool vfs::unmount(std::string_view vpath)
 
 	vfs_log.notice("About to unmount '%s'", vpath);
 
-	// Workaround
-	g_fxo->need<vfs_manager>();
+	if (!g_fxo->is_init<vfs_manager>())
+	{
+		return false;
+	}
 
 	auto& table = g_fxo->get<vfs_manager>();
 

--- a/rpcs3/util/auto_typemap.hpp
+++ b/rpcs3/util/auto_typemap.hpp
@@ -44,6 +44,7 @@ namespace stx
 			static void call_dtor(void* ptr) noexcept
 			{
 				std::launder(static_cast<T*>(ptr))->~T();
+				std::memset(ptr, 0xCC, sizeof(T)); // Set to trap values
 			}
 
 			template <typename T>
@@ -93,8 +94,10 @@ namespace stx
 			{
 				ensure(Size >= stx::typelist<typeinfo>().size());
 				ensure(Align >= stx::typelist<typeinfo>().align());
-				m_data[0] = 0;
 			}
+
+			// Set to trap values
+			std::memset(Size == 0 ? m_list : m_data, 0xCC, stx::typelist<typeinfo>().size());
 
 			for (const auto& type : stx::typelist<typeinfo>())
 			{

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -122,6 +122,7 @@ namespace stx
 			static void call_dtor(void* ptr) noexcept
 			{
 				std::launder(static_cast<T*>(ptr))->~T();
+				std::memset(ptr, 0xCC, sizeof(T)); // Set to trap values
 			}
 
 			template <typename T>
@@ -219,8 +220,10 @@ namespace stx
 			{
 				ensure(Size >= stx::typelist<typeinfo>().size());
 				ensure(Align >= stx::typelist<typeinfo>().align());
-				m_data[0] = 0;
 			}
+
+			// Set to trap values
+			std::memset(Size == 0 ? m_list : m_data, 0xCC, stx::typelist<typeinfo>().size());
 
 			*m_order++ = nullptr;
 			*m_info++ = nullptr;

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -396,14 +396,16 @@ namespace stx
 		}
 
 		// Explicitly initialize object of type T possibly with dynamic type As and arguments
-		template <typename T, typename As = T, typename... Args>
+		template <typename T, typename As = T, typename... Args> requires (std::is_constructible_v<std::decay_t<As>, Args&&...>)
 		As* init(Args&&... args) noexcept
 		{
-			if (std::exchange(m_init[stx::typeindex<typeinfo, std::decay_t<T>, std::decay_t<As>>()], true))
+			if (m_init[stx::typeindex<typeinfo, std::decay_t<T>, std::decay_t<As>>()])
 			{
 				// Already exists, recreation is not supported (may be added later)
 				return nullptr;
 			}
+
+			m_init[stx::typeindex<typeinfo, std::decay_t<T>, std::decay_t<As>>()] = true;
 
 			As* obj = nullptr;
 
@@ -471,7 +473,7 @@ namespace stx
 		{
 			if (is_init<T>())
 			{
-				[[likely]] return &get<T>();
+				[[likely]] return std::addressof(get<T>());
 			}
 
 			[[unlikely]] return nullptr;

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -503,7 +503,9 @@ public:
 			else if constexpr (TupleAlike<T>)
 			{
 				static_assert(std::tuple_size_v<type> == 2, "Unimplemented tuple serialization!");
-				return type{ operator std::remove_cvref_t<decltype(std::get<0>(std::declval<type&>()))>
+
+				auto first = operator std::remove_cvref_t<decltype(std::get<0>(std::declval<type&>()))>();
+				return type{ std::move(first)
 					, operator std::remove_cvref_t<decltype(std::get<1>(std::declval<type&>()))> };
 			}
 		}

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1045,7 +1045,18 @@ template <typename CT> requires requires (const CT& x) { std::size(x); }
 	const char* file = __builtin_FILE(),
 	const char* func = __builtin_FUNCTION())
 {
-	return narrow<u32>(std::size(container), line, col, file, func);
+	// TODO: Supoort std::array
+	constexpr bool is_const = std::is_array_v<std::remove_cvref_t<CT>>;
+
+	if constexpr (is_const)
+	{
+		constexpr usz Size = sizeof(container) / sizeof(container[0]);
+		return std::conditional_t<is_const, u32, usz>{Size};
+	}
+	else
+	{
+		return narrow<u32>(std::size(container), line, col, file, func);
+	}
 }
 
 template <typename CT, typename T> requires requires (CT&& x) { std::size(x); std::data(x); } || requires (CT&& x) { std::size(x); x.front(); }

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1174,13 +1174,21 @@ namespace stx
 	template <typename T>
 	struct exact_t
 	{
+		static_assert(std::is_reference_v<T> || std::is_convertible_v<T, const T&>);
+
 		T obj;
 
-		exact_t(T&& _obj) : obj(std::forward<T>(_obj)) {}
+		explicit exact_t(T&& _obj) : obj(std::forward<T>(_obj)) {}
+		exact_t& operator=(const exact_t&) = delete;
 
-		// TODO: More conversions
 		template <typename U> requires (std::is_same_v<U&, T>)
-		operator U&() const { return obj; };
+		operator U&() const noexcept { return obj; };
+
+		template <typename U> requires (std::is_same_v<const U&, T>)
+		operator const U&() const noexcept { return obj; };
+
+		template <typename U> requires (std::is_same_v<U, T> && std::is_copy_constructible_v<T>)
+		operator U() const noexcept { return obj; };
 	};
 }
 


### PR DESCRIPTION
* Set up a trap for uninitialized access to FXO objects, see #14897.
* Fix independent threads with FXO management, launch threads only after all default-constructibles have been created.
* Resolve a dependency chain between PSN handler and network thread.
* Fix TCP monitor thread abort in some cases, the previous bug could have led to deadlocks when trying to quit games.
* Fix UB with g_fxo->init regarding multi-threaded access in some cases.