### PR TITLE
Enable WOLFSSL_ALT_CERT_CHAINS

### DIFF
--- a/3rdparty/curl/libcurl.vcxproj
+++ b/3rdparty/curl/libcurl.vcxproj
@@ -44,7 +44,7 @@
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>curl\include;curl\lib;extra;$(SolutionDir)3rdparty\wolfssl\wolfssl\wolfssl;$(SolutionDir)3rdparty\wolfssl\wolfssl;$(SolutionDir)3rdparty\wolfssl\extra\win32;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>HAVE_SNI;NDEBUG;BUILDING_LIBCURL;CURL_STATICLIB;USE_WOLFSSL;NO_MD4;WOLFSSL_USER_SETTINGS;USE_IPV6;SIZEOF_LONG=4;SIZEOF_LONG_LONG=8;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WOLFSSL_ALT_CERT_CHAINS;HAVE_SNI;NDEBUG;BUILDING_LIBCURL;CURL_STATICLIB;USE_WOLFSSL;NO_MD4;WOLFSSL_USER_SETTINGS;USE_IPV6;SIZEOF_LONG=4;SIZEOF_LONG_LONG=8;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <WarningLevel>TurnOffAllWarnings</WarningLevel>

--- a/3rdparty/wolfssl/CMakeLists.txt
+++ b/3rdparty/wolfssl/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
 	set(WOLFSSL_SNI ON CACHE STRING "Enable SNI (default: disabled)")
 	set(WOLFSSL_OPENSSLEXTRA ON CACHE STRING "Enable extra OpenSSL API, size+ (default: disabled)")
 	set(WOLFSSL_HARDEN OFF CACHE STRING "Enable Hardened build, Enables Timing Resistance and Blinding (default: enabled)")
+	set(WOLFSSL_ALT_CERT_CHAINS ON CACHE STRING "Enable support for Alternate certification chains (default: disabled)")
 
 	add_subdirectory(wolfssl EXCLUDE_FROM_ALL)
 

--- a/3rdparty/wolfssl/extra/win32/user_settings.h
+++ b/3rdparty/wolfssl/extra/win32/user_settings.h
@@ -51,6 +51,9 @@
 #define ECC_TIMING_RESISTANT
 #define USE_FAST_MATH
 #define FP_MAX_BITS 8192
+#ifndef WOLFSSL_ALT_CERT_CHAINS
+#define WOLFSSL_ALT_CERT_CHAINS
+#endif
 
 /* UTF-8 aware filesystem functions for Windows */
 #define WOLFSSL_USER_FILESYSTEM


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/15321.

By default WolfSSL doesn't consider alternate certificate chains and cloudflare recently changed their certificates to include a reference to an old certificate that is not in modern trust stores which caused issues.