### PR TITLE
Minor arm64 improvements

### DIFF
--- a/buildfiles/cmake/ConfigureCompiler.cmake
+++ b/buildfiles/cmake/ConfigureCompiler.cmake
@@ -34,12 +34,15 @@ else()
 	add_compile_options(-fstack-protector)
 
 	if (COMPILER_ARM)
+		# This section needs a review. Apple claims armv8.5-a on M-series but doesn't support SVE.
+		# Note that compared to the rest of the 8.x family, 8.1 is very restrictive and we'll have to bump the requirement in future to get anything meaningful.
 		if (APPLE)
 			add_compile_options(-march=armv8.4-a)
 		else()
 			add_compile_options(-march=armv8.1-a)
 		endif()
-	else()
+	elseif(COMPILER_X86)
+		# Some compilers will set both X86 and ARM, so check explicitly for ARM first
 		add_compile_options(-msse -msse2 -mcx16)
 	endif()
 

--- a/buildfiles/cmake/ConfigureCompiler.cmake
+++ b/buildfiles/cmake/ConfigureCompiler.cmake
@@ -33,16 +33,14 @@ else()
 	add_compile_options(-fno-exceptions)
 	add_compile_options(-fstack-protector)
 
-	if (COMPILER_X86)
-		add_compile_options(-msse -msse2 -mcx16)
-	endif()
-
 	if (COMPILER_ARM)
 		if (APPLE)
 			add_compile_options(-march=armv8.4-a)
 		else()
 			add_compile_options(-march=armv8.1-a)
 		endif()
+	else()
+		add_compile_options(-msse -msse2 -mcx16)
 	endif()
 
 	add_compile_options(-Werror=old-style-cast)

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -2806,6 +2806,7 @@ public:
 		}
 		case SPU_RdDec:
 		{
+#if defined(ARCH_X64)
 			if (utils::get_tsc_freq() && !(g_cfg.core.spu_loop_detection) && (g_cfg.core.clocks_scale == 100))
 			{
 				const auto timestamp = m_ir->CreateLoad(get_type<u64>(), spu_ptr<u64>(&spu_thread::ch_dec_start_timestamp));
@@ -2823,7 +2824,7 @@ public:
 				res.value = m_ir->CreateSub(dec_value, deltax);
 				break;
 			}
-
+#endif
 			res.value = call("spu_read_decrementer", &exec_read_dec, m_thread);
 			break;
 		}
@@ -3511,6 +3512,7 @@ public:
 		{
 			call("spu_get_events", &exec_get_events, m_thread, m_ir->getInt32(SPU_EVENT_TM));
 
+#if defined(ARCH_X64)
 			if (utils::get_tsc_freq() && !(g_cfg.core.spu_loop_detection) && (g_cfg.core.clocks_scale == 100))
 			{
 				const auto tsc = m_ir->CreateCall(get_intrinsic(llvm::Intrinsic::x86_rdtsc));
@@ -3520,6 +3522,7 @@ public:
 				m_ir->CreateStore(tsctb, spu_ptr<u64>(&spu_thread::ch_dec_start_timestamp));
 			}
 			else
+#endif
 			{
 				m_ir->CreateStore(call("get_timebased_time", &get_timebased_time), spu_ptr<u64>(&spu_thread::ch_dec_start_timestamp));
 			}

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
@@ -98,7 +98,7 @@ namespace gl
 		{
 			// This format is completely worthless to CPU processing algorithms where cache lines on die are linear.
 			// If this is happening, usually it means it was not a planned readback (e.g shared pages situation)
-			rsx_log.warning("[Performance warning] CPU readback of swizzled data");
+			rsx_log.trace("[Performance warning] CPU readback of swizzled data");
 
 			// Read-modify-write to avoid corrupting already resident memory outside texture region
 			std::vector<u8> tmp_data(rsx_pitch * height);

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -323,7 +323,7 @@ namespace vk
 			{
 				// This format is completely worthless to CPU processing algorithms where cache lines on die are linear.
 				// If this is happening, usually it means it was not a planned readback (e.g shared pages situation)
-				rsx_log.warning("[Performance warning] CPU readback of swizzled data");
+				rsx_log.trace("[Performance warning] CPU readback of swizzled data");
 
 				// Read-modify-write to avoid corrupting already resident memory outside texture region
 				void* data = get_ptr(range.start);


### PR DESCRIPTION
- Do not add x64 switches to arm64 output. This happens on clang which exports both compilerx86 and compilerarm somehow.
- Do not use x86-specific intrinsics without preprocessor guards. This fixes SPU module compilation allowing SPU llvm to be used in some games.

Most games still hang after loading modules when using llvm. I haven't really checked why and tbh it's not a priority right now.