### PR TITLE
overlays: fix race condition during performance/debug overlay reset

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlay_debug_overlay.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_debug_overlay.cpp
@@ -59,6 +59,7 @@ namespace rsx
 				}
 				else if (overlay)
 				{
+					std::lock_guard lock(*manager); // Force lock. remove does not guarantee an internal lock
 					manager->remove<rsx::overlays::debug_overlay>();
 				}
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_perf_metrics.cpp
@@ -910,6 +910,7 @@ namespace rsx
 				}
 				else if (perf_overlay)
 				{
+					std::lock_guard lock(*manager); // Force lock. remove does not guarantee an internal lock
 					manager->remove<rsx::overlays::perf_metrics_overlay>();
 				}
 			}


### PR DESCRIPTION
- Lock performance- and debug overlay removal
- Fixes a crash that may happen when you change the overlays during runtime