### PR TITLE
Fix lv2_file::file_view::size() and fix SPU cache gen on first boot

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1941,9 +1941,9 @@ bool fs::dir::open(const std::string& path)
 	return true;
 }
 
-bool fs::file::strict_read_check(u64 _size, u64 type_size) const
+bool fs::file::strict_read_check(u64 offset, u64 _size, u64 type_size) const
 {
-	if (usz pos0 = pos(), size0 = size(); (pos0 >= size0 ? 0 : (size0 - pos0)) / type_size < _size)
+	if (usz pos0 = offset, size0 = size(); (pos0 >= size0 ? 0 : (size0 - pos0)) / type_size < _size)
 	{
 		fs::g_tls_error = fs::error::inval;
 		return false;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3798,8 +3798,21 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 						{
 							mself_record rec{};
 
+							std::set<u64> offs;
+
 							if (mself.read(rec) && rec.get_pos(mself.size()))
 							{
+								if (rec.size <= 0x20)
+								{
+									continue;
+								}
+
+								if (!offs.emplace(rec.off).second)
+								{
+									// Duplicate
+									continue;
+								}
+
 								// Read characters safely
 								std::string name(sizeof(rec.name), '\0');
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3800,7 +3800,11 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 
 							if (mself.read(rec) && rec.get_pos(mself.size()))
 							{
-								std::string name = rec.name;
+								// Read characters safely
+								std::string name(sizeof(rec.name), '\0');
+
+								std::memcpy(name.data(), rec.name, name.size());
+								name = std::string(name.c_str());
 
 								upper = fmt::to_upper(name);
 
@@ -3881,7 +3885,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 			if (u64 off = offset)
 			{
 				// Adjust offset for MSELF
-				src = make_file_view(std::move(src), offset);
+				src = make_file_view(std::move(src), offset, file_size);
 
 				// Adjust path for MSELF too
 				fmt::append(path, "_x%x", off);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3821,14 +3821,14 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 
 								upper = fmt::to_upper(name);
 
-								if (upper.ends_with(".SPRX"))
+								if (upper.find(".SPRX") != umax || upper.find(".PRX") != umax)
 								{
 									// .sprx inside .mself found
 									file_queue.emplace_back(dir_queue[i] + entry.name, rec.off, rec.size);
 									continue;
 								}
 
-								if (upper.ends_with(".SELF"))
+								if (upper.find(".SELF") != umax || upper.find(".ELF") != umax)
 								{
 									// .self inside .mself found
 									file_queue.emplace_back(dir_queue[i] + entry.name, rec.off, rec.size);

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -3569,6 +3569,13 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 		}
 	}
 
+	if (!m_bbs.count(entry_point))
+	{
+		// Invalid code
+		spu_log.error("[0x%x] Invalid code", entry_point);
+		return {};
+	}
+
 	// Fill entry map
 	while (true)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -632,7 +632,13 @@ struct lv2_file::file_view : fs::file_base
 
 	fs::stat_t get_stat() override
 	{
-		return m_file->file.get_stat();
+		fs::stat_t stat = m_file->file.get_stat();
+
+		// TODO: Check this on realhw
+		//stat.size = utils::sub_saturate<u64>(stat.size, m_off);
+
+		stat.is_writable = false;
+		return stat;
 	}
 
 	bool trunc(u64) override
@@ -677,7 +683,7 @@ struct lv2_file::file_view : fs::file_base
 
 	u64 size() override
 	{
-		return m_file->file.size();
+		return utils::sub_saturate<u64>(m_file->file.size(), m_off);
 	}
 
 	fs::file_id get_id() override

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -648,7 +648,7 @@ struct lv2_file::file_view : fs::file_base
 
 	u64 read(void* buffer, u64 size) override
 	{
-		const u64 result = m_file->file.read_at(m_pos, buffer, size);
+		const u64 result = file_view::read_at(m_pos, buffer, size);
 
 		m_pos += result;
 		return result;

--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -2622,7 +2622,7 @@ error_code sys_fs_lseek(ppu_thread& ppu, u32 fd, s64 offset, s32 whence, vm::ptr
 	{
 		switch (auto error = fs::g_tls_error)
 		{
-		case fs::error::inval: return CELL_EINVAL;
+		case fs::error::inval: return {CELL_EINVAL, "fd=%u, offset=0x%x, whence=%d", fd, offset, whence};
 		default: sys_fs.error("sys_fs_lseek(): unknown error %s", error);
 		}
 

--- a/rpcs3/Emu/Cell/lv2/sys_memory.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.cpp
@@ -126,7 +126,7 @@ error_code sys_memory_allocate(cpu_thread& cpu, u32 size, u64 flags, vm::ptr<u32
 	// Try to get "physical memory"
 	if (!dct.take(size))
 	{
-		return CELL_ENOMEM;
+		return {CELL_ENOMEM, dct.size - dct.used};
 	}
 
 	if (const auto area = reserve_map(size, align))
@@ -200,7 +200,7 @@ error_code sys_memory_allocate_from_container(cpu_thread& cpu, u32 size, u32 cid
 
 	if (ct.ret)
 	{
-		return ct.ret;
+		return {ct.ret, ct->size - ct->used};
 	}
 
 	if (const auto area = reserve_map(size, align))

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.cpp
@@ -74,6 +74,7 @@ CellError lv2_memory::on_id_create()
 {
 	if (!exists && !ct->take(size))
 	{
+		sys_mmapper.error("lv2_memory::on_id_create(): Cannot allocate 0x%x bytes (0x%x available)", size, ct->size - ct->used);
 		return CELL_ENOMEM;
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -36,7 +36,15 @@ static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vp
 
 	u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 
-	ppu_exec_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic), nullptr, true);
+	src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic), nullptr, true);
+
+	if (!src)
+	{
+		return {CELL_ENOEXEC, +"Failed to decrypt file"};
+	}
+
+	ppu_exec_object obj = std::move(src);
+	src.close();
 
 	if (obj != elf_error::ok)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -507,7 +507,7 @@ error_code _sys_ppu_thread_create(ppu_thread& ppu, vm::ptr<u64> thread_id, vm::p
 	// Try to obtain "physical memory" from the default container
 	if (!dct.take(stack_size))
 	{
-		return CELL_ENOMEM;
+		return {CELL_ENOMEM, dct.size - dct.used};
 	}
 
 	const vm::addr_t stack_base{vm::alloc(stack_size, vm::stack, 4096)};

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -263,11 +263,19 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 
-	ppu_prx_object obj = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic), nullptr, true);
+	src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic), nullptr, true);
+
+	if (!src)
+	{
+		return {CELL_PRX_ERROR_UNSUPPORTED_PRX_TYPE, +"Failed to decrypt file"};
+	}
+
+	ppu_prx_object obj = std::move(src);
+	src.close();
 
 	if (obj != elf_error::ok)
 	{
-		return CELL_PRX_ERROR_UNSUPPORTED_PRX_TYPE;
+		return {CELL_PRX_ERROR_UNSUPPORTED_PRX_TYPE, obj.get_error()};
 	}
 
 	const auto prx = ppu_load_prx(obj, false, path, file_offset);


### PR DESCRIPTION
* Fixes #15209 (lv2_file::file_view::read() regressed)
* Fixes lv2_file::file_view::size() too.
* Avoid changing file position in elf_object::open(), should allow concurrent usage if we ever need it.
* Fix a potential access violation with PPU LLVM builder.
* Prevent using duplicate MSELF entries.
* Fix crash on analyzing invalid code when searching SPU code for the first time.
* Make PPU LLVM compile more MSELF entries by relaxing file name constraints.