### PR TITLE
rsx: Fix RSX tiling when using optimized DMA views

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1171,7 +1171,14 @@ namespace rsx
 			notify_range_valid();
 		}
 
+		void create_dma_only(u16 width, u16 height, u32 pitch)
+		{
+			this->width = width;
+			this->height = height;
+			this->rsx_pitch = pitch;
 
+			set_context(rsx::texture_upload_context::dma);
+		}
 
 		/**
 		 * Destroyed Flag

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -708,14 +708,18 @@ namespace gl
 			return &cached;
 		}
 
-		cached_texture_section* create_nul_section(gl::command_context& /*cmd*/, const utils::address_range& rsx_range, bool /*memory_load*/) override
+		cached_texture_section* create_nul_section(
+			gl::command_context& /*cmd*/,
+			const utils::address_range& rsx_range,
+			const rsx::image_section_attributes_t& attrs,
+			bool /*memory_load*/) override
 		{
 			auto& cached = *find_cached_texture(rsx_range, { .gcm_format = RSX_GCM_FORMAT_IGNORED }, true, false, false);
 			ensure(!cached.is_locked());
 
 			// Prepare section
 			cached.reset(rsx_range);
-			cached.set_context(rsx::texture_upload_context::dma);
+			cached.create_dma_only(attrs.width, attrs.height, attrs.pitch);
 			cached.set_dirty(false);
 
 			no_access_range = cached.get_min_max(no_access_range, rsx::section_bounds::locked_range);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -984,14 +984,18 @@ namespace vk
 		return &region;
 	}
 
-	cached_texture_section* texture_cache::create_nul_section(vk::command_buffer& /*cmd*/, const utils::address_range& rsx_range, bool memory_load)
+	cached_texture_section* texture_cache::create_nul_section(
+		vk::command_buffer& /*cmd*/,
+		const utils::address_range& rsx_range,
+		const rsx::image_section_attributes_t& attrs,
+		bool memory_load)
 	{
 		auto& region = *find_cached_texture(rsx_range, { .gcm_format = RSX_GCM_FORMAT_IGNORED }, true, false, false);
 		ensure(!region.is_locked());
 
 		// Prepare section
 		region.reset(rsx_range);
-		region.set_context(rsx::texture_upload_context::dma);
+		region.create_dma_only(attrs.width, attrs.height, attrs.pitch);
 		region.set_dirty(false);
 		region.set_unpack_swap_bytes(true);
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -482,7 +482,7 @@ namespace vk
 		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch,
 			u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t flags) override;
 
-		cached_texture_section* create_nul_section(vk::command_buffer& cmd, const utils::address_range& rsx_range, bool memory_load) override;
+		cached_texture_section* create_nul_section(vk::command_buffer& cmd, const utils::address_range& rsx_range, const rsx::image_section_attributes_t& attrs, bool memory_load) override;
 
 		cached_texture_section* upload_image_from_cpu(vk::command_buffer& cmd, const utils::address_range& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch, u32 gcm_format,
 			rsx::texture_upload_context context, const std::vector<rsx::subresource_layout>& subresource_layout, rsx::texture_dimension_extended type, bool swizzled) override;


### PR DESCRIPTION
Allows tiled targets to work properly with linear DMA sections. This keeps performance up while allowing the detiler to work properly.

Closes https://github.com/RPCS3/rpcs3/issues/14984