### PR TITLE
Qt: replace refresh progress slot with timer

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -158,7 +158,9 @@ private:
 	game_list_table* m_game_list = nullptr;
 	game_compatibility* m_game_compat = nullptr;
 	progress_dialog* m_progress_dialog = nullptr;
-	QTimer* m_progress_dialog_timer = nullptr;
+	atomic_t<int> m_progress_dialog_value = 0; // Workaround for inexplicable setValue crash in progressValueChanged slot
+	QTimer m_progress_dialog_update_timer;     // Workaround for inexplicable setValue crash in progressValueChanged slot
+	QTimer m_progress_dialog_timer;
 	QList<QAction*> m_columnActs;
 	Qt::SortOrder m_col_sort_order{};
 	int m_sort_column{};

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -37,7 +37,7 @@ void progress_dialog::SetRange(int min, int max)
 {
 	m_progress_indicator->set_range(min, max);
 
-	QProgressDialog::setRange(min, max);
+	setRange(min, max);
 }
 
 void progress_dialog::SetValue(int progress)
@@ -46,7 +46,7 @@ void progress_dialog::SetValue(int progress)
 
 	m_progress_indicator->set_value(value);
 
-	QProgressDialog::setValue(value);
+	setValue(value);
 }
 
 void progress_dialog::SetDeleteOnClose()


### PR DESCRIPTION
For some reason setValue crashes in the progressValueChanged slot for no apparent reason.
I'm losing my patience with this and blame the Qt devs as they've proven to produce QtConcurrent bugs :)
So let's just use a timer to update the dialog.