### PR TITLE
Qt: use initial style as default style

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -94,6 +94,8 @@ private:
 	std::shared_ptr<gui_settings> m_gui_settings;
 	std::shared_ptr<persistent_settings> m_persistent_settings;
 
+	QString m_default_style;
+
 	bool m_show_gui = true;
 	bool m_use_cli_style = false;
 	bool m_with_cli_boot = false;


### PR DESCRIPTION
- Use the initial style on boot as default style applied before changing stylesheets (kinda like a foundation).
- It's a bit dumb because accoring to Qt it should be the first style in the list...
- This may fix a regression with stylesheets on linux (unless it's the same style after all)