### PR TITLE
Improve macOS < 14.3 Rosetta blocker message

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -532,7 +532,7 @@ int main(int argc, char** argv)
     int osx_ver_patch = Darwin_Version::getNSpatchVersion();
 	if ((osx_ver_major == 14 && osx_ver_minor < 3) && (utils::get_cpu_brand().rfind("VirtualApple", 0) == 0))
 	{
-		report_fatal_error(fmt::format("RPCS3 requires macOS 14.3.0 or later.\nYou're currently running macOS %i.%i.%i.\nPlease update macOS from System Settings.\n\n", osx_ver_major, osx_ver_minor, osx_ver_patch));
+		report_fatal_error(fmt::format("RPCS3 requires macOS 14.3.0 or later.\nYou're currently using macOS %i.%i.%i.\nPlease update macOS from System Settings.\n\n", osx_ver_major, osx_ver_minor, osx_ver_patch));
 	}
 #endif
 

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -527,8 +527,8 @@ int main(int argc, char** argv)
 #endif
 
 #ifdef __APPLE__
-    int osx_ver_major = Darwin_Version::getNSmajorVersion();
-    int osx_ver_minor = Darwin_Version::getNSminorVersion();
+	const int osx_ver_major = Darwin_Version::getNSmajorVersion();
+	const int osx_ver_minor = Darwin_Version::getNSminorVersion();
 	if ((osx_ver_major == 14 && osx_ver_minor < 3) && (utils::get_cpu_brand().rfind("VirtualApple", 0) == 0))
 	{
     	int osx_ver_patch = Darwin_Version::getNSpatchVersion();

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -529,9 +529,9 @@ int main(int argc, char** argv)
 #ifdef __APPLE__
     int osx_ver_major = Darwin_Version::getNSmajorVersion();
     int osx_ver_minor = Darwin_Version::getNSminorVersion();
-    int osx_ver_patch = Darwin_Version::getNSpatchVersion();
 	if ((osx_ver_major == 14 && osx_ver_minor < 3) && (utils::get_cpu_brand().rfind("VirtualApple", 0) == 0))
 	{
+    	int osx_ver_patch = Darwin_Version::getNSpatchVersion();
 		report_fatal_error(fmt::format("RPCS3 requires macOS 14.3.0 or later.\nYou're currently using macOS %i.%i.%i.\nPlease update macOS from System Settings.\n\n", osx_ver_major, osx_ver_minor, osx_ver_patch));
 	}
 #endif

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -527,9 +527,12 @@ int main(int argc, char** argv)
 #endif
 
 #ifdef __APPLE__
-	if ((Darwin_Version::getNSmajorVersion() == 14 && Darwin_Version::getNSminorVersion() < 3) && (utils::get_cpu_brand().rfind("VirtualApple", 0) == 0))
+    int osx_ver_major = Darwin_Version::getNSmajorVersion();
+    int osx_ver_minor = Darwin_Version::getNSminorVersion();
+    int osx_ver_patch = Darwin_Version::getNSpatchVersion();
+	if ((osx_ver_major == 14 && osx_ver_minor < 3) && (utils::get_cpu_brand().rfind("VirtualApple", 0) == 0))
 	{
-		report_fatal_error("Unsupported Rosetta version.\nPlease update macOS to a supported version.");
+		report_fatal_error(fmt::format("RPCS3 requires macOS 14.3.0 or later.\nYou're currently running macOS %i.%i.%i.\nPlease update macOS from System Settings.\n\n", osx_ver_major, osx_ver_minor, osx_ver_patch));
 	}
 #endif
 


### PR DESCRIPTION
Improves the error message added with #15237.
I've already updated to 14.3.1, so I cannot test this.