### PR TITLE
vk: Force GPU texture processing if the input is already GPU-resident

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -1007,7 +1007,7 @@ namespace vk
 			// Only do GPU-side conversion if occupancy is good
 			if (check_caps)
 			{
-				caps.supports_byteswap = (image_linear_size >= 1024);
+				caps.supports_byteswap = (image_linear_size >= 1024) || (image_setup_flags & source_is_gpu_resident);
 				caps.supports_hw_deswizzle = caps.supports_byteswap;
 				caps.supports_zero_copy = caps.supports_byteswap;
 				caps.supports_vtc_decoding = false;


### PR DESCRIPTION
This only really applies to buffer loads from tiled regions.

Fixes https://github.com/RPCS3/rpcs3/issues/14981