### PR TITLE
[Bugfix] sys_fs: Fixed sys_fs_unlink()'s failing to delete files in dev_usbXXX & Misc syscall implementation fixups

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -250,7 +250,7 @@ public:
 	static std::string get_normalized_path(std::string_view path);
 
 	// Get the device's root path (e.g. "/dev_hdd0") from a given path
-	static std::string_view get_device_root(std::string_view path);
+	static std::string get_device_root(std::string_view filename);
 
 	// Filename can be either a path starting with '/' or a CELL_FS device name
 	// This should be used only when handling devices that are not mounted

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -215,6 +215,7 @@ public:
 	bool remove(std::string_view path);
 	const lv2_fs_mount_info& lookup(std::string_view path, bool no_cell_fs_path = false, std::string* mount_path = nullptr) const;
 	u64 get_all(CellFsMountInfo* info = nullptr, u64 len = 0) const;
+	bool is_device_mounted(std::string_view device_name) const;
 
 	static bool vfs_unmount(std::string_view vpath, bool remove_from_map = true);
 
@@ -620,11 +621,7 @@ struct CellFsMountInfo
 	char mount_path[0x20]; // 0x0
 	char filesystem[0x20]; // 0x20
 	char dev_name[0x40];   // 0x40
-	be_t<u32> unk1;        // 0x80
-	be_t<u32> unk2;        // 0x84
-	be_t<u32> unk3;        // 0x88
-	be_t<u32> unk4;        // 0x8C
-	be_t<u32> unk5;        // 0x90
+	be_t<u32> unk[5];      // 0x80, probably attributes
 };
 
 CHECK_SIZE(CellFsMountInfo, 0x94);
@@ -682,6 +679,6 @@ error_code sys_fs_mapped_free(ppu_thread& ppu, u32 fd, vm::ptr<void> ptr);
 error_code sys_fs_truncate2(ppu_thread& ppu, u32 fd, u64 size);
 error_code sys_fs_newfs(ppu_thread& ppu, vm::cptr<char> dev_name, vm::cptr<char> file_system, s32 unk1, vm::cptr<char> str1);
 error_code sys_fs_mount(ppu_thread& ppu, vm::cptr<char> dev_name, vm::cptr<char> file_system, vm::cptr<char> path, s32 unk1, s32 prot, s32 unk3, vm::cptr<char> str1, u32 str_len);
-error_code sys_fs_unmount(ppu_thread& ppu, vm::cptr<char> path, s32 unk1, s32 unk2);
+error_code sys_fs_unmount(ppu_thread& ppu, vm::cptr<char> path, s32 unk1, s32 force);
 error_code sys_fs_get_mount_info_size(ppu_thread& ppu, vm::ptr<u64> len);
 error_code sys_fs_get_mount_info(ppu_thread& ppu, vm::ptr<CellFsMountInfo> info, u64 len, vm::ptr<u64> out_len);

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -213,7 +213,7 @@ public:
 		return map.try_emplace(std::forward<Args>(args)...).second;
 	}
 	bool remove(std::string_view path);
-	const lv2_fs_mount_info& lookup(std::string_view path, bool no_cell_fs_path = false) const;
+	const lv2_fs_mount_info& lookup(std::string_view path, bool no_cell_fs_path = false, std::string* mount_path = nullptr) const;
 	u64 get_all(CellFsMountInfo* info = nullptr, u64 len = 0) const;
 
 	static bool vfs_unmount(std::string_view vpath, bool remove_from_map = true);

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -498,7 +498,7 @@ error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64
 		if (!addr_ptr)
 			return CELL_EFAULT;
 
-		vm::write64(addr_ptr, 0x340ULL << 40); // 3.40
+		vm::write64(addr_ptr, 0x30040ULL << 32); // 3.40
 
 		break;
 	}


### PR DESCRIPTION
sys_fs_unlink() used to fail to delete files in dev_usbXXX because it used `mp->root`, which is always "dev_usb" for all dev_usbXXX devices, as argument `dev_root` passed to `vfs::host::unlink()` for further processing.

This PR fixed the bug mentioned above.