### PR TITLE
SPU LLVM: Improve SPU code precompilation

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -1024,7 +1024,7 @@ void spu_cache::initialize(bool build_existing_cache)
 					}
 				}
 
-				if (new_entry != umax && !spu_thread::is_exec_code(new_entry, { reinterpret_cast<const u8*>(ls.data()), SPU_LS_SIZE }))
+				if (new_entry != umax && !spu_thread::is_exec_code(new_entry, { reinterpret_cast<const u8*>(ls.data()), SPU_LS_SIZE }, 0, true))
 				{
 					new_entry = umax;
 				}
@@ -1033,7 +1033,7 @@ void spu_cache::initialize(bool build_existing_cache)
 				{
 					new_entry = start_new;
 
-					while (new_entry < next_func && (ls[start_new / 4] < 0x3fffc || !spu_thread::is_exec_code(new_entry, { reinterpret_cast<const u8*>(ls.data()), SPU_LS_SIZE })))
+					while (new_entry < next_func && (ls[start_new / 4] < 0x3fffc || !spu_thread::is_exec_code(new_entry, { reinterpret_cast<const u8*>(ls.data()), SPU_LS_SIZE }, 0, true)))
 					{
 						new_entry += 4;
 					}
@@ -2281,13 +2281,13 @@ std::vector<u32> spu_thread::discover_functions(u32 base_addr, std::span<const u
 	calls.erase(std::remove_if(calls.begin(), calls.end(), [&](u32 caller)
 	{
 		// Check the validity of both the callee code and the following caller code
-		return !is_exec_code(caller, ls, base_addr) || !is_exec_code(caller + 4, ls, base_addr);
+		return !is_exec_code(caller, ls, base_addr, true) || !is_exec_code(caller + 4, ls, base_addr, true);
 	}), calls.end());
 
 	branches.erase(std::remove_if(branches.begin(), branches.end(), [&](u32 caller)
 	{
 		// Check the validity of the callee code
-		return !is_exec_code(caller, ls, base_addr);
+		return !is_exec_code(caller, ls, base_addr, true);
 	}), branches.end());
 
 	std::vector<u32> addrs;

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1114,6 +1114,7 @@ public:
 		}
 
 		const u32 start0 = _func.entry_point;
+		const usz func_size = _func.data.size();
 
 		const auto add_loc = m_spurt->add_empty(std::move(_func));
 
@@ -2117,7 +2118,7 @@ public:
 
 		if (g_fxo->get<spu_cache>().operator bool())
 		{
-			spu_log.success("New block compiled successfully");
+			spu_log.success("New SPU block compiled successfully (size=%u)", func_size);
 		}
 
 		return fn;

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4241,6 +4241,13 @@ bool spu_thread::is_exec_code(u32 addr, std::span<const u8> ls_ptr, u32 base_add
 						return false;
 					}
 
+					if (type == spu_itype::BRSL)
+					{
+						// Insert a virtual return-to-next, because it is usually a call
+						results[1] = addr + 4;
+						std::swap(results[1], results[0]);
+					}
+
 					break;
 				}
 				default:

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -835,7 +835,7 @@ public:
 	void set_events(u32 bits);
 	void set_interrupt_status(bool enable);
 	bool check_mfc_interrupts(u32 next_pc);
-	static bool is_exec_code(u32 addr, std::span<const u8> ls_ptr, u32 base_addr = 0); // Only a hint, do not rely on it other than debugging purposes
+	static bool is_exec_code(u32 addr, std::span<const u8> ls_ptr, u32 base_addr = 0, bool avoid_dead_code = false); // Only a hint, do not rely on it other than debugging purposes
 	static std::vector<u32> discover_functions(u32 base_addr, std::span<const u8> ls, bool is_known_addr, u32 /*entry*/);
 	u32 get_ch_count(u32 ch);
 	s64 get_ch_value(u32 ch);


### PR DESCRIPTION
* Detect invalid SPU relative branches (rely on the size of the SPU local storage), this would decrease the amount of false positives in SPU code mining.
* Detect 'argument passing' block before the main function.
* Detect tail calls by inspecting the called code of branches too, not just the previous code to the branch.