### PR TITLE
Fixes for 0.0.30

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -46,7 +46,7 @@ KeyboardHandlerBase::KeyboardHandlerBase(utils::serial* ar)
 
 	if (m_info.max_connect)
 	{
-		Emu.DeferDeserialization([this]()
+		Emu.PostponeInitCode([this]()
 		{
 			Init(m_info.max_connect);
 			auto lk = init.init();

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -46,7 +46,7 @@ MouseHandlerBase::MouseHandlerBase(utils::serial* ar)
 
 	if (m_info.max_connect)
 	{
-		Emu.DeferDeserialization([this]()
+		Emu.PostponeInitCode([this]()
 		{
 			Init(m_info.max_connect);
 			auto lk = init.init();

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -60,6 +60,7 @@ pad_info::pad_info(utils::serial& ar)
 	, port_setting(ar)
 	, reported_info(ar)
 {
+	reported_info = {};
 	sys_io_serialize(ar);
 }
 
@@ -159,7 +160,7 @@ void cellPad_NotifyStateChange(usz index, u64 /*state*/)
 
 extern void pad_state_notify_state_change(usz index, u32 state)
 {
-	cellPad_NotifyStateChange(index, state);
+	send_sys_io_connect_event(index, state);
 }
 
 error_code cellPadInit(ppu_thread& ppu, u32 max_connect)

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -58,6 +58,7 @@ extern void sys_io_serialize(utils::serial& ar);
 pad_info::pad_info(utils::serial& ar)
 	: max_connect(ar)
 	, port_setting(ar)
+	, reported_info(ar)
 {
 	sys_io_serialize(ar);
 }
@@ -66,7 +67,7 @@ void pad_info::save(utils::serial& ar)
 {
 	USING_SERIALIZATION_VERSION(sys_io);
 
-	ar(max_connect, port_setting);
+	ar(max_connect, port_setting, reported_info);
 
 	sys_io_serialize(ar);
 }

--- a/rpcs3/Emu/Cell/Modules/cellPad.h
+++ b/rpcs3/Emu/Cell/Modules/cellPad.h
@@ -49,6 +49,8 @@ struct pad_data_internal
 	u32 device_type;
 	u32 pclass_type;
 	u32 pclass_profile;
+
+	ENABLE_BITWISE_SERIALIZATION;
 };
 
 struct CellPadInfo

--- a/rpcs3/Emu/Cell/Modules/sys_io_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_io_.cpp
@@ -36,7 +36,7 @@ extern void sys_io_serialize(utils::serial& ar)
 	ensure(g_fxo->try_get<libio_sys_config>())->save_or_load(ar);
 }
 
-extern void cellPad_NotifyStateChange(usz index, u64 state);
+extern void cellPad_NotifyStateChange(usz index, u64 state, bool lock = true);
 
 void config_event_entry(ppu_thread& ppu)
 {

--- a/rpcs3/Emu/Cell/Modules/sys_io_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_io_.cpp
@@ -33,14 +33,14 @@ struct libio_sys_config
 extern void sys_io_serialize(utils::serial& ar)
 {
 	// Do not assign a serialization tag for now, call it from cellPad serialization
-	g_fxo->get<libio_sys_config>().save_or_load(ar);
+	ensure(g_fxo->try_get<libio_sys_config>())->save_or_load(ar);
 }
 
 extern void cellPad_NotifyStateChange(usz index, u64 state);
 
 void config_event_entry(ppu_thread& ppu)
 {
-	auto& cfg = g_fxo->get<libio_sys_config>();
+	auto& cfg = *ensure(g_fxo->try_get<libio_sys_config>());
 
 	if (!ppu.loaded_from_savestate)
 	{
@@ -106,6 +106,12 @@ std::unique_lock<shared_mutex> lock_lv2_mutex_alike(shared_mutex& mtx, ppu_threa
 
 extern void send_sys_io_connect_event(usz index, u32 state)
 {
+	if (Emu.IsStarting() || Emu.IsReady())
+	{
+		cellPad_NotifyStateChange(index, state);
+		return;
+	}
+
 	auto& cfg = g_fxo->get<libio_sys_config>();
 
 	auto lock = lock_lv2_mutex_alike(cfg.mtx, cpu_thread::get_current<ppu_thread>());

--- a/rpcs3/Emu/Cell/SPURecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPURecompiler.cpp
@@ -4531,7 +4531,8 @@ class spu_llvm_recompiler : public spu_recompiler_base, public cpu_translator
 		bool does_gpr_barrier_preceed_first_store(u32 i) const noexcept
 		{
 			const usz counter = store_context_ctr[i];
-			return counter != 1 && counter < store_context_first_id[i];
+			const usz first_id = store_context_first_id[i];
+			return counter != 1 && first_id != umax && counter < first_id;
 		}
 	};
 

--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -45,7 +45,7 @@ CellError lv2_cond::on_id_create()
 
 	ensure(!!Emu.DeserialManager());
 
-	Emu.DeferDeserialization([this]()
+	Emu.PostponeInitCode([this]()
 	{
 		if (!mutex)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<lv2_event_queue> lv2_event_queue::load_ptr(utils::serial& ar, st
 		fmt::throw_exception("Failed in event queue pointer deserialization (invalid ID): location: %s, id=0x%x", msg, id);
 	}
 
-	Emu.DeferDeserialization([id, &queue, msg_str = std::string{msg}]()
+	Emu.PostponeInitCode([id, &queue, msg_str = std::string{msg}]()
 	{
 		// Defer resolving
 		queue = idm::get_unlocked<lv2_obj, lv2_event_queue>(id);

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -28,7 +28,7 @@ lv2_int_tag::lv2_int_tag(utils::serial& ar) noexcept
 
 		if (!ptr && id)
 		{
-			Emu.DeferDeserialization([id, &handler = this->handler]()
+			Emu.PostponeInitCode([id, &handler = this->handler]()
 			{
 				handler = ensure(idm::get_unlocked<lv2_obj, lv2_int_serv>(id));
 			});

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1352,7 +1352,8 @@ error_code sys_spu_thread_group_terminate(ppu_thread& ppu, u32 id, s32 value)
 	if (group->set_terminate)
 	{
 		// Wait for termination, only then return error code
-		const u64 last_stop = group->stop_count;
+		const u32 last_stop = group->stop_count;
+		group->wait_term_count++;
 		lock.unlock();
 		short_sleep(ppu);
 
@@ -1361,6 +1362,7 @@ error_code sys_spu_thread_group_terminate(ppu_thread& ppu, u32 id, s32 value)
 			group->stop_count.wait(last_stop);
 		}
 
+		group->wait_term_count--;
 		return CELL_ESTAT;
 	}
 
@@ -1414,7 +1416,8 @@ error_code sys_spu_thread_group_terminate(ppu_thread& ppu, u32 id, s32 value)
 	group->join_state = SYS_SPU_THREAD_GROUP_JOIN_TERMINATED;
 
 	// Wait until the threads are actually stopped
-	const u64 last_stop = group->stop_count;
+	const u32 last_stop = group->stop_count;
+	group->wait_term_count++;
 	lock.unlock();
 	short_sleep(ppu);
 
@@ -1423,6 +1426,7 @@ error_code sys_spu_thread_group_terminate(ppu_thread& ppu, u32 id, s32 value)
 		group->stop_count.wait(last_stop);
 	}
 
+	group->wait_term_count--;
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -289,7 +289,8 @@ struct lv2_spu_group
 	atomic_t<s32> exit_status; // SPU Thread Group Exit Status
 	atomic_t<u32> join_state; // flags used to detect exit cause and signal
 	atomic_t<u32> running = 0; // Number of running threads
-	atomic_t<u64> stop_count = 0;
+	atomic_t<u32> stop_count = 0;
+	atomic_t<u32> wait_term_count = 0; 
 	u32 waiter_spu_index = -1; // Index of SPU executing a waiting syscall
 	class ppu_thread* waiter = nullptr;
 	bool set_terminate = false;

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -105,7 +105,7 @@ u64 lv2_timer::check_unlocked(u64 _now) noexcept
 
 lv2_timer_thread::lv2_timer_thread()
 {
-	Emu.DeferDeserialization([this]()
+	Emu.PostponeInitCode([this]()
 	{
 		idm::select<lv2_obj, lv2_timer>([&](u32 id, lv2_timer&)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -149,6 +149,11 @@ void lv2_timer_thread::operator()()
 		{
 			while (lv2_obj::check(timer))
 			{
+				if (thread_ctrl::state() == thread_state::aborting)
+				{
+					break;
+				}
+
 				if (const u64 advised_sleep_time = timer->check(_now))
 				{
 					if (sleep_time > advised_sleep_time)

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -25,7 +25,7 @@ struct lv2_timer_thread
 	lv2_timer_thread();
 	void operator()();
 
-	SAVESTATE_INIT_POS(46); // Dependency on LV2 objects (lv2_timer)
+	//SAVESTATE_INIT_POS(46); // FREE SAVESTATE_INIT_POS number
 
 	static constexpr auto thread_name = "Timer Thread"sv;
 };
@@ -105,9 +105,12 @@ u64 lv2_timer::check_unlocked(u64 _now) noexcept
 
 lv2_timer_thread::lv2_timer_thread()
 {
-	idm::select<lv2_obj, lv2_timer>([&](u32 id, lv2_timer&)
+	Emu.DeferDeserialization([this]()
 	{
-		timers.emplace_back(idm::get_unlocked<lv2_obj, lv2_timer>(id));
+		idm::select<lv2_obj, lv2_timer>([&](u32 id, lv2_timer&)
+		{
+			timers.emplace_back(idm::get_unlocked<lv2_obj, lv2_timer>(id));
+		});
 	});
 }
 

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -570,7 +570,7 @@ namespace vm
 						}
 
 						addr2 += size3;
-						size2 -= size3;
+						size2 -= static_cast<u32>(size3);
 					}
 
 					return 0;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -1665,13 +1665,13 @@ namespace vm
 
 		ar.breathe();
 
-		for (usz iter_count = 0; size; iter_count++, ptr += byte_of_pages)
+		for (usz iter_count = 0; size; iter_count += sizeof(u32), ptr += byte_of_pages * sizeof(u32))
 		{
-			size -= byte_of_pages;
+			const u32 bitmap = read_from_ptr<le_t<u32>>(bit_array, iter_count);
 
-			const u8 bitmap = bit_array[iter_count];
+			size -= byte_of_pages * sizeof(bitmap);
 
-			for (usz i = 0; i < byte_of_pages;)
+			for (usz i = 0; i < byte_of_pages * sizeof(bitmap);)
 			{
 				usz block_count = 0;
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -339,10 +339,12 @@ namespace rsx
 						max_result_by_division = std::max<u32>(max_result_by_division, max);
 
 						// Discard lower frequencies because it has been proven that there are indices higher than them
-						freq_count -= frequencies + freq_count - std::remove_if(frequencies, frequencies + freq_count, [&max_result_by_division](u32 freq)
+						const usz discard_cnt = frequencies + freq_count - std::remove_if(frequencies, frequencies + freq_count, [&max_result_by_division](u32 freq)
 						{
 							return freq <= max_result_by_division;
 						});
+
+						freq_count -= static_cast<u32>(discard_cnt);
 					}
 				}
 			}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3287,8 +3287,6 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 		{
 			cpu_thread::cleanup();
 
-			initialize_timebased_time(0, true);
-
 			lv2_obj::cleanup();
 
 			g_fxo->reset();
@@ -3341,6 +3339,8 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 			read_used_savestate_versions();
 			m_savestate_extension_flags1 = {};
 			m_savestate_pending = false;
+
+			initialize_timebased_time(0, true);
 
 			// Complete the operation
 			m_state = system_state::stopped;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -145,11 +145,11 @@ class Emulator final
 
 	std::vector<std::shared_ptr<atomic_t<u32>>> m_pause_msgs_refs;
 
-	std::vector<std::function<void()>> deferred_deserialization;
+	std::vector<std::function<void()>> m_postponed_init_code;
 
-	void ExecDeserializationRemnants()
+	void ExecPostponedInitCode()
 	{
-		for (auto&& func : ::as_rvalue(std::move(deferred_deserialization)))
+		for (auto&& func : ::as_rvalue(std::move(m_postponed_init_code)))
 		{
 			func();
 		}
@@ -200,9 +200,9 @@ public:
 		CallFromMainThread(std::move(func), nullptr, true, static_cast<u64>(counter));
 	}
 
-	void DeferDeserialization(std::function<void()>&& func)
+	void PostponeInitCode(std::function<void()>&& func)
 	{
-		deferred_deserialization.emplace_back(std::move(func));
+		m_postponed_init_code.emplace_back(std::move(func));
 	}
 
 	/** Set emulator mode to running unconditionnaly.

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -311,7 +311,7 @@ namespace stx
 		u16 saved = tag;
 		ar(saved);
 
-		sys_log.trace("serial_breathe_and_tag(): %s, object: '%s', next-object: '%s', expected/tag: 0x%x == 0x%x", ar, s_tls_object_name, name, tag, saved);
+		sys_log.warning("serial_breathe_and_tag(): %s, object: '%s', next-object: '%s', expected/tag: 0x%x == 0x%x", ar, s_tls_object_name, name, tag, saved);
 
 		if ((saved ^ tag) & data_mask)
 		{

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -79,7 +79,7 @@ SERIALIZATION_VER(cellGcm, 19,                                  1)
 SERIALIZATION_VER(sysPrxForUser, 20,                            1)
 SERIALIZATION_VER(cellSaveData, 21,                             1)
 SERIALIZATION_VER(cellAudioOut, 22,                             1)
-SERIALIZATION_VER(sys_io, 23,                                   1)
+SERIALIZATION_VER(sys_io, 23,                                   2)
 
 // Misc versions for HLE/LLE not included so main version would not invalidated
 SERIALIZATION_VER(LLE, 24,                                      1)

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -455,8 +455,9 @@ void tar_object::save_directory(const std::string& target_path, utils::serial& a
 					const usz read_size = std::min<usz>(transfer_block_size, file_stat.size - read_index);
 
 					// Read file data
-					ar.data.resize(ar.data.size() + read_size);
-					ensure(fd.read_at(read_index, ar.data.data() + old_size, read_size) == read_size);
+					const usz buffer_tail = ar.data.size();
+					ar.data.resize(buffer_tail + read_size);
+					ensure(fd.read_at(read_index, ar.data.data() + buffer_tail, read_size) == read_size);
 
 					// Set position to the end of data, so breathe() would work correctly
 					ar.seek_end();

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -105,31 +105,25 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 #ifdef __linux__
 	extern void jit_announce(uptr, usz, std::string_view);
 #endif
-
-	std::string buf;
+	std::string buf(_text);
 
 	// Check if thread id is in string
 	if (_text.find("\nThread id = "sv) == umax && !thread_ctrl::is_main())
 	{
-		// Copy only when needed
-		buf = std::string(_text);
-
 		// Append thread id if it isn't already, except on main thread
 		fmt::append(buf, "\n\nThread id = %u.", thread_ctrl::get_tid());
 	}
 
 	if (!g_tls_serialize_name.empty())
 	{
-		// Copy only when needed
-		if (!buf.empty())
-		{
-			buf = std::string(_text);
-		}
-
 		fmt::append(buf, "\nSerialized Object: %s", g_tls_serialize_name);
 	}
 
-	std::string_view text = buf.empty() ? _text : buf;
+	fmt::append(buf, "\nTitle: \"%s\" (emulation is %s)", Emu.GetTitleAndTitleID(), Emu.IsStopped() ? "stopped" : "running");
+	fmt::append(buf, "\nBuild: \"%s\"", rpcs3::get_verbose_version());
+	fmt::append(buf, "\nDate: \"%s\"", std::chrono::system_clock::now());
+
+	std::string_view text = buf;
 
 	if (s_headless)
 	{

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -242,7 +242,7 @@ namespace stx
 			*m_info++ = nullptr;
 		}
 
-		void init(bool reset = true, utils::serial* ar = nullptr)
+		void init(bool reset = true, utils::serial* ar = nullptr, std::function<void()> func = {})
 		{
 			if (reset)
 			{
@@ -295,6 +295,11 @@ namespace stx
 						serial_breathe_and_tag(*ar, type.name, false);
 					}
 				}
+			}
+
+			if (func)
+			{
+				func();
 			}
 
 			// Launch threads

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -456,7 +456,20 @@ namespace stx
 			if constexpr ((std::is_same_v<std::remove_cvref_t<Args>, utils::serial> || ...))
 			{
 				ensure(type_info->save);
+
 				serial_breathe_and_tag(std::get<0>(std::tie(args...)), get_name<T, As>(), false);
+			}
+
+			if constexpr ((std::is_same_v<std::remove_cvref_t<Args>, utils::serial*> || ...))
+			{
+				ensure(type_info->save);
+
+				utils::serial* ar = std::get<0>(std::tie(args...));
+
+				if (ar)
+				{
+					serial_breathe_and_tag(*ar, get_name<T, As>(), false);
+				}
 			}
 
 			g_tls_serialize_name = {};

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -109,11 +109,7 @@ public:
 		// Reserve memory for serialization
 		void reserve(usz size)
 		{
-			// Is a NO-OP for deserialization in order to allow usage from serialization specializations regardless
-			if (is_writing())
-			{
-				data.reserve(data.size() + size);
-			}
+			data.reserve(data.size() + size);
 		}
 
 		template <typename Func> requires (std::is_convertible_v<std::invoke_result_t<Func>, const void*>)
@@ -136,9 +132,9 @@ public:
 
 			if (is_writing())
 			{
-				ensure(pos >= data_offset);
+				ensure(pos == data_offset + data.size());
 				const auto ptr = reinterpret_cast<const u8*>(memory_provider());
-				data.insert(data.begin() + (pos - data_offset), ptr, ptr + size);
+				data.insert(data.end(), ptr, ptr + size);
 				pos += size;
 				return true;
 			}

--- a/rpcs3/util/serialization_ext.cpp
+++ b/rpcs3/util/serialization_ext.cpp
@@ -171,12 +171,17 @@ void uncompressed_serialization_file_handler::finalize(utils::serial& ar)
 	ar.data = {}; // Deallocate and clear
 }
 
+enum : u64
+{
+	pending_compress_bytes_bound = 0x400'0000,
+	pending_data_wait_bit = 1ull << 63,
+};
+
 struct compressed_stream_data
 {
 	z_stream m_zs{};
 	lf_queue<std::vector<u8>> m_queued_data_to_process;
 	lf_queue<std::vector<u8>> m_queued_data_to_write;
-	atomic_t<usz> m_pending_bytes = 0;
 };
 
 void compressed_serialization_file_handler::initialize(utils::serial& ar)
@@ -286,21 +291,24 @@ bool compressed_serialization_file_handler::handle_file_op(utils::serial& ar, us
 				// Avoid flooding RAM, wait if there is too much pending memory
 				const usz new_value = m_pending_bytes.atomic_op([&](usz v)
 				{
-					v &= ~(1ull << 63);
+					v &= ~pending_data_wait_bit;
 
-					if (v > 0x400'0000)
+					if (v >= pending_compress_bytes_bound)
 					{
-						v |= 1ull << 63;
+						v |= pending_data_wait_bit;
 					}
 					else
 					{
+						// Overflow detector
+						ensure(~v - pending_data_wait_bit > ar.data.size());
+
 						v += ar.data.size();
 					}
 
 					return v;
 				});
 
-				if (new_value & (1ull << 63))
+				if (new_value & pending_data_wait_bit)
 				{
 					m_pending_bytes.wait(new_value);
 				}
@@ -635,19 +643,32 @@ void compressed_serialization_file_handler::stream_data_prepare_thread_op()
 
 				buffer_offset = m_zs.next_out - m_stream_data.data();
 
+				m_zs.avail_in = adjust_for_uint(data.size() - (m_zs.next_in - data.data()));
+
 				if (m_zs.avail_out == 0)
 				{
 					m_stream_data.resize(m_stream_data.size() + (m_zs.avail_in + 3ull) / 4);
 				}
-
-				m_zs.avail_in = adjust_for_uint(data.size() - (m_zs.next_in - data.data()));
 			}
 			while (m_zs.avail_out == 0 || m_zs.avail_in != 0);
 
 			// Forward for file write
 			const usz queued_size = data.size();
 			ensure(buffer_offset);
-			m_pending_bytes += buffer_offset - queued_size;
+
+			const usz size_diff = buffer_offset - queued_size;
+			const usz new_val = m_pending_bytes.add_fetch(size_diff);
+			const usz left = new_val & ~pending_data_wait_bit;
+
+			if (new_val & pending_data_wait_bit && left < pending_compress_bytes_bound && left - size_diff >= pending_compress_bytes_bound && !m_pending_signal)
+			{
+				// Notification is postponed until data write and memory release
+				m_pending_signal = true;
+			}
+
+			// Ensure wait bit state has not changed by the update
+			ensure(~((new_val - size_diff) ^ new_val) & pending_data_wait_bit);
+
 			m_stream_data.resize(buffer_offset);
 			stream.m_queued_data_to_write.push(std::move(m_stream_data));
 		}
@@ -673,10 +694,17 @@ void compressed_serialization_file_handler::file_writer_thread_op()
 			m_file->write(data);
 			data = {}; // Deallocate before notification
 
-			if (m_pending_bytes.sub_fetch(last_size) == 1ull << 63)
+			const usz new_val = m_pending_bytes.sub_fetch(last_size);
+			const usz left = new_val & ~pending_data_wait_bit;
+			const bool pending_sig = m_pending_signal && m_pending_signal.exchange(false);
+
+			if (pending_sig || (new_val & pending_data_wait_bit && left < pending_compress_bytes_bound && left + last_size >= pending_compress_bytes_bound))
 			{
 				m_pending_bytes.notify_all();
 			}
+
+			// Ensure wait bit state has not changed by the update
+			ensure(~((new_val + last_size) ^ new_val) & pending_data_wait_bit);
 		}
 	}
 }

--- a/rpcs3/util/serialization_ext.cpp
+++ b/rpcs3/util/serialization_ext.cpp
@@ -289,7 +289,7 @@ bool compressed_serialization_file_handler::handle_file_op(utils::serial& ar, us
 			while (true)
 			{
 				// Avoid flooding RAM, wait if there is too much pending memory
-				const usz new_value = m_pending_bytes.atomic_op([&](usz v)
+				const usz new_value = m_pending_bytes.atomic_op([&](usz& v)
 				{
 					v &= ~pending_data_wait_bit;
 
@@ -647,7 +647,7 @@ void compressed_serialization_file_handler::stream_data_prepare_thread_op()
 
 				if (m_zs.avail_out == 0)
 				{
-					m_stream_data.resize(m_stream_data.size() + (m_zs.avail_in + 3ull) / 4);
+					m_stream_data.resize(m_stream_data.size() + (m_zs.avail_in / 4) + (m_stream_data.size() / 16) + 1);
 				}
 			}
 			while (m_zs.avail_out == 0 || m_zs.avail_in != 0);

--- a/rpcs3/util/serialization_ext.hpp
+++ b/rpcs3/util/serialization_ext.hpp
@@ -91,6 +91,7 @@ private:
 	usz m_stream_data_index = 0;
 	usz m_file_read_index = 0;
 	atomic_t<usz> m_pending_bytes = 0;
+	atomic_t<bool> m_pending_signal = false;
 	bool m_write_inited = false;
 	bool m_read_inited = false;
 	bool m_errored = false;


### PR DESCRIPTION
* Fix an optimization miss in SPU LLVM when using GPR barriers.
* Fix TAR serialization for individual files if they need to be processed in more than 1 iteration due to their size.
* Don't block the compression-requesting thread until all bytes are processed and written to file, instead free the thread the moment it can continue execution in order to improve saving performance.
* Fix an infinite loop in compression thread.
* Fix lv2_timer_thread abort
* Fix pad_state_notify_state_change
* Make bf_t<T> warning-friendly by using small integers when possible.
* Add cellPad event when registering LDD pads.
* Do not rely solely on value-inequality in sys_spu, this can cause a theoretical bug when overflows.