### PR TITLE
Trim Network settings line edit input (+ update miniupnp)

### DIFF
--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -742,7 +742,12 @@ void emu_settings::EnhanceLineEdit(QLineEdit* edit, emu_settings_type type)
 
 	connect(edit, &QLineEdit::textChanged, this, [type, this](const QString &text)
 	{
-		SetSetting(type, sstr(text));
+		const QString trimmed = text.trimmed();
+		if (trimmed.size() != text.size())
+		{
+			cfg_log.warning("EnhanceLineEdit '%s' input was trimmed", cfg_adapter::get_setting_name(type));
+		}
+		SetSetting(type, sstr(trimmed));
 	});
 
 	connect(this, &emu_settings::RestoreDefaultsSignal, edit, [this, edit, type]()


### PR DESCRIPTION
- Trim whitespace in text fields used for emu settings
- Update miniupnp to 2.3.4

Fixes #15082