### PR TITLE
appimage: Do not bundle libvulkan.so

### DIFF
--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -17,6 +17,9 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     # Remove libwayland-client because it has platform-dependent exports and breaks other OSes
     rm -f ./AppDir/usr/lib/libwayland-client.so*
 
+    # Remove libvulkan because it causes issues with gamescope
+    rm -f ./AppDir/usr/lib/libvulkan.so*
+
     # Remove git directory containing local commit history file
     rm -rf ./AppDir/usr/share/rpcs3/git
 


### PR DESCRIPTION
libvulkan.so being bundled in the AppImage causes issues with gamescope, see https://github.com/RPCS3/rpcs3/issues/14917

Tested with: 
- Manjaro Linux 23.1.3 with mesa RADV
- Steam Deck LCD on Desktop Mode
- Steam Deck OLED with Gamescope

AppImage now requires the system to have [vulkan-icd-loader](https://archlinux.org/packages/extra/x86_64/vulkan-icd-loader/) installed, as many other gaming related packages such as steam