### PR TITLE
vk: Driver compatibility improvements

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -121,6 +121,21 @@ namespace vk
 		case driver_vendor::MVK:
 			// Apple GPUs / moltenVK need more testing
 			break;
+		case driver_vendor::LAVAPIPE:
+			// This software device works well, with poor performance as the only downside
+			break;
+		case driver_vendor::DOZEN:
+			// This driver is often picked by mistake when the user meant to select something else. Complain loudly.
+#ifdef _WIN32
+			MessageBox(NULL,
+				L"You're attempting to run rpcs3 on Microsoft's Dozen driver that emulates vulkan on top of Direct3D12.\n"
+				"This driver is unsupported. You should use your vendor's vulkan driver whenever possible.",
+				L"Unsupported Driver",
+				MB_ICONWARNING | MB_OK);
+#else
+			rsx_log.error("Dozen is currently unsupported. How did you even get this to run outside windows?");
+#endif
+			break;
 		default:
 			rsx_log.warning("Unsupported device: %s", gpu_name);
 		}

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -186,6 +186,8 @@ namespace vk
 			case driver_vendor::NVIDIA:
 			case driver_vendor::INTEL:
 			case driver_vendor::MVK:
+			case driver_vendor::DOZEN:
+			case driver_vendor::LAVAPIPE:
 				break;
 			}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/chip_class.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/chip_class.h
@@ -36,7 +36,9 @@ namespace vk
 		RADV,
 		INTEL,
 		ANV,
-		MVK
+		MVK,
+		DOZEN,
+		LAVAPIPE
 	};
 
 	driver_vendor get_driver_vendor();

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -224,6 +224,11 @@ namespace vk
 		{
 			const auto gpu_name = get_name();
 
+			if (gpu_name.find("Microsoft Direct3D12") != umax)
+			{
+				return driver_vendor::DOZEN;
+			}
+
 			if (gpu_name.find("RADV") != umax)
 			{
 				return driver_vendor::RADV;
@@ -248,6 +253,11 @@ namespace vk
 #endif
 			}
 
+			if (gpu_name.find("llvmpipe") != umax)
+			{
+				return driver_vendor::LAVAPIPE;
+			}
+
 			return driver_vendor::unknown;
 		}
 		else
@@ -265,6 +275,10 @@ namespace vk
 				return driver_vendor::INTEL;
 			case VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA_KHR:
 				return driver_vendor::ANV;
+			case VK_DRIVER_ID_MESA_DOZEN:
+				return driver_vendor::DOZEN;
+			case VK_DRIVER_ID_MESA_LLVMPIPE:
+				return driver_vendor::LAVAPIPE;
 			default:
 				// Mobile?
 				return driver_vendor::unknown;

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -509,6 +509,13 @@ namespace vk
 		enabled_features.shaderStorageBufferArrayDynamicIndexing = VK_TRUE;
 
 		// Optionally disable unsupported stuff
+		if (!pgpu->features.fullDrawIndexUint32)
+		{
+			// There's really nothing we can do about PS3 draw indices, just pray your GPU doesn't crash.
+			rsx_log.error("Your GPU driver does not fully support 32-bit vertex indices. This may result in graphical corruption or crashes in some cases.");
+			enabled_features.fullDrawIndexUint32 = VK_FALSE;
+		}
+
 		if (!pgpu->features.shaderStorageImageMultisample || !pgpu->features.shaderStorageImageWriteWithoutFormat)
 		{
 			// Disable MSAA if any of these two features are unsupported
@@ -554,6 +561,12 @@ namespace vk
 			enabled_features.depthBounds = VK_FALSE;
 		}
 
+		if (!pgpu->features.largePoints)
+		{
+			rsx_log.error("Your GPU does not support large points. Graphics may not render correctly.");
+			enabled_features.largePoints = VK_FALSE;
+		}
+
 		if (!pgpu->features.wideLines)
 		{
 			rsx_log.error("Your GPU does not support wide lines. Graphics may not render correctly.");
@@ -579,13 +592,11 @@ namespace vk
 			enabled_features.occlusionQueryPrecise = VK_FALSE;
 		}
 
-#ifdef __APPLE__
 		if (!pgpu->features.logicOp)
 		{
 			rsx_log.error("Your GPU does not support framebuffer logical operations. Graphics may not render correctly.");
 			enabled_features.logicOp = VK_FALSE;
 		}
-#endif
 
 		VkDeviceCreateInfo device = {};
 		device.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;


### PR DESCRIPTION
- Explicitly add support for dozen and lavapipe by identifying them.
- Show a warning box if the user selected the dozen driver. With exception of developers, this driver should really never be used outside of environments like WSL.
- Make more required features "optional". This allows dozen to complete swapchain creation successfully. The driver will obviously crash later but the user has been warned approrpiately by then.

Fixes https://github.com/RPCS3/rpcs3/issues/15131