### PR TITLE
VSH fix: Fix sys_fs_fcntl default_sys_fs_container use

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -632,9 +632,6 @@ CHECK_SIZE(CellFsMountInfo, 0x94);
 // Default IO container
 struct default_sys_fs_container
 {
-	default_sys_fs_container(const default_sys_fs_container&) = delete;
-	default_sys_fs_container& operator=(const default_sys_fs_container&) = delete;
-
 	shared_mutex mutex;
 	u32 id   = 0;
 	u32 cap  = 0;


### PR DESCRIPTION
Fixes VSH crash due to uninitialized mutex use due to default_sys_fs_container not being default-constructible (so it was not initialized via g_fxo->init())due to it having a deleted constructor, I removed the explicit constructor erasure instead of declaring a default constructor due to shared_mutex already being non-copyable. Bug was found on discord using this log file:
[VSH.log.gz](https://github.com/RPCS3/rpcs3/files/13729868/VSH.log.gz)
