### PR TITLE
rsx: Improved 24-bit format handling and shader refactoring

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -188,6 +188,7 @@ void GLGSRender::update_draw_state()
 	if (m_rtts.get_color_surface_count())
 	{
 		// Color buffer is active
+		const auto host_write_mask = rsx::get_write_output_mask(rsx::method_registers.surface_color());
 		for (int index = 0; index < m_rtts.get_color_surface_count(); ++index)
 		{
 			bool color_mask_b = rsx::method_registers.color_mask_b(index);
@@ -207,7 +208,12 @@ void GLGSRender::update_draw_state()
 				break;
 			}
 
-			gl_state.color_maski(index, color_mask_r, color_mask_g, color_mask_b, color_mask_a);
+			gl_state.color_maski(
+				index,
+				color_mask_r && host_write_mask[0],
+				color_mask_g && host_write_mask[1],
+				color_mask_b && host_write_mask[2],
+				color_mask_a && host_write_mask[3]);
 		}
 
 		// LogicOp and Blend are mutually exclusive. If both are enabled, LogicOp takes precedence.

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentPrologue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentPrologue.glsl
@@ -6,11 +6,6 @@ R"(
 #else
 // Mixed types. We have fp16 outputs
 #define _mrt_color_t f16vec4
-f16vec4 round_to_8bit(const in f16vec4 v4)
-{
-	uvec4 raw = uvec4(floor(fma(v4, f16vec4(255.), f16vec4(0.5))));
-	return f16vec4(raw) / f16vec4(255.);
-}
 #endif
 
 #if defined(_ENABLE_ROP_OUTPUT_ROUNDING) || defined(_ENABLE_PROGRAMMABLE_BLENDING)
@@ -20,6 +15,13 @@ vec4 round_to_8bit(const in vec4 v4)
 	uvec4 raw = uvec4(floor(fma(v4, vec4(255.), vec4(0.5))));
 	return vec4(raw) / vec4(255.);
 }
+#ifndef _32_BIT_OUTPUT
+f16vec4 round_to_8bit(const in f16vec4 v4)
+{
+	uvec4 raw = uvec4(floor(fma(v4, f16vec4(255.), f16vec4(0.5))));
+	return f16vec4(raw) / f16vec4(255.);
+}
+#endif
 #endif
 
 #ifdef _DISABLE_EARLY_DISCARD

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentPrologue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentPrologue.glsl
@@ -1,10 +1,19 @@
 R"(
-#ifdef _32_BIT_OUTPUT
+
+#if defined(_ENABLE_ROP_OUTPUT_ROUNDING) || defined(_ENABLE_PROGRAMMABLE_BLENDING)
 // Default. Used when we're not utilizing native fp16
-#define round_to_8bit(v4) (floor(fma(v4, vec4(255.), vec4(0.5))) / vec4(255.))
-#else
-// FP16 version
-#define round_to_8bit(v4) (floor(fma(v4, f16vec4(255.), f16vec4(0.5))) / f16vec4(255.))
+vec4 round_to_8bit(const in vec4 v4)
+{
+	uvec4 raw = uvec4(floor(fma(v4, vec4(255.), vec4(0.5))));
+	return vec4(raw) / vec4(255.);
+}
+#if !defined(_32_BIT_OUTPUT)
+f16vec4 round_to_8bit(const in f16vec4 v4)
+{
+	uvec4 raw = uvec4(floor(fma(v4, f16vec4(255.), f16vec4(0.5))));
+	return f16vec4(raw) / f16vec4(255.);
+}
+#endif
 #endif
 
 #ifdef _DISABLE_EARLY_DISCARD

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentPrologue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentPrologue.glsl
@@ -1,5 +1,18 @@
 R"(
 
