### PR TITLE
Savestates: Fixes Maxima

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2193,7 +2193,10 @@ u64 thread_base::finalize(thread_state result_state) noexcept
 		return thread_ctrl::get_name_cached();
 	};
 
-	sig_log.notice("Thread time: %fs (%fGc); Faults: %u [rsx:%u, spu:%u]; [soft:%u hard:%u]; Switches:[vol:%u unvol:%u]; Wait:[%.3fs, spur:%u]",
+	const bool is_cpu_thread = !!cpu_thread::get_current();
+	auto& thread_log = (is_cpu_thread || g_tls_fault_all ? sig_log.notice : sig_log.trace);
+
+	thread_log("Thread time: %fs (%fGc); Faults: %u [rsx:%u, spu:%u]; [soft:%u hard:%u]; Switches:[vol:%u unvol:%u]; Wait:[%.3fs, spur:%u]",
 		time / 1000000000.,
 		cycles / 1000000000.,
 		g_tls_fault_all,

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -1638,7 +1638,7 @@ error_code cellGemGetState(u32 gem_num, u32 flag, u64 time_parameter, vm::ptr<Ce
 
 	if (!gem.is_controller_ready(gem_num))
 	{
-		return CELL_GEM_NOT_CONNECTED;
+		return not_an_error(CELL_GEM_NOT_CONNECTED);
 	}
 
 	// TODO: Get the gem state at the specified time

--- a/rpcs3/Emu/Cell/PPUModule.h
+++ b/rpcs3/Emu/Cell/PPUModule.h
@@ -289,9 +289,9 @@ inline RT ppu_execute(ppu_thread& ppu, Args... args)
 	return func(ppu, args...);
 }
 
-#define BIND_FUNC_WITH_BLR(func) BIND_FUNC(func, if (cpu_flag::again - ppu.state) ppu.cia = static_cast<u32>(ppu.lr) & ~3)
+#define BIND_FUNC_WITH_BLR(func, _module) BIND_FUNC(func, if (cpu_flag::again - ppu.state) ppu.cia = static_cast<u32>(ppu.lr) & ~3; else ppu.current_module = _module)
 
-#define REG_FNID(_module, nid, func) ppu_module_manager::register_static_function<&func>(#_module, ppu_select_name(#func, nid), BIND_FUNC_WITH_BLR(func), ppu_generate_id(nid))
+#define REG_FNID(_module, nid, func) ppu_module_manager::register_static_function<&func>(#_module, ppu_select_name(#func, nid), BIND_FUNC_WITH_BLR(func, #_module), ppu_generate_id(nid))
 
 #define REG_FUNC(_module, func) REG_FNID(_module, #func, func)
 
@@ -299,7 +299,7 @@ inline RT ppu_execute(ppu_thread& ppu, Args... args)
 
 #define REG_VAR(_module, var) REG_VNID(_module, #var, var)
 
-#define REG_HIDDEN_FUNC(func) ppu_function_manager::register_function<decltype(&func), &func>(BIND_FUNC_WITH_BLR(func))
+#define REG_HIDDEN_FUNC(func) ppu_function_manager::register_function<decltype(&func), &func>(BIND_FUNC_WITH_BLR(func, ""))
 
 #define REG_HIDDEN_FUNC_PURE(func) ppu_function_manager::register_function<decltype(&func), &func>(func)
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2542,6 +2542,7 @@ ppu_thread::ppu_thread(utils::serial& ar)
 					ppu.loaded_from_savestate = true;
 					ppu.prio.raw().preserve_bit = 1;
 					table.decode(op)(ppu, {op}, vm::_ptr<u32>(ppu.cia), &ppu_ret);
+					ppu.prio.raw().preserve_bit = 0;
 
 					ppu.optional_savestate_state->clear(); // Reset to writing state
 					ppu.loaded_from_savestate = false;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2421,6 +2421,14 @@ ppu_thread::ppu_thread(utils::serial& ar)
 		ar(lv2_obj::g_priority_order_tag);
 	}
 
+	if (version >= 3)
+	{
+		// Function and module for HLE function relocation
+		// TODO: Use it
+		ar.pop<std::string>();
+		ar.pop<std::string>();
+	}
+
 	serialize_common(ar);
 
 	// Restore jm_mask
@@ -2593,6 +2601,17 @@ void ppu_thread::save(utils::serial& ar)
 	if (!is_null && !g_fxo->get<save_lv2_tag>().saved.exchange(true))
 	{
 		ar(lv2_obj::g_priority_order_tag);
+	}
+
+	if (current_module && current_module[0])
+	{
+		ar(std::string{current_module});
+		ar(std::string{last_function});
+	}
+	else
+	{
+		ar(std::string{});
+		ar(std::string{});
 	}
 
 	serialize_common(ar);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3377,11 +3377,12 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 
 			data += 0;
 			auto range_lock = vm::alloc_range_lock();
+			bool success = false;
 			{
 				rsx::reservation_lock rsx_lock(addr, 128);
 
 				auto& super_data = *vm::get_super_ptr<spu_rdata_t>(addr);
-				const bool success = [&]()
+				success = [&]()
 				{
 					// Full lock (heavyweight)
 					// TODO: vm::check_addr

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -295,6 +295,7 @@ public:
 	u64 syscall_args[8]{0}; // Last syscall arguments stored
 	const char* current_function{}; // Current function name for diagnosis, optimized for speed.
 	const char* last_function{}; // Sticky copy of current_function, is not cleared on function return
+	const char* current_module{}; // Current module name, for savestates.
 
 	const bool is_interrupt_thread; // True for interrupts-handler threads
 

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1050,7 +1050,7 @@ class spu_llvm_recompiler : public spu_recompiler_base, public cpu_translator
 		m_ir->SetInsertPoint(check);
 		update_pc(addr);
 
-		if (may_be_unsafe_for_savestate && std::none_of(std::begin(m_block->phi), std::end(m_block->phi), FN(!!x)))
+		if (may_be_unsafe_for_savestate && m_block && m_block->bb->preds.empty())
 		{
 			may_be_unsafe_for_savestate = false;
 		}
@@ -1904,8 +1904,10 @@ public:
 									auto si = llvm::cast<StoreInst>(m_ir->Insert(bs->clone()));
 									if (b2->store[i] == nullptr)
 									{
+										// Protect against backwards ordering now
 										b2->store[i] = si;
 										b2->store_context_last_id[i] = 0;
+										b2->store_context_first_id[i] = b2->store_context_ctr[i] + 1;
 
 										if (!std::count(block_q.begin() + bi, block_q.end(), b2))
 										{

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -3070,7 +3070,7 @@ public:
 	{
 		if (!_spu->process_mfc_cmd() || _spu->state & cpu_flag::again)
 		{
-			spu_runtime::g_escape(_spu);
+			fmt::throw_exception("exec_mfc_cmd(): Should not abort!");
 		}
 
 		static_cast<void>(_spu->test_stopped());

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -448,11 +448,6 @@ namespace vm
 	{
 		if (range_lock)
 		{
-			if (!*range_lock)
-			{
-				return;
-			}
-
 			g_range_lock_bits[1] &= ~(1ull << (range_lock - g_range_lock_set));
 			range_lock->release(0);
 			return;

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -473,13 +473,13 @@ namespace vm
 			}
 		}
 
-		bool to_prepare_memory = addr >= 0x10000;
+		bool to_prepare_memory = true;
 
 		for (u64 i = 0;; i++)
 		{
 			auto& bits = get_range_lock_bits(true);
 
-			if (!range_lock || addr < 0x10000)
+			if (!range_lock)
 			{
 				if (!bits && bits.compare_and_swap_test(0, u64{umax}))
 				{
@@ -521,7 +521,7 @@ namespace vm
 			}
 		}
 
-		if (addr >= 0x10000)
+		if (range_lock)
 		{
 			perf_meter<"SUSPEND"_u64> perf0;
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -620,6 +620,32 @@ namespace rsx
 			rsx_log.error("Savestate created in draw call scope. Report to developers if there are issues with it.");
 		}
 
+		if (ar.is_writing() || version >= 2)
+		{
+			ar(vblank_count);
+
+			b8 flip_pending{};
+
+			if (ar.is_writing())
+			{
+				flip_pending = !!(async_flip_requested & flip_request::emu_requested);
+			}
+
+			ar(flip_pending);
+
+			if (flip_pending)
+			{
+				ar(vblank_at_flip);
+				ar(async_flip_buffer);
+
+				if (!ar.is_writing())
+				{
+					async_flip_requested |= flip_request::emu_requested;
+					flip_notification_count = 1;
+				}
+			}
+		}
+
 		if (ar.is_writing())
 		{
 			if (fifo_ctrl && state & cpu_flag::again)

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -54,7 +54,7 @@ SERIALIZATION_VER(lv2_config, 9,                                1)
 
 namespace rsx
 {
-	SERIALIZATION_VER(rsx, 10,                                  1)
+	SERIALIZATION_VER(rsx, 10,                                  1, 2/*Pending flip*/)
 }
 
 namespace np

--- a/rpcs3/Emu/savestate_utils.hpp
+++ b/rpcs3/Emu/savestate_utils.hpp
@@ -21,7 +21,7 @@ struct hle_locks_t
 		finalized = -2,
 	};
 
-	void lock();
+	[[noreturn]] void lock();
 	bool try_lock();
 	void unlock();
 	bool try_finalize(std::function<bool()> test);

--- a/rpcs3/Emu/savestate_utils.hpp
+++ b/rpcs3/Emu/savestate_utils.hpp
@@ -10,6 +10,23 @@ struct version_entry
 	ENABLE_BITWISE_SERIALIZATION;
 };
 
+
+struct hle_locks_t
+{
+	atomic_t<s64> lock_val{0};
+
+	enum states : s64
+	{
+		waiting_for_evaluation = -1,
+		finalized = -2,
+	};
+
+	void lock();
+	bool try_lock();
+	void unlock();
+	bool try_finalize(std::function<bool()> test);
+};
+
 bool load_and_check_reserved(utils::serial& ar, usz size);
 bool is_savestate_version_compatible(const std::vector<version_entry>& data, bool is_boot_check);
 std::vector<version_entry> get_savestate_versioning_data(fs::file&& file, std::string_view filepath);


### PR DESCRIPTION
* Fix a deadlock regarding VM locks with emulation stopping and savestate loading.
* Fixup emulation stopping.
* Fix SPU LLVM sinking stores beyond a saveable code point.
* Make saving state impossible while a cellSaveData operation is active.
* Save pending RSX flip, fixes savestate freeze on load with Tales Of Xillia 2, or I guess, every game that needs PS3 Native frame rate mode.

I can't anymore find bugs in games with savestates anymore, if you do, please report.