### PR TITLE
Update AppStream Metainfo for Linux software centers

### DIFF
--- a/rpcs3/rpcs3.metainfo.xml
+++ b/rpcs3/rpcs3.metainfo.xml
@@ -1,68 +1,46 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2018 RPCS3-->
-<component type="desktop-application">
+<?xml version='1.0' encoding='utf-8'?>
+<!-- Copyright 2018 RPCS3 -->
+<component type="desktop">
+    <!--Created with jdAppStreamEdit 8.0-->
     <id>net.rpcs3.RPCS3</id>
-    <metadata_license>FSFAP</metadata_license>
-    <project_license>GPL-2.0-only</project_license>
     <name>RPCS3</name>
     <summary>Open-source Sony PlayStation 3 Emulator</summary>
-
-    <description>
-        <p>
-            RPCS3 is an experimental open-source Sony PlayStation 3 emulator and debugger written in C++ for Windows and Linux. RPCS3 started development in May of 2011 by its founders DH and Hykem.
-            The emulator is currently capable of running over 1800 commercial titles powered by Vulkan and OpenGL.
-        </p>
-        <p>
-            The goal of this project is to experiment, research, and educate on the topic of PlayStation 3 emulation that can be performed on compatible devices and operating systems.
-            All information was obtained legally by purchasing PlayStation 3 hardware and software. Additional information was obtained from various sources on the internet that include but is not limited to system hardware and software documentation.
-            Most of this information can be found on the PlayStation 3 Developer Wiki.
-        </p>
-    </description>
-
+    <developer_name></developer_name>
     <launchable type="desktop-id">rpcs3.desktop</launchable>
-
+    <metadata_license>FSFAP</metadata_license>
+    <project_license>GPL-2.0-only</project_license>
+    <description>
+        <p>RPCS3 is an experimental open-source Sony PlayStation 3 emulator and debugger written in C++ for Windows and Linux. RPCS3 started development in May of 2011 by its founders DH and Hykem.
+                        The emulator is currently capable of running over 1800 commercial titles powered by Vulkan and OpenGL.</p>
+        <p>The goal of this project is to experiment, research, and educate on the topic of PlayStation 3 emulation that can be performed on compatible devices and operating systems.
+                        All information was obtained legally by purchasing PlayStation 3 hardware and software. Additional information was obtained from various sources on the internet that include but is not limited to system hardware and software documentation.
+                        Most of this information can be found on the PlayStation 3 Developer Wiki.</p>
+    </description>
+    <screenshots>
+        <screenshot type="default">
+            <caption>RPCS3 running a game using the Vulkan backend</caption>
+            <image type="source">https://rpcs3.net/blog/wp-content/uploads/2017/05/progress/vklinux.jpg</image>
+        </screenshot>
+    </screenshots>
     <url type="homepage">https://rpcs3.net</url>
     <url type="bugtracker">https://github.com/RPCS3/rpcs3/issues</url>
     <url type="help">https://rpcs3.net/quickstart</url>
     <url type="donation">https://www.patreon.com/Nekotekina</url>
-
-    <screenshots>
-        <screenshot type="default">
-            <caption>RPCS3 running a game using the Vulkan backend</caption>
-            <image>https://rpcs3.net/blog/wp-content/uploads/2017/05/progress/vklinux.jpg</image>
-        </screenshot>
-    </screenshots>
-
-    <provides>
-        <binary>rpcs3</binary>
-    </provides>
-
     <categories>
         <category>Game</category>
         <category>Emulator</category>
     </categories>
-
-    <keywords>
-        <keyword>ps3</keyword>
-        <keyword>playstation</keyword>
-    </keywords>
-
     <recommends>
         <control>gamepad</control>
         <!-- 768 logical pixels is given as the value for small screens in the AppStream spec -->
         <display_length compare="ge">768</display_length>
     </recommends>
-
-    <content_rating type="oars-1.0">
-        <content_attribute id="language-profanity">none</content_attribute>
-        <content_attribute id="language-humor">none</content_attribute>
-        <content_attribute id="language-discrimination">none</content_attribute>
-        <content_attribute id="social-chat">none</content_attribute>
-        <content_attribute id="social-info">none</content_attribute>
-        <content_attribute id="social-audio">none</content_attribute>
-        <content_attribute id="social-location">none</content_attribute>
-        <content_attribute id="social-contacts">none</content_attribute>
-        <content_attribute id="money-purchasing">none</content_attribute>
-        <content_attribute id="money-gambling">none</content_attribute>
-    </content_rating>
+    <content_rating type="oars-1.1"/>
+    <provides>
+        <binary>rpcs3</binary>
+    </provides>
+    <keywords>
+        <keyword>ps3</keyword>
+        <keyword>playstation</keyword>
+    </keywords>
 </component>

--- a/rpcs3/rpcs3.metainfo.xml
+++ b/rpcs3/rpcs3.metainfo.xml
@@ -5,16 +5,19 @@
     <id>net.rpcs3.RPCS3</id>
     <name>RPCS3</name>
     <summary>Open-source Sony PlayStation 3 Emulator</summary>
-    <developer_name></developer_name>
+    <summary xml:lang="de">Quelloffener Sony PlayStation 3 Emulator</summary>
+    <developer_name>RPCS3 Developers</developer_name>
     <launchable type="desktop-id">rpcs3.desktop</launchable>
     <metadata_license>FSFAP</metadata_license>
     <project_license>GPL-2.0-only</project_license>
     <description>
         <p>RPCS3 is an experimental open-source Sony PlayStation 3 emulator and debugger written in C++ for Windows and Linux. RPCS3 started development in May of 2011 by its founders DH and Hykem.
-                        The emulator is currently capable of running over 1800 commercial titles powered by Vulkan and OpenGL.</p>
+The emulator is currently capable of running over 1800 commercial titles powered by Vulkan and OpenGL.</p>
+        <p xml:lang="de">RPCS3 ist ein experimenteller, quelloffener Emulator und Debugger für die Sony PlayStation 3, der in C++ für Windows und Linux entwickelt wurde. Die Entwicklung von RPCS3 begann im Mai 2011 durch seine Gründer DH und Hykem. Der Emulator ist derzeit in der Lage, über 1800 kommerzielle Titel mit Vulkan und OpenGL auszuführen.</p>
         <p>The goal of this project is to experiment, research, and educate on the topic of PlayStation 3 emulation that can be performed on compatible devices and operating systems.
-                        All information was obtained legally by purchasing PlayStation 3 hardware and software. Additional information was obtained from various sources on the internet that include but is not limited to system hardware and software documentation.
-                        Most of this information can be found on the PlayStation 3 Developer Wiki.</p>
+All information was obtained legally by purchasing PlayStation 3 hardware and software. Additional information was obtained from various sources on the internet that include but is not limited to system hardware and software documentation.
+Most of this information can be found on the PlayStation 3 Developer Wiki.</p>
+        <p xml:lang="de">Das Ziel dieses Projekts besteht darin, auf dem Gebiet der PlayStation 3 Emulation auf kompatiblen Geräten und Betriebssystemen zu experimentieren, zu forschen und Wissen zu vermitteln. Alle Informationen wurden legal durch den Kauf von PlayStation 3 Hardware und Software erlangt. Zusätzliche Informationen wurden aus verschiedenen Quellen im Internet bezogen, einschließlich, aber nicht beschränkt auf System-Hardware- und Software-Dokumentation. Die meisten dieser Informationen sind im PlayStation 3 Developer Wiki zu finden.</p>
     </description>
     <screenshots>
         <screenshot type="default">
@@ -24,8 +27,11 @@
     </screenshots>
     <url type="homepage">https://rpcs3.net</url>
     <url type="bugtracker">https://github.com/RPCS3/rpcs3/issues</url>
+    <url type="faq">https://rpcs3.net/faq</url>
     <url type="help">https://rpcs3.net/quickstart</url>
     <url type="donation">https://www.patreon.com/Nekotekina</url>
+    <url type="vcs-browser">https://github.com/RPCS3/rpcs3</url>
+    <url type="contribute">https://github.com/RPCS3/rpcs3#contributing</url>
     <categories>
         <category>Game</category>
         <category>Emulator</category>

--- a/rpcs3/rpcs3.metainfo.xml
+++ b/rpcs3/rpcs3.metainfo.xml
@@ -12,8 +12,8 @@
     <project_license>GPL-2.0-only</project_license>
     <description>
         <p>RPCS3 is an experimental open-source Sony PlayStation 3 emulator and debugger written in C++ for Windows and Linux. RPCS3 started development in May of 2011 by its founders DH and Hykem.
-The emulator is currently capable of running over 1800 commercial titles powered by Vulkan and OpenGL.</p>
-        <p xml:lang="de">RPCS3 ist ein experimenteller, quelloffener Emulator und Debugger für die Sony PlayStation 3, der in C++ für Windows und Linux entwickelt wurde. Die Entwicklung von RPCS3 begann im Mai 2011 durch seine Gründer DH und Hykem. Der Emulator ist derzeit in der Lage, über 1800 kommerzielle Titel mit Vulkan und OpenGL auszuführen.</p>
+The emulator is currently capable of running over 2500 commercial titles powered by Vulkan and OpenGL.</p>
+        <p xml:lang="de">RPCS3 ist ein experimenteller, quelloffener Emulator und Debugger für die Sony PlayStation 3, der in C++ für Windows und Linux entwickelt wurde. Die Entwicklung von RPCS3 begann im Mai 2011 durch seine Gründer DH und Hykem. Der Emulator ist derzeit in der Lage, über 2500 kommerzielle Titel mit Vulkan und OpenGL auszuführen.</p>
         <p>The goal of this project is to experiment, research, and educate on the topic of PlayStation 3 emulation that can be performed on compatible devices and operating systems.
 All information was obtained legally by purchasing PlayStation 3 hardware and software. Additional information was obtained from various sources on the internet that include but is not limited to system hardware and software documentation.
 Most of this information can be found on the PlayStation 3 Developer Wiki.</p>

--- a/rpcs3/rpcs3.metainfo.xml
+++ b/rpcs3/rpcs3.metainfo.xml
@@ -28,6 +28,7 @@
 
     <screenshots>
         <screenshot type="default">
+            <caption>RPCS3 running a game using the Vulkan backend</caption>
             <image>https://rpcs3.net/blog/wp-content/uploads/2017/05/progress/vklinux.jpg</image>
         </screenshot>
     </screenshots>
@@ -48,7 +49,8 @@
 
     <recommends>
         <control>gamepad</control>
-        <display_length compare="ge">small</display_length>
+        <!-- 768 logical pixels is given as the value for small screens in the AppStream spec -->
+        <display_length compare="ge">768</display_length>
     </recommends>
 
     <content_rating type="oars-1.0">


### PR DESCRIPTION
I validated the file with `appstreamcli` and only warnings remain, one of them a pedantic one:

The deprecated `developer_name` is still required by the old version of AppStream that Flathub uses and the `<releases>` section is added downstream: https://github.com/flathub/net.rpcs3.RPCS3/blob/a2cf3ae4e309ffb5943339bdb21e2f0f9cb77dbd/net.rpcs3.RPCS3.yaml#L86

```
$ flatpak run org.freedesktop.appstream.cli validate --pedantic --explain rpcs3/rpcs3.metainfo.xml
P: net.rpcs3.RPCS3:5: cid-contains-uppercase-letter net.rpcs3.RPCS3
   The component ID should only contain lowercase characters.

W: net.rpcs3.RPCS3:9: developer-name-tag-deprecated
   The toplevel `developer_name` element is deprecated. Please use the `name` element in a
   `developer` block instead.

P: net.rpcs3.RPCS3:~: releases-info-missing
   This component is missing information about releases. Consider adding a `releases` tag to
   describe releases and their changes.

✘ Validation failed: warnings: 1, pedantic: 2
```

The `<content_rating>` tag has been simplified, since all `<content_attribute>` tags were `none`.