### PR TITLE
Fix games passing invalid npids

### DIFF
--- a/rpcs3/Emu/NP/np_cache.cpp
+++ b/rpcs3/Emu/NP/np_cache.cpp
@@ -9,12 +9,13 @@ LOG_CHANNEL(np_cache);
 
 namespace np
 {
-	memberbin_cache::memberbin_cache(SceNpMatching2RoomMemberBinAttrInternal* sce_memberbin)
+	memberbin_cache::memberbin_cache(const SceNpMatching2RoomMemberBinAttrInternal* sce_memberbin)
 	{
-		id              = sce_memberbin->data.id;
+		ensure(sce_memberbin && (sce_memberbin->data.ptr.get_ptr() || !sce_memberbin->data.size));
+
+		id = sce_memberbin->data.id;
 		updateDate.tick = sce_memberbin->updateDate.tick;
-		data.resize(sce_memberbin->data.size);
-		memcpy(data.data(), sce_memberbin->data.ptr.get_ptr(), sce_memberbin->data.size);
+		data = std::vector<u8>(sce_memberbin->data.ptr.get_ptr(), sce_memberbin->data.ptr.get_ptr() + sce_memberbin->data.size);
 	}
 
 	member_cache::member_cache(const SceNpMatching2RoomMemberDataInternal* sce_member)

--- a/rpcs3/Emu/NP/np_cache.h
+++ b/rpcs3/Emu/NP/np_cache.h
@@ -19,7 +19,7 @@ namespace np
 
 	struct memberbin_cache
 	{
-		memberbin_cache(SceNpMatching2RoomMemberBinAttrInternal* sce_memberbin);
+		memberbin_cache(const SceNpMatching2RoomMemberBinAttrInternal* sce_memberbin);
 
 		SceNpMatching2AttributeId id;
 		CellRtcTick updateDate;

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -1073,7 +1073,7 @@ namespace np
 						}
 						else
 						{
-							if (basic_handler.context_sensitive && !pr_info.pr_com_id.data[0] == 0)
+							if (basic_handler.context_sensitive && pr_info.online)
 							{
 								to_add.event = SCE_NP_BASIC_EVENT_OUT_OF_CONTEXT;
 							}

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -1413,6 +1413,13 @@ namespace rpcn
 			std::vector<flatbuffers::Offset<flatbuffers::String>> davec;
 			for (u32 i = 0; i < req->allowedUserNum; i++)
 			{
+				// Some games just give us garbage, make sure npid is valid before passing
+				// Ex: Aquapazza (gives uninitialized buffer on the stack and allowedUserNum is hardcoded to 100)
+				if (!np::is_valid_npid(req->allowedUser[i]))
+				{
+					continue;
+				}
+
 				auto bin = builder.CreateString(req->allowedUser[i].handle.data);
 				davec.push_back(bin);
 			}
@@ -1424,6 +1431,11 @@ namespace rpcn
 			std::vector<flatbuffers::Offset<flatbuffers::String>> davec;
 			for (u32 i = 0; i < req->blockedUserNum; i++)
 			{
+				if (!np::is_valid_npid(req->blockedUser[i]))
+				{
+					continue;
+				}
+
 				auto bin = builder.CreateString(req->blockedUser[i].handle.data);
 				davec.push_back(bin);
 			}


### PR DESCRIPTION
- Fixes Aquapazza sending invalid SceNpMatching2CreateJoinRoomRequest(random pointer to the stack and hardcoded 100 for allowedUser/allowedUserNum)