### PR TITLE
rsx: Avoid data loss in blit engine when WCB/WDB + RCB/RDB is active

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -448,6 +448,13 @@ namespace rsx
 		}
 #endif
 
+		void invalidate_GPU_memory()
+		{
+			// Here be dragons. Use with caution.
+			shuffle_tag();
+			state_flags |= rsx::surface_state_flags::erase_bkgnd;
+		}
+
 		void clear_rw_barrier()
 		{
 			for (auto &e : old_contents)


### PR DESCRIPTION
There is a data loss path if WCB is enabled when CELL writes to RSX mem, or RSX commands do a write that causes a flush from GPU to CPU then is overwritten. If we don't detect it in the surface "test" method (very likely due to low sample count) we just lock the memory again and the writes are lost forever. This is extremely bad in some cases because we can lose shaders and other important RSX data causing all kinds of problems and crashes.

Closes https://github.com/RPCS3/rpcs3/issues/14901
Relates to https://github.com/RPCS3/rpcs3/issues/9133