### PR TITLE
Add sceNpPlus to registered modules

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -347,6 +347,7 @@ target_sources(rpcs3_emu PRIVATE
     Cell/Modules/sceNpCommerce2.cpp
     Cell/Modules/sceNp.cpp
     Cell/Modules/sceNpMatchingInt.cpp
+    Cell/Modules/sceNpPlus.cpp
     Cell/Modules/sceNpSns.cpp
     Cell/Modules/sceNpTrophy.cpp
     Cell/Modules/sceNpTus.cpp

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -279,6 +279,7 @@ static void ppu_initialize_modules(ppu_linkage_info* link, utils::serial* ar = n
 		&ppu_module_manager::sceNpClans,
 		&ppu_module_manager::sceNpCommerce2,
 		&ppu_module_manager::sceNpMatchingInt,
+		&ppu_module_manager::sceNpPlus,
 		&ppu_module_manager::sceNpSns,
 		&ppu_module_manager::sceNpTrophy,
 		&ppu_module_manager::sceNpTus,


### PR DESCRIPTION
Hopefully fixes https://github.com/RPCS3/rpcs3/issues/15149.
The module was missing from hle list and the file wasn't even in the CMakeLists.txt