### PR TITLE
GL: fix segfault in GLGSRender::flip

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -342,7 +342,7 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 			}
 
 			gl::screen.bind();
-			m_video_output_pass.run(cmd, areau(aspect_ratio), images.map(FN(x->id())), gamma, limited_range, avconfig.stereo_mode, filter);
+			m_video_output_pass.run(cmd, areau(aspect_ratio), images.map(FN(x ? x->id() : GL_NONE)), gamma, limited_range, avconfig.stereo_mode, filter);
 		}
 	}
 


### PR DESCRIPTION
It turns out that image_to_flip2 is nullptr in GLGSRender::flip, which then leads to a simple_array of size 2 and then images.map(FN...). It then tries to call xform with the dereferenced nullptr in simple_array::map.

So there's 3 potential bugs here:
1. deref nullptr in map
2. using a simple_array of size 2 even though image_to_flip2 is nullptr
3. having a nullptr in image_to_flip2 in the first place

I tried to check the iterator for nullptr, but it seems to enter the scope and call xform anyway.
So we can just make sure not to call map with a nullptr in the first place.

fixes #15361