### PR TITLE
cellImeJp: fix softlock and improve some of the logic

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1906,8 +1906,9 @@ std::string fs::get_executable_path()
 	static const std::string s_exe_path = []
 	{
 #if defined(_WIN32)
-		std::vector<wchar_t> buffer(32767);
-		GetModuleFileNameW(nullptr, buffer.data(), buffer.size());
+		constexpr DWORD size = 32767;
+		std::vector<wchar_t> buffer(size);
+		GetModuleFileNameW(nullptr, buffer.data(), size);
 		return wchar_to_utf8(buffer.data());
 #elif defined(__APPLE__)
 		char bin_path[PATH_MAX];

--- a/rpcs3/Emu/Cell/Modules/cellImeJp.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellImeJp.cpp
@@ -758,8 +758,10 @@ static error_code cellImeJpConvertCancel(CellImeJpHandle hImeJpHandle)
 		return CELL_IMEJP_ERROR_ERR;
 	}
 
-	// TODO: only cancel all if cursor is at 0
-	return cellImeJpAllConvertCancel(hImeJpHandle);
+	manager.converted_string.clear();
+	manager.input_state = CELL_IMEJP_BEFORE_CONVERT;
+
+	return CELL_OK;
 }
 
 static error_code cellImeJpExtendConvertArea(CellImeJpHandle hImeJpHandle)

--- a/rpcs3/Emu/Cell/Modules/cellImeJp.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellImeJp.cpp
@@ -126,7 +126,7 @@ void ime_jp_manager::moveCursorEnd(s8 amount)
 	}
 }
 
-error_code cellImeJpOpen(sys_memory_container_t container_id, vm::ptr<CellImeJpHandle> hImeJpHandle, vm::cptr<CellImeJpAddDic> addDicPath)
+static error_code cellImeJpOpen(sys_memory_container_t container_id, vm::ptr<CellImeJpHandle> hImeJpHandle, vm::cptr<CellImeJpAddDic> addDicPath)
 {
 	cellImeJp.todo("cellImeJpOpen(container_id=*0x%x, hImeJpHandle=*0x%x, addDicPath=*0x%x)", container_id, hImeJpHandle, addDicPath);
 
@@ -156,7 +156,7 @@ error_code cellImeJpOpen(sys_memory_container_t container_id, vm::ptr<CellImeJpH
 	return CELL_OK;
 }
 
-error_code cellImeJpOpen2(sys_memory_container_t container_id, vm::ptr<CellImeJpHandle> hImeJpHandle, vm::cptr<CellImeJpAddDic> addDicPath)
+static error_code cellImeJpOpen2(sys_memory_container_t container_id, vm::ptr<CellImeJpHandle> hImeJpHandle, vm::cptr<CellImeJpAddDic> addDicPath)
 {
 	cellImeJp.todo("cellImeJpOpen2(container_id=*0x%x, hImeJpHandle=*0x%x, addDicPath=*0x%x)", container_id, hImeJpHandle, addDicPath);
 
@@ -187,7 +187,7 @@ error_code cellImeJpOpen2(sys_memory_container_t container_id, vm::ptr<CellImeJp
 	return CELL_OK;
 }
 
-error_code cellImeJpOpen3(sys_memory_container_t container_id, vm::ptr<CellImeJpHandle> hImeJpHandle, vm::cpptr<CellImeJpAddDic> addDicPath)
+static error_code cellImeJpOpen3(sys_memory_container_t container_id, vm::ptr<CellImeJpHandle> hImeJpHandle, vm::cpptr<CellImeJpAddDic> addDicPath)
 {
 	cellImeJp.todo("cellImeJpOpen3(container_id=*0x%x, hImeJpHandle=*0x%x, addDicPath=*0x%x)", container_id, hImeJpHandle, addDicPath);
 
@@ -224,13 +224,13 @@ error_code cellImeJpOpen3(sys_memory_container_t container_id, vm::ptr<CellImeJp
 	return CELL_OK;
 }
 
-error_code cellImeJpOpenExt()
+static error_code cellImeJpOpenExt()
 {
 	cellImeJp.todo("cellImeJpOpenExt()");
 	return CELL_OK;
 }
 
-error_code cellImeJpClose(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpClose(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpClose(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -253,7 +253,7 @@ error_code cellImeJpClose(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpSetKanaInputMode(CellImeJpHandle hImeJpHandle, s16 inputOption)
+static error_code cellImeJpSetKanaInputMode(CellImeJpHandle hImeJpHandle, s16 inputOption)
 {
 	cellImeJp.todo("cellImeJpSetKanaInputMode(hImeJpHandle=*0x%x, inputOption=%d)", hImeJpHandle, inputOption);
 
@@ -275,7 +275,7 @@ error_code cellImeJpSetKanaInputMode(CellImeJpHandle hImeJpHandle, s16 inputOpti
 	return CELL_OK;
 }
 
-error_code cellImeJpSetInputCharType(CellImeJpHandle hImeJpHandle, s16 charTypeOption)
+static error_code cellImeJpSetInputCharType(CellImeJpHandle hImeJpHandle, s16 charTypeOption)
 {
 	cellImeJp.todo("cellImeJpSetInputCharType(hImeJpHandle=*0x%x, charTypeOption=%d)", hImeJpHandle, charTypeOption);
 
@@ -292,7 +292,7 @@ error_code cellImeJpSetInputCharType(CellImeJpHandle hImeJpHandle, s16 charTypeO
 	return CELL_OK;
 }
 
-error_code cellImeJpSetFixInputMode(CellImeJpHandle hImeJpHandle, s16 fixInputMode)
+static error_code cellImeJpSetFixInputMode(CellImeJpHandle hImeJpHandle, s16 fixInputMode)
 {
 	cellImeJp.todo("cellImeJpSetFixInputMode(hImeJpHandle=*0x%x, fixInputMode=%d)", hImeJpHandle, fixInputMode);
 
@@ -309,7 +309,7 @@ error_code cellImeJpSetFixInputMode(CellImeJpHandle hImeJpHandle, s16 fixInputMo
 	return CELL_OK;
 }
 
-error_code cellImeJpAllowExtensionCharacters(CellImeJpHandle hImeJpHandle, s16 extensionCharacters)
+static error_code cellImeJpAllowExtensionCharacters(CellImeJpHandle hImeJpHandle, s16 extensionCharacters)
 {
 	cellImeJp.todo("cellImeJpSetFixInputMode(hImeJpHandle=*0x%x, extensionCharacters=%d)", hImeJpHandle, extensionCharacters);
 
@@ -331,7 +331,7 @@ error_code cellImeJpAllowExtensionCharacters(CellImeJpHandle hImeJpHandle, s16 e
 	return CELL_OK;
 }
 
-error_code cellImeJpReset(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpReset(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpReset(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -353,7 +353,7 @@ error_code cellImeJpReset(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpGetStatus(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pInputStatus)
+static error_code cellImeJpGetStatus(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pInputStatus)
 {
 	cellImeJp.warning("cellImeJpGetStatus(hImeJpHandle=*0x%x, pInputStatus=%d)", hImeJpHandle, pInputStatus);
 
@@ -375,7 +375,7 @@ error_code cellImeJpGetStatus(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pInputS
 	return CELL_OK;
 }
 
-error_code cellImeJpEnterChar(CellImeJpHandle hImeJpHandle, u16 inputChar, vm::ptr<s16> pOutputStatus)
+static error_code cellImeJpEnterChar(CellImeJpHandle hImeJpHandle, u16 inputChar, vm::ptr<s16> pOutputStatus)
 {
 	cellImeJp.todo("cellImeJpEnterChar(hImeJpHandle=*0x%x, inputChar=%d, pOutputStatus=%d)", hImeJpHandle, inputChar, pOutputStatus);
 
@@ -404,13 +404,13 @@ error_code cellImeJpEnterChar(CellImeJpHandle hImeJpHandle, u16 inputChar, vm::p
 	return CELL_OK;
 }
 
-error_code cellImeJpEnterCharExt(CellImeJpHandle hImeJpHandle, u16 inputChar, vm::ptr<s16> pOutputStatus)
+static error_code cellImeJpEnterCharExt(CellImeJpHandle hImeJpHandle, u16 inputChar, vm::ptr<s16> pOutputStatus)
 {
 	cellImeJp.todo("cellImeJpEnterCharExt(hImeJpHandle=*0x%x, inputChar=%d, pOutputStatus=%d", hImeJpHandle, inputChar, pOutputStatus);
 	return cellImeJpEnterChar(hImeJpHandle, inputChar, pOutputStatus);
 }
 
-error_code cellImeJpEnterString(CellImeJpHandle hImeJpHandle, vm::cptr<u16> pInputString, vm::ptr<s16> pOutputStatus)
+static error_code cellImeJpEnterString(CellImeJpHandle hImeJpHandle, vm::cptr<u16> pInputString, vm::ptr<s16> pOutputStatus)
 {
 	cellImeJp.todo("cellImeJpEnterString(hImeJpHandle=*0x%x, pInputString=*0x%x, pOutputStatus=%d", hImeJpHandle, pInputString, pOutputStatus);
 
@@ -439,13 +439,13 @@ error_code cellImeJpEnterString(CellImeJpHandle hImeJpHandle, vm::cptr<u16> pInp
 	return CELL_OK;
 }
 
-error_code cellImeJpEnterStringExt(CellImeJpHandle hImeJpHandle, vm::cptr<u16> pInputString, vm::ptr<s16> pOutputStatus)
+static error_code cellImeJpEnterStringExt(CellImeJpHandle hImeJpHandle, vm::cptr<u16> pInputString, vm::ptr<s16> pOutputStatus)
 {
 	cellImeJp.todo("cellImeJpEnterStringExt(hImeJpHandle=*0x%x, pInputString=*0x%x, pOutputStatus=%d", hImeJpHandle, pInputString, pOutputStatus);
 	return cellImeJpEnterString(hImeJpHandle, pInputString, pOutputStatus);
 }
 
-error_code cellImeJpModeCaretRight(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpModeCaretRight(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpModeCaretRight(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -467,7 +467,7 @@ error_code cellImeJpModeCaretRight(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpModeCaretLeft(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpModeCaretLeft(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpModeCaretLeft(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -489,7 +489,7 @@ error_code cellImeJpModeCaretLeft(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpBackspaceWord(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpBackspaceWord(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpBackspaceWord(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -511,7 +511,7 @@ error_code cellImeJpBackspaceWord(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpDeleteWord(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpDeleteWord(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpDeleteWord(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -533,7 +533,7 @@ error_code cellImeJpDeleteWord(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpAllDeleteConvertString(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpAllDeleteConvertString(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpAllDeleteConvertString(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -559,7 +559,7 @@ error_code cellImeJpAllDeleteConvertString(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpConvertForward(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpConvertForward(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpConvertForward(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -581,7 +581,7 @@ error_code cellImeJpConvertForward(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpConvertBackward(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpConvertBackward(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpConvertBackward(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -603,7 +603,7 @@ error_code cellImeJpConvertBackward(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpCurrentPartConfirm(CellImeJpHandle hImeJpHandle, s16 listItem)
+static error_code cellImeJpCurrentPartConfirm(CellImeJpHandle hImeJpHandle, s16 listItem)
 {
 	cellImeJp.todo("cellImeJpCurrentPartConfirm(hImeJpHandle=*0x%x, listItem=%d)", hImeJpHandle, listItem);
 
@@ -623,7 +623,7 @@ error_code cellImeJpCurrentPartConfirm(CellImeJpHandle hImeJpHandle, s16 listIte
 	return CELL_OK;
 }
 
-error_code cellImeJpAllConfirm(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpAllConfirm(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpAllConfirm(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -651,7 +651,7 @@ error_code cellImeJpAllConfirm(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpAllConvertCancel(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpAllConvertCancel(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpAllConvertCancel(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -674,7 +674,7 @@ error_code cellImeJpAllConvertCancel(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpConvertCancel(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpConvertCancel(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpConvertCancel(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -695,7 +695,7 @@ error_code cellImeJpConvertCancel(CellImeJpHandle hImeJpHandle)
 	return cellImeJpAllConvertCancel(hImeJpHandle);
 }
 
-error_code cellImeJpExtendConvertArea(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpExtendConvertArea(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpExtendConvertArea(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -717,7 +717,7 @@ error_code cellImeJpExtendConvertArea(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpShortenConvertArea(CellImeJpHandle hImeJpHandle)
+static error_code cellImeJpShortenConvertArea(CellImeJpHandle hImeJpHandle)
 {
 	cellImeJp.todo("cellImeJpShortenConvertArea(hImeJpHandle=*0x%x)", hImeJpHandle);
 
@@ -739,7 +739,7 @@ error_code cellImeJpShortenConvertArea(CellImeJpHandle hImeJpHandle)
 	return CELL_OK;
 }
 
-error_code cellImeJpTemporalConfirm(CellImeJpHandle hImeJpHandle, s16 selectIndex)
+static error_code cellImeJpTemporalConfirm(CellImeJpHandle hImeJpHandle, s16 selectIndex)
 {
 	cellImeJp.todo("cellImeJpTemporalConfirm(hImeJpHandle=*0x%x, selectIndex=%d)", hImeJpHandle, selectIndex);
 
@@ -759,7 +759,7 @@ error_code cellImeJpTemporalConfirm(CellImeJpHandle hImeJpHandle, s16 selectInde
 	return CELL_OK;
 }
 
-error_code cellImeJpPostConvert(CellImeJpHandle hImeJpHandle, s16 postType)
+static error_code cellImeJpPostConvert(CellImeJpHandle hImeJpHandle, s16 postType)
 {
 	cellImeJp.todo("cellImeJpPostConvert(hImeJpHandle=*0x%x, postType=%d)", hImeJpHandle, postType);
 
@@ -779,7 +779,7 @@ error_code cellImeJpPostConvert(CellImeJpHandle hImeJpHandle, s16 postType)
 	return CELL_OK;
 }
 
-error_code cellImeJpMoveFocusClause(CellImeJpHandle hImeJpHandle, s16 moveType)
+static error_code cellImeJpMoveFocusClause(CellImeJpHandle hImeJpHandle, s16 moveType)
 {
 	cellImeJp.todo("cellImeJpMoveFocusClause(hImeJpHandle=*0x%x, moveType=%d)", hImeJpHandle, moveType);
 
@@ -820,7 +820,7 @@ error_code cellImeJpMoveFocusClause(CellImeJpHandle hImeJpHandle, s16 moveType)
 	return CELL_OK;
 }
 
-error_code cellImeJpGetFocusTop(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pFocusTop)
+static error_code cellImeJpGetFocusTop(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pFocusTop)
 {
 	cellImeJp.todo("cellImeJpGetFocusTop(hImeJpHandle=*0x%x, pFocusTop=*0x%x)", hImeJpHandle, pFocusTop);
 
@@ -842,7 +842,7 @@ error_code cellImeJpGetFocusTop(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pFocu
 	return CELL_OK;
 }
 
-error_code cellImeJpGetFocusLength(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pFocusLength)
+static error_code cellImeJpGetFocusLength(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pFocusLength)
 {
 	cellImeJp.todo("cellImeJpGetFocusLength(hImeJpHandle=*0x%x, pFocusLength=*0x%x)", hImeJpHandle, pFocusLength);
 
@@ -871,7 +871,7 @@ error_code cellImeJpGetFocusLength(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pF
 	return CELL_OK;
 }
 
-error_code cellImeJpGetConfirmYomiString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> pYomiString)
+static error_code cellImeJpGetConfirmYomiString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> pYomiString)
 {
 	cellImeJp.todo("cellImeJpGetConfirmYomiString(hImeJpHandle=*0x%x, pYomiString=*0x%x)", hImeJpHandle, pYomiString);
 
@@ -903,7 +903,7 @@ error_code cellImeJpGetConfirmYomiString(CellImeJpHandle hImeJpHandle, vm::ptr<u
 	return CELL_OK;
 }
 
-error_code cellImeJpGetConfirmString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> pConfirmString)
+static error_code cellImeJpGetConfirmString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> pConfirmString)
 {
 	cellImeJp.todo("cellImeJpGetConfirmString(hImeJpHandle=*0x%x, pConfirmString=*0x%x)", hImeJpHandle, pConfirmString);
 
@@ -935,7 +935,7 @@ error_code cellImeJpGetConfirmString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> 
 	return CELL_OK;
 }
 
-error_code cellImeJpGetConvertYomiString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> pYomiString)
+static error_code cellImeJpGetConvertYomiString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> pYomiString)
 {
 	cellImeJp.todo("cellImeJpGetConvertYomiString(hImeJpHandle=*0x%x, pYomiString=*0x%x)", hImeJpHandle, pYomiString);
 
@@ -967,7 +967,7 @@ error_code cellImeJpGetConvertYomiString(CellImeJpHandle hImeJpHandle, vm::ptr<u
 	return CELL_OK;
 }
 
-error_code cellImeJpGetConvertString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> pConvertString)
+static error_code cellImeJpGetConvertString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> pConvertString)
 {
 	cellImeJp.warning("cellImeJpGetConvertString(hImeJpHandle=*0x%x, pConvertString=*0x%x)", hImeJpHandle, pConvertString);
 
@@ -999,7 +999,7 @@ error_code cellImeJpGetConvertString(CellImeJpHandle hImeJpHandle, vm::ptr<u16> 
 	return CELL_OK;
 }
 
-error_code cellImeJpGetCandidateListSize(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pListSize)
+static error_code cellImeJpGetCandidateListSize(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pListSize)
 {
 	cellImeJp.todo("cellImeJpGetCandidateListSize(hImeJpHandle=*0x%x, pListSize=*0x%x)", hImeJpHandle, pListSize);
 
@@ -1026,7 +1026,7 @@ error_code cellImeJpGetCandidateListSize(CellImeJpHandle hImeJpHandle, vm::ptr<s
 	return CELL_OK;
 }
 
-error_code cellImeJpGetCandidateList(CellImeJpHandle hImeJpHandle, vm::ptr<s16> plistNum, vm::ptr<u16> pCandidateString)
+static error_code cellImeJpGetCandidateList(CellImeJpHandle hImeJpHandle, vm::ptr<s16> plistNum, vm::ptr<u16> pCandidateString)
 {
 	cellImeJp.todo("cellImeJpGetCandidateList(hImeJpHandle=*0x%x, plistNum=*0x%x, pCandidateString=*0x%x)", hImeJpHandle, plistNum, pCandidateString);
 
@@ -1053,7 +1053,7 @@ error_code cellImeJpGetCandidateList(CellImeJpHandle hImeJpHandle, vm::ptr<s16> 
 	return CELL_OK;
 }
 
-error_code cellImeJpGetCandidateSelect(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pIndex)
+static error_code cellImeJpGetCandidateSelect(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pIndex)
 {
 	cellImeJp.todo("cellImeJpGetCandidateSelect(hImeJpHandle=*0x%x, pIndex=*0x%x)", hImeJpHandle, pIndex);
 
@@ -1080,7 +1080,7 @@ error_code cellImeJpGetCandidateSelect(CellImeJpHandle hImeJpHandle, vm::ptr<s16
 	return CELL_OK;
 }
 
-error_code cellImeJpGetPredictList(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pYomiString, s32 itemNum, vm::ptr<s32> plistCount, vm::ptr<CellImeJpPredictItem> pPredictItem)
+static error_code cellImeJpGetPredictList(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pYomiString, s32 itemNum, vm::ptr<s32> plistCount, vm::ptr<CellImeJpPredictItem> pPredictItem)
 {
 	cellImeJp.todo("cellImeJpGetPredictList(hImeJpHandle=*0x%x, pYomiString=*0x%x, itemNum=%d, plistCount=*0x%x, pPredictItem=*0x%x)", hImeJpHandle, pYomiString, itemNum, plistCount, pPredictItem);
 
@@ -1102,7 +1102,7 @@ error_code cellImeJpGetPredictList(CellImeJpHandle hImeJpHandle, vm::ptr<s16> pY
 	return CELL_OK;
 }
 
-error_code cellImeJpConfirmPrediction(CellImeJpHandle hImeJpHandle, vm::ptr<CellImeJpPredictItem> pPredictItem)
+static error_code cellImeJpConfirmPrediction(CellImeJpHandle hImeJpHandle, vm::ptr<CellImeJpPredictItem> pPredictItem)
 {
 	cellImeJp.todo("cellImeJpConfirmPrediction(hImeJpHandle=*0x%x, pPredictItem=*0x%x)", hImeJpHandle, pPredictItem);
 

--- a/rpcs3/Emu/Cell/Modules/cellImeJp.h
+++ b/rpcs3/Emu/Cell/Modules/cellImeJp.h
@@ -118,6 +118,7 @@ struct ime_jp_manager
 	std::u16string confirmed_string; // Confirmed part of the string (first part of the entire string)
 	std::u16string converted_string; // Converted part of the unconfirmed input string
 	std::u16string input_string;     // Unconfirmed part of the string (second part of the entire string)
+	usz cursor = 0;       // The cursor. Can move across the entire input string.
 	usz focus_begin = 0;  // Begin of the focus string
 	usz focus_length = 0; // Length of the focus string
 	s16 fix_input_mode = CELL_IMEJP_FIXINMODE_OFF;
@@ -131,6 +132,8 @@ struct ime_jp_manager
 	bool addString(vm::cptr<u16> str);
 	bool backspaceWord();
 	bool deleteWord();
+	void clear_input();
+	void move_cursor(s8 amount);                      // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
 	void move_focus(s8 amount);                       // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
 	void move_focus_end(s8 amount, bool wrap_around); // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
 };

--- a/rpcs3/Emu/Cell/Modules/cellImeJp.h
+++ b/rpcs3/Emu/Cell/Modules/cellImeJp.h
@@ -132,6 +132,7 @@ struct ime_jp_manager
 	bool addString(vm::cptr<u16> str);
 	bool backspaceWord();
 	bool deleteWord();
+	bool remove_character(bool forward);
 	void clear_input();
 	void move_cursor(s8 amount);                      // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
 	void move_focus(s8 amount);                       // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128

--- a/rpcs3/Emu/Cell/Modules/cellImeJp.h
+++ b/rpcs3/Emu/Cell/Modules/cellImeJp.h
@@ -115,11 +115,11 @@ struct ime_jp_manager
 
 	u32 input_state = CELL_IMEJP_BEFORE_INPUT;
 	std::vector<std::string> dictionary_paths;
-	std::u16string confirmed_string;
-	std::u16string converted_string;
-	std::u16string input_string;
-	usz cursor = 0;
-	usz cursor_end = 0;
+	std::u16string confirmed_string; // Confirmed part of the string (first part of the entire string)
+	std::u16string converted_string; // Converted part of the unconfirmed input string
+	std::u16string input_string;     // Unconfirmed part of the string (second part of the entire string)
+	usz focus_begin = 0;  // Begin of the focus string
+	usz focus_length = 0; // Length of the focus string
 	s16 fix_input_mode = CELL_IMEJP_FIXINMODE_OFF;
 	s16 input_char_type = CELL_IMEJP_DSPCHAR_HIRA;
 	s16 kana_input_mode = CELL_IMEJP_ROMAN_INPUT;
@@ -131,6 +131,6 @@ struct ime_jp_manager
 	bool addString(vm::cptr<u16> str);
 	bool backspaceWord();
 	bool deleteWord();
-	void moveCursor(s8 amount);
-	void moveCursorEnd(s8 amount);
+	void move_focus(s8 amount);                       // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
+	void move_focus_end(s8 amount, bool wrap_around); // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
 };

--- a/rpcs3/Emu/Cell/Modules/cellImeJp.h
+++ b/rpcs3/Emu/Cell/Modules/cellImeJp.h
@@ -136,4 +136,12 @@ struct ime_jp_manager
 	void move_cursor(s8 amount);                      // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
 	void move_focus(s8 amount);                       // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
 	void move_focus_end(s8 amount, bool wrap_around); // s8 because CELL_IMEJP_STRING_MAXLENGTH is 128
+
+	struct candidate
+	{
+		std::u16string text; // Actual text of the candidate
+		u16 offset = 0;      // The offset of the next character after the candidate replaced part of the current focus.
+	};
+	std::vector<candidate> get_candidate_list() const;
+	std::u16string get_focus_string() const;
 };

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -187,10 +187,11 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 		}
 
 #ifdef _WIN32
-		wchar_t buffer[32767];
-		GetModuleFileNameW(nullptr, buffer, sizeof(buffer) / 2);
+		constexpr DWORD size = 32767;
+		std::vector<wchar_t> buffer(size);
+		GetModuleFileNameW(nullptr, buffer.data(), size);
 		const std::wstring arg(text.cbegin(), text.cend()); // ignore unicode for now
-		_wspawnl(_P_WAIT, buffer, buffer, L"--error", arg.c_str(), nullptr);
+		_wspawnl(_P_WAIT, buffer.data(), buffer.data(), L"--error", arg.c_str(), nullptr);
 #else
 		pid_t pid;
 		std::vector<char> data(text.data(), text.data() + text.size() + 1);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -962,7 +962,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		const std::string selected_device = m_emu_settings->GetSetting(emu_settings_type::AudioDevice);
 		int device_index = 0;
 
-		for (auto& dev : dev_array)
+		for (const audio_device_enumerator::audio_device& dev : dev_array)
 		{
 			const QString cur_item = qstr(dev.id);
 			ui->audioDeviceBox->addItem(qstr(dev.name), cur_item);
@@ -2307,6 +2307,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	m_emu_settings->EnhanceCheckBox(ui->disableVertexCache, emu_settings_type::DisableVertexCache);
 	SubscribeTooltip(ui->disableVertexCache, tooltips.settings.disable_vertex_cache);
+
+	m_emu_settings->EnhanceCheckBox(ui->forceHwMSAAResolve, emu_settings_type::ForceHwMSAAResolve);
+	SubscribeTooltip(ui->forceHwMSAAResolve, tooltips.settings.force_hw_MSAA);
 
 	// Checkboxes: core debug options
 	m_emu_settings->EnhanceCheckBox(ui->alwaysStart, emu_settings_type::StartOnBoot);


### PR DESCRIPTION
- Fixes some new GetModuleFileNameW warnings
- Fixes deadlock in cellImeJpConvertCancel
- Adds focus area wrap around in cellImeJp and fixes an issue where its length would always return at least 1
- Adds a differentiation between cursor and focus area, although this doesn't seem to work properly (neither really better nor worse)
- Adds a fake conversion candidate so that the game doesn't break if you open the candidate list

![image](https://github.com/RPCS3/rpcs3/assets/23019877/2484fdbe-0898-4d95-af8d-5071772e7159)
