### PR TITLE
Fix and improve savestates

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2641,9 +2641,10 @@ void thread_base::exec()
 
 	sig_log.fatal("Thread terminated due to fatal error: %s", reason);
 
+	logs::listener::sync_all();
+
 	if (IsDebuggerPresent())
 	{
-		logs::listener::sync_all();
 		utils::trap();
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -678,9 +678,10 @@ void cell_audio_thread::reset_counters()
 
 cell_audio_thread::cell_audio_thread()
 {
-	// Initialize dependencies
-	g_fxo->need<audio_out_configuration>();
+}
 
+void cell_audio_thread::operator()()
+{
 	// Initialize loop variables (regardless of provider in order to initialize timestamps)
 	reset_counters();
 
@@ -694,14 +695,6 @@ cell_audio_thread::cell_audio_thread()
 
 	// Allocate ringbuffer
 	ringbuffer.reset(new audio_ringbuffer(cfg));
-}
-
-void cell_audio_thread::operator()()
-{
-	if (cfg.raw.provider != audio_provider::cell_audio)
-	{
-		return;
-	}
 
 	thread_ctrl::scoped_priority high_prio(+1);
 

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -3019,7 +3019,7 @@ std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_ex
 
 	if (!ar && !virtual_load)
 	{
-		idm::import_existing<lv2_obj, lv2_overlay>(ovlm);
+		ensure(idm::import_existing<lv2_obj, lv2_overlay>(ovlm));
 		try_spawn_ppu_if_exclusive_program(*ovlm);
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
@@ -1306,9 +1306,6 @@ namespace audio
 
 rsxaudio_backend_thread::rsxaudio_backend_thread()
 {
-	// Initialize dependencies
-	g_fxo->need<audio_out_configuration>();
-
 	new_emu_cfg = get_emu_cfg();
 
 	const u64 new_vol = g_cfg.audio.volume;

--- a/rpcs3/Emu/Cell/lv2/sys_rsxaudio.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsxaudio.h
@@ -463,6 +463,8 @@ public:
 
 	static constexpr auto thread_name = "RsxAudio Backend Thread"sv;
 
+	SAVESTATE_INIT_POS(8.91); // Depends on audio_out_configuration
+
 private:
 
 	struct emu_audio_cfg

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -227,8 +227,8 @@ lv2_spu_group::lv2_spu_group(utils::serial& ar) noexcept
 		if (ar.pop<bool>())
 		{
 			ar(id_manager::g_id);
-			thread = std::make_shared<named_thread<spu_thread>>(ar, this);
-			idm::import_existing<named_thread<spu_thread>>(thread, idm::last_id());
+			thread = std::make_shared<named_thread<spu_thread>>(stx::launch_retainer{}, ar, this);
+			ensure(idm::import_existing<named_thread<spu_thread>>(thread, idm::last_id()));
 			running += !thread->stop_flag_removal_protection;
 		}
 	}

--- a/rpcs3/Emu/IdManager.cpp
+++ b/rpcs3/Emu/IdManager.cpp
@@ -35,10 +35,13 @@ std::vector<std::pair<u128, id_manager::typeinfo>>& id_manager::get_typeinfo_map
 
 idm::map_data* idm::allocate_id(std::vector<map_data>& vec, u32 type_id, u32 dst_id, u32 base, u32 step, u32 count, bool uses_lowest_id, std::pair<u32, u32> invl_range)
 {
-	if (const u32 index = id_manager::get_index(dst_id, base, step, count, invl_range); index < count)
+	if (dst_id != (base ? 0 : u32{umax}))
 	{
 		// Fixed position construction
-		ensure(index < vec.size());
+		const u32 index = id_manager::get_index(dst_id, base, step, count, invl_range);
+		ensure(index < count);
+
+		vec.resize(std::max<usz>(vec.size(), index + 1));
 
 		if (vec[index].second)
 		{

--- a/rpcs3/Emu/IdManager.h
+++ b/rpcs3/Emu/IdManager.h
@@ -17,6 +17,8 @@ constexpr auto* g_fxo = &g_fixed_typemap;
 
 enum class thread_state : u32;
 
+extern u16 serial_breathe_and_tag(utils::serial& ar, std::string_view name, bool tag_bit);
+
 // Helper namespace
 namespace id_manager
 {
@@ -270,16 +272,22 @@ namespace id_manager
 		{
 			vec.resize(T::id_count);
 
-			u32 i = ar.pop<u32>();
+			usz highest = 0;
 
-			ensure(i <= T::id_count);
-
-			while (--i != umax)
+			while (true)
 			{
-				// ID, type hash
-				const u32 id = ar;
+				const u16 tag = serial_breathe_and_tag(ar, g_fxo->get_name<id_map<T>>(), false);
 
-				const u128 type_init_pos = u128{u32{ar}} << 64 | std::bit_cast<u64>(T::savestate_init_pos);
+				if (tag >> 15)
+				{
+					// End
+					break;
+				}
+
+				// ID, type hash
+				const u32 id = ar.pop<u32>();
+
+				const u128 type_init_pos = u128{ar.pop<u32>()} << 64 | std::bit_cast<u64>(T::savestate_init_pos);
 				const typeinfo* info = nullptr;
 
 				// Search load functions for the one of this type (see make_typeinfo() for explenation about key composition reasoning)
@@ -298,22 +306,21 @@ namespace id_manager
 				// Simulate construction semantics (idm::last_id() value)
 				g_id = id;
 
-				auto& obj = vec[get_index(id, info->base, info->step, info->count, info->invl_range)];
+				const usz object_index = get_index(id, info->base, info->step, info->count, info->invl_range);
+				auto& obj = ::at32(vec, object_index);
 				ensure(!obj.second);
+
+				highest = std::max<usz>(highest, object_index + 1);
 
 				obj.first = id_key(id, static_cast<u32>(static_cast<u64>(type_init_pos >> 64)));
 				obj.second = info->load(ar);
 			}
+
+			vec.resize(highest);
 		}
 
 		void save(utils::serial& ar) requires IdmSavable<T>
 		{
-			u32 obj_count = 0;
-			usz obj_count_offs = ar.pos;
-
-			// To be patched at the end of the function
-			ar(obj_count);
-
 			for (const auto& p : vec)
 			{
 				if (!p.second) continue;
@@ -333,20 +340,24 @@ namespace id_manager
 				// Save each object with needed information
 				if (info && info->savable(p.second.get()))
 				{
+					// Create a tag for each object
+					serial_breathe_and_tag(ar, g_fxo->get_name<id_map<T>>(), false);
+
 					ar(p.first.value(), p.first.type());
 					info->save(ar, p.second.get());
-					obj_count++;
 				}
 			}
 
-			// Patch object count
-			ar.patch_raw_data(obj_count_offs, &obj_count, sizeof(obj_count));
+			// End sequence with tag bit set
+			serial_breathe_and_tag(ar, g_fxo->get_name<id_map<T>>(), true);
 		}
 
 		id_map& operator=(thread_state state) noexcept requires (std::is_assignable_v<T&, thread_state>)
 		{
-			if (private_copy.empty())
+			if (private_copy.size() != vec.size())
 			{
+				private_copy.clear();
+
 				reader_lock lock(g_mutex);
 
 				// Save all entries

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2761,6 +2761,12 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 				if (!try_lock_spu_threads_in_a_state_compatible_with_savestates())
 				{
 					sys_log.error("Failed to savestate: failed to lock SPU threads execution.");
+
+					if (!g_cfg.savestate.compatible_mode)
+					{
+						sys_log.error("Enabling SPU Savestates-Compatible Mode in Advanced tab may fix this.");
+					}
+
 					m_savestate_pending = false;
 
 					CallFromMainThread([pause = std::move(pause_thread)]()

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -41,7 +41,7 @@ static std::array<serial_ver_t, 26> s_serial_versions;
 		return ::s_serial_versions[identifier].current_version;\
 	}
 
-SERIALIZATION_VER(global_version, 0,                            15) // For stuff not listed here
+SERIALIZATION_VER(global_version, 0,                            16) // For stuff not listed here
 SERIALIZATION_VER(ppu, 1,                                       1)
 SERIALIZATION_VER(spu, 2,                                       1)
 SERIALIZATION_VER(lv2_sync, 3,                                  1)

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -296,14 +296,37 @@ bool load_and_check_reserved(utils::serial& ar, usz size)
 
 namespace stx
 {
-	extern void serial_breathe(utils::serial& ar)
+	extern u16 serial_breathe_and_tag(utils::serial& ar, std::string_view name, bool tag_bit)
 	{
+		thread_local std::string_view s_tls_object_name = "none";
+
+		constexpr u16 data_mask = 0x7fff;
+
+		if (ar.m_file_handler && ar.m_file_handler->is_null())
+		{
+			return (tag_bit ? data_mask + 1 : 0);
+		}
+
+		u16 tag = static_cast<u16>((static_cast<u16>(ar.pos / 2) & data_mask) | (tag_bit ? data_mask + 1 : 0));
+		u16 saved = tag;
+		ar(saved);
+
+		sys_log.trace("serial_breathe_and_tag(): %s, object: '%s', next-object: '%s', expected/tag: 0x%x == 0x%x", ar, s_tls_object_name, name, tag, saved);
+
+		if ((saved ^ tag) & data_mask)
+		{
+			ensure(!ar.is_writing());
+			fmt::throw_exception("serial_breathe_and_tag(): %s, object: '%s', next-object: '%s', expected/tag: 0x%x != 0x%x,", ar, s_tls_object_name, name, tag, saved);
+		}
+
+		s_tls_object_name = name;
 		ar.breathe();
+		return saved;
 	}
 }
 
 // MSVC bug workaround, see above similar case
-extern void serial_breathe(utils::serial& ar)
+extern u16 serial_breathe_and_tag(utils::serial& ar, std::string_view name, bool tag_bit)
 {
-	::stx::serial_breathe(ar);
+	return ::stx::serial_breathe_and_tag(ar, name, tag_bit);
 }

--- a/rpcs3/rpcs3_version.h
+++ b/rpcs3/rpcs3_version.h
@@ -7,7 +7,7 @@ namespace rpcs3
 	std::string_view get_branch();
 	std::string_view get_full_branch();
 	std::pair<std::string, std::string> get_commit_and_hash();
-	const utils::version& get_version();
+	const ::utils::version& get_version();
 	std::string get_version_and_branch();
 	std::string get_verbose_version();
 	bool is_release_build();

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -85,12 +85,13 @@ namespace stx
 					if constexpr (std::is_constructible_v<T, exact_t<manual_typemap&>, exact_t<utils::serial&>>)
 					{
 						g_tls_serialize_name = name;
-						new (ptr) T(_this, exact_t<utils::serial&>(*ar));
+						new (ptr) T(exact_t<manual_typemap&>(_this), exact_t<utils::serial&>(*ar));
 						return true;
 					}
 
 					if constexpr (std::is_constructible_v<T, exact_t<const launch_retainer&>, exact_t<utils::serial&>>)
 					{
+						g_tls_serialize_name = name;
 						new (ptr) T(exact_t<const launch_retainer&>(launch_retainer{}), exact_t<utils::serial&>(*ar));
 						return true;
 					}
@@ -106,7 +107,7 @@ namespace stx
 				// Allow passing reference to "this"
 				if constexpr (std::is_constructible_v<T, exact_t<manual_typemap&>>)
 				{
-					new (ptr) T(_this);
+					new (ptr) T(exact_t<manual_typemap&>(_this));
 					return true;
 				}
 
@@ -400,14 +401,14 @@ namespace stx
 		}
 
 		// Check if object is not initialized but shall be initialized first (to use in initializing other objects)
-		template <typename T> requires (std::is_constructible_v<T, manual_typemap&> || std::is_default_constructible_v<T>)
+		template <typename T> requires (!std::is_constructible_v<T, exact_t<utils::serial&>> && (std::is_constructible_v<T, exact_t<manual_typemap&>> || std::is_default_constructible_v<T>))
 		void need() noexcept
 		{
 			if (!m_init[stx::typeindex<typeinfo, std::decay_t<T>>()])
 			{
-				if constexpr (std::is_constructible_v<T, manual_typemap&>)
+				if constexpr (std::is_constructible_v<T, exact_t<manual_typemap&>>)
 				{
-					init<T>(*this);
+					init<T>(exact_t<manual_typemap&>(*this));
 					return;
 				}
 

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -13,9 +13,16 @@ enum class thread_state : u32;
 
 extern thread_local std::string_view g_tls_serialize_name;
 
+namespace utils
+{
+	struct serial;
+}
+
 namespace stx
 {
 	struct launch_retainer{};
+
+	extern u16 serial_breathe_and_tag(utils::serial& ar, std::string_view name, bool tag_bit);
 
 	// Simplified typemap with exactly one object of each used type, non-moveable. Initialized on init(). Destroyed on clear().
 	template <typename Tag /*Tag should be unique*/, u32 Size = 0, u32 Align = (Size ? 64 : __STDCPP_DEFAULT_NEW_ALIGNMENT__)>
@@ -67,6 +74,7 @@ namespace stx
 			void(*thread_op)(void* ptr, thread_state) noexcept = nullptr;
 			void(*save)(void* ptr, utils::serial&) noexcept = nullptr;
 			void(*destroy)(void* ptr) noexcept = nullptr;
+			bool is_trivial_and_nonsavable = false;
 			std::string_view name;
 
 			template <typename T>
@@ -143,7 +151,7 @@ namespace stx
 			{
 				static_assert(!std::is_copy_assignable_v<T> && !std::is_copy_constructible_v<T>, "Please make sure the object cannot be accidentally copied.");
 
-				typeinfo r;
+				typeinfo r{};
 				r.create = &call_ctor<T>;
 				r.destroy = &call_dtor<T>;
 
@@ -156,6 +164,9 @@ namespace stx
 				{
 					r.save = &call_save<T>;
 				}
+
+				r.is_trivial_and_nonsavable = std::is_trivially_default_constructible_v<T> && !r.save;
+
 #ifdef _MSC_VER
 				constexpr std::string_view name = parse_type(__FUNCSIG__);
 #else
@@ -237,7 +248,8 @@ namespace stx
 			}
 
 			// Use unique_ptr to reduce header dependencies in this commonly used header
-			const auto order = std::make_unique<std::pair<double, const type_info<typeinfo>*>[]>(stx::typelist<typeinfo>().count());
+			const usz type_count = stx::typelist<typeinfo>().count();
+			const auto order = std::make_unique<std::pair<double, const type_info<typeinfo>*>[]>(type_count);
 
 			usz pos = 0;
 			for (const auto& type : stx::typelist<typeinfo>())
@@ -245,14 +257,19 @@ namespace stx
 				order[pos++] = {type.init_pos(), std::addressof(type)};
 			}
 
-			std::stable_sort(order.get(), order.get() + stx::typelist<typeinfo>().count(), [](auto a, auto b)
+			std::stable_sort(order.get(), order.get() + type_count, [](auto& a, auto& b)
 			{
+				if (a.second->is_trivial_and_nonsavable && !b.second->is_trivial_and_nonsavable)
+				{
+					return true;
+				}
+
 				return a.first < b.first;
 			});
 
 			const auto info_before = m_info;
 
-			for (pos = 0; pos < stx::typelist<typeinfo>().count(); pos++)
+			for (pos = 0; pos < type_count; pos++)
 			{
 				const auto& type = *order[pos].second;
 
@@ -271,10 +288,9 @@ namespace stx
 					*m_info++ = &type;
 					m_init[id] = true;
 
-					if (ar)
+					if (ar && type.save)
 					{
-						extern void serial_breathe(utils::serial& ar);
-						serial_breathe(*ar);
+						serial_breathe_and_tag(*ar, type.name, false);
 					}
 				}
 			}
@@ -372,10 +388,13 @@ namespace stx
 			// Save data in forward order
 			for (u32 i = _max; i; i--)
 			{
-				if (auto save = (*std::prev(m_info, i))->save)
+				const auto info = (*std::prev(m_info, i));
+
+				if (auto save = info->save)
 				{
 					save(*std::prev(m_order, i), ar);
-					ar.breathe();
+
+					serial_breathe_and_tag(ar, info->name, false);
 				}
 			}
 		}
@@ -414,6 +433,8 @@ namespace stx
 
 			As* obj = nullptr;
 
+			const auto type_info = &stx::typedata<typeinfo, std::decay_t<T>, std::decay_t<As>>();
+
 			g_tls_serialize_name = get_name<T, As>();
 
 			if constexpr (Size != 0)
@@ -425,10 +446,16 @@ namespace stx
 				obj = new (m_list + stx::typeoffset<typeinfo, std::decay_t<T>>()) std::decay_t<As>(std::forward<Args>(args)...);
 			}
 
+			if constexpr ((std::is_same_v<std::remove_cvref_t<Args>, utils::serial> || ...))
+			{
+				ensure(type_info->save);
+				serial_breathe_and_tag(std::get<0>(std::tie(args...)), get_name<T, As>(), false);
+			}
+
 			g_tls_serialize_name = {};
 
 			*m_order++ = obj;
-			*m_info++ = &stx::typedata<typeinfo, std::decay_t<T>, std::decay_t<As>>();
+			*m_info++ = type_info;
 			return obj;
 		}
 

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -219,6 +219,8 @@ class b8
 public:
 	b8() = default;
 
+	using enable_bitcopy = std::true_type;
+
 	constexpr b8(bool value) noexcept
 		: m_value(value)
 	{


### PR DESCRIPTION
* Fix audio_out_configuration initialization. This was a recent regression caused by #14897.
* Fix SPU access violations when loading savestates with SPU LLVM.
* Implement SPU reservation saving, remove its hack.
* Add data tags in savestates to ensure state integrity on savestate load.
* Improve compression rate of savestate by saving PS3 memory blocks together.
* Invalidate all old savestates.
* Add  saving date and time and RPCS3 build title to the file data itself.