+#ifdef _32_BIT_OUTPUT
+// Everything is fp32 on ouput channels
+#define _mrt_color_t(expr) expr
+#else
+// Mixed types. We have fp16 outputs
+#define _mrt_color_t f16vec4
+f16vec4 round_to_8bit(const in f16vec4 v4)
+{
+	uvec4 raw = uvec4(floor(fma(v4, f16vec4(255.), f16vec4(0.5))));
+	return f16vec4(raw) / f16vec4(255.);
+}
+#endif
+
 #if defined(_ENABLE_ROP_OUTPUT_ROUNDING) || defined(_ENABLE_PROGRAMMABLE_BLENDING)
 // Default. Used when we're not utilizing native fp16
 vec4 round_to_8bit(const in vec4 v4)
@@ -7,13 +20,6 @@ vec4 round_to_8bit(const in vec4 v4)
 	uvec4 raw = uvec4(floor(fma(v4, vec4(255.), vec4(0.5))));
 	return vec4(raw) / vec4(255.);
 }
-#if !defined(_32_BIT_OUTPUT)
-f16vec4 round_to_8bit(const in f16vec4 v4)
-{
-	uvec4 raw = uvec4(floor(fma(v4, f16vec4(255.), f16vec4(0.5))));
-	return f16vec4(raw) / f16vec4(255.);
-}
-#endif
 #endif
 
 #ifdef _DISABLE_EARLY_DISCARD

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXProgrammableBlendPrologue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXProgrammableBlendPrologue.glsl
@@ -1,0 +1,152 @@
+R"(
+
+/**
+ * Required register definitions from ROP config
+ struct {
+ 	vec4 blend_constants;    // fp32x4
+	uint blend_func;         // rgb16, a16
+	uint blend_factors_a;    // src16, dst16
+	uint blend_factors_rgb;  // src16, dst16
+ }
+*/
+
+#define BLEND_FACTOR_ZERO 0
+#define BLEND_FACTOR_ONE  1
+#define BLEND_FACTOR_SRC_COLOR 0x0300
+#define BLEND_FACTOR_ONE_MINUS_SRC_COLOR 0x0301
+#define BLEND_FACTOR_SRC_ALPHA 0x0302
+#define BLEND_FACTOR_ONE_MINUS_SRC_ALPHA 0x0303
+#define BLEND_FACTOR_DST_ALPHA 0x0304
+#define BLEND_FACTOR_ONE_MINUS_DST_ALPHA 0x0305
+#define BLEND_FACTOR_DST_COLOR 0x0306
+#define BLEND_FACTOR_ONE_MINUS_DST_COLOR 0x0307
+#define BLEND_FACTOR_SRC_ALPHA_SATURATE 0x0308
+#define BLEND_FACTOR_CONSTANT_COLOR 0x8001
+#define BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR 0x8002
+#define BLEND_FACTOR_CONSTANT_ALPHA 0x8003
+#define BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA 0x8004
+
+#define BLEND_FUNC_ADD 0x8006
+#define BLEND_MIN 0x8007
+#define BLEND_MAX 0x8008
+#define BLEND_FUNC_SUBTRACT 0x800A
+#define BLEND_FUNC_REVERSE_SUBTRACT 0x800B
+#define BLEND_FUNC_REVERSE_SUBTRACT_SIGNED 0x0000F005
+#define BLEND_FUNC_ADD_SIGNED 0x0000F006
+#define BLEND_FUNC_REVERSE_ADD_SIGNED 0x0000F007
+
+float get_blend_factor_a(const in uint op, const in vec4 src, const in vec4 dst)
+{
+	switch (op)
+	{
+	case BLEND_FACTOR_ZERO: return 0.;
+	case BLEND_FACTOR_ONE: return 1.;
+	case BLEND_FACTOR_SRC_COLOR:
+	case BLEND_FACTOR_SRC_ALPHA: return src.a;
+	case BLEND_FACTOR_ONE_MINUS_SRC_COLOR:
+	case BLEND_FACTOR_ONE_MINUS_SRC_ALPHA: return 1. - src.a;
+	case BLEND_FACTOR_DST_ALPHA:
+	case BLEND_FACTOR_DST_COLOR: return dst.a;
+	case BLEND_FACTOR_ONE_MINUS_DST_ALPHA:
+	case BLEND_FACTOR_ONE_MINUS_DST_COLOR: return 1. - dst.a;
+	case BLEND_FACTOR_SRC_ALPHA_SATURATE: return 1;
+	case BLEND_FACTOR_CONSTANT_COLOR:
+	case BLEND_FACTOR_CONSTANT_ALPHA: return constants.a;
+	case BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR:
+	case BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA: return 1. - constants.a;
+	}
+	return 0.;
+}
+
+vec3 get_blend_factor_rgb(const in uint op, const in vec4 src, const in vec4 dst)
+{
+	switch (op)
+	{
+	case BLEND_FACTOR_ZERO: return vec3(0.);
+	case BLEND_FACTOR_ONE: return vec3(1.);
+	case BLEND_FACTOR_SRC_COLOR: return src.rgb;
+	case BLEND_FACTOR_SRC_ALPHA: return src.aaa;
+	case BLEND_FACTOR_ONE_MINUS_SRC_COLOR: return 1. - src.rgb;
+	case BLEND_FACTOR_ONE_MINUS_SRC_ALPHA: return 1. - src.aaa;
+	case BLEND_FACTOR_DST_COLOR: return dst.rgb;
+	case BLEND_FACTOR_DST_ALPHA: return dst.a;
+	case BLEND_FACTOR_ONE_MINUS_DST_COLOR: return 1. - dst.rgb;
+	case BLEND_FACTOR_ONE_MINUS_DST_ALPHA: return 1. - dst.a;
+	case BLEND_FACTOR_SRC_ALPHA_SATURATE: return src.rgb;
+	case BLEND_FACTOR_CONSTANT_COLOR: return blend_constants.rgb;
+	case BLEND_FACTOR_CONSTANT_ALPHA: return blend_constants.aaa;
+	case BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR: return 1. - blend_constants.rgb;
+	case BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA: return 1. - blend_constants.aaa;
+	}
+	return vec3(0.);
+}
+
+float apply_blend_func_a(const in vec4 src, const in vec4 dst)
+{
+	uint blend_factor_a_s = _get_bits(blend_factors_a, 0, 16);
+	uint blend_factor_a_d = _get_bits(blend_factors_a, 16, 16);
+	uint func = _get_bits(blend_func, 16, 16);
+
+	const float src_factor_a = get_blend_factor_a(blend_factor_a_s, src, dst);
+	const float dst_factor_a = get_blend_factor_a(blend_factor_a_d, src, dst);
+
+	// NOTE: Destination data is already saturated due to encoding.
+	const float s = src.a * src_factor_a;
+	const float d = dst.a * dst_factor_a;
+
+	switch (func)
+	{
+	case BLEND_FUNC_ADD: return _saturate(s) + d;
+	case BLEND_MIN: return min(_saturate(s), d);
+	case BLEND_MAX: return max(_saturate(s), d);
+	case BLEND_FUNC_SUBTRACT: return _saturate(s) - d;
+	case BLEND_FUNC_REVERSE_SUBTRACT: return d - _saturate(s);
+	case BLEND_FUNC_REVERSE_SUBTRACT_SIGNED: return d - s;
+	case BLEND_FUNC_ADD_SIGNED: return s + d;
+	case BLEND_FUNC_REVERSE_ADD_SIGNED: return s + d;
+	}
+
+	return vec3(0.);
+}
+
+vec3 apply_blend_func_rgb(const in vec4 src, const in vec4 dst)
+{
+	uint blend_factor_rgb_s = _get_bits(blend_factors_rgb, 0, 16);
+	uint blend_factor_rgb_d = _get_bits(blend_factors_rgb, 16, 16);
+	uint func = _get_bits(blend_func, 0, 16);
+
+	const vec3 src_factor_rgb = get_blend_factor_rgb(blend_factor_rgb_s, src, dst);
+	const vec3 dst_factor_rgb = get_blend_factor_rgb(blend_factor_rgb_d, src, dst);
+
+	// NOTE: Destination data is already saturated due to encoding.
+	const vec3 s = src.rgb * src_factor_rgb;
+	const vec3 d = dst.rgb * dst_factor_rgb;
+
+	switch (func)
+	{
+	case BLEND_FUNC_ADD: return _saturate(s) + d;
+	case BLEND_MIN: return min(_saturate(s), d);
+	case BLEND_MAX: return max(_saturate(s), d);
+	case BLEND_FUNC_SUBTRACT: return _saturate(s) - d;
+	case BLEND_FUNC_REVERSE_SUBTRACT: return d - _saturate(s);
+	case BLEND_FUNC_REVERSE_SUBTRACT_SIGNED: return d - s;
+	case BLEND_FUNC_ADD_SIGNED: return s + d;
+	case BLEND_FUNC_REVERSE_ADD_SIGNED: return s + d;
+	}
+
+	return vec3(0.);
+}
+
+vec4 do_blend(const in vec4 src, const in vec4 dst)
+{
+	// Read blend_constants from config and apply blend op
+	const vec4 result = vec4(
+		apply_blend_func_rgb(src, dst),
+		apply_blend_func_a(src, dst)
+	);
+
+	// Accurate int conversion with wrapping
+	return round_to_8bit(result);
+}
+
+)"

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPEpilogue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPEpilogue.glsl
@@ -10,10 +10,10 @@ R"(
 #ifdef _ENABLE_FRAMEBUFFER_SRGB
 	if (_test_bit(rop_control, SRGB_FRAMEBUFFER_BIT))
 	{
-		col0.rgb = linear_to_srgb(col0).rgb;
-		col1.rgb = linear_to_srgb(col1).rgb;
-		col2.rgb = linear_to_srgb(col2).rgb;
-		col3.rgb = linear_to_srgb(col3).rgb;
+		col0.rgb = _mrt_color_t(linear_to_srgb(col0)).rgb;
+		col1.rgb = _mrt_color_t(linear_to_srgb(col1)).rgb;
+		col2.rgb = _mrt_color_t(linear_to_srgb(col2)).rgb;
+		col3.rgb = _mrt_color_t(linear_to_srgb(col3)).rgb;
 	}
 #endif
 

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPEpilogue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPEpilogue.glsl
@@ -1,0 +1,63 @@
+R"(
+
+#ifdef _DISABLE_EARLY_DISCARD
+	if (_fragment_discard)
+	{
+		discard;
+	}
+#endif
+
+#ifdef _ENABLE_FRAMEBUFFER_SRGB
+	if (_test_bit(rop_control, SRGB_FRAMEBUFFER_BIT))
+	{
+		col0.rgb = linear_to_srgb(col0).rgb;
+		col1.rgb = linear_to_srgb(col1).rgb;
+		col2.rgb = linear_to_srgb(col2).rgb;
+		col3.rgb = linear_to_srgb(col3).rgb;
+	}
+#endif
+
+#ifdef _ENABLE_ROP_OUTPUT_ROUNDING
+	if (_test_bit(rop_control, INT_FRAMEBUFFER_BIT))
+	{
+		col0 = round_to_8bit(col0);
+		col1  = round_to_8bit(col1);
+		col2 = round_to_8bit(col2);
+		col3 = round_to_8bit(col3);
+	}
+#endif
+
+	// Post-output stages
+	// Alpha Testing
+	if (_test_bit(rop_control, ALPHA_TEST_ENABLE_BIT))
+	{
+		const uint alpha_func = _get_bits(rop_control, ALPHA_TEST_FUNC_OFFSET, ALPHA_TEST_FUNC_LENGTH);
+		if (!comparison_passes(col0.a, alpha_ref, alpha_func))
+		{
+			discard;
+		}
+	}
+
+#ifdef _EMULATE_COVERAGE_TEST
+	if (_test_bit(rop_control, ALPHA_TO_COVERAGE_ENABLE_BIT))
+	{
+		if (!_test_bit(rop_control, MSAA_WRITE_ENABLE_BIT) || !coverage_test_passes(col0))
+		{
+			discard;
+		}
+	}
+#endif
+
+#ifdef _ENABLE_PROGRAMMABLE_BLENDING
+	col0 = do_blend(col0, mrt_color[0]);
+	if (framebufferCount > 1) col1 = do_blend(col1, mrt_color[1]);
+	if (framebufferCount > 2) col2 = do_blend(col2, mrt_color[2]);
+	if (framebufferCount > 3) col3 = do_blend(col3, mrt_color[3]);
+#endif
+
+	// Commit
+	ocol0 = col0;
+	ocol1 = col1;
+	ocol2 = col2;
+	ocol3 = col3;
+)"

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPEpilogue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPEpilogue.glsl
@@ -21,7 +21,7 @@ R"(
 	if (_test_bit(rop_control, INT_FRAMEBUFFER_BIT))
 	{
 		col0 = round_to_8bit(col0);
-		col1  = round_to_8bit(col1);
+		col1 = round_to_8bit(col1);
 		col2 = round_to_8bit(col2);
 		col3 = round_to_8bit(col3);
 	}
