### PR TITLE
Fixup a race in emulation stopping, More SaveState fixes

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2367,7 +2367,7 @@ void ppu_thread::serialize_common(utils::serial& ar)
 
 	ar(gpr, fpr, cr, fpscr.bits, lr, ctr, vrsave, cia, xer, sat, nj, prio.raw().all);
 
-	if (cia % 4 || !vm::check_addr(cia))
+	if (cia % 4 || (cia >> 28) >= 0xCu)
 	{
 		fmt::throw_exception("Failed to serialize PPU thread ID=0x%x (cia=0x%x, ar=%s)", this->id, cia, ar);
 	}

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -2971,6 +2971,12 @@ public:
 		}
 		case SPU_RdInMbox:
 		{
+			if (g_cfg.savestate.compatible_mode)
+			{
+				ensure_gpr_stores();
+				check_state(m_pos, false);
+			}
+
 			const auto value = m_ir->CreateLoad(get_type<u32>(), spu_ptr<u32>(&spu_thread::ch_in_mbox));
 			value->setAtomic(llvm::AtomicOrdering::Acquire);
 			res.value = value;
@@ -2980,6 +2986,12 @@ public:
 		}
 		case SPU_RdEventStat:
 		{
+			if (g_cfg.savestate.compatible_mode)
+			{
+				ensure_gpr_stores();
+				check_state(m_pos, false);
+			}
+
 			const auto mask = m_ir->CreateTrunc(m_ir->CreateLShr(m_ir->CreateLoad(get_type<u64>(), spu_ptr<u64>(&spu_thread::ch_events)), 32), get_type<u32>());
 			res.value = call("spu_get_events", &exec_get_events, m_thread, mask);
 			break;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -64,7 +64,7 @@ struct EmuCallbacks
 	std::function<void()> on_ready;
 	std::function<bool()> on_missing_fw;
 	std::function<void(std::shared_ptr<atomic_t<bool>>, int)> on_emulation_stop_no_response;
-	std::function<void(std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>)> on_save_state_progress;
+	std::function<void(std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, std::shared_ptr<void>)> on_save_state_progress;
 	std::function<void(bool enabled)> enable_disc_eject;
 	std::function<void(bool enabled)> enable_disc_insert;
 	std::function<bool(bool, std::function<void()>)> try_to_quit; // (force_quit, on_exit) Try to close RPCS3

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -148,7 +148,7 @@ void headless_application::InitializeCallbacks()
 		}
 	};
 
-	callbacks.on_save_state_progress = [](std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>)
+	callbacks.on_save_state_progress = [](std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, std::shared_ptr<void>)
 	{
 	};
 

--- a/rpcs3/util/serialization_ext.cpp
+++ b/rpcs3/util/serialization_ext.cpp
@@ -150,12 +150,12 @@ usz uncompressed_serialization_file_handler::get_size(const utils::serial& ar, u
 {
 	if (ar.is_writing())
 	{
-		return m_file->size();
+		return *m_file ? m_file->size() : 0;
 	}
 
 	const usz memory_available = ar.data_offset + ar.data.size();
 
-	if (memory_available >= recommended)
+	if (memory_available >= recommended || !*m_file)
 	{
 		// Avoid calling size() if possible
 		return memory_available;
@@ -756,12 +756,12 @@ usz compressed_serialization_file_handler::get_size(const utils::serial& ar, usz
 {
 	if (ar.is_writing())
 	{
-		return m_file->size();
+		return *m_file ? m_file->size() : 0;
 	}
 
 	const usz memory_available = ar.data_offset + ar.data.size();
 
-	if (memory_available >= recommended)
+	if (memory_available >= recommended || !*m_file)
 	{
 		// Avoid calling size() if possible
 		return memory_available;

--- a/rpcs3/util/serialization_ext.hpp
+++ b/rpcs3/util/serialization_ext.hpp
@@ -30,6 +30,7 @@ struct uncompressed_serialization_file_handler : utils::serialization_file_handl
 	}
 
 	uncompressed_serialization_file_handler(const uncompressed_serialization_file_handler&) = delete;
+	uncompressed_serialization_file_handler& operator=(const uncompressed_serialization_file_handler&) = delete;
 
 	// Handle file read and write requests
 	bool handle_file_op(utils::serial& ar, usz pos, usz size, const void* data) override;
@@ -68,6 +69,7 @@ struct compressed_serialization_file_handler : utils::serialization_file_handler
 	}
 
 	compressed_serialization_file_handler(const compressed_serialization_file_handler&) = delete;
+	compressed_serialization_file_handler& operator=(const compressed_serialization_file_handler&) = delete;
 
 	// Handle file read and write requests
 	bool handle_file_op(utils::serial& ar, usz pos, usz size, const void* data) override;


### PR DESCRIPTION
* Fixup savestates that I broke again in #15346 
* Include RawSPU's loops  for SPU-Compatible Savestates Mode by making RCHCNT IN_MBOX/EVENT_STAT a safe return point. (because they are likely in a loop) 