### PR TITLE
[Experimental] SPU LLVM: More compilation threads

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -889,6 +889,7 @@ public:
 
 	static atomic_t<u32> g_raw_spu_ctr;
 	static atomic_t<u32> g_raw_spu_id[5];
+	static atomic_t<u32> g_spu_work_count;
 
 	static u32 find_raw_spu(u32 id)
 	{


### PR DESCRIPTION
Target: SPU Compilation performance 🚀🚀🚀
Add another compilation thread for 6+ threaded cpus, at the expense of making some SPU threads relax a bit while compiling blocks.
This PR only affects 6-11 threaded CPUs.