### PR TITLE
rsx: Properly propagate surface properties on surface reuse.

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -452,7 +452,7 @@ namespace rsx
 				{
 					if (!pitch_compatible)
 					{
-						Traits::invalidate_surface_contents(command_list, Traits::get(surface), address, pitch);
+						Traits::invalidate_surface_contents(command_list, Traits::get(surface), format, address, pitch);
 					}
 
 					Traits::notify_surface_persist(surface);
@@ -512,7 +512,7 @@ namespace rsx
 						}
 
 						new_surface = Traits::get(new_surface_storage);
-						Traits::invalidate_surface_contents(command_list, new_surface, address, pitch);
+						Traits::invalidate_surface_contents(command_list, new_surface, format, address, pitch);
 						Traits::prepare_surface_for_drawing(command_list, new_surface);
 						allocate_rsx_memory(new_surface);
 						break;

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -271,7 +271,7 @@ struct gl_render_target_traits
 	}
 
 	static
-	void invalidate_surface_contents(gl::command_context&, gl::render_target *surface, u32 address, usz pitch)
+	void int_invalidate_surface_contents(gl::command_context&, gl::render_target *surface, u32 address, usz pitch)
 	{
 		surface->set_rsx_pitch(static_cast<u32>(pitch));
 		surface->queue_tag(address);
@@ -279,6 +279,34 @@ struct gl_render_target_traits
 		surface->stencil_init_flags = 0;
 		surface->memory_usage_flags = rsx::surface_usage_flags::unknown;
 		surface->raster_type = rsx::surface_raster_type::linear;
+	}
+
+	static
+	void invalidate_surface_contents(
+		gl::command_context& cmd,
+		gl::render_target* surface,
+		rsx::surface_color_format format,
+		u32 address,
+		usz pitch)
+	{
+		auto fmt = rsx::internals::surface_color_format_to_gl(format);
+		std::array<GLenum, 4> native_layout = { static_cast<GLenum>(fmt.swizzle.a), static_cast<GLenum>(fmt.swizzle.r), static_cast<GLenum>(fmt.swizzle.g), static_cast<GLenum>(fmt.swizzle.b) };
+		surface->set_native_component_layout(native_layout);
+		surface->set_format(format);
+
+		int_invalidate_surface_contents(cmd, surface, address, pitch);
+	}
+
+	static
+	void invalidate_surface_contents(
+		gl::command_context& cmd,
+		gl::render_target* surface,
+		rsx::surface_depth_format2 format,
+		u32 address,
+		usz pitch)
+	{
+		surface->set_format(format);
+		int_invalidate_surface_contents(cmd, surface, address, pitch);
 	}
 
 	static

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -243,7 +243,7 @@ namespace vk
 				VMM_ALLOCATION_POOL_SURFACE_CACHE,
 				RSX_FORMAT_CLASS_COLOR);
 
-			rtt->set_debug_name(fmt::format("RTV @0x%x", address));
+			rtt->set_debug_name(fmt::format("RTV @0x%x, fmt=0x%x", address, static_cast<int>(format)));
 			rtt->change_layout(cmd, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
 			rtt->set_format(format);
@@ -438,7 +438,11 @@ namespace vk
 			return surface->rsx_pitch == pitch;
 		}
 
-		static void invalidate_surface_contents(vk::command_buffer& /*cmd*/, vk::render_target* surface, u32 address, usz pitch)
+		static void int_invalidate_surface_contents(
+			vk::command_buffer& /*cmd*/,
+			vk::render_target* surface,
+			u32 address,
+			usz pitch)
 		{
 			surface->rsx_pitch = static_cast<u32>(pitch);
 			surface->queue_tag(address);
@@ -446,6 +450,34 @@ namespace vk
 			surface->stencil_init_flags = 0;
 			surface->memory_usage_flags = rsx::surface_usage_flags::unknown;
 			surface->raster_type = rsx::surface_raster_type::linear;
+		}
+
+		static void invalidate_surface_contents(
+			vk::command_buffer& cmd,
+			vk::render_target* surface,
+			rsx::surface_color_format format,
+			u32 address,
+			usz pitch)
+		{
+			const auto fmt = vk::get_compatible_surface_format(format);
+			surface->set_format(format);
+			surface->set_native_component_layout(fmt.second);
+			surface->set_debug_name(fmt::format("RTV @0x%x, fmt=0x%x", address, static_cast<int>(format)));
+
+			int_invalidate_surface_contents(cmd, surface, address, pitch);
+		}
+
+		static void invalidate_surface_contents(
+			vk::command_buffer& cmd,
+			vk::render_target* surface,
+			rsx::surface_depth_format2 format,
+			u32 address,
+			usz pitch)
+		{
+			surface->set_format(format);
+			surface->set_debug_name(fmt::format("DSV @0x%x", address));
+
+			int_invalidate_surface_contents(cmd, surface, address, pitch);
 		}
 
 		static void notify_surface_invalidated(const std::unique_ptr<vk::render_target>& surface)


### PR DESCRIPTION
When reusing surfaces, attach the new properties correctly.
Fixes some mismatches when debugging but no games have been observed so far with visual changes.