@@ -49,10 +49,21 @@ R"(
 #endif
 
 #ifdef _ENABLE_PROGRAMMABLE_BLENDING
-	col0 = do_blend(col0, mrt_color[0]);
-	if (framebufferCount > 1) col1 = do_blend(col1, mrt_color[1]);
-	if (framebufferCount > 2) col2 = do_blend(col2, mrt_color[2]);
-	if (framebufferCount > 3) col3 = do_blend(col3, mrt_color[3]);
+	switch (framebufferCount)
+	{
+		case 4:
+			col3 = do_blend(col3, mrt_color[3]);
+			// Fallthrough
+		case 3:
+			col2 = do_blend(col2, mrt_color[2]);
+			// Fallthrough
+		case 2:
+			col1 = do_blend(col1, mrt_color[1]);
+			// Fallthrough
+		default:
+			col0 = do_blend(col0, mrt_color[0]);
+			break;
+	}
 #endif
 
 	// Commit

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPPrologue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPPrologue.glsl
@@ -1,0 +1,27 @@
+R"(
+
+#ifdef _ENABLE_POLYGON_STIPPLE
+	if (_test_bit(rop_control, POLYGON_STIPPLE_ENABLE_BIT))
+	{
+		// Convert x,y to linear address
+		const uvec2 stipple_coord = uvec2(gl_FragCoord.xy) % uvec2(32, 32);
+		const uint address = stipple_coord.y * 32u + stipple_coord.x;
+		const uint bit_offset = (address & 31u);
+		const uint word_index = _get_bits(address, 7, 3);
+		const uint sub_index = _get_bits(address, 5, 2);
+
+		if (!_test_bit(stipple_pattern[word_index][sub_index], int(bit_offset)))
+		{
+			_kill();
+		}
+	}
+#endif
+
+#ifdef _ENABLE_PROGRAMMABLE_BLENDING
+	vec4 mrt_color[4];
+	for (int n = 0; n < framebufferCount; ++n)
+	{
+		mrt_color[n] = subPassLoad(mrtAttachments[n]);
+	}
+#endif
+)"

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -872,10 +872,10 @@ namespace rsx
 
 	static inline const std::array<bool, 4> get_write_output_mask(rsx::surface_color_format format)
 	{
-		const std::array<bool, 4> rgba = { true, true, true, true };
-		const std::array<bool, 4> rgb = { true, true, true, false };
-		const std::array<bool, 4> rg = { true, true, false, false };
-		const std::array<bool, 4> r = { true, false, false, false };
+		constexpr std::array<bool, 4> rgba = { true, true, true, true };
+		constexpr std::array<bool, 4> rgb = { true, true, true, false };
+		constexpr std::array<bool, 4> rg = { true, true, false, false };
+		constexpr std::array<bool, 4> r = { true, false, false, false };
 
 		switch (format)
 		{

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -870,6 +870,38 @@ namespace rsx
 		return result;
 	}
 
+	static inline const std::array<bool, 4> get_write_output_mask(rsx::surface_color_format format)
+	{
+		const std::array<bool, 4> rgba = { true, true, true, true };
+		const std::array<bool, 4> rgb = { true, true, true, false };
+		const std::array<bool, 4> rg = { true, true, false, false };
+		const std::array<bool, 4> r = { true, false, false, false };
+
+		switch (format)
+		{
+		case rsx::surface_color_format::a8r8g8b8:
+		case rsx::surface_color_format::a8b8g8r8:
+		case rsx::surface_color_format::w16z16y16x16:
+		case rsx::surface_color_format::w32z32y32x32:
+			return rgba;
+		case rsx::surface_color_format::x1r5g5b5_z1r5g5b5:
+		case rsx::surface_color_format::x1r5g5b5_o1r5g5b5:
+		case rsx::surface_color_format::r5g6b5:
+		case rsx::surface_color_format::x8r8g8b8_z8r8g8b8:
+		case rsx::surface_color_format::x8r8g8b8_o8r8g8b8:
+		case rsx::surface_color_format::x8b8g8r8_z8b8g8r8:
+		case rsx::surface_color_format::x8b8g8r8_o8b8g8r8:
+			return rgb;
+		case rsx::surface_color_format::g8b8:
+			return rg;
+		case rsx::surface_color_format::b8:
+		case rsx::surface_color_format::x32:
+			return r;
+		default:
+			fmt::throw_exception("Unknown surface format 0x%x", static_cast<int>(format));
+		}
+	}
+
 	template <uint integer, uint frac, bool sign = true, typename To = f32>
 	static inline To decode_fxp(u32 bits)
 	{

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -928,6 +928,9 @@
     <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXFragmentTextureMSAAOpsInternal.glsl" />
     <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXFragmentTextureOps.glsl" />
     <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXProgramCommon.glsl" />
+    <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXProgrammableBlendPrologue.glsl" />
+    <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXROPEpilogue.glsl" />
+    <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXROPPrologue.glsl" />
     <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXVertexFetch.glsl" />
     <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXVertexPrologue.glsl" />
     <None Include="Emu\RSX\Program\GLSLSnippets\ShuffleBytes.glsl" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2472,5 +2472,14 @@
     <None Include="Emu\RSX\Program\GLSLSnippets\RSXMemoryTiling.glsl">
       <Filter>Emu\GPU\RSX\Program\Snippets</Filter>
     </None>
+    <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXProgrammableBlendPrologue.glsl">
+      <Filter>Emu\GPU\RSX\Program\Snippets\RSXProg</Filter>
+    </None>
+    <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXROPEpilogue.glsl">
+      <Filter>Emu\GPU\RSX\Program\Snippets\RSXProg</Filter>
+    </None>
+    <None Include="Emu\RSX\Program\GLSLSnippets\RSXProg\RSXROPPrologue.glsl">
+      <Filter>Emu\GPU\RSX\Program\Snippets\RSXProg</Filter>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Changes
1. Do not write to host channels that are disabled. This largely applies to RGBX formats where on PS3 the alpha channel is disabled. On PC we were writing to this non-existent channel which is wrong.
2. Refactor shader ROP stuff in preparation for programmable blending down the line. The full implementation will come in a later PR.
3. Correctly perform float->fixed conversion for 8-bit formats. During the vanillaware investigation it became clear that PS3 wraps negatives before clamping.