### PR TITLE
Savestates: More fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellScreenshot.cpp
@@ -134,24 +134,31 @@ error_code cellScreenShotSetOverlayImage(vm::cptr<char> srcDir, vm::cptr<char> s
 
 error_code cellScreenShotEnable()
 {
-	cellScreenshot.warning("cellScreenShotEnable()");
+	cellScreenshot.trace("cellScreenShotEnable()");
 
 	auto& manager = g_fxo->get<screenshot_manager>();
 	std::lock_guard lock(manager.mutex);
 
-	manager.is_enabled = true;
+	if (!std::exchange(manager.is_enabled, true))
+	{
+		cellScreenshot.warning("cellScreenShotEnable(): Enabled");
+	}
 
 	return CELL_OK;
 }
 
 error_code cellScreenShotDisable()
 {
-	cellScreenshot.warning("cellScreenShotDisable()");
+	cellScreenshot.trace("cellScreenShotDisable()");
 
 	auto& manager = g_fxo->get<screenshot_manager>();
 	std::lock_guard lock(manager.mutex);
 
-	manager.is_enabled = false;
+	if (std::exchange(manager.is_enabled, false))
+	{
+		cellScreenshot.warning("cellScreenShotDisable(): Disabled");
+	}
+
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1646,7 +1646,7 @@ std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, bool virtual_lo
 
 				if (ar)
 				{
-					break;
+					continue;
 				}
 
 				switch (rtype)

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -268,7 +268,8 @@ public:
 	{
 		u64 all;
 		bf_t<s64, 0, 13> prio; // Thread priority (0..3071) (firs 12-bits)
-		bf_t<s64, 13, 51> order; // Thread enqueue order (last 52-bits)
+		bf_t<s64, 13, 50> order; // Thread enqueue order (last 52-bits)
+		bf_t<u64, 63, 1> preserve_bit; // Preserve value for savestates
 	};
 
 	atomic_t<ppu_prio_t> prio{};

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -2655,13 +2655,13 @@ public:
 		}
 
 		update_pc();
+		ensure_gpr_stores();
 		call("spu_syscall", &exec_stop, m_thread, m_ir->getInt32(op.opcode & 0x3fff));
 
 		if (g_cfg.core.spu_block_size == spu_block_size_type::safe)
 		{
 			m_block->block_end = m_ir->GetInsertBlock();
 			update_pc(m_pos + 4);
-			ensure_gpr_stores();
 			tail_chunk(m_dispatch);
 			return;
 		}

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -2924,6 +2924,29 @@ public:
 		switch (op.ra)
 		{
 		case SPU_WrOutMbox:
+		case SPU_WrOutIntrMbox:
+		case SPU_RdSigNotify1:
+		case SPU_RdSigNotify2:
+		case SPU_RdInMbox:
+		case SPU_RdEventStat:
+		{
+			if (g_cfg.savestate.compatible_mode)
+			{
+				ensure_gpr_stores();
+				check_state(m_pos, false);
+			}
+
+			break;
+		}
+		default:
+		{
+			break;
+		}
+		}
+
+		switch (op.ra)
+		{
+		case SPU_WrOutMbox:
 		{
 			res.value = get_rchcnt(::offset32(&spu_thread::ch_out_mbox), true);
 			break;
@@ -2971,12 +2994,6 @@ public:
 		}
 		case SPU_RdInMbox:
 		{
-			if (g_cfg.savestate.compatible_mode)
-			{
-				ensure_gpr_stores();
-				check_state(m_pos, false);
-			}
-
 			const auto value = m_ir->CreateLoad(get_type<u32>(), spu_ptr<u32>(&spu_thread::ch_in_mbox));
 			value->setAtomic(llvm::AtomicOrdering::Acquire);
 			res.value = value;
@@ -2986,12 +3003,6 @@ public:
 		}
 		case SPU_RdEventStat:
 		{
-			if (g_cfg.savestate.compatible_mode)
-			{
-				ensure_gpr_stores();
-				check_state(m_pos, false);
-			}
-
 			const auto mask = m_ir->CreateTrunc(m_ir->CreateLShr(m_ir->CreateLoad(get_type<u64>(), spu_ptr<u64>(&spu_thread::ch_events)), 32), get_type<u32>());
 			res.value = call("spu_get_events", &exec_get_events, m_thread, mask);
 			break;

--- a/rpcs3/Emu/Cell/lv2/sys_time.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_time.cpp
@@ -220,7 +220,7 @@ u64 get_guest_system_time(u64 time)
 // Functions
 error_code sys_time_get_timezone(vm::ptr<s32> timezone, vm::ptr<s32> summertime)
 {
-	sys_time.notice("sys_time_get_timezone(timezone=*0x%x, summertime=*0x%x)", timezone, summertime);
+	sys_time.trace("sys_time_get_timezone(timezone=*0x%x, summertime=*0x%x)", timezone, summertime);
 
 #ifdef _WIN32
 	TIME_ZONE_INFORMATION tz{};

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -615,6 +615,11 @@ namespace rsx
 		ar(display_buffers, display_buffers_count, current_display_buffer);
 		ar(unsent_gcm_events, rsx::method_registers.current_draw_clause);
 
+		if (in_begin_end)
+		{
+			rsx_log.error("Savestate created in draw call scope. Report to developers if there are issues with it.");
+		}
+
 		if (ar.is_writing())
 		{
 			if (fifo_ctrl && state & cpu_flag::again)

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -111,7 +111,7 @@ class Emulator final
 	atomic_t<u64> m_pause_start_time{0}; // set when paused
 	atomic_t<u64> m_pause_amend_time{0}; // increased when resumed
 	atomic_t<u64> m_stop_ctr{1}; // Increments when emulation is stopped
-	atomic_t<bool> m_savestate_pending = false;
+	atomic_t<bool> m_emu_state_close_pending = false;
 
 	games_config m_games_config;
 

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -42,7 +42,7 @@ static std::array<serial_ver_t, 26> s_serial_versions;
 	}
 
 SERIALIZATION_VER(global_version, 0,                            16) // For stuff not listed here
-SERIALIZATION_VER(ppu, 1,                                       1)
+SERIALIZATION_VER(ppu, 1,                                       1, 2/*PPU sleep order*/)
 SERIALIZATION_VER(spu, 2,                                       1)
 SERIALIZATION_VER(lv2_sync, 3,                                  1)
 SERIALIZATION_VER(lv2_vm, 4,                                    1)

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -655,7 +655,7 @@ void kernel_explorer::update()
 	idm::select<named_thread<ppu_thread>>([&](u32 id, ppu_thread& ppu)
 	{
 		const auto func = ppu.last_function;
-		const ppu_thread_status status = lv2_obj::ppu_state(&ppu, false, false);
+		const ppu_thread_status status = lv2_obj::ppu_state(&ppu, false, false).first;
 
 		add_leaf(find_node(root, additional_nodes::ppu_threads), qstr(fmt::format(u8"PPU 0x%07x: “%s”, PRIO: %d, Joiner: %s, Status: %s, State: %s, %s func: “%s”%s", id, *ppu.ppu_tname.load(), ppu.prio.load().prio, ppu.joiner.load(), status, ppu.state.load()
 			, ppu.ack_suspend ? "After" : (ppu.current_function ? "In" : "Last"), func ? func : "", get_wait_time_str(ppu.start_time))));


### PR DESCRIPTION
* Save PPU threads running order.
* Extend RCHCNT safe returns to include more channels when using SPU-Compatible Savestates setting.
* Make SPU STOP instruction a safe return point for savestates also in SPU Mega mode.
* Fix conflicts between shutting down emulation and savestates.
* Fix PRX functions with savestates.