### PR TITLE
Replaces page fault triggers with assembly

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -3721,7 +3721,7 @@ bool spu_thread::do_putllc(const spu_mfc_cmd& args)
 
 		if (!vm::check_addr(addr, vm::page_writable))
 		{
-			vm::_ref<atomic_t<u8>>(addr) += 0; // Access violate
+			utils::trigger_write_page_fault(vm::base(addr));
 		}
 
 		raddr = 0;
@@ -3823,7 +3823,7 @@ void do_cell_atomic_128_store(u32 addr, const void* to_write)
 		else if (!g_use_rtm)
 		{
 			// Provoke page fault
-			vm::_ref<atomic_t<u32>>(addr) += 0;
+			utils::trigger_write_page_fault(vm::base(addr));
 
 			// Hard lock
 			auto spu = cpu ? cpu->try_get<spu_thread>() : nullptr;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -237,7 +237,7 @@ namespace vm
 
 					// Try triggering a page fault (write)
 					// TODO: Read memory if needed
-					vm::_ref<atomic_t<u8>>(test / 4096 == begin / 4096 ? begin : test) += 0;
+					utils::trigger_write_page_fault(vm::base(test / 4096 == begin / 4096 ? begin : test));
 					continue;
 				}
 			}

--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -2,6 +2,7 @@
 
 #include "util/types.hpp"
 #include "util/tsc.hpp"
+#include "util/atomic.hpp"
 #include <functional>
 
 extern bool g_use_rtm;
@@ -433,6 +434,15 @@ namespace utils
 	constexpr T mul_saturate(T factor1, T factor2)
 	{
 		return factor1 > 0 && T{umax} / factor1 < factor2 ? T{umax} : static_cast<T>(factor1 * factor2);
+	}
+
+	inline void trigger_write_page_fault(void* ptr)
+	{
+#if defined(ARCH_X64) && !defined(_MSC_VER)
+		__asm__ volatile("lock orl $0, 0(%0)" :: "r" (ptr));
+#else
+		*static_cast<atomic_t<u32> *>(ptr) += 0;
+#endif
 	}
 
 	inline void trap()


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/14949.

Clang optimizes vm::_ref<atomic_t<u8>>(test / 4096 == begin / 4096 ? begin : test) += 0; to a simple memory barrier as it considers it's the only possible side effect:
```x86asm
lock orl $0x0,-0x40(%rsp)
```
I added a function with inline assembly to make sure it's not optimized away with a fallback to a volatile value that shouldn't be optimized away either.