### PR TITLE
Remove destructor dependencies on nph

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
@@ -56,15 +56,6 @@ lv2_socket_native::~lv2_socket_native()
 		::close(socket);
 #endif
 	}
-
-	if (bound_port)
-	{
-		if (auto* nph = g_fxo->try_get<named_thread<np::np_handler>>())
-		{
-			nph->upnp_remove_port_mapping(bound_port, type == SYS_NET_SOCK_STREAM ? "TCP" : "UDP");
-		}
-		bound_port = 0;
-	}
 }
 
 s32 lv2_socket_native::create_socket()

--- a/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
@@ -90,11 +90,6 @@ nt_p2p_port::~nt_p2p_port()
 		::close(p2p_socket);
 #endif
 	}
-
-	if (auto* nph = g_fxo->try_get<named_thread<np::np_handler>>())
-	{
-		nph->upnp_remove_port_mapping(port, "UDP");
-	}
 }
 
 void nt_p2p_port::dump_packet(p2ps_encapsulated_tcp* tcph)


### PR DESCRIPTION
lv2_socket_native should get upnp unbound during close() call during emulation.
nt_p2p_port are only destroyed on network_thread termination.

In both those cases if there are any straggling upnp binds left upnp_handler will unbind them in its destructor on emulation termination.