### PR TITLE
RSX: Fix Visual studio debug runtime 

### DIFF
--- a/rpcs3/Emu/RSX/Common/ranged_map.hpp
+++ b/rpcs3/Emu/RSX/Common/ranged_map.hpp
@@ -128,7 +128,7 @@ namespace rsx
 		public:
 			bool operator == (const iterator& other) const
 			{
-				return m_it == other.m_it;
+				return m_current == other.m_current && m_it == other.m_it;
 			}
 
 			auto* operator -> ()
@@ -183,10 +183,10 @@ namespace rsx
 			m_data[block_for(range.start)].insert_or_assign(range.start, std::forward<T>(value));
 		}
 
-		usz count(const u32 key)
+		usz count(const u32 key) const
 		{
-			auto& block = m_data[block_for(key)];
-			if (auto found = block.find(key);
+			const auto& block = m_data[block_for(key)];
+			if (const auto found = block.find(key);
 				found != block.end())
 			{
 				return 1;

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -353,7 +353,7 @@ namespace rsx
 
 					// If this surface has already been added via another descendant, just ignore it
 					bool ignore = false;
-					for (auto &slice : new_surface->old_contents)
+					for (const auto& slice : new_surface->old_contents)
 					{
 						if (slice.source == surface)
 						{
@@ -374,8 +374,8 @@ namespace rsx
 					surface == e.second)
 				{
 					// This has been 'swallowed' by the new surface and can be safely freed
-					auto &storage = surface->is_depth_surface() ? m_depth_stencil_storage : m_render_targets_storage;
-					auto &object = ::at32(storage, e.first);
+					auto& storage = surface->is_depth_surface() ? m_depth_stencil_storage : m_render_targets_storage;
+					auto& object = ::at32(storage, e.first);
 
 					ensure(object);
 
@@ -411,8 +411,9 @@ namespace rsx
 			// Workaround. Preserve new surface tag value because pitch convert is unimplemented
 			u64 new_content_tag = 0;
 
-			address_range *storage_bounds;
-			surface_ranged_map *primary_storage, *secondary_storage;
+			address_range* storage_bounds;
+			surface_ranged_map* primary_storage;
+			surface_ranged_map* secondary_storage;
 			if constexpr (depth)
 			{
 				primary_storage = &m_depth_stencil_storage;
@@ -430,7 +431,7 @@ namespace rsx
 			auto It = primary_storage->find(address);
 			if (It != primary_storage->end())
 			{
-				surface_storage_type &surface = It->second;
+				surface_storage_type& surface = It->second;
 				const bool pitch_compatible = Traits::surface_is_pitch_compatible(surface, pitch);
 
 				if (!pitch_compatible)

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -30,11 +30,13 @@ draw_context_t gl_gs_frame::make_context()
 
 	if (m_primary_context)
 	{
-		auto surface = new QOffscreenSurface();
-		surface->setFormat(m_format);
+		QOffscreenSurface* surface = nullptr;
+
 		// Workaround for the Qt warning: "Attempting to create QWindow-based QOffscreenSurface outside the gui thread. Expect failures."
 		Emu.BlockingCallFromMainThread([&]()
 		{
+			surface = new QOffscreenSurface();
+			surface->setFormat(m_format);
 			surface->create();
 		});
 


### PR DESCRIPTION
- Move entire creation of QOffscreenSurface to main thread (assert due to signal from wrong thread)
- Fix invalid ranged_map iterator comparison (assert due to different iterator types).
This happens if m_it is not set to an iterator of the same object as other.m_it.

```
iterator it1 = obj1.find(...);
iterator it2 = obj2.find(...);
iterator def1 = {};
iterator def2 = {};

 it1 == def1       // assert
 it1 == it2        // assert
def1 == def2       // fine
 it1 == obj1.end() // fine
```