### PR TITLE
overlays: use signed short for position to allow negative positions

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -586,8 +586,8 @@ static bool check_gem_num(const u32 gem_num)
 
 static inline void draw_overlay_cursor(u32 gem_num, const gem_config::gem_controller&, s32 x_pos, s32 y_pos, s32 x_max, s32 y_max)
 {
-	const u16 x = static_cast<u16>(x_pos / (x_max / static_cast<f32>(rsx::overlays::overlay::virtual_width)));
-	const u16 y = static_cast<u16>(y_pos / (y_max / static_cast<f32>(rsx::overlays::overlay::virtual_height)));
+	const s16 x = static_cast<s16>(x_pos / (x_max / static_cast<f32>(rsx::overlays::overlay::virtual_width)));
+	const s16 y = static_cast<s16>(y_pos / (y_max / static_cast<f32>(rsx::overlays::overlay::virtual_height)));
 
 	// Note: We shouldn't use sphere_rgb here. The game will set it to black in many cases.
 	const gem_config_data::gem_color& rgb = gem_config_data::gem_color::get_default_color(gem_num);

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_components.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_components.h
@@ -147,7 +147,7 @@ namespace rsx
 				{
 					const f64 percentage = std::clamp((this->m_last_value - static_cast<T>(m_minimum)) / std::fabs(m_maximum - m_minimum), 0.0, 1.0);
 					m_slider.set_pos(m_slider.x, this->y + (this->h - m_slider.h) / 2);
-					m_handle.set_pos(m_slider.x + static_cast<u16>(percentage * (m_slider.w - m_handle.w)), this->y + (this->h - m_handle.h) / 2);
+					m_handle.set_pos(m_slider.x + static_cast<s16>(percentage * (m_slider.w - m_handle.w)), this->y + (this->h - m_handle.h) / 2);
 
 					const auto set_label_text = [this]() -> void
 					{

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_main_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_main_menu.cpp
@@ -12,7 +12,7 @@ namespace rsx
 {
 	namespace overlays
 	{
-		home_menu_main_menu::home_menu_main_menu(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_main_menu::home_menu_main_menu(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_TITLE))
 		{
 			is_current_page = true;

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_main_menu.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_main_menu.h
@@ -9,7 +9,7 @@ namespace rsx
 	{
 		struct home_menu_main_menu : public home_menu_page
 		{
-			home_menu_main_menu(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_main_menu(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 		};
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_message_box.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_message_box.cpp
@@ -7,7 +7,7 @@ namespace rsx
 {
 	namespace overlays
 	{
-		home_menu_message_box::home_menu_message_box(u16 x, u16 y, u16 width, u16 height)
+		home_menu_message_box::home_menu_message_box(s16 x, s16 y, u16 width, u16 height)
 			: overlay_element()
 			, m_accept_btn(120, 30)
 			, m_cancel_btn(120, 30)

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_message_box.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_message_box.h
@@ -9,7 +9,7 @@ namespace rsx
 		struct home_menu_message_box : public overlay_element
 		{
 		public:
-			home_menu_message_box(u16 x, u16 y, u16 width, u16 height);
+			home_menu_message_box(s16 x, s16 y, u16 width, u16 height);
 			compiled_resource& get_compiled() override;
 			void show(const std::string& text, std::function<void()> on_accept = nullptr, std::function<void()> on_cancel = nullptr);
 			void hide();

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_page.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_page.cpp
@@ -7,7 +7,7 @@ namespace rsx
 {
 	namespace overlays
 	{
-		home_menu_page::home_menu_page(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent, const std::string& title)
+		home_menu_page::home_menu_page(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent, const std::string& title)
 			: list_view(width, height, use_separators)
 			, parent(parent)
 			, title(title)

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_page.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_page.h
@@ -12,7 +12,7 @@ namespace rsx
 		struct home_menu_page : public list_view
 		{
 		public:
-			home_menu_page(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent, const std::string& text);
+			home_menu_page(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent, const std::string& text);
 
 			void set_current_page(home_menu_page* page);
 			home_menu_page* get_current_page(bool include_this);

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
@@ -10,7 +10,7 @@ namespace rsx
 {
 	namespace overlays
 	{
-		home_menu_settings::home_menu_settings(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_settings::home_menu_settings(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS))
 		{
 			add_page(std::make_shared<home_menu_settings_audio>(x, y, width, height, use_separators, this));
@@ -24,7 +24,7 @@ namespace rsx
 			apply_layout();
 		}
 
-		home_menu_settings_audio::home_menu_settings_audio(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_settings_audio::home_menu_settings_audio(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_AUDIO))
 		{
 			add_signed_slider(&g_cfg.audio.volume, "Master Volume", " %", 1);
@@ -39,7 +39,7 @@ namespace rsx
 			apply_layout();
 		}
 
-		home_menu_settings_video::home_menu_settings_video(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_settings_video::home_menu_settings_video(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_VIDEO))
 		{
 			add_dropdown(&g_cfg.video.frame_limit, "Frame Limit");
@@ -56,7 +56,7 @@ namespace rsx
 			apply_layout();
 		}
 
-		home_menu_settings_advanced::home_menu_settings_advanced(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_settings_advanced::home_menu_settings_advanced(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_ADVANCED))
 		{
 			add_signed_slider(&g_cfg.core.preferred_spu_threads, "Preferred SPU Threads", "", 1);
@@ -71,7 +71,7 @@ namespace rsx
 			apply_layout();
 		}
 
-		home_menu_settings_input::home_menu_settings_input(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_settings_input::home_menu_settings_input(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_INPUT))
 		{
 			add_checkbox(&g_cfg.io.background_input_enabled, "Background Input Enabled");
@@ -89,7 +89,7 @@ namespace rsx
 			apply_layout();
 		}
 
-		home_menu_settings_overlays::home_menu_settings_overlays(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_settings_overlays::home_menu_settings_overlays(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_OVERLAYS))
 		{
 			add_checkbox(&g_cfg.misc.show_trophy_popups, "Show Trophy Popups");
@@ -99,7 +99,7 @@ namespace rsx
 			apply_layout();
 		}
 
-		home_menu_settings_performance_overlay::home_menu_settings_performance_overlay(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_settings_performance_overlay::home_menu_settings_performance_overlay(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_PERFORMANCE_OVERLAY))
 		{
 			add_checkbox(&g_cfg.video.perf_overlay.perf_overlay_enabled, "Enable Performance Overlay");
@@ -125,7 +125,7 @@ namespace rsx
 			apply_layout();
 		}
 
-		home_menu_settings_debug::home_menu_settings_debug(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
+		home_menu_settings_debug::home_menu_settings_debug(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent)
 			: home_menu_settings_page(x, y, width, height, use_separators, parent, get_localized_string(localized_string_id::HOME_MENU_SETTINGS_DEBUG))
 		{
 			add_checkbox(&g_cfg.video.overlay, "Debug Overlay");

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.h
@@ -11,7 +11,7 @@ namespace rsx
 		struct home_menu_settings : public home_menu_page
 		{
 		public:
-			home_menu_settings(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_settings(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 
 		private:
 			std::vector<std::shared_ptr<home_menu_page>> m_settings_pages;
@@ -207,37 +207,37 @@ namespace rsx
 
 		struct home_menu_settings_audio : public home_menu_settings_page
 		{
-			home_menu_settings_audio(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_settings_audio(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 		};
 
 		struct home_menu_settings_video : public home_menu_settings_page
 		{
-			home_menu_settings_video(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_settings_video(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 		};
 
 		struct home_menu_settings_advanced : public home_menu_settings_page
 		{
-			home_menu_settings_advanced(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_settings_advanced(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 		};
 
 		struct home_menu_settings_input : public home_menu_settings_page
 		{
-			home_menu_settings_input(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_settings_input(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 		};
 
 		struct home_menu_settings_overlays : public home_menu_settings_page
 		{
-			home_menu_settings_overlays(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_settings_overlays(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 		};
 
 		struct home_menu_settings_performance_overlay : public home_menu_settings_page
 		{
-			home_menu_settings_performance_overlay(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_settings_performance_overlay(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 		};
 
 		struct home_menu_settings_debug : public home_menu_settings_page
 		{
-			home_menu_settings_debug(u16 x, u16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
+			home_menu_settings_debug(s16 x, s16 y, u16 width, u16 height, bool use_separators, home_menu_page* parent);
 		};
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
@@ -285,8 +285,8 @@ namespace rsx
 
 		void overlay_element::translate(s16 _x, s16 _y)
 		{
-			x = static_cast<u16>(x + _x);
-			y = static_cast<u16>(y + _y);
+			x += _x;
+			y += _y;
 
 			is_compiled = false;
 		}
@@ -295,8 +295,8 @@ namespace rsx
 		{
 			if (origin_scaling)
 			{
-				x = static_cast<u16>(_x * x);
-				y = static_cast<u16>(_y * y);
+				x = static_cast<s16>(_x * x);
+				y = static_cast<s16>(_y * y);
 			}
 
 			w = static_cast<u16>(_x * w);
@@ -305,7 +305,7 @@ namespace rsx
 			is_compiled = false;
 		}
 
-		void overlay_element::set_pos(u16 _x, u16 _y)
+		void overlay_element::set_pos(s16 _x, s16 _y)
 		{
 			x = _x;
 			y = _y;
@@ -646,10 +646,10 @@ namespace rsx
 				itm->translate(_x, _y);
 		}
 
-		void layout_container::set_pos(u16 _x, u16 _y)
+		void layout_container::set_pos(s16 _x, s16 _y)
 		{
-			s16 dx = static_cast<s16>(_x - x);
-			s16 dy = static_cast<s16>(_y - y);
+			s16 dx = _x - x;
+			s16 dy = _y - y;
 			translate(dx, dy);
 		}
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.h
@@ -135,8 +135,8 @@ namespace rsx
 				right
 			};
 
-			u16 x = 0;
-			u16 y = 0;
+			s16 x = 0;
+			s16 y = 0;
 			u16 w = 0;
 			u16 h = 0;
 
@@ -178,7 +178,7 @@ namespace rsx
 			virtual void refresh();
 			virtual void translate(s16 _x, s16 _y);
 			virtual void scale(f32 _x, f32 _y, bool origin_scaling);
-			virtual void set_pos(u16 _x, u16 _y);
+			virtual void set_pos(s16 _x, s16 _y);
 			virtual void set_size(u16 _w, u16 _h);
 			virtual void set_padding(u16 left, u16 right, u16 top, u16 bottom);
 			virtual void set_padding(u16 padding);
@@ -210,7 +210,7 @@ namespace rsx
 			layout_container();
 
 			void translate(s16 _x, s16 _y) override;
-			void set_pos(u16 _x, u16 _y) override;
+			void set_pos(s16 _x, s16 _y) override;
 
 			compiled_resource& get_compiled() override;
 
@@ -315,7 +315,7 @@ namespace rsx
 
 		public:
 			graph();
-			void set_pos(u16 _x, u16 _y) override;
+			void set_pos(s16 _x, s16 _y) override;
 			void set_size(u16 _w, u16 _h) override;
 			void set_title(const char* title);
 			void set_font(const char* font_name, u16 font_size) override;

--- a/rpcs3/Emu/RSX/Overlays/overlay_cursor.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_cursor.cpp
@@ -12,7 +12,7 @@ namespace rsx
 			m_cross_v.set_size(1, 15);
 		}
 
-		bool cursor_item::set_position(u16 x, u16 y)
+		bool cursor_item::set_position(s16 x, s16 y)
 		{
 			if (m_x == x && m_y == y)
 			{
@@ -115,7 +115,7 @@ namespace rsx
 			return cr;
 		}
 
-		void cursor_manager::update_cursor(u32 id, u16 x, u16 y, const color4f& color, u64 duration_us, bool force_update)
+		void cursor_manager::update_cursor(u32 id, s16 x, s16 y, const color4f& color, u64 duration_us, bool force_update)
 		{
 			std::lock_guard lock(m_mutex);
 
@@ -136,7 +136,7 @@ namespace rsx
 			}
 		}
 
-		void set_cursor(u32 id, u16 x, u16 y, const color4f& color, u64 duration_us, bool force_update)
+		void set_cursor(u32 id, s16 x, s16 y, const color4f& color, u64 duration_us, bool force_update)
 		{
 			if (auto manager = g_fxo->try_get<rsx::overlays::display_manager>())
 			{

--- a/rpcs3/Emu/RSX/Overlays/overlay_cursor.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_cursor.h
@@ -19,7 +19,7 @@ namespace rsx
 			cursor_item();
 
 			void set_expiration(u64 expiration_time);
-			bool set_position(u16 x, u16 y);
+			bool set_position(s16 x, s16 y);
 			bool set_color(color4f color);
 
 			bool update_visibility(u64 time);
@@ -32,8 +32,8 @@ namespace rsx
 			overlay_element m_cross_h{};
 			overlay_element m_cross_v{};
 			u64 m_expiration_time = 0;
-			u16 m_x = 0;
-			u16 m_y = 0;
+			s16 m_x = 0;
+			s16 m_y = 0;
 		};
 
 		class cursor_manager final : public overlay
@@ -42,14 +42,14 @@ namespace rsx
 			void update(u64 timestamp_us) override;
 			compiled_resource get_compiled() override;
 
-			void update_cursor(u32 id, u16 x, u16 y, const color4f& color, u64 duration_us, bool force_update);
+			void update_cursor(u32 id, s16 x, s16 y, const color4f& color, u64 duration_us, bool force_update);
 
 		private:
 			shared_mutex m_mutex;
 			std::map<u32, cursor_item> m_cursors;
 		};
 
-		void set_cursor(u32 id, u16 x, u16 y, const color4f& color, u64 duration_us, bool force_update);
+		void set_cursor(u32 id, s16 x, s16 y, const color4f& color, u64 duration_us, bool force_update);
 
 	} // namespace overlays
 } // namespace rsx

--- a/rpcs3/Emu/RSX/Overlays/overlay_message.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message.cpp
@@ -71,7 +71,7 @@ namespace rsx
 			return m_text.text == text;
 		}
 
-		void message_item::set_pos(u16 _x, u16 _y)
+		void message_item::set_pos(s16 _x, s16 _y)
 		{
 			rounded_rect::set_pos(_x, _y);
 			m_text.set_pos(_x + m_margin, y + m_margin);
@@ -108,7 +108,7 @@ namespace rsx
 			return compiled_resources;
 		}
 
-		void message_item::update(usz index, u64 timestamp_us, u16 y_offset)
+		void message_item::update(usz index, u64 timestamp_us, s16 y_offset)
 		{
 			if (m_cur_pos != index)
 			{
@@ -186,7 +186,8 @@ namespace rsx
 
 			// Render reversed list. Oldest entries are furthest from the border
 			constexpr u16 spacing = 4;
-			u16 y_offset = 8, index = 0;
+			s16 y_offset = 8;
+			usz index = 0;
 			for (auto it = vis_set.rbegin(); it != vis_set.rend(); ++it, ++index)
 			{
 				if (origin == message_pin_location::top) [[ likely ]]

--- a/rpcs3/Emu/RSX/Overlays/overlay_message.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message.h
@@ -20,8 +20,8 @@ namespace rsx
 		public:
 			template <typename T>
 			message_item(T msg_id, u64 expiration, std::shared_ptr<atomic_t<u32>> refs, std::shared_ptr<overlay_element> icon = {});
-			void update(usz index, u64 timestamp_us, u16 y_offset);
-			void set_pos(u16 _x, u16 _y) override;
+			void update(usz index, u64 timestamp_us, s16 y_offset);
+			void set_pos(s16 _x, s16 _y) override;
 
 			void reset_expiration();
 			u64 get_expiration() const;

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -208,7 +208,7 @@ namespace rsx
 			num_progress_bars = type.progress_bar_count;
 			if (num_progress_bars)
 			{
-				u16 offset = 58;
+				s16 offset = 58;
 				::at32(progress_bars, 0).set_pos(240, 412);
 
 				if (num_progress_bars > 1)

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -349,14 +349,14 @@ namespace rsx
 
 			// Calculate initial position and analog movement range.
 			constexpr f32 margin = 50.0f; // Let's add a minimal margin on all sides
-			const u16 x_min = static_cast<u16>(margin);
-			const u16 x_max = static_cast<u16>(static_cast<f32>(virtual_width - total_w) - margin);
-			const u16 y_min = static_cast<u16>(margin);
-			const u16 y_max = static_cast<u16>(static_cast<f32>(virtual_height - total_h) - margin);
-			u16 input_x = 0;
-			u16 input_y = 0;
-			u16 panel_x = 0;
-			u16 panel_y = 0;
+			const s16 x_min = static_cast<s16>(margin);
+			const s16 x_max = static_cast<s16>(static_cast<f32>(virtual_width - total_w) - margin);
+			const s16 y_min = static_cast<s16>(margin);
+			const s16 y_max = static_cast<s16>(static_cast<f32>(virtual_height - total_h) - margin);
+			s16 input_x = 0;
+			s16 input_y = 0;
+			s16 panel_x = 0;
+			s16 panel_y = 0;
 
 			// x pos should only be 0 the first time, because we always add a margin
 			if (m_x_input_pos == 0)
@@ -397,15 +397,15 @@ namespace rsx
 
 				if (m_use_separate_windows)
 				{
-					input_x = m_x_input_pos = static_cast<u16>(std::clamp<f32>(get_x(m_input_layout, input_w), x_min, x_max));
-					input_y = m_y_input_pos = static_cast<u16>(std::clamp<f32>(get_y(m_input_layout, input_h), y_min, y_max));
-					panel_x = m_x_panel_pos = static_cast<u16>(std::clamp<f32>(get_x(m_panel_layout, panel_w), x_min, x_max));
-					panel_y = m_y_panel_pos = static_cast<u16>(std::clamp<f32>(get_y(m_panel_layout, panel_h), static_cast<f32>(y_min + input_h), static_cast<f32>(y_max + input_h)));
+					input_x = m_x_input_pos = static_cast<s16>(std::clamp<f32>(get_x(m_input_layout, input_w), x_min, x_max));
+					input_y = m_y_input_pos = static_cast<s16>(std::clamp<f32>(get_y(m_input_layout, input_h), y_min, y_max));
+					panel_x = m_x_panel_pos = static_cast<s16>(std::clamp<f32>(get_x(m_panel_layout, panel_w), x_min, x_max));
+					panel_y = m_y_panel_pos = static_cast<s16>(std::clamp<f32>(get_y(m_panel_layout, panel_h), static_cast<f32>(y_min + input_h), static_cast<f32>(y_max + input_h)));
 				}
 				else
 				{
 					input_x = panel_x = m_x_input_pos = m_x_panel_pos = static_cast<u16>(std::clamp<f32>(get_x(m_layout, total_w), x_min, x_max));
-					input_y = m_y_input_pos = static_cast<u16>(std::clamp<f32>(get_y(m_layout, total_h), y_min, y_max));
+					input_y = m_y_input_pos = static_cast<s16>(std::clamp<f32>(get_y(m_layout, total_h), y_min, y_max));
 					panel_y = m_y_panel_pos = input_y + input_h;
 				}
 			}
@@ -414,7 +414,7 @@ namespace rsx
 				input_x = m_x_input_pos = std::clamp(m_x_input_pos, x_min, x_max);
 				input_y = m_y_input_pos = std::clamp(m_y_input_pos, y_min, y_max);
 				panel_x = m_x_panel_pos = std::clamp(m_x_panel_pos, x_min, x_max);
-				panel_y = m_y_panel_pos = std::clamp<u16>(m_y_panel_pos, y_min + input_h, y_max + input_h);
+				panel_y = m_y_panel_pos = std::clamp<s16>(m_y_panel_pos, y_min + input_h, y_max + input_h);
 			}
 			else
 			{
@@ -437,7 +437,7 @@ namespace rsx
 			m_preview.set_size(input_w, preview_height);
 			m_preview.set_padding(get_scaled(15), 0, get_scaled(10), 0);
 
-			const u16 button_y = panel_y + panel_h + button_margin;
+			const s16 button_y = panel_y + panel_h + button_margin;
 
 			m_btn_cancel.set_pos(panel_x, button_y);
 			m_btn_cancel.set_size(get_scaled(140), button_height);
@@ -1169,7 +1169,7 @@ namespace rsx
 				m_update = true;
 			}
 
-			if (m_pointer.visible() && m_pointer.set_position(static_cast<u16>(info.pointer_x), static_cast<u16>(info.pointer_y)))
+			if (m_pointer.visible() && m_pointer.set_position(static_cast<s16>(info.pointer_x), static_cast<s16>(info.pointer_y)))
 			{
 				m_update = true;
 			}
@@ -1245,8 +1245,8 @@ namespace rsx
 
 				for (const auto& c : m_grid)
 				{
-					u16 x = static_cast<u16>(c.pos.x);
-					u16 y = static_cast<u16>(c.pos.y);
+					s16 x = static_cast<s16>(c.pos.x);
+					s16 y = static_cast<s16>(c.pos.y);
 					u16 w = cell_size_x;
 					u16 h = cell_size_y;
 
@@ -1270,7 +1270,7 @@ namespace rsx
 
 						if (output_count)
 						{
-							const u16 offset_x = static_cast<u16>(buffered_cell_count * cell_size_x);
+							const s16 offset_x = static_cast<s16>(buffered_cell_count * cell_size_x);
 							const u16 full_width = static_cast<u16>(offset_x + cell_size_x);
 
 							label.set_pos(x - offset_x, y);

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.h
@@ -66,10 +66,10 @@ namespace rsx
 			cursor_item m_pointer{};
 
 			// Analog movement
-			u16 m_x_input_pos = 0;
-			u16 m_y_input_pos = 0;
-			u16 m_x_panel_pos = 0;
-			u16 m_y_panel_pos = 0;
+			s16 m_x_input_pos = 0;
+			s16 m_y_input_pos = 0;
+			s16 m_x_panel_pos = 0;
+			s16 m_y_panel_pos = 0;
 
 			// Grid
 			u16 cell_size_x = 0;
@@ -141,9 +141,9 @@ namespace rsx
 			std::pair<u32, u32> get_cell_geometry(u32 index);
 
 			template <typename T>
-			u16 get_scaled(T val)
+			s16 get_scaled(T val)
 			{
-				return static_cast<u16>(static_cast<f32>(val) * m_scaling);
+				return static_cast<s16>(static_cast<f32>(val) * m_scaling);
 			}
 
 			compiled_resource get_compiled() override;

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -183,11 +183,11 @@ namespace rsx
 				// Position the graphs within the body
 				const u16 graphs_width = m_body.w;
 				const u16 body_left = m_body.x;
-				u16 y_offset = m_body.y;
+				s16 y_offset = m_body.y;
 
 				if (m_body.h > 0)
 				{
-					y_offset += m_body.h + m_padding;
+					y_offset += static_cast<s16>(m_body.h + m_padding);
 				}
 
 				if (m_framerate_graph_enabled)
@@ -646,7 +646,7 @@ namespace rsx
 			back_color = { 0.f, 0.f, 0.f, 0.5f };
 		}
 
-		void graph::set_pos(u16 _x, u16 _y)
+		void graph::set_pos(s16 _x, s16 _y)
 		{
 			m_label.set_pos(_x, _y);
 			overlay_element::set_pos(_x, _y + m_label.h);

--- a/rpcs3/Emu/RSX/Overlays/overlay_progress_bar.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_progress_bar.cpp
@@ -35,7 +35,7 @@ namespace rsx
 			is_compiled = false;
 		}
 
-		void progress_bar::set_pos(u16 _x, u16 _y)
+		void progress_bar::set_pos(s16 _x, s16 _y)
 		{
 			u16 text_w, text_h;
 			text_view.measure_text(text_w, text_h);

--- a/rpcs3/Emu/RSX/Overlays/overlay_progress_bar.hpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_progress_bar.hpp
@@ -21,7 +21,7 @@ namespace rsx
 			void dec(f32 value);
 			void set_limit(f32 limit);
 			void set_value(f32 value);
-			void set_pos(u16 _x, u16 _y) override;
+			void set_pos(s16 _x, s16 _y) override;
 			void set_size(u16 _w, u16 _h) override;
 			void translate(s16 dx, s16 dy) override;
 			void set_text(const std::string& str) override;

--- a/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_trophy_notification.cpp
@@ -163,8 +163,8 @@ namespace rsx
 			text_view.auto_resize();
 
 			// Resize background to cover the text
-			u16 margin_sz = 9;
-			frame.w       = margin_sz * 3 + image.w + text_view.w;
+			constexpr u16 margin_sz = 9;
+			frame.w = margin_sz * 3 + image.w + text_view.w;
 
 			sliding_animation.current = { -f32(frame.x + frame.w), 0, 0 };
 			sliding_animation.end = { 0, 0, 0 };


### PR DESCRIPTION
- Fixes positioning an overlay to the top and/or left of the screen. This would previously overflow and disappear
- This fixes the mouse/move pointer disappearing partially or completely when it's near to the left or upper border

This was previously invisible at that location:
![image](https://github.com/RPCS3/rpcs3/assets/23019877/739074f9-90fd-4e16-b083-8cb76f70a1d4)
