### PR TITLE
Utilities: Add support for portable user directory.

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -660,6 +660,12 @@ namespace fs
 		}
 	};
 
+	// Get executable path
+	std::string get_executable_path();
+
+	// Get executable containing directory
+	std::string get_executable_dir();
+
 	// Get configuration directory
 	const std::string& get_config_dir();
 

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -14,18 +14,6 @@
 #include <charconv>
 #include <thread>
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <unistd.h>
-#endif
-
-#ifdef __APPLE__
-#include <mach-o/dyld.h>
-#include <limits.h>
-#include <filesystem>
-#endif
-
 LOG_CHANNEL(sys_log, "SYS");
 
 namespace rpcs3::utils
@@ -111,56 +99,6 @@ namespace rpcs3::utils
 
 		return worker();
 	}
-
-#ifdef _WIN32
-	std::string get_exe_dir()
-	{
-		wchar_t buffer[32767];
-		GetModuleFileNameW(nullptr, buffer, sizeof(buffer) / 2);
-
-		const std::string path_to_exe = wchar_to_utf8(buffer);
-		const usz last = path_to_exe.find_last_of('\\');
-		return last == std::string::npos ? std::string("") : path_to_exe.substr(0, last + 1);
-	}
-#elif defined(__APPLE__)
-	std::string get_app_bundle_path()
-	{
-		char bin_path[PATH_MAX];
-		uint32_t bin_path_size = sizeof(bin_path);
-		if (_NSGetExecutablePath(bin_path, &bin_path_size) != 0)
-		{
-			sys_log.error("Failed to find app binary path");
-			return {};
-		}
-
-		return std::filesystem::path(bin_path).parent_path().parent_path().parent_path();
-	}
-#else
-	std::string get_executable_path()
-	{
-		if (const char* appimage_path = ::getenv("APPIMAGE"))
-		{
-			sys_log.notice("Found AppImage path: %s", appimage_path);
-			return std::string(appimage_path);
-		}
-
-		sys_log.warning("Failed to find AppImage path");
-
-		char exe_path[PATH_MAX];
-		const ssize_t len = ::readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
-
-		if (len == -1)
-		{
-			sys_log.error("Failed to find executable path");
-			return {};
-		}
-
-		exe_path[len] = '\0';
-		sys_log.trace("Found exec path: %s", exe_path);
-
-		return std::string(exe_path);
-	}
-#endif
 
 	std::string get_emu_dir()
 	{

--- a/rpcs3/Emu/system_utils.hpp
+++ b/rpcs3/Emu/system_utils.hpp
@@ -13,14 +13,6 @@ namespace rpcs3::utils
 
 	bool install_pkg(const std::string& path);
 
-#ifdef _WIN32
-	std::string get_exe_dir();
-#elif defined(__APPLE__)
-	std::string get_app_bundle_path();
-#else
-	std::string get_executable_path();
-#endif
-
 	std::string get_emu_dir();
 	std::string get_hdd0_dir();
 	std::string get_hdd1_dir();

--- a/rpcs3/rpcs3qt/shortcut_utils.cpp
+++ b/rpcs3/rpcs3qt/shortcut_utils.cpp
@@ -4,6 +4,7 @@
 #include "Emu/system_utils.hpp"
 #include "Emu/VFS.h"
 #include "Emu/vfs_config.h"
+#include "Utilities/File.h"
 #include "Utilities/StrUtil.h"
 
 #ifdef _WIN32
@@ -154,7 +155,7 @@ namespace gui::utils
 		if (FAILED(res))
 			return cleanup(false, "CoCreateInstance failed");
 
-		const std::string working_dir{ rpcs3::utils::get_exe_dir() };
+		const std::string working_dir{ fs::get_executable_dir() };
 		const std::string rpcs3_path{ working_dir + "rpcs3.exe" };
 
 		const std::wstring w_target_file = utf8_to_wchar(rpcs3_path);
@@ -219,7 +220,7 @@ namespace gui::utils
 
 #elif defined(__APPLE__)
 
-		const std::string app_bundle_path = rpcs3::utils::get_app_bundle_path();
+		const std::string app_bundle_path = fs::get_executable_path();
 		if (app_bundle_path.empty())
 		{
 			sys_log.error("Failed to create shortcut. App bundle path empty.");
@@ -307,7 +308,7 @@ namespace gui::utils
 
 #else
 
-		const std::string exe_path = rpcs3::utils::get_executable_path();
+		const std::string exe_path = fs::get_executable_path();
 		if (exe_path.empty())
 		{
 			sys_log.error("Failed to create shortcut. Executable path empty.");

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -393,7 +393,7 @@ bool update_manager::handle_rpcs3(const QByteArray& data, bool auto_accept)
 #ifdef _WIN32
 
 	// Get executable path
-	const std::string exe_dir = rpcs3::utils::get_exe_dir();
+	const std::string exe_dir = fs::get_executable_dir();
 	const std::string orig_path = exe_dir + "rpcs3.exe";
 	const std::wstring wchar_orig_path = utf8_to_wchar(orig_path);
 	const std::string tmpfile_path = fs::get_temp_dir() + "\\rpcs3_update.7z";
@@ -583,7 +583,7 @@ bool update_manager::handle_rpcs3(const QByteArray& data, bool auto_accept)
 
 #else
 
-	std::string replace_path = rpcs3::utils::get_executable_path();
+	std::string replace_path = fs::get_executable_path();
 	if (replace_path.empty())
 	{
 		return false;


### PR DESCRIPTION
Adds support for using a portable data directory. Similar to other emulators, you can put a directory named "portable" next to the executable, and it will be auto-detected and used for all emulator data.

As part of this, I moved the utility functions for getting the executable path over to `Utilities/File.cpp` and cleaned them up a bit, so that they can be used to locate the portable directory. Now there are two main functions for this purpose:
* `get_executable_path()`: Gets the path of the executable itself. This is the actual binary file on Windows/Linux, and the .app bundle on macOS.
* `get_executable_dir()`: Gets the path of the directory that the executable is in.

Tested on a Mac and confirmed that when a portable directory is next to the .app bundle, it is used instead of the normal user directory.