### PR TITLE
Qt: use default colors for native styles

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -199,10 +199,12 @@ void debugger_frame::ChangeColors() const
 {
 	if (m_debugger_list)
 	{
-		m_debugger_list->m_color_bp = m_breakpoint_list->m_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint", QPalette::Window);
-		m_debugger_list->m_color_pc = gui::utils::get_label_color("debugger_frame_pc", QPalette::Window);
-		m_debugger_list->m_text_color_bp = m_breakpoint_list->m_text_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint");
-		m_debugger_list->m_text_color_pc = gui::utils::get_label_color("debugger_frame_pc");
+		const QColor color = gui::utils::get_foreground_color();
+
+		m_debugger_list->m_color_bp = m_breakpoint_list->m_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint", Qt::yellow, Qt::darkYellow, QPalette::Window);
+		m_debugger_list->m_color_pc = gui::utils::get_label_color("debugger_frame_pc", Qt::green, Qt::darkGreen, QPalette::Window);
+		m_debugger_list->m_text_color_bp = m_breakpoint_list->m_text_color_bp = gui::utils::get_label_color("debugger_frame_breakpoint", color, color);
+		m_debugger_list->m_text_color_pc = gui::utils::get_label_color("debugger_frame_pc", color, color);
 	}
 }
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2344,7 +2344,7 @@ void game_list_frame::RepaintIcons(const bool& from_settings)
 		}
 		else
 		{
-			m_icon_color = gui::utils::get_label_color("gamelist_icon_background_color");
+			m_icon_color = gui::utils::get_label_color("gamelist_icon_background_color", Qt::transparent, Qt::transparent);
 		}
 	}
 

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -37,6 +37,7 @@
 #include <QMessageBox>
 #include <QTextDocument>
 #include <QStyleFactory>
+#include <QStyleHints>
 
 #include <clocale>
 
@@ -293,6 +294,8 @@ void gui_application::InitializeConnects()
 		connect(this, &gui_application::OnEmulatorReady, m_main_window, &main_window::OnEmuReady);
 		connect(this, &gui_application::OnEnableDiscEject, m_main_window, &main_window::OnEnableDiscEject);
 		connect(this, &gui_application::OnEnableDiscInsert, m_main_window, &main_window::OnEnableDiscInsert);
+
+		connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, [this](){ OnChangeStyleSheetRequest(); });
 	}
 
 #ifdef WITH_DISCORD_RPC
@@ -789,11 +792,13 @@ void gui_application::OnChangeStyleSheetRequest()
 	};
 
 	gui_log.notice("Changing stylesheet to '%s'", stylesheet_name);
+	gui::custom_stylesheet_active = false;
 
 	if (stylesheet_name.isEmpty() || stylesheet_name == gui::DefaultStylesheet)
 	{
 		gui_log.notice("Using default stylesheet");
 		setStyleSheet(gui::stylesheets::default_style_sheet);
+		gui::custom_stylesheet_active = true;
 	}
 	else if (stylesheet_name == gui::NoStylesheet)
 	{
@@ -871,6 +876,8 @@ void gui_application::OnChangeStyleSheetRequest()
 			gui_log.error("Could not find stylesheet '%s'. Using default.", stylesheet_name);
 			setStyleSheet(gui::stylesheets::default_style_sheet);
 		}
+
+		gui::custom_stylesheet_active = true;
 	}
 
 	gui::stylesheet = styleSheet();

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -16,6 +16,7 @@ LOG_CHANNEL(cfg_log, "CFG");
 namespace gui
 {
 	QString stylesheet;
+	bool custom_stylesheet_active = false;
 
 	QString get_game_list_column_name(game_list_columns col)
 	{

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -12,6 +12,7 @@
 namespace gui
 {
 	extern QString stylesheet;
+	extern bool custom_stylesheet_active;
 
 	enum custom_roles
 	{

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -484,18 +484,20 @@ void log_frame::RepaintTextColors()
 	QList<QColor> old_colors = m_color;
 	QColor old_stack_color = m_color_stack;
 
+	const QColor color = gui::utils::get_foreground_color();
+
 	// Get text color. Do this once to prevent possible slowdown
 	m_color.clear();
-	m_color.append(gui::utils::get_label_color("log_level_always"));
-	m_color.append(gui::utils::get_label_color("log_level_fatal"));
-	m_color.append(gui::utils::get_label_color("log_level_error"));
-	m_color.append(gui::utils::get_label_color("log_level_todo"));
-	m_color.append(gui::utils::get_label_color("log_level_success"));
-	m_color.append(gui::utils::get_label_color("log_level_warning"));
-	m_color.append(gui::utils::get_label_color("log_level_notice"));
-	m_color.append(gui::utils::get_label_color("log_level_trace"));
+	m_color.append(gui::utils::get_label_color("log_level_always", Qt::darkCyan, Qt::cyan));
+	m_color.append(gui::utils::get_label_color("log_level_fatal", Qt::darkMagenta, Qt::magenta));
+	m_color.append(gui::utils::get_label_color("log_level_error", Qt::red, Qt::red));
+	m_color.append(gui::utils::get_label_color("log_level_todo", Qt::darkYellow, Qt::darkYellow));
+	m_color.append(gui::utils::get_label_color("log_level_success", Qt::darkGreen, Qt::green));
+	m_color.append(gui::utils::get_label_color("log_level_warning", Qt::darkYellow, Qt::darkYellow));
+	m_color.append(gui::utils::get_label_color("log_level_notice", color, color));
+	m_color.append(gui::utils::get_label_color("log_level_trace", color, color));
 
-	m_color_stack = gui::utils::get_label_color("log_stack");
+	m_color_stack = gui::utils::get_label_color("log_stack", color, color);
 
 	// Use new colors if the old colors weren't set yet
 	if (old_colors.empty())
@@ -511,7 +513,7 @@ void log_frame::RepaintTextColors()
 	// Repaint TTY with new colors
 	QTextCursor tty_cursor = m_tty->textCursor();
 	QTextCharFormat text_format = tty_cursor.charFormat();
-	text_format.setForeground(gui::utils::get_label_color("tty_text"));
+	text_format.setForeground(gui::utils::get_label_color("tty_text", color, color));
 	tty_cursor.setCharFormat(text_format);
 	m_tty->setTextCursor(tty_cursor);
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1684,7 +1684,8 @@ void main_window::SaveWindowState() const
 
 void main_window::RepaintThumbnailIcons()
 {
-	[[maybe_unused]] const QColor new_color = gui::utils::get_label_color("thumbnail_icon_color");
+	const QColor color = gui::utils::get_foreground_color();
+	[[maybe_unused]] const QColor new_color = gui::utils::get_label_color("thumbnail_icon_color", color, color);
 
 	[[maybe_unused]] const auto icon = [&new_color](const QString& path)
 	{
@@ -1707,23 +1708,13 @@ void main_window::RepaintThumbnailIcons()
 
 void main_window::RepaintToolBarIcons()
 {
+	const QColor color = gui::utils::get_foreground_color();
+
 	std::map<QIcon::Mode, QColor> new_colors{};
-	new_colors[QIcon::Normal] = gui::utils::get_label_color("toolbar_icon_color");
-
-	const QString sheet = static_cast<QApplication *>(QCoreApplication::instance())->styleSheet();
-
-	if (sheet.contains("toolbar_icon_color_disabled"))
-	{
-		new_colors[QIcon::Disabled] = gui::utils::get_label_color("toolbar_icon_color_disabled");
-	}
-	if (sheet.contains("toolbar_icon_color_active"))
-	{
-		new_colors[QIcon::Active] = gui::utils::get_label_color("toolbar_icon_color_active");
-	}
-	if (sheet.contains("toolbar_icon_color_selected"))
-	{
-		new_colors[QIcon::Selected] = gui::utils::get_label_color("toolbar_icon_color_selected");
-	}
+	new_colors[QIcon::Normal] = gui::utils::get_label_color("toolbar_icon_color", color, color);
+	new_colors[QIcon::Disabled] = gui::utils::get_label_color("toolbar_icon_color_disabled", Qt::gray, Qt::lightGray);
+	new_colors[QIcon::Active] = gui::utils::get_label_color("toolbar_icon_color_active", color, color);
+	new_colors[QIcon::Selected] = gui::utils::get_label_color("toolbar_icon_color_selected", color, color);
 
 	const auto icon = [&new_colors](const QString& path)
 	{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -214,7 +214,8 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 	QPainter painter(&controller_pixmap);
 	painter.setRenderHints(QPainter::TextAntialiasing | QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
 	renderer.render(&painter, controller_pixmap.rect());
-	ui->l_controller->setPixmap(gui::utils::get_colorized_pixmap(controller_pixmap, QColor(), gui::utils::get_label_color("l_controller"), false, true));
+	const QColor color = gui::utils::get_foreground_color();
+	ui->l_controller->setPixmap(gui::utils::get_colorized_pixmap(controller_pixmap, QColor(), gui::utils::get_label_color("l_controller", color, color), false, true));
 
 	// Show default widgets first in order to calculate the required size for the scroll area (see pad_settings_dialog::ResizeDialog)
 	ui->left_stack->setCurrentIndex(0);

--- a/rpcs3/rpcs3qt/patch_creator_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.cpp
@@ -32,8 +32,8 @@ patch_creator_dialog::patch_creator_dialog(QWidget* parent)
 	: QDialog(parent)
 	, ui(new Ui::patch_creator_dialog)
 	, mMonoFont(QFontDatabase::systemFont(QFontDatabase::FixedFont))
-	, mValidColor(gui::utils::get_label_color("log_level_success"))
-	, mInvalidColor(gui::utils::get_label_color("log_level_error"))
+	, mValidColor(gui::utils::get_label_color("log_level_success", Qt::darkGreen, Qt::green))
+	, mInvalidColor(gui::utils::get_label_color("log_level_error", Qt::red, Qt::red))
 	, m_offset_validator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?[a-fA-F0-9]{0,8}$"), this))
 {
 	ui->setupUi(this);
@@ -120,7 +120,7 @@ void patch_creator_dialog::init_patch_type_bombo_box(QComboBox* combo_box, patch
 	}
 }
 
-QComboBox* patch_creator_dialog::create_patch_type_bombo_box(patch_type set_type)
+QComboBox* patch_creator_dialog::create_patch_type_bombo_box(patch_type set_type) const
 {
 	QComboBox* combo_box = new QComboBox;
 	init_patch_type_bombo_box(combo_box, set_type, true);
@@ -208,7 +208,7 @@ void patch_creator_dialog::show_table_menu(const QPoint& pos)
 	menu.exec(ui->instructionTable->viewport()->mapToGlobal(pos));
 }
 
-void patch_creator_dialog::update_validator(int index, QComboBox* combo_box, QLineEdit* line_edit)
+void patch_creator_dialog::update_validator(int index, QComboBox* combo_box, QLineEdit* line_edit) const
 {
 	if (index < 0 || !combo_box || !line_edit || !combo_box->itemData(index).canConvert<patch_type>())
 	{

--- a/rpcs3/rpcs3qt/patch_creator_dialog.h
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.h
@@ -39,9 +39,9 @@ private:
 	bool can_move_instructions(QModelIndexList& selection, move_direction dir);
 
 	static void init_patch_type_bombo_box(QComboBox* combo_box, patch_type set_type, bool searchable);
-	QComboBox* create_patch_type_bombo_box(patch_type set_type);
+	QComboBox* create_patch_type_bombo_box(patch_type set_type) const;
 
-	void update_validator(int index, QComboBox* combo_box, QLineEdit* line_edit);
+	void update_validator(int index, QComboBox* combo_box, QLineEdit* line_edit) const;
 
 private Q_SLOTS:
 	void show_table_menu(const QPoint& pos);

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -174,9 +174,28 @@ namespace gui
 			}
 			return res;
 		}
-
-		QColor get_label_color(const QString& object_name, QPalette::ColorRole color_role)
+		
+		QColor get_foreground_color()
 		{
+			QLabel dummy_color;
+			dummy_color.ensurePolished();
+			return dummy_color.palette().color(QPalette::ColorRole::WindowText);
+		}
+
+		QColor get_background_color()
+		{
+			QLabel dummy_color;
+			dummy_color.ensurePolished();
+			return dummy_color.palette().color(QPalette::ColorRole::Window);
+		}
+
+		QColor get_label_color(const QString& object_name, const QColor& fallback_light, const QColor& fallback_dark, QPalette::ColorRole color_role)
+		{
+			if (!gui::custom_stylesheet_active || !gui::stylesheet.contains(object_name))
+			{
+				return dark_mode_active() ? fallback_dark : fallback_light;
+			}
+
 			QLabel dummy_color;
 			dummy_color.setObjectName(object_name);
 			dummy_color.ensurePolished();
@@ -200,7 +219,7 @@ namespace gui
 
 		QColor get_link_color(const QString& name)
 		{
-			return gui::utils::get_label_color(name);
+			return gui::utils::get_label_color(name, QColor(0, 116, 231), QColor(135, 206, 250));
 		}
 
 		QString get_link_color_string(const QString& name)
@@ -210,11 +229,6 @@ namespace gui
 
 		QString get_link_style(const QString& name)
 		{
-			if (!gui::stylesheet.contains(name))
-			{
-				return {};
-			}
-
 			return QString("style=\"color: %0;\"").arg(get_link_color_string(name));
 		}
 

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -13,6 +13,8 @@
 #include <QTreeWidgetItem>
 #include <QPainter>
 #include <QFutureWatcher>
+#include <QGuiApplication>
+#include <QStyleHints>
 
 #include <string>
 #include <map>
@@ -65,8 +67,14 @@ namespace gui
 		// Returns a list of all base names of files in dir whose complete file names contain one of the given name_filters
 		QStringList get_dir_entries(const QDir& dir, const QStringList& name_filters, bool full_path = false);
 
+		// Returns the foreground color of QLabel with respect to the current light/dark mode.
+		QColor get_foreground_color();
+
+		// Returns the background color of QLabel with respect to the current light/dark mode.
+		QColor get_background_color();
+
 		// Returns the color specified by its color_role for the QLabels with object_name
-		QColor get_label_color(const QString& object_name, QPalette::ColorRole color_role = QPalette::WindowText);
+		QColor get_label_color(const QString& object_name, const QColor& fallback_light, const QColor& fallback_dark, QPalette::ColorRole color_role = QPalette::WindowText);
 
 		// Returns the font of the QLabels with object_name
 		QFont get_label_font(const QString& object_name);
@@ -138,6 +146,16 @@ namespace gui
 
 		// Convert an arbitrary count of bytes to a readable format using global units (KB, MB...)
 		QString format_byte_size(usz size);
+
+		static Qt::ColorScheme color_scheme()
+		{
+			return QGuiApplication::styleHints()->colorScheme();
+		}
+
+		static bool dark_mode_active()
+		{
+			return color_scheme() == Qt::ColorScheme::Dark;
+		}
 
 		template <typename T>
 		void stop_future_watcher(QFutureWatcher<T>& watcher, bool cancel, std::shared_ptr<atomic_t<bool>> cancel_flag = nullptr)

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -310,7 +310,7 @@ void save_manager_dialog::UpdateList()
 	}
 	else
 	{
-		m_icon_color = gui::utils::get_label_color("save_manager_icon_background_color");
+		m_icon_color = gui::utils::get_label_color("save_manager_icon_background_color", Qt::transparent, Qt::transparent);
 	}
 
 	QPixmap placeholder(320, 176);

--- a/rpcs3/rpcs3qt/syntax_highlighter.cpp
+++ b/rpcs3/rpcs3qt/syntax_highlighter.cpp
@@ -55,14 +55,16 @@ void Highlighter::highlightBlock(const QString &text)
 
 LogHighlighter::LogHighlighter(QTextDocument* parent) : Highlighter(parent)
 {
-	//addRule("^[^·].*$", gui::utils::get_label_color("log_level_always")); // unused for now
-	addRule("^·F.*$", gui::utils::get_label_color("log_level_fatal"));
-	addRule("^·E.*$", gui::utils::get_label_color("log_level_error"));
-	addRule("^·U.*$", gui::utils::get_label_color("log_level_todo"));
-	addRule("^·S.*$", gui::utils::get_label_color("log_level_success"));
-	addRule("^·W.*$", gui::utils::get_label_color("log_level_warning"));
-	addRule("^·!.*$", gui::utils::get_label_color("log_level_notice"));
-	addRule("^·T.*$", gui::utils::get_label_color("log_level_trace"));
+	const QColor color = gui::utils::get_foreground_color();
+
+	//addRule("^[^·].*$", gui::utils::get_label_color("log_level_always", Qt::darkCyan, Qt::cyan)); // unused for now
+	addRule("^·F.*$", gui::utils::get_label_color("log_level_fatal", Qt::darkMagenta, Qt::magenta));
+	addRule("^·E.*$", gui::utils::get_label_color("log_level_error", Qt::red, Qt::red));
+	addRule("^·U.*$", gui::utils::get_label_color("log_level_todo", Qt::darkYellow, Qt::darkYellow));
+	addRule("^·S.*$", gui::utils::get_label_color("log_level_success", Qt::darkGreen, Qt::green));
+	addRule("^·W.*$", gui::utils::get_label_color("log_level_warning", Qt::darkYellow, Qt::darkYellow));
+	addRule("^·!.*$", gui::utils::get_label_color("log_level_notice", color, color));
+	addRule("^·T.*$", gui::utils::get_label_color("log_level_trace", color, color));
 }
 
 AsmHighlighter::AsmHighlighter(QTextDocument *parent) : Highlighter(parent)

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -493,7 +493,7 @@ void trophy_manager_dialog::RepaintUI(bool restore_layout)
 	}
 	else
 	{
-		m_game_icon_color = gui::utils::get_label_color("trophy_manager_icon_background_color");
+		m_game_icon_color = gui::utils::get_label_color("trophy_manager_icon_background_color", Qt::transparent, Qt::transparent);
 	}
 
 	PopulateGameTable();

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -10,13 +10,6 @@
 #include <QPushButton>
 #include <QCheckBox>
 #include <QSvgWidget>
-#include <QStyleHints>
-#include <QGuiApplication>
-
-static bool recommend_dark_theme()
-{
-	return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
-}
 
 welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool is_manual_show, QWidget* parent)
 	: QDialog(parent)
@@ -33,7 +26,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->i_have_read->setEnabled(!is_manual_show);
 	ui->do_not_show->setEnabled(!is_manual_show);
 	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
-	ui->use_dark_theme->setChecked(recommend_dark_theme());
+	ui->use_dark_theme->setChecked(gui::utils::dark_mode_active());
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));
 	ui->label_3->setText(tr(
 		R"(


### PR DESCRIPTION
Fixes several color issues when using native styles:
- Sets icon background colors to transparent
- Uses the native styles' label foreground color for any regular texts
- Uses the native styles' label foreground color for toolbar icons
- Uses the native styles' label foreground color for the gamepad image in the pad settings
- Uses green/red color some patch creator labels
- Uses blue/brightblue link color depending on dark mode (ironically link colors are broken in Qt 6.6.0)
- Uses log colors inspired by existing stylesheets depending on dark mode
- Repaints the UI when the OS switches between light and dark mode

Fusion:
![image](https://github.com/RPCS3/rpcs3/assets/23019877/af1bef1e-f7d5-4958-828e-7008cf7b3319)
