### PR TITLE
rsx: Display output format correction

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -416,9 +416,9 @@ void GLGSRender::on_exit()
 		m_flip_fbo.remove();
 	}
 
-	if (m_flip_tex_color)
+	for (auto& flip_tex_image : m_flip_tex_color)
 	{
-		m_flip_tex_color.reset();
+		flip_tex_image.reset();
 	}
 
 	if (m_vao)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -64,6 +64,7 @@ namespace gl
 		u32 width;
 		u32 height;
 		u32 pitch;
+		u8  eye;
 	};
 }
 
@@ -125,7 +126,7 @@ class GLGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 	gl::fbo* m_draw_fbo = nullptr;
 	std::list<gl::framebuffer_holder> m_framebuffer_cache;
 	gl::fbo m_flip_fbo;
-	std::unique_ptr<gl::texture> m_flip_tex_color;
+	std::unique_ptr<gl::texture> m_flip_tex_color[2];
 
 	//vaos are mandatory for core profile
 	gl::vao m_vao;

--- a/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
@@ -304,6 +304,7 @@ namespace vk
 		u32 width;
 		u32 height;
 		u32 pitch;
+		u8  eye;
 	};
 
 	struct draw_call_t

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -504,6 +504,13 @@ namespace vk
 
 		void destroy() override;
 
+		std::unique_ptr<vk::viewable_image> create_temporary_subresource_storage(
+			rsx::format_class format_class, VkFormat format,
+			u16 width, u16 height, u16 depth, u16 layers, u8 mips,
+			VkImageType image_type, VkFlags image_flags, VkFlags usage_flags);
+
+		void dispose_reusable_image(std::unique_ptr<vk::viewable_image>& tex);
+
 		bool is_depth_texture(u32 rsx_address, u32 rsx_size) override;
 
 		void on_frame_end() override;


### PR DESCRIPTION
In very rare cases, we can see a developer choosing a backbuffer of the wrong format compared to what they declared when setting up the display. In such scenarios, the output format of the compositing render does not actually match the display format. We need to correct this before present or the colors will not match what is expected.

Fixes https://github.com/RPCS3/rpcs3/issues/11324