### PR TITLE
More fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -60,7 +60,7 @@ pad_info::pad_info(utils::serial& ar)
 	, port_setting(ar)
 	, reported_info(ar)
 {
-	reported_info = {};
+	//reported_info = {};
 	sys_io_serialize(ar);
 }
 

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -201,7 +201,7 @@ void progress_dialog_server::operator()()
 					if (pdone < ptotal && g_cfg.misc.show_ppu_compilation_hint)
 					{
 						const u64 passed_usec = (get_system_time() - start_time);
-						const u64 remaining_usec = passed_usec * (pdone ? ((static_cast<u64>(ptotal) - pdone) / pdone) : ptotal);
+						const u64 remaining_usec = pdone ? utils::rational_mul<u64>(passed_usec, pdone, static_cast<u64>(ptotal) - pdone) : (passed_usec * ptotal);
 
 						// Only show compile notification if we estimate at least 100ms
 						if (remaining_usec >= 100'000ULL)


### PR DESCRIPTION
* Fix PPU progress dialog hint - it actually did not work for a while now, because the integral division resulted in 0.
* Fixup fatal error dialog message.
* Fix a bug in Emulator::GetNdvdDir and make it perform less filesystem operations. May address #14679 