### PR TITLE
rsx: Move SPIRV stuff into common code

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -502,6 +502,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/Program/GLSLCommon.cpp
     RSX/Program/program_util.cpp
     RSX/Program/ProgramStateCache.cpp
+    RSX/Program/SPIRVCommon.cpp
     RSX/Program/VertexProgramDecompiler.cpp
     RSX/Capture/rsx_capture.cpp
     RSX/Capture/rsx_replay.cpp

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -118,7 +118,7 @@ namespace glsl
 
 	void insert_vertex_input_fetch(std::stringstream& OS, glsl_rules rules, bool glsl4_compliant)
 	{
-		std::string vertex_id_name = (rules != glsl_rules_spirv) ? "gl_VertexID" : "gl_VertexIndex";
+		std::string vertex_id_name = (rules != glsl_rules_vulkan) ? "gl_VertexID" : "gl_VertexIndex";
 
 		// Actually decode a vertex attribute from a raw byte stream
 		program_common::define_glsl_constants<int>(OS,

--- a/rpcs3/Emu/RSX/Program/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Program/GLSLTypes.h
@@ -12,7 +12,7 @@ namespace glsl
 	enum glsl_rules : unsigned char
 	{
 		glsl_rules_opengl4,
-		glsl_rules_spirv
+		glsl_rules_vulkan
 	};
 
 	struct shader_properties

--- a/rpcs3/Emu/RSX/Program/SPIRVCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/SPIRVCommon.cpp
@@ -1,0 +1,200 @@
+#include "stdafx.h"
+
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wextra"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsuggest-override"
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+#endif
+#include "3rdparty/glslang/glslang/SPIRV/GlslangToSpv.h"
+#ifdef _MSC_VER
+#pragma warning(pop)
+#else
+#pragma GCC diagnostic pop
+#endif
+
+#include "SPIRVCommon.h"
+#include "GLSLCommon.h"
+
+namespace spirv
+{
+	static TBuiltInResource g_default_config;
+
+	void init_default_resources(TBuiltInResource& rsc)
+	{
+		rsc.maxLights = 32;
+		rsc.maxClipPlanes = 6;
+		rsc.maxTextureUnits = 32;
+		rsc.maxTextureCoords = 32;
+		rsc.maxVertexAttribs = 64;
+		rsc.maxVertexUniformComponents = 4096;
+		rsc.maxVaryingFloats = 64;
+		rsc.maxVertexTextureImageUnits = 32;
+		rsc.maxCombinedTextureImageUnits = 80;
+		rsc.maxTextureImageUnits = 32;
+		rsc.maxFragmentUniformComponents = 4096;
+		rsc.maxDrawBuffers = 32;
+		rsc.maxVertexUniformVectors = 128;
+		rsc.maxVaryingVectors = 8;
+		rsc.maxFragmentUniformVectors = 16;
+		rsc.maxVertexOutputVectors = 16;
+		rsc.maxFragmentInputVectors = 15;
+		rsc.minProgramTexelOffset = -8;
+		rsc.maxProgramTexelOffset = 7;
+		rsc.maxClipDistances = 8;
+		rsc.maxComputeWorkGroupCountX = 65535;
+		rsc.maxComputeWorkGroupCountY = 65535;
+		rsc.maxComputeWorkGroupCountZ = 65535;
+		rsc.maxComputeWorkGroupSizeX = 1024;
+		rsc.maxComputeWorkGroupSizeY = 1024;
+		rsc.maxComputeWorkGroupSizeZ = 64;
+		rsc.maxComputeUniformComponents = 1024;
+		rsc.maxComputeTextureImageUnits = 16;
+		rsc.maxComputeImageUniforms = 8;
+		rsc.maxComputeAtomicCounters = 8;
+		rsc.maxComputeAtomicCounterBuffers = 1;
+		rsc.maxVaryingComponents = 60;
+		rsc.maxVertexOutputComponents = 64;
+		rsc.maxGeometryInputComponents = 64;
+		rsc.maxGeometryOutputComponents = 128;
+		rsc.maxFragmentInputComponents = 128;
+		rsc.maxImageUnits = 8;
+		rsc.maxCombinedImageUnitsAndFragmentOutputs = 8;
+		rsc.maxCombinedShaderOutputResources = 8;
+		rsc.maxImageSamples = 0;
+		rsc.maxVertexImageUniforms = 0;
+		rsc.maxTessControlImageUniforms = 0;
+		rsc.maxTessEvaluationImageUniforms = 0;
+		rsc.maxGeometryImageUniforms = 0;
+		rsc.maxFragmentImageUniforms = 8;
+		rsc.maxCombinedImageUniforms = 8;
+		rsc.maxGeometryTextureImageUnits = 16;
+		rsc.maxGeometryOutputVertices = 256;
+		rsc.maxGeometryTotalOutputComponents = 1024;
+		rsc.maxGeometryUniformComponents = 1024;
+		rsc.maxGeometryVaryingComponents = 64;
+		rsc.maxTessControlInputComponents = 128;
+		rsc.maxTessControlOutputComponents = 128;
+		rsc.maxTessControlTextureImageUnits = 16;
+		rsc.maxTessControlUniformComponents = 1024;
+		rsc.maxTessControlTotalOutputComponents = 4096;
+		rsc.maxTessEvaluationInputComponents = 128;
+		rsc.maxTessEvaluationOutputComponents = 128;
+		rsc.maxTessEvaluationTextureImageUnits = 16;
+		rsc.maxTessEvaluationUniformComponents = 1024;
+		rsc.maxTessPatchComponents = 120;
+		rsc.maxPatchVertices = 32;
+		rsc.maxTessGenLevel = 64;
+		rsc.maxViewports = 16;
+		rsc.maxVertexAtomicCounters = 0;
+		rsc.maxTessControlAtomicCounters = 0;
+		rsc.maxTessEvaluationAtomicCounters = 0;
+		rsc.maxGeometryAtomicCounters = 0;
+		rsc.maxFragmentAtomicCounters = 8;
+		rsc.maxCombinedAtomicCounters = 8;
+		rsc.maxAtomicCounterBindings = 1;
+		rsc.maxVertexAtomicCounterBuffers = 0;
+		rsc.maxTessControlAtomicCounterBuffers = 0;
+		rsc.maxTessEvaluationAtomicCounterBuffers = 0;
+		rsc.maxGeometryAtomicCounterBuffers = 0;
+		rsc.maxFragmentAtomicCounterBuffers = 1;
+		rsc.maxCombinedAtomicCounterBuffers = 1;
+		rsc.maxAtomicCounterBufferSize = 16384;
+		rsc.maxTransformFeedbackBuffers = 4;
+		rsc.maxTransformFeedbackInterleavedComponents = 64;
+		rsc.maxCullDistances = 8;
+		rsc.maxCombinedClipAndCullDistances = 8;
+		rsc.maxSamples = 4;
+
+		rsc.limits.nonInductiveForLoops = true;
+		rsc.limits.whileLoops = true;
+		rsc.limits.doWhileLoops = true;
+		rsc.limits.generalUniformIndexing = true;
+		rsc.limits.generalAttributeMatrixVectorIndexing = true;
+		rsc.limits.generalVaryingIndexing = true;
+		rsc.limits.generalSamplerIndexing = true;
+		rsc.limits.generalVariableIndexing = true;
+		rsc.limits.generalConstantMatrixVectorIndexing = true;
+	}
+
+	bool compile_glsl_to_spv(std::vector<u32>& spv, std::string& shader, ::glsl::program_domain domain, ::glsl::glsl_rules rules)
+	{
+		EShLanguage lang = (domain == ::glsl::glsl_fragment_program)
+			? EShLangFragment
+			: (domain == ::glsl::glsl_vertex_program)
+				? EShLangVertex
+				: EShLangCompute;
+
+		glslang::EShClient client;
+		glslang::EShTargetClientVersion target_version;
+		EShMessages msg;
+
+		if (rules == ::glsl::glsl_rules_vulkan)
+		{
+			client = glslang::EShClientVulkan;
+			target_version = glslang::EShTargetClientVersion::EShTargetVulkan_1_0;
+			msg = static_cast<EShMessages>(EShMsgVulkanRules | EShMsgSpvRules | EShMsgEnhanced);
+		}
+		else
+		{
+			client = glslang::EShClientOpenGL;
+			target_version = glslang::EShTargetClientVersion::EShTargetOpenGL_450;
+			msg = static_cast<EShMessages>(EShMsgDefault | EShMsgSpvRules | EShMsgEnhanced);
+		}
+
+		glslang::TProgram program;
+		glslang::TShader shader_object(lang);
+
+		shader_object.setEnvInput(glslang::EShSourceGlsl, lang, client, 100);
+		shader_object.setEnvClient(client, target_version);
+		shader_object.setEnvTarget(glslang::EshTargetSpv, glslang::EShTargetLanguageVersion::EShTargetSpv_1_0);
+
+		bool success = false;
+		const char* shader_text = shader.data();
+		shader_object.setStrings(&shader_text, 1);
+
+		if (shader_object.parse(&g_default_config, 430, EProfile::ECoreProfile, false, true, msg))
+		{
+			program.addShader(&shader_object);
+			success = program.link(msg);
+			if (success)
+			{
+				glslang::SpvOptions options;
+				options.disableOptimizer = true;
+				options.optimizeSize = true;
+				glslang::GlslangToSpv(*program.getIntermediate(lang), spv, &options);
+
+				// Now we optimize
+				//spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_0);
+				//optimizer.RegisterPass(spvtools::CreateUnifyConstantPass());      // Remove duplicate constants
+				//optimizer.RegisterPass(spvtools::CreateMergeReturnPass());        // Huge savings in vertex interpreter and likely normal vertex shaders
+				//optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());      // Remove dead code
+				//optimizer.Run(spv.data(), spv.size(), &spv);
+			}
+		}
+		else
+		{
+			rsx_log.error("%s", shader_object.getInfoLog());
+			rsx_log.error("%s", shader_object.getInfoDebugLog());
+		}
+
+		return success;
+	}
+
+	void initialize_compiler_context()
+	{
+		glslang::InitializeProcess();
+		init_default_resources(g_default_config);
+	}
+
+	void finalize_compiler_context()
+	{
+		glslang::FinalizeProcess();
+	}
+}

--- a/rpcs3/Emu/RSX/Program/SPIRVCommon.h
+++ b/rpcs3/Emu/RSX/Program/SPIRVCommon.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace glsl
+{
+	enum program_domain : unsigned char;
+	enum glsl_rules : unsigned char;
+}
+
+namespace spirv
+{
+	bool compile_glsl_to_spv(std::vector<u32>& spv, std::string& shader, ::glsl::program_domain domain, ::glsl::glsl_rules rules);
+
+	void initialize_compiler_context();
+	void finalize_compiler_context();
+}

--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.cpp
@@ -1,128 +1,10 @@
 #include "stdafx.h"
 #include "VKCommonDecompiler.h"
 
-#ifdef _MSC_VER
-#pragma warning(push, 0)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wall"
-#pragma GCC diagnostic ignored "-Wextra"
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-#pragma GCC diagnostic ignored "-Wsuggest-override"
-#ifdef __clang__
-#pragma clang diagnostic ignored "-Winconsistent-missing-override"
-#endif
-#endif
-#include "SPIRV/GlslangToSpv.h"
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
-
 namespace vk
 {
-	static TBuiltInResource g_default_config;
-
-	void init_default_resources(TBuiltInResource &rsc)
-	{
-		rsc.maxLights = 32;
-		rsc.maxClipPlanes = 6;
-		rsc.maxTextureUnits = 32;
-		rsc.maxTextureCoords = 32;
-		rsc.maxVertexAttribs = 64;
-		rsc.maxVertexUniformComponents = 4096;
-		rsc.maxVaryingFloats = 64;
-		rsc.maxVertexTextureImageUnits = 32;
-		rsc.maxCombinedTextureImageUnits = 80;
-		rsc.maxTextureImageUnits = 32;
-		rsc.maxFragmentUniformComponents = 4096;
-		rsc.maxDrawBuffers = 32;
-		rsc.maxVertexUniformVectors = 128;
-		rsc.maxVaryingVectors = 8;
-		rsc.maxFragmentUniformVectors = 16;
-		rsc.maxVertexOutputVectors = 16;
-		rsc.maxFragmentInputVectors = 15;
-		rsc.minProgramTexelOffset = -8;
-		rsc.maxProgramTexelOffset = 7;
-		rsc.maxClipDistances = 8;
-		rsc.maxComputeWorkGroupCountX = 65535;
-		rsc.maxComputeWorkGroupCountY = 65535;
-		rsc.maxComputeWorkGroupCountZ = 65535;
-		rsc.maxComputeWorkGroupSizeX = 1024;
-		rsc.maxComputeWorkGroupSizeY = 1024;
-		rsc.maxComputeWorkGroupSizeZ = 64;
-		rsc.maxComputeUniformComponents = 1024;
-		rsc.maxComputeTextureImageUnits = 16;
-		rsc.maxComputeImageUniforms = 8;
-		rsc.maxComputeAtomicCounters = 8;
-		rsc.maxComputeAtomicCounterBuffers = 1;
-		rsc.maxVaryingComponents = 60;
-		rsc.maxVertexOutputComponents = 64;
-		rsc.maxGeometryInputComponents = 64;
-		rsc.maxGeometryOutputComponents = 128;
-		rsc.maxFragmentInputComponents = 128;
-		rsc.maxImageUnits = 8;
-		rsc.maxCombinedImageUnitsAndFragmentOutputs = 8;
-		rsc.maxCombinedShaderOutputResources = 8;
-		rsc.maxImageSamples = 0;
-		rsc.maxVertexImageUniforms = 0;
-		rsc.maxTessControlImageUniforms = 0;
-		rsc.maxTessEvaluationImageUniforms = 0;
-		rsc.maxGeometryImageUniforms = 0;
-		rsc.maxFragmentImageUniforms = 8;
-		rsc.maxCombinedImageUniforms = 8;
-		rsc.maxGeometryTextureImageUnits = 16;
-		rsc.maxGeometryOutputVertices = 256;
-		rsc.maxGeometryTotalOutputComponents = 1024;
-		rsc.maxGeometryUniformComponents = 1024;
-		rsc.maxGeometryVaryingComponents = 64;
-		rsc.maxTessControlInputComponents = 128;
-		rsc.maxTessControlOutputComponents = 128;
-		rsc.maxTessControlTextureImageUnits = 16;
-		rsc.maxTessControlUniformComponents = 1024;
-		rsc.maxTessControlTotalOutputComponents = 4096;
-		rsc.maxTessEvaluationInputComponents = 128;
-		rsc.maxTessEvaluationOutputComponents = 128;
-		rsc.maxTessEvaluationTextureImageUnits = 16;
-		rsc.maxTessEvaluationUniformComponents = 1024;
-		rsc.maxTessPatchComponents = 120;
-		rsc.maxPatchVertices = 32;
-		rsc.maxTessGenLevel = 64;
-		rsc.maxViewports = 16;
-		rsc.maxVertexAtomicCounters = 0;
-		rsc.maxTessControlAtomicCounters = 0;
-		rsc.maxTessEvaluationAtomicCounters = 0;
-		rsc.maxGeometryAtomicCounters = 0;
-		rsc.maxFragmentAtomicCounters = 8;
-		rsc.maxCombinedAtomicCounters = 8;
-		rsc.maxAtomicCounterBindings = 1;
-		rsc.maxVertexAtomicCounterBuffers = 0;
-		rsc.maxTessControlAtomicCounterBuffers = 0;
-		rsc.maxTessEvaluationAtomicCounterBuffers = 0;
-		rsc.maxGeometryAtomicCounterBuffers = 0;
-		rsc.maxFragmentAtomicCounterBuffers = 1;
-		rsc.maxCombinedAtomicCounterBuffers = 1;
-		rsc.maxAtomicCounterBufferSize = 16384;
-		rsc.maxTransformFeedbackBuffers = 4;
-		rsc.maxTransformFeedbackInterleavedComponents = 64;
-		rsc.maxCullDistances = 8;
-		rsc.maxCombinedClipAndCullDistances = 8;
-		rsc.maxSamples = 4;
-
-		rsc.limits.nonInductiveForLoops = true;
-		rsc.limits.whileLoops = true;
-		rsc.limits.doWhileLoops = true;
-		rsc.limits.generalUniformIndexing = true;
-		rsc.limits.generalAttributeMatrixVectorIndexing = true;
-		rsc.limits.generalVaryingIndexing = true;
-		rsc.limits.generalSamplerIndexing = true;
-		rsc.limits.generalVariableIndexing = true;
-		rsc.limits.generalConstantMatrixVectorIndexing = true;
-	}
-
 	static constexpr std::array<std::pair<std::string_view, int>, 18> varying_registers =
-	{{
+	{ {
 		{ "tc0", 0 },
 		{ "tc1", 1 },
 		{ "tc2", 2 },
@@ -139,7 +21,7 @@ namespace vk
 		{ "spec_color1", 13 },
 		{ "fog_c", 14 },
 		{ "fogc", 14 }
-	}};
+	} };
 
 	int get_varying_register_location(std::string_view varying_register_name)
 	{
@@ -152,62 +34,5 @@ namespace vk
 		}
 
 		fmt::throw_exception("Unknown register name: %s", varying_register_name);
-	}
-
-	bool compile_glsl_to_spv(std::string& shader, program_domain domain, std::vector<u32>& spv)
-	{
-		EShLanguage lang = (domain == glsl_fragment_program) ? EShLangFragment :
-			(domain == glsl_vertex_program)? EShLangVertex : EShLangCompute;
-
-		glslang::TProgram program;
-		glslang::TShader shader_object(lang);
-
-		shader_object.setEnvInput(glslang::EShSourceGlsl, lang, glslang::EShClientVulkan, 100);
-		shader_object.setEnvClient(glslang::EShClientVulkan, glslang::EShTargetClientVersion::EShTargetVulkan_1_0);
-		shader_object.setEnvTarget(glslang::EshTargetSpv, glslang::EShTargetLanguageVersion::EShTargetSpv_1_0);
-
-		bool success = false;
-		const char *shader_text = shader.data();
-
-		shader_object.setStrings(&shader_text, 1);
-
-		EShMessages msg = static_cast<EShMessages>(EShMsgVulkanRules | EShMsgSpvRules);
-		if (shader_object.parse(&g_default_config, 400, EProfile::ECoreProfile, false, true, msg))
-		{
-			program.addShader(&shader_object);
-			success = program.link(msg);
-			if (success)
-			{
-				glslang::SpvOptions options;
-				options.disableOptimizer = true;
-				options.optimizeSize = true;
-				glslang::GlslangToSpv(*program.getIntermediate(lang), spv, &options);
-
-				// Now we optimize
-				//spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_0);
-				//optimizer.RegisterPass(spvtools::CreateUnifyConstantPass());      // Remove duplicate constants
-				//optimizer.RegisterPass(spvtools::CreateMergeReturnPass());        // Huge savings in vertex interpreter and likely normal vertex shaders
-				//optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());      // Remove dead code
-				//optimizer.Run(spv.data(), spv.size(), &spv);
-			}
-		}
-		else
-		{
-			rsx_log.error("%s", shader_object.getInfoLog());
-			rsx_log.error("%s", shader_object.getInfoDebugLog());
-		}
-
-		return success;
-	}
-
-	void initialize_compiler_context()
-	{
-		glslang::InitializeProcess();
-		init_default_resources(g_default_config);
-	}
-
-	void finalize_compiler_context()
-	{
-		glslang::FinalizeProcess();
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKCommonDecompiler.h
+++ b/rpcs3/Emu/RSX/VK/VKCommonDecompiler.h
@@ -6,8 +6,4 @@ namespace vk
 	using namespace ::glsl;
 
 	int get_varying_register_location(std::string_view varying_register_name);
-	bool compile_glsl_to_spv(std::string& shader, program_domain domain, std::vector<u32> &spv);
-
-	void initialize_compiler_context();
-	void finalize_compiler_context();
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -18,6 +18,7 @@
 #include "Emu/Memory/vm_locking.h"
 
 #include "../Program/program_state_cache2.hpp"
+#include "../Program/SPIRVCommon.h"
 
 #include "util/asm.hpp"
 
@@ -693,7 +694,7 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	null_buffer = std::make_unique<vk::buffer>(*m_device, 32, memory_map.device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, 0, VMM_ALLOCATION_POOL_UNDEFINED);
 	null_buffer_view = std::make_unique<vk::buffer_view>(*m_device, null_buffer->value, VK_FORMAT_R8_UINT, 0, 32);
 
-	vk::initialize_compiler_context();
+	spirv::initialize_compiler_context();
 	vk::initialize_pipe_compiler(g_cfg.video.shader_compiler_threads_count);
 
 	m_prog_buffer = std::make_unique<vk::program_cache>
@@ -918,9 +919,9 @@ VKGSRender::~VKGSRender()
 	m_flush_requests.clear_pending_flag();
 
 	// Shaders
-	vk::destroy_pipe_compiler();      // Ensure no pending shaders being compiled
-	vk::finalize_compiler_context();  // Shut down the glslang compiler
-	m_prog_buffer->clear();           // Delete shader objects
+	vk::destroy_pipe_compiler();        // Ensure no pending shaders being compiled
+	spirv::finalize_compiler_context(); // Shut down the glslang compiler
+	m_prog_buffer->clear();             // Delete shader objects
 	m_shader_interpreter.destroy();
 
 	m_persistent_attribute_storage.reset();

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -2,7 +2,8 @@
 #include "VKProgramPipeline.h"
 #include "vkutils/descriptors.h"
 #include "vkutils/device.h"
-#include <string>
+
+#include "../Program/SPIRVCommon.h"
 
 namespace vk
 {
@@ -20,7 +21,7 @@ namespace vk
 		{
 			ensure(m_handle == VK_NULL_HANDLE);
 
-			if (!vk::compile_glsl_to_spv(m_source, type, m_compiled))
+			if (!spirv::compile_glsl_to_spv(m_compiled, m_source, type, ::glsl::glsl_rules_vulkan))
 			{
 				const std::string shader_type = type == ::glsl::program_domain::glsl_vertex_program ? "vertex" :
 					type == ::glsl::program_domain::glsl_fragment_program ? "fragment" : "compute";

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -44,7 +44,7 @@ namespace vk
 		"};\n\n";
 
 		::glsl::insert_glsl_legacy_function(builder, properties);
-		::glsl::insert_vertex_input_fetch(builder, ::glsl::glsl_rules::glsl_rules_spirv);
+		::glsl::insert_vertex_input_fetch(builder, ::glsl::glsl_rules::glsl_rules_vulkan);
 
 		builder << program_common::interpreter::get_vertex_interpreter();
 		const std::string s = builder.str();

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -211,7 +211,7 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	properties2.require_explicit_invariance = (vk::get_driver_vendor() == vk::driver_vendor::NVIDIA && g_cfg.video.shader_precision != gpu_preset_level::low);
 
 	glsl::insert_glsl_legacy_function(OS, properties2);
-	glsl::insert_vertex_input_fetch(OS, glsl::glsl_rules_spirv);
+	glsl::insert_vertex_input_fetch(OS, glsl::glsl_rules_vulkan);
 
 	// Declare global registers with optional initialization
 	std::string registers;

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.cpp" />
     <ClCompile Include="Emu\RSX\Program\ProgramStateCache.cpp" />
     <ClCompile Include="Emu\RSX\Program\program_util.cpp" />
+    <ClCompile Include="Emu\RSX\Program\SPIRVCommon.cpp" />
     <ClCompile Include="Emu\RSX\RSXDisAsm.cpp" />
     <ClCompile Include="Emu\RSX\RSXZCULL.cpp" />
     <ClCompile Include="Emu\RSX\rsx_vertex_data.cpp" />
@@ -622,6 +623,7 @@
     <ClInclude Include="Emu\RSX\Overlays\overlay_utils.h" />
     <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.h" />
     <ClInclude Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.h" />
+    <ClInclude Include="Emu\RSX\Program\SPIRVCommon.h" />
     <ClInclude Include="Emu\RSX\RSXDisAsm.h" />
     <ClInclude Include="Emu\RSX\RSXZCULL.h" />
     <ClInclude Include="Emu\savestate_utils.hpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1207,6 +1207,9 @@
     <ClCompile Include="Emu\Io\rb3drums_config.cpp">
       <Filter>Emu\Io</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Program\SPIRVCommon.cpp">
+      <Filter>Emu\GPU\RSX\Program</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -2442,6 +2445,9 @@
     </ClInclude>
     <ClInclude Include="Input\raw_mouse_config.h">
       <Filter>Emu\Io</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Program\SPIRVCommon.h">
+      <Filter>Emu\GPU\RSX\Program</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
First part of the effort to add SPIRV support to OpenGL backend. Unfortunately a lot of the final code for OGL was lost after an angry hard reset :(
SPIRV shaders will be required for some buggy drivers to function with rpcs3 such as intel.