### PR TITLE
SPU LLVM: Improve runtime SPU compilation preferences

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -4601,7 +4601,7 @@ struct spu_llvm
 					{
 						if (notify_compile[i])
 						{
-							(workers.begin() + (worker_index % worker_count))->registered.notify();
+							(workers.begin() + (i % worker_count))->registered.notify();
 						}
 					}
 				}

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -4589,8 +4589,7 @@ struct spu_llvm
 				const auto lock = prof_mutex.init_always([&]{});
 
 				// Register new blocks to collect samples
-				// If the sample count is the same, prefer the last block that was pushed
-				samples.emplace(pair.first ? pair.first * 65536 + (add_count-- % 65536) : pair.first * 65536, 0);
+				samples.emplace(pair.first, 0);
 			}
 
 			if (enqueued.empty())

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -4652,7 +4652,7 @@ struct spu_llvm
 			if (notify && !notify_compile[worker_index % worker_count])
 			{
 				notify_compile[worker_index % worker_count] = 1;
-				notify_compile_cout++;
+				notify_compile_count++;
 
 				if (notify_compile_count == notify_compile.size())
 				{

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -4570,10 +4570,14 @@ struct spu_llvm
 		}
 
 		u32 worker_index = 0;
+		u32 notify_compile_count = 0;
+		std::vector<u8> notify_compile(worker_count);
 
 		m_workers = make_single<named_thread_group<spu_llvm_worker>>("SPUW.", worker_count);
 		auto workers_ptr = m_workers.load();
 		auto& workers = *workers_ptr;
+
+		usz add_count = 65535;
 
 		while (thread_ctrl::state() != thread_state::aborting)
 		{
@@ -4585,14 +4589,30 @@ struct spu_llvm
 				const auto lock = prof_mutex.init_always([&]{});
 
 				// Register new blocks to collect samples
-				samples.emplace(pair.first, 0);
+				// If the sample count is the same, prefer the last block that was pushed
+				samples.emplace(pair.first ? pair.first * 65536 + (add_count-- % 65536) : pair.first * 65536, 0);
 			}
 
 			if (enqueued.empty())
 			{
+				// Send pending notifications
+				if (notify_compile_count)
+				{
+					for (usz i = 0; i < worker_count; i++)
+					{
+						if (notify_compile[i])
+						{
+							(workers.begin() + (worker_index % worker_count))->registered.notify();
+						}
+					}
+				}
+
 				// Interrupt profiler thread and put it to sleep
 				static_cast<void>(prof_mutex.reset());
 				thread_ctrl::wait_on(utils::bless<atomic_t<u32>>(&registered)[1], 0);
+				add_count = 65535; // Reset count
+				std::fill(notify_compile.begin(), notify_compile.end(), 0); // Reset notification flags
+				notify_compile_count = 0;
 				continue;
 			}
 
@@ -4620,8 +4640,34 @@ struct spu_llvm
 			// Remove item from the queue
 			enqueued.erase(found_it);
 
+			// Prefer using an inactive thread
+			for (usz i = 0; i < worker_count && !!(workers.begin() + (worker_index % worker_count))->registered; i++)
+			{
+				worker_index++;
+			}
+
 			// Push the workload
-			(workers.begin() + (worker_index++ % worker_count))->registered.push(reinterpret_cast<u64>(_old), &func);
+			const bool notify = (workers.begin() + (worker_index % worker_count))->registered.template push<false>(reinterpret_cast<u64>(_old), &func);
+
+			if (notify && !notify_compile[worker_index % worker_count])
+			{
+				notify_compile[worker_index % worker_count] = 1;
+				notify_compile_cout++;
+
+				if (notify_compile_count == notify_compile.size())
+				{
+					// Notify all
+					for (usz i = 0; i < worker_count; i++)
+					{
+						(workers.begin() + (i % worker_count))->registered.notify();
+					}
+
+					std::fill(notify_compile.begin(), notify_compile.end(), 0); // Reset notification flags
+					notify_compile_count = 0;
+				}
+			}
+
+			worker_index++;
 		}
 
 		static_cast<void>(prof_mutex.init_always([&]{ samples.clear(); }));


### PR DESCRIPTION
1. Prefer using inactive worker threads to ompile new SPU blocks for maximum concurrency.
2. Postpone thread notifications to when block queue is drained so all threads would start at once, not delaying the managing thread to push more blocks.
3. If more than one block has the same use count as others, apply for compilation first the one which has been queued earlier. Similarly to distance / time = speed, here the time here is compared (estimation) for rate of block usage. 

Some of these affect only CPUs with 12 or more threads at the current implementation, point 3 affects all.

Tests: Tested to improve massively the perfprmance of SPU LLVM ingame compilation for Red Dead Redemption on 14600KF