### PR TITLE
SPU LLVM: Postpone cache writes until compiled

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -4659,6 +4659,7 @@ struct spu_llvm
 
 		u32 worker_index = 0;
 		u32 notify_compile_count = 0;
+		u32 compile_pending = 0;
 		std::vector<u8> notify_compile(worker_count);
 
 		m_workers = make_single<named_thread_group<spu_llvm_worker>>("SPUW.", worker_count);
@@ -4689,7 +4690,7 @@ struct spu_llvm
 					{
 						if (notify_compile[i])
 						{
-							(workers.begin() + (i % worker_count))->registered.notify();
+							(workers.begin() + i)->registered.notify();
 						}
 					}
 				}
@@ -4700,6 +4701,7 @@ struct spu_llvm
 				add_count = 65535; // Reset count
 				std::fill(notify_compile.begin(), notify_compile.end(), 0); // Reset notification flags
 				notify_compile_count = 0;
+				compile_pending = 0;
 				continue;
 			}
 
@@ -4740,18 +4742,26 @@ struct spu_llvm
 			{
 				notify_compile[worker_index % worker_count] = 1;
 				notify_compile_count++;
+			}
 
-				if (notify_compile_count == notify_compile.size())
+			compile_pending++;
+
+			// Notify all before queue runs out if there is considerable excess
+			// Optimized that: if there are many workers, it acts soon
+			// If there are only a few workers, it postpones notifications until there is some more workload
+			if (notify_compile_count && std::min<u32>(7, utils::aligned_div<u32>(worker_count * 2, 3) + 2) <= compile_pending)
+			{
+				for (usz i = 0; i < worker_count; i++)
 				{
-					// Notify all
-					for (usz i = 0; i < worker_count; i++)
+					if (notify_compile[i])
 					{
-						(workers.begin() + (i % worker_count))->registered.notify();
+						(workers.begin() + i)->registered.notify();
 					}
-
-					std::fill(notify_compile.begin(), notify_compile.end(), 0); // Reset notification flags
-					notify_compile_count = 0;
 				}
+
+				std::fill(notify_compile.begin(), notify_compile.end(), 0); // Reset notification flags
+				notify_compile_count = 0;
+				compile_pending = 0;
 			}
 
 			worker_index++;

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1138,9 +1138,11 @@ public:
 
 		std::string log;
 
+		bool add_to_file = false;
+
 		if (auto& cache = g_fxo->get<spu_cache>(); cache && g_cfg.core.spu_cache && !add_loc->cached.exchange(1))
 		{
-			cache.add(func);
+			add_to_file = true;
 		}
 
 		{
@@ -2096,6 +2098,14 @@ public:
 		// Rebuild trampoline if necessary
 		if (!m_spurt->rebuild_ubertrampoline(func.data[0]))
 		{
+			if (auto& cache = g_fxo->get<spu_cache>())
+			{
+				if (add_to_file)
+				{
+					cache.add(func);
+				}
+			}
+
 			return nullptr;
 		}
 
@@ -2116,8 +2126,13 @@ public:
 		asm("DSB ISH");
 #endif
 
-		if (g_fxo->get<spu_cache>().operator bool())
+		if (auto& cache = g_fxo->get<spu_cache>())
 		{
+			if (add_to_file)
+			{
+				cache.add(func);
+			}
+
 			spu_log.success("New SPU block compiled successfully (size=%u)", func_size);
 		}
 


### PR DESCRIPTION
Make SPU threads happy by releasing the LLVM block pointer as early as possible by writing block data to disk *after* it is compiled and SPUs see and able to use it.
Aims to improve perfiramce while compiling SPU blocks ingame.