### PR TITLE
Qt/Stylesheets: allow to use native styles

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -89,6 +89,7 @@ namespace gui
 	const QString Settings = "CurrentSettings";
 	const QString DefaultStylesheet = "default";
 	const QString NoStylesheet = "none";
+	const QString NativeStylesheet = "native";
 
 	const QString main_window  = "main_window";
 	const QString game_list    = "GameList";

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -11,6 +11,7 @@
 #include <QSpinBox>
 #include <QTimer>
 #include <QScreen>
+#include <QStyleFactory>
 
 #include "gui_settings.h"
 #include "display_sleep_control.h"
@@ -2412,6 +2413,13 @@ void settings_dialog::AddStylesheets()
 	ui->combo_stylesheets->clear();
 
 	ui->combo_stylesheets->addItem(tr("None", "Stylesheets"), gui::NoStylesheet);
+
+	for (const QString& key : QStyleFactory::keys())
+	{
+		// Variant value: "native (<style>)"
+		ui->combo_stylesheets->addItem(tr("Native (%0)", "Stylesheets").arg(key), QString("%0 (%1)").arg(gui::NativeStylesheet, key));
+	}
+
 	ui->combo_stylesheets->addItem(tr("Default (Bright)", "Stylesheets"), gui::DefaultStylesheet);
 
 	for (const QString& entry : m_gui_settings->GetStylesheetEntries())


### PR DESCRIPTION
- Allows the selection of all the available native system styles.
- In windows, the default style is windowsvista and is basically the same as "None". It is always bright.
The other styles work with both bright and dark mode (I don't know about other OS).
- Fixes #14762

<img src="https://github.com/RPCS3/rpcs3/assets/23019877/4a0bce7b-f5b7-47dd-a3f7-0c3711c9458d" width="50%" height="50%">
<img src="https://github.com/RPCS3/rpcs3/assets/23019877/86ecfc27-2ed6-4adf-a558-b6572d30be8e" width="50%" height="50%">
<img src="https://github.com/RPCS3/rpcs3/assets/23019877/65d32c14-648f-4ff3-aae4-b6f8442807d1" width="50%" height="50%">
