### PR TITLE
sys_usbd: Prevent sys_usbd_get_descriptor() from buffer overflow & Add some more arguments to sys_usbd_attach()'s logging for better debugging

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -104,7 +104,7 @@ git submodule update --init
 
 Open `rpcs3.sln`. The recommended build configuration is `Release`. (On older revisions: `Release - LLVM`)
 
-You may want to download the precompiled [LLVM libs](https://github.com/RPCS3/llvm-mirror/releases/download/custom-build-win-16.0.1/llvmlibs_mt.7z) and extract them to `3rdparty\llvm\`, as well as download and extract the [additional libs](https://github.com/RPCS3/glslang/releases/download/custom-build-win/glslanglibs_mt.7z) to `lib\%CONFIGURATION%-x64\` to speed up compilation time (unoptimised/debug libs are currently not available precompiled).
+You may want to download the precompiled [LLVM libs](https://github.com/RPCS3/llvm-mirror/releases/download/custom-build-win-16.0.1/llvmlibs_mt.7z) and extract them to `3rdparty\llvm\`, as well as download and extract the [additional libs](https://github.com/RPCS3/glslang/releases/latest/download/glslanglibs_mt.7z) to `lib\%CONFIGURATION%-x64\` to speed up compilation time (unoptimised/debug libs are currently not available precompiled).
 
 If you're not using the precompiled libs, build the following projects in *__BUILD_BEFORE* folder by right-clicking on a project > *Build*.:
 * glslang

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.h
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.h
@@ -73,7 +73,7 @@ error_code sys_usbd_open_default_pipe(ppu_thread& ppu, u32 handle, u32 device_ha
 error_code sys_usbd_close_pipe(ppu_thread& ppu, u32 handle, u32 pipe_handle);
 error_code sys_usbd_receive_event(ppu_thread& ppu, u32 handle, vm::ptr<u64> arg1, vm::ptr<u64> arg2, vm::ptr<u64> arg3);
 error_code sys_usbd_detect_event(ppu_thread& ppu);
-error_code sys_usbd_attach(ppu_thread& ppu, u32 handle);
+error_code sys_usbd_attach(ppu_thread& ppu, u32 handle, u32 unk1, u32 unk2, u32 device_handle);
 error_code sys_usbd_transfer_data(ppu_thread& ppu, u32 handle, u32 id_pipe, vm::ptr<u8> buf, u32 buf_size, vm::ptr<UsbDeviceRequest> request, u32 type_transfer);
 error_code sys_usbd_isochronous_transfer_data(ppu_thread& ppu, u32 handle, u32 id_pipe, vm::ptr<UsbDeviceIsoRequest> iso_request);
 error_code sys_usbd_get_transfer_status(ppu_thread& ppu, u32 handle, u32 id_transfer, u32 unk1, vm::ptr<u32> result, vm::ptr<u32> count);

--- a/rpcs3/Emu/Io/usb_device.h
+++ b/rpcs3/Emu/Io/usb_device.h
@@ -144,6 +144,7 @@ struct UsbDescriptorNode
 		subnodes.push_back(newnode);
 		return subnodes.back();
 	}
+
 	u32 get_size() const
 	{
 		u32 nodesize = bLength;
@@ -153,16 +154,18 @@ struct UsbDescriptorNode
 		}
 		return nodesize;
 	}
-	void write_data(u8*& ptr)
+
+	u32 write_data(u8* ptr, u32 max_size) const
 	{
-		ptr[0] = bLength;
-		ptr[1] = bDescriptorType;
-		memcpy(ptr + 2, data, bLength - 2);
-		ptr += bLength;
-		for (auto& node : subnodes)
+		u32 size = std::min<u32>(bLength, max_size);
+		memcpy(ptr, this, size);
+		for (const auto& node : subnodes)
 		{
-			node.write_data(ptr);
+			const u32 remaining = max_size - size;
+			if (remaining == 0) break;
+			size += node.write_data(ptr + size, remaining);
 		}
+		return size;
 	}
 };
 


### PR DESCRIPTION
Originally `sys_usbd_get_descriptor()` didn't take the argument `desc_size` into account when writing the descriptor into the vm memory and it didn't check if the given `descriptor` pointer is null, so there were chances that the syscall could run into access violation.
I also added some more arguments to `sys_usbd_attach()`'s logging for better debugging (especially the argument `device_handle` is notable when debugging sys_usbd).