### PR TITLE
GUI/SaveState: Progress Dialog On Save State Creation,  Saving Fixes And Speed Improvement

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -218,6 +218,11 @@ public:
 	// Get current thread name
 	static std::string get_name()
 	{
+		if (!g_tls_this_thread)
+		{
+			return "not named_thread";
+		}
+
 		return *g_tls_this_thread->m_tname.load();
 	}
 

--- a/rpcs3/Crypto/decrypt_binaries.cpp
+++ b/rpcs3/Crypto/decrypt_binaries.cpp
@@ -74,6 +74,7 @@ usz decrypt_binaries_t::decrypt(std::string klic_input)
 		const std::string old_path = _module;
 
 		fs::file elf_file;
+		fs::file internal_file;
 
 		bool invalid = false;
 		usz key_it = 0;
@@ -83,6 +84,8 @@ usz decrypt_binaries_t::decrypt(std::string klic_input)
 		{
 			for (; key_it < m_klics.size(); key_it++)
 			{
+				internal_file.close();
+
 				if (!elf_file.open(old_path) || !elf_file.read(file_magic))
 				{
 					file_magic = 0;
@@ -106,7 +109,8 @@ usz decrypt_binaries_t::decrypt(std::string klic_input)
 				case "NPD\0"_u32:
 				{
 					// EDAT / SDAT
-					elf_file = DecryptEDAT(elf_file, old_path, key_it != 0 ? 8 : 1, reinterpret_cast<u8*>(&m_klics[key_it]));
+					internal_file = std::move(elf_file);
+					elf_file = DecryptEDAT(internal_file, old_path, key_it != 0 ? 8 : 1, reinterpret_cast<u8*>(&m_klics[key_it]));
 
 					if (!elf_file)
 					{

--- a/rpcs3/Crypto/unzip.cpp
+++ b/rpcs3/Crypto/unzip.cpp
@@ -139,7 +139,8 @@ bool zip(const void* src, usz size, fs::file& out, bool multi_thread_it)
 		return false;
 	}
 
-	utils::serial compressor(!multi_thread_it || size < 0x40'0000);
+	utils::serial compressor;
+	compressor.set_expect_little_data(!multi_thread_it || size < 0x40'0000);
 	compressor.m_file_handler = make_compressed_serialization_file_handler(out);
 
 	std::string_view buffer_view{static_cast<const char*>(src), size};

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -5253,7 +5253,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 			}
 		}
 
-		const bool seed = (utils::get_tsc() >> 8) % 100;
+		const usz seed = (utils::get_tsc() >> 8) % 100;
 
 #ifdef __linux__
 		const bool reservation_busy_waiting = false;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -2,6 +2,7 @@
 
 #include "util/types.hpp"
 #include "util/atomic.hpp"
+#include "util/shared_ptr.hpp"
 #include "Utilities/bit_set.h"
 #include "config_mode.h"
 #include "games_config.h"
@@ -63,6 +64,7 @@ struct EmuCallbacks
 	std::function<void()> on_ready;
 	std::function<bool()> on_missing_fw;
 	std::function<void(std::shared_ptr<atomic_t<bool>>, int)> on_emulation_stop_no_response;
+	std::function<void(std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>)> on_save_state_progress;
 	std::function<void(bool enabled)> enable_disc_eject;
 	std::function<void(bool enabled)> enable_disc_insert;
 	std::function<bool(bool, std::function<void()>)> try_to_quit; // (force_quit, on_exit) Try to close RPCS3

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -183,7 +183,11 @@ public:
 	}
 
 	// Call from the GUI thread
-	void CallFromMainThread(std::function<void()>&& func, atomic_t<u32>* wake_up = nullptr, bool track_emu_state = true, u64 stop_ctr = umax) const;
+	void CallFromMainThread(std::function<void()>&& func, atomic_t<u32>* wake_up = nullptr, bool track_emu_state = true, u64 stop_ctr = umax,
+		u32 line = __builtin_LINE(),
+		u32 col = __builtin_COLUMN(),
+		const char* file = __builtin_FILE(),
+		const char* fun = __builtin_FUNCTION()) const;
 
 	// Blocking call from the GUI thread
 	void BlockingCallFromMainThread(std::function<void()>&& func,
@@ -200,9 +204,13 @@ public:
 		return stop_counter_t{+m_stop_ctr};
 	}
 
-	void CallFromMainThread(std::function<void()>&& func, stop_counter_t counter) const
+	void CallFromMainThread(std::function<void()>&& func, stop_counter_t counter,
+		u32 line = __builtin_LINE(),
+		u32 col = __builtin_COLUMN(),
+		const char* file = __builtin_FILE(),
+		const char* fun = __builtin_FUNCTION()) const
 	{
-		CallFromMainThread(std::move(func), nullptr, true, static_cast<u64>(counter));
+		CallFromMainThread(std::move(func), nullptr, true, static_cast<u64>(counter), line, col, file, fun);
 	}
 
 	void PostponeInitCode(std::function<void()>&& func)

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -148,6 +148,10 @@ void headless_application::InitializeCallbacks()
 		}
 	};
 
+	callbacks.on_save_state_progress = [](std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>)
+	{
+	};
+
 	callbacks.enable_disc_eject  = [](bool) {};
 	callbacks.enable_disc_insert = [](bool) {};
 

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -83,11 +83,7 @@ public:
 		usz m_max_data = umax;
 		std::unique_ptr<serialization_file_handler> m_file_handler;
 
-		serial(bool expect_little_data = false) noexcept
-			: m_expect_little_data(expect_little_data)
-		{
-		}
-
+		serial() noexcept = default;
 		serial(const serial&) = delete;
 		serial& operator=(const serial&) = delete;
 		explicit serial(serial&&) noexcept = default;
@@ -98,6 +94,11 @@ public:
 		bool is_writing() const
 		{
 			return m_is_writing;
+		}
+
+		void set_expect_little_data(bool value)
+		{
+			m_expect_little_data = value;
 		}
 
 		// Return true if small amounts of both input and output memory are expected (performance hint)  

--- a/rpcs3/util/serialization_ext.cpp
+++ b/rpcs3/util/serialization_ext.cpp
@@ -209,7 +209,7 @@ void compressed_serialization_file_handler::initialize(utils::serial& ar)
 		}
 
 		m_zs = {};
-		ensure(deflateInit2(&m_zs, 9, Z_DEFLATED, 16 + 15, 9, Z_DEFAULT_STRATEGY) == Z_OK);
+		ensure(deflateInit2(&m_zs, ar.expect_little_data() ? 9 : 8, Z_DEFLATED, 16 + 15, 9, Z_DEFAULT_STRATEGY) == Z_OK);
 #ifndef _MSC_VER
 #pragma GCC diagnostic pop
 #endif

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -598,7 +598,7 @@ namespace stx
 		constexpr atomic_ptr() noexcept = default;
 
 		// Optimized value construct
-		template <typename... Args, typename = std::enable_if_t<std::is_constructible_v<T, Args...>>>
+		template <typename... Args> requires (!(sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, shared_type> || ...)) && std::is_constructible_v<T, Args...>)
 		explicit atomic_ptr(Args&&... args) noexcept
 		{
 			shared_type r = make_single<T>(std::forward<Args>(args)...);
@@ -805,7 +805,9 @@ namespace stx
 			}
 		}
 
-		template <typename... Args, typename = std::enable_if_t<std::is_constructible_v<T, Args...>>>
+		// Create an object from variadic args
+		// If a type needs shared_type to be constructed, std::reference_wrapper can be used
+		template <typename... Args> requires (!(sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, shared_type> || ...)) && std::is_constructible_v<T, Args...>)
 		void store(Args&&... args) noexcept
 		{
 			shared_type r = make_single<T>(std::forward<Args>(args)...);
@@ -827,7 +829,7 @@ namespace stx
 			old.m_val.raw() = m_val.exchange(reinterpret_cast<uptr>(std::exchange(value.m_ptr, nullptr)) << c_ref_size);
 		}
 
-		template <typename... Args, typename = std::enable_if_t<std::is_constructible_v<T, Args...>>>
+		template <typename... Args> requires (!(sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, shared_type> || ...)) && std::is_constructible_v<T, Args...>)
 		[[nodiscard]] shared_type exchange(Args&&... args) noexcept
 		{
 			shared_type r = make_single<T>(std::forward<Args>(args)...);


### PR DESCRIPTION
Savestate creation is relatively long due to compression, it makes some users think savestates do not work or that RPCS3 crashed. So I propose for now a progress dialog for savestate creation which shows how much time passed and how many bytes were written.
The percentage shown is not accurate and is an estimation of the amount of bytes written, never actually reaching 100% before completion in order to simplify the implementation.

![image](https://github.com/RPCS3/rpcs3/assets/18193363/ae84845d-de43-49d6-b00a-b773a57fbc74)