### PR TITLE
Don't search games when the dialog is cancelled

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2424,10 +2424,15 @@ void main_window::CreateConnects()
 			return;
 		}
 
-		QStringList paths;
-
 		// Only select one folder for now
-		paths << QFileDialog::getExistingDirectory(this, tr("Select a folder containing one or more games"), qstr(fs::get_config_dir()), QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+		QString dir = QFileDialog::getExistingDirectory(this, tr("Select a folder containing one or more games"), qstr(fs::get_config_dir()), QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+		if (dir.isEmpty())
+		{
+			return;
+		}
+
+		QStringList paths;
+		paths << dir;
 		AddGamesFromDirs(std::move(paths));
 	});
 


### PR DESCRIPTION
Avoid showing this message when Add Games dialog is cancelled:
![image](https://github.com/RPCS3/rpcs3/assets/2995486/3d6fab0c-1523-4d3c-877c-bd91dc6a2267)
