### PR TITLE
rsx: Allow native UI render even when we have pending draw calls if FIFO queue is empty.

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1070,7 +1070,8 @@ void GLGSRender::do_local_task(rsx::FIFO::state state)
 
 	if (m_overlay_manager)
 	{
-		if (!in_begin_end && async_flip_requested & flip_request::native_ui && !is_stopped())
+		const auto should_ignore = in_begin_end && state != rsx::FIFO::state::empty;
+		if ((async_flip_requested & flip_request::native_ui) && !should_ignore && !is_stopped())
 		{
 			rsx::display_flip_info_t info{};
 			info.buffer = current_display_buffer;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1968,7 +1968,8 @@ void VKGSRender::do_local_task(rsx::FIFO::state state)
 
 	if (m_overlay_manager)
 	{
-		if (!in_begin_end && async_flip_requested & flip_request::native_ui && !is_stopped())
+		const auto should_ignore = in_begin_end && state != rsx::FIFO::state::empty;
+		if ((async_flip_requested & flip_request::native_ui) && !should_ignore && !is_stopped())
 		{
 			flush_command_queue(true);
 			rsx::display_flip_info_t info{};


### PR DESCRIPTION
Should solve a rare deadlock if the game dev is insane and does some insane things with the RSX FIFO queue.