### PR TITLE
Add Wii Harmonix instruments to USB device whitelist

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -293,6 +293,14 @@ usb_handler_thread::usb_handler_thread()
 		check_device(0x12BA, 0x2430, 0x243F, "Harmonix Button Guitar");
 		check_device(0x12BA, 0x2530, 0x253F, "Harmonix Real Guitar");
 
+		check_device(0x1BAD, 0x0004, 0x0004, "Harmonix RB1 Guitar - Wii");
+		check_device(0x1BAD, 0x0005, 0x0005, "Harmonix RB1 Drums - Wii");
+		check_device(0x1BAD, 0x3010, 0x301F, "Harmonix RB2 Guitar - Wii");
+		check_device(0x1BAD, 0x3110, 0x313F, "Harmonix RB2 Drums - Wii");
+		check_device(0x1BAD, 0x3330, 0x333F, "Harmonix Keyboard - Wii");
+		check_device(0x1BAD, 0x3430, 0x343F, "Harmonix Button Guitar - Wii");
+		check_device(0x1BAD, 0x3530, 0x353F, "Harmonix Real Guitar - Wii");
+
 		if (desc.idVendor == 0x1209 && desc.idProduct == 0x2882)
 		{
 			sys_usbd.success("Found device: Santroller");


### PR DESCRIPTION
With game patches, it's possible to patch certain music games to use Wii instruments rather than PS3 ones, so expose those to the emulator. 

![image](https://github.com/RPCS3/rpcs3/assets/22731889/c374b6cd-01de-429f-b5bf-7a7a7d3c767b)

(Since the protocol is 1:1 identical - see https://github.com/TheNathannator/PlasticBand/blob/main/Docs/Instruments/Pro%20Keyboard/PS3%20and%20Wii.md - it might be better to remap them internally in the emulator rather than making game patches to do it)