### PR TITLE
Qt: don't deleteLater the progress_dialog

### DIFF
--- a/rpcs3/rpcs3qt/curl_handle.cpp
+++ b/rpcs3/rpcs3qt/curl_handle.cpp
@@ -1,3 +1,4 @@
+#include "stdafx.h"
 #include "curl_handle.h"
 #include "Emu/system_utils.hpp"
 #include "util/logs.hpp"
@@ -11,7 +12,7 @@ LOG_CHANNEL(network_log, "NET");
 namespace rpcs3::curl
 {
 
-curl_handle::curl_handle(QObject* parent) : QObject(parent)
+curl_handle::curl_handle()
 {
 	reset_error_buffer();
 
@@ -48,7 +49,7 @@ void curl_handle::reset_error_buffer()
 	m_error_buffer[0] = 0;
 }
 
-std::string curl_handle::get_verbose_error(CURLcode code)
+std::string curl_handle::get_verbose_error(CURLcode code) const
 {
 	if (m_uses_error_buffer)
 	{

--- a/rpcs3/rpcs3qt/curl_handle.h
+++ b/rpcs3/rpcs3qt/curl_handle.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <array>
-#include <QObject>
 
 #ifndef CURL_STATICLIB
 #define CURL_STATICLIB
@@ -12,10 +11,10 @@ namespace rpcs3::curl
 {
 inline bool g_curl_verbose = false;
 
-class curl_handle : public QObject
+class curl_handle
 {
 public:
-	explicit curl_handle(QObject* parent = nullptr);
+	explicit curl_handle();
 	~curl_handle();
 
 	CURL* get_curl() const;
@@ -26,7 +25,7 @@ public:
 	}
 
 	void reset_error_buffer();
-	std::string get_verbose_error(CURLcode code);
+	std::string get_verbose_error(CURLcode code) const;
 
 private:
 	CURL* m_curl = nullptr;

--- a/rpcs3/rpcs3qt/downloader.cpp
+++ b/rpcs3/rpcs3qt/downloader.cpp
@@ -18,7 +18,7 @@ usz curl_write_cb_compat(char* ptr, usz /*size*/, usz nmemb, void* userdata)
 downloader::downloader(QWidget* parent)
 	: QObject(parent)
 	, m_parent(parent)
-	, m_curl(new rpcs3::curl::curl_handle(this))
+	, m_curl(new rpcs3::curl::curl_handle())
 {
 }
 
@@ -85,10 +85,9 @@ void downloader::start(const std::string& url, bool follow_location, bool show_p
 			return;
 		}
 
-		if (m_progress_dialog && (!m_keep_progress_dialog_open || !m_curl_success))
+		if (!m_keep_progress_dialog_open || !m_curl_success)
 		{
-			m_progress_dialog->close();
-			m_progress_dialog = nullptr;
+			close_progress_dialog();
 		}
 
 		if (m_curl_success)
@@ -126,7 +125,7 @@ void downloader::start(const std::string& url, bool follow_location, bool show_p
 				close_progress_dialog();
 				Q_EMIT signal_download_canceled();
 			});
-			connect(m_progress_dialog, &QProgressDialog::finished, m_progress_dialog, &QProgressDialog::deleteLater);
+			connect(m_progress_dialog, &QProgressDialog::finished, this, &downloader::close_progress_dialog);
 		}
 	}
 

--- a/rpcs3/rpcs3qt/downloader.cpp
+++ b/rpcs3/rpcs3qt/downloader.cpp
@@ -122,10 +122,13 @@ void downloader::start(const std::string& url, bool follow_location, bool show_p
 			connect(m_progress_dialog, &QProgressDialog::canceled, this, [this]()
 			{
 				m_curl_abort = true;
-				close_progress_dialog();
+				m_progress_dialog = nullptr; // The progress dialog deletes itself on close
 				Q_EMIT signal_download_canceled();
 			});
-			connect(m_progress_dialog, &QProgressDialog::finished, this, &downloader::close_progress_dialog);
+			connect(m_progress_dialog, &QProgressDialog::finished, this, [this]()
+			{
+				m_progress_dialog = nullptr; // The progress dialog deletes itself on close
+			});
 		}
 	}
 

--- a/rpcs3/rpcs3qt/downloader.h
+++ b/rpcs3/rpcs3qt/downloader.h
@@ -25,9 +25,11 @@ public:
 	usz update_buffer(char* data, usz size);
 
 	void update_progress_dialog(const QString& title) const;
-	void close_progress_dialog();
 
 	progress_dialog* get_progress_dialog() const;
+
+public Q_SLOTS:
+	void close_progress_dialog();
 
 private Q_SLOTS:
 	void handle_buffer_update(int size, int max) const;
@@ -41,7 +43,7 @@ Q_SIGNALS:
 private:
 	QWidget* m_parent = nullptr;
 
-	rpcs3::curl::curl_handle* m_curl = nullptr;
+	std::unique_ptr<rpcs3::curl::curl_handle> m_curl;
 	QByteArray m_curl_buf;
 	atomic_t<bool> m_curl_abort = false;
 	atomic_t<bool> m_curl_success = false;

--- a/rpcs3/rpcs3qt/downloader.h
+++ b/rpcs3/rpcs3qt/downloader.h
@@ -25,11 +25,9 @@ public:
 	usz update_buffer(char* data, usz size);
 
 	void update_progress_dialog(const QString& title) const;
+	void close_progress_dialog();
 
 	progress_dialog* get_progress_dialog() const;
-
-public Q_SLOTS:
-	void close_progress_dialog();
 
 private Q_SLOTS:
 	void handle_buffer_update(int size, int max) const;

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -307,7 +307,9 @@ void update_manager::update(bool auto_accept)
 	{
 		if (m_update_message.isEmpty())
 		{
+			// This can happen if we abort the check_for_updates download. Just check again in this case.
 			m_downloader->close_progress_dialog();
+			check_for_updates(false, false, false, m_parent);
 			return;
 		}
 


### PR DESCRIPTION
- Don't deleteLater the progress_dialog. It's already deleted on close by Qt anyway (at least in the downloader).
- Don't close the progress_dialog if it's already closing anyway.
- Also, remove QObject from curl_handle.(thanks @RipleyTom)

Maybe this fixes random crashes when accepting or canceling the updater.