### PR TITLE
rsx: Misc tiling improvements

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXMemoryTiling.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXMemoryTiling.glsl
@@ -308,9 +308,9 @@ void do_memory_op(const in uint row, const in uint col)
 	tile_address ^= ((tile_address >> 11) & 1) << 10;
 
 	// Calculate relative addresses and sample
-	const uint linear_image_offset = (row * image_pitch) + (col * image_bpp);
-	const uint tile_base_offset = tile_address - conf.tile_base_address; // Distance from tile base address
-	const uint tile_data_offset = tile_base_offset - conf.tile_offset;   // Distance from data base address
+	uint linear_image_offset = (row * image_pitch) + (col * image_bpp);
+	uint tile_base_offset = tile_address - tile_base_address; // Distance from tile base address
+	uint tile_data_offset = tile_base_offset - tile_offset;   // Distance from data base address
 
 	if (tile_base_offset >= tile_size)
 	{

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXMemoryTiling.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXMemoryTiling.glsl
@@ -308,10 +308,11 @@ void do_memory_op(const in uint row, const in uint col)
 	tile_address ^= ((tile_address >> 11) & 1) << 10;
 
 	// Calculate relative addresses and sample
-	uint linear_image_offset = (row * image_pitch) + (col * image_bpp);
-	uint tile_data_offset = tile_address - (tile_base_address + tile_offset);
+	const uint linear_image_offset = (row * image_pitch) + (col * image_bpp);
+	const uint tile_base_offset = tile_address - conf.tile_base_address; // Distance from tile base address
+	const uint tile_data_offset = tile_base_offset - conf.tile_offset;   // Distance from data base address
 
-	if (tile_data_offset >= tile_size)
+	if (tile_base_offset >= tile_size)
 	{
 		// Do not touch anything out of bounds
 		return;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -696,7 +696,11 @@ namespace vk
 #if DEBUG_DMA_TILING
 			auto real_data = vm::get_super_ptr<u8>(range.start);
 			ext_data.resize(tiled_region.tile->size);
-			rsx::tile_texel_data<u32, true>(
+			auto detile_func = get_bpp() == 4
+				? rsx::detile_texel_data32
+				: rsx::detile_texel_data16;
+
+			detile_func(
 				ext_data.data(),
 				real_data,
 				tiled_region.base_address,
@@ -706,7 +710,7 @@ namespace vk
 				tiled_region.tile->pitch,
 				subres.width_in_block,
 				subres.height_in_block
-				);
+			);
 			subres.data = std::span(ext_data);
 #else
 			const auto [scratch_buf, linear_data_scratch_offset] = vk::detile_memory_block(cmd, tiled_region, range, subres.width_in_block, subres.height_in_block, get_bpp());

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -1790,7 +1790,11 @@ namespace rsx
 
 			if (tiled_region)
 			{
-				rsx::tile_texel_data<u32, false>(
+				const auto tile_func = dst.bpp == 4
+					? rsx::tile_texel_data32
+					: rsx::tile_texel_data16;
+
+				tile_func(
 					real_dst,
 					dst.pixels,
 					tiled_region.base_address,


### PR DESCRIPTION
- Out of bounds write fix to fix some crashing scenarios.
- Allow CPU side to pick the correct image texel size depending on the bpp. This is still not as complete as the GPU code which can do all sizes from 1 byte to 16, but it's something at least.
