### PR TITLE
sys_usbd: Fix up sys_usbd_get_descriptor() error handling according to hardware test

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -850,6 +850,11 @@ error_code sys_usbd_get_descriptor(ppu_thread& ppu, u32 handle, u32 device_handl
 
 	sys_usbd.trace("sys_usbd_get_descriptor(handle=0x%x, deviceNumber=0x%x, descriptor=0x%x, desc_size=0x%x)", handle, device_handle, descriptor, desc_size);
 
+	if (!descriptor)
+	{
+		return CELL_EINVAL;
+	}
+
 	auto& usbh = g_fxo->get<named_thread<usb_handler_thread>>();
 
 	std::lock_guard lock(usbh.mutex);
@@ -859,9 +864,9 @@ error_code sys_usbd_get_descriptor(ppu_thread& ppu, u32 handle, u32 device_handl
 		return CELL_EINVAL;
 	}
 
-	if (!descriptor)
+	if (!desc_size)
 	{
-		return CELL_EFAULT;
+		return CELL_ENOMEM;
 	}
 
 	usbh.handled_devices[device_handle].second->device.write_data(reinterpret_cast<u8*>(descriptor.get_ptr()), desc_size);


### PR DESCRIPTION
Today I carried out a hardware test for this syscall in response to @elad335's last comment in #14900 yesterday.
I tested the following conditions on my real hardware, and fixed up the error handling of this syscall accordingly:
1. descriptor=NULL, desc_size=0x32 -> CELL_EINVAL
2. descriptor=*ptr, desc_size=0 -> CELL_ENOMEM
3. descriptor=NULL, desc_size=0 -> CELL_EINVAL