### PR TITLE
Savestate and filesystem fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
@@ -20,7 +20,7 @@ lv2_socket_native::lv2_socket_native(lv2_socket_family family, lv2_socket_type t
 }
 
 lv2_socket_native::lv2_socket_native(utils::serial& ar, lv2_socket_type type)
-	: lv2_socket(ar, type)
+	: lv2_socket(stx::make_exact(ar), type)
 {
 #ifdef _WIN32
 	ar(so_reuseaddr, so_reuseport);
@@ -37,7 +37,7 @@ lv2_socket_native::lv2_socket_native(utils::serial& ar, lv2_socket_type type)
 
 void lv2_socket_native::save(utils::serial& ar)
 {
-	static_cast<lv2_socket*>(this)->save(ar, true);
+	lv2_socket::save(ar, true);
 #ifdef _WIN32
 	ar(so_reuseaddr, so_reuseport);
 #else

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
@@ -10,13 +10,13 @@ lv2_socket_raw::lv2_socket_raw(lv2_socket_family family, lv2_socket_type type, l
 }
 
 lv2_socket_raw::lv2_socket_raw(utils::serial& ar, lv2_socket_type type)
-	: lv2_socket(ar, type)
+	: lv2_socket(stx::make_exact(ar), type)
 {
 }
 
 void lv2_socket_raw::save(utils::serial& ar)
 {
-	static_cast<lv2_socket*>(this)->save(ar, true);
+	lv2_socket::save(ar, true);
 }
 
 std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_raw::accept([[maybe_unused]] bool is_lock)

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -201,7 +201,7 @@ void progress_dialog_server::operator()()
 					if (pdone < ptotal && g_cfg.misc.show_ppu_compilation_hint)
 					{
 						const u64 passed_usec = (get_system_time() - start_time);
-						const u64 remaining_usec = pdone ? utils::rational_mul<u64>(passed_usec, pdone, static_cast<u64>(ptotal) - pdone) : (passed_usec * ptotal);
+						const u64 remaining_usec = pdone ? utils::rational_mul<u64>(passed_usec, static_cast<u64>(ptotal) - pdone, pdone) : (passed_usec * ptotal);
 
 						// Only show compile notification if we estimate at least 100ms
 						if (remaining_usec >= 100'000ULL)

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -232,6 +232,9 @@ bool tar_object::extract(std::string prefix_path, bool is_vfs)
 		const TARHeader& header = iter->second.second;
 		const std::string& name = iter->first;
 
+		// Backwards compatibility measure
+		const bool should_ignore = name.find(reinterpret_cast<const char*>(u8"＄")) != umax;
+
 		std::string result = name;
 
 		if (!prefix_path.empty())
@@ -291,7 +294,16 @@ bool tar_object::extract(std::string prefix_path, bool is_vfs)
 
 			std::unique_ptr<utils::serial> file_data = get_file(name);
 
-			fs::file file(result, fs::rewrite);
+			fs::file file;
+
+			if (should_ignore)
+			{
+				file = fs::make_stream<std::vector<u8>>();
+			}
+			else
+			{
+				file.open(result, fs::rewrite);
+			}
 
 			if (file && file_data)
 			{
@@ -301,7 +313,7 @@ bool tar_object::extract(std::string prefix_path, bool is_vfs)
 
 					if (unread_size == 0)
 					{
-						file.write(filedata_span.data(), filedata_span.size());
+						file.write(filedata_span.data(), should_ignore ? 0 : filedata_span.size());
 						continue;
 					}
 
@@ -310,13 +322,14 @@ bool tar_object::extract(std::string prefix_path, bool is_vfs)
 					if (usz read_size = filedata_span.size() - unread_size)
 					{
 						ensure(file_data->try_read(filedata_span.first(read_size)) == 0);
-						file.write(filedata_span.data(), read_size);
+						file.write(filedata_span.data(), should_ignore ? 0 : read_size);
 					}
 
 					break;
 				}
 
 				file.close();
+
 
 				file_data->seek_pos(m_ar_tar_start + largest_offset, true);
 
@@ -325,6 +338,11 @@ bool tar_object::extract(std::string prefix_path, bool is_vfs)
 					// Restore m_ar
 					*m_ar = std::move(*file_data);
 					m_ar->m_max_data = restore_limit;
+				}
+
+				if (should_ignore)
+				{
+					break;
 				}
 
 				if (mtime != umax && !fs::utime(result, atime, mtime))
@@ -351,6 +369,11 @@ bool tar_object::extract(std::string prefix_path, bool is_vfs)
 
 		case '5':
 		{
+			if (should_ignore)
+			{
+				break;
+			}
+
 			if (!fs::create_path(result))
 			{
 				tar_log.error("TAR Loader: failed to create directory %s (%s)", name, fs::g_tls_error);
@@ -576,7 +599,7 @@ void tar_object::save_directory(const std::string& target_path, utils::serial& a
 			{
 				exists = true;
 
-				if (entry.name.find_first_not_of('.') == umax)
+				if (entry.name.find_first_not_of('.') == umax || entry.name.starts_with(reinterpret_cast<const char*>(u8"＄")))
 				{
 					continue;
 				}

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -124,7 +124,8 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 			fmt::append(buf, "\nSerialized Object: %s", g_tls_serialize_name);
 		}
 
-		fmt::append(buf, "\nTitle: \"%s\" (emulation is %s)", Emu.GetTitleAndTitleID(), Emu.IsStopped() ? "stopped" : "running");
+		const system_state state = Emu.GetStatus(false);
+		fmt::append(buf, "\nTitle: \"%s\" (emulation is %s)", state == system_state::stopped ? "N/A" : Emu.GetTitleAndTitleID(), state <= system_state::stopping ? "stopped" : "running");
 		fmt::append(buf, "\nBuild: \"%s\"", rpcs3::get_verbose_version());
 		fmt::append(buf, "\nDate: \"%s\"", std::chrono::system_clock::now());
 	}

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -383,6 +383,14 @@ void gs_frame::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const QKey
 	{
 		if (!m_disable_kb_hotkeys)
 		{
+			if (!g_cfg.savestate.suspend_emu)
+			{
+				Emu.after_kill_callback = []()
+				{
+					Emu.Restart();
+				};
+			}
+
 			Emu.Kill(false, true);
 			return;
 		}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -57,6 +57,7 @@
 #include "Emu/vfs_config.h"
 #include "Emu/System.h"
 #include "Emu/system_utils.hpp"
+#include "Emu/system_config.h"
 
 #include "Crypto/unpkg.h"
 #include "Crypto/unself.h"
@@ -2395,6 +2396,21 @@ void main_window::CreateConnects()
 	connect(ui->actionCreate_Savestate, &QAction::triggered, this, []()
 	{
 		gui_log.notice("User triggered savestate creation from utilities.");
+
+		if (!g_cfg.savestate.suspend_emu)
+		{
+			Emu.after_kill_callback = []()
+			{
+				Emu.Restart();
+			};
+		}
+
+		Emu.Kill(false, true);
+	});
+
+	connect(ui->actionCreate_Savestate_And_Exit, &QAction::triggered, this, []()
+	{
+		gui_log.notice("User triggered savestate creation and emulation stop from utilities.");
 		Emu.Kill(false, true);
 	});
 

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -300,6 +300,7 @@
     <addaction name="separator"/>
     <addaction name="actionCreate_RSX_Capture"/>
     <addaction name="actionCreate_Savestate"/>
+    <addaction name="actionCreate_Savestate_And_Exit"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -1191,6 +1192,14 @@
    </property>
    <property name="text">
     <string>Create Savestate</string>
+   </property>
+  </action>
+    <action name="actionCreate_Savestate_And_Exit">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Stop And Create Savestate</string>
    </property>
   </action>
   <action name="actionManage_Game_Patches">

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -962,7 +962,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		const std::string selected_device = m_emu_settings->GetSetting(emu_settings_type::AudioDevice);
 		int device_index = 0;
 
-		for (const audio_device_enumerator::audio_device& dev : dev_array)
+		for (auto& dev : dev_array)
 		{
 			const QString cur_item = qstr(dev.id);
 			ui->audioDeviceBox->addItem(qstr(dev.name), cur_item);
@@ -2307,9 +2307,6 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	m_emu_settings->EnhanceCheckBox(ui->disableVertexCache, emu_settings_type::DisableVertexCache);
 	SubscribeTooltip(ui->disableVertexCache, tooltips.settings.disable_vertex_cache);
-
-	m_emu_settings->EnhanceCheckBox(ui->forceHwMSAAResolve, emu_settings_type::ForceHwMSAAResolve);
-	SubscribeTooltip(ui->forceHwMSAAResolve, tooltips.settings.force_hw_MSAA);
 
 	// Checkboxes: core debug options
 	m_emu_settings->EnhanceCheckBox(ui->alwaysStart, emu_settings_type::StartOnBoot);

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1203,6 +1203,12 @@ namespace stx
 		template <typename U> requires (std::is_same_v<U, T> && std::is_copy_constructible_v<T>)
 		operator U() const noexcept { return obj; };
 	};
+
+	template <typename T>
+	stx::exact_t<T&> make_exact(T&& obj) noexcept
+	{
+		return stx::exact_t<T&>(static_cast<T&>(obj));
+	}
 }
 
 // Read object of type T from raw pointer, array, string, vector, or any contiguous container


### PR DESCRIPTION
* Fixup HDD1 corruption detection.
* Fixup a minor bug in PPU module compilation overlay hint.
* Optimize PS3 filesystem reads when possible by using complete reads.
* Early protection againt space shortage when installing PUP (avoid incomplete installation).
* Fix P2P sockets saving for save-states.