### PR TITLE
PPU LLVM: Fix memory leaks and protect against the rise of CPU threads in the coming years

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -16,7 +16,7 @@
 extern std::pair<std::shared_ptr<lv2_overlay>, CellError> ppu_load_overlay(const ppu_exec_object&, bool virtual_load, const std::string& path, s64 file_offset, utils::serial* ar = nullptr);
 
 extern bool ppu_initialize(const ppu_module&, bool check_only = false, u64 file_size = 0);
-extern void ppu_finalize(const ppu_module&);
+extern void ppu_finalize(const ppu_module& info, bool force_mem_release = false);
 
 LOG_CHANNEL(sys_overlay);
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -20,7 +20,7 @@
 extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, bool virtual_load, const std::string&, s64, utils::serial* = nullptr);
 extern void ppu_unload_prx(const lv2_prx& prx);
 extern bool ppu_initialize(const ppu_module&, bool check_only = false, u64 file_size = 0);
-extern void ppu_finalize(const ppu_module&);
+extern void ppu_finalize(const ppu_module& info, bool force_mem_release = false);
 extern void ppu_manual_load_imports_exports(u32 imports_start, u32 imports_size, u32 exports_start, u32 exports_size, std::basic_string<bool>& loaded_flags);
 
 LOG_CHANNEL(sys_prx);


### PR DESCRIPTION
* In #15376, vsh.self is being precompiled. And when that happens, RPCS3 attempts to precompile nearly every PPU executable it finds lying inisde the firmware. By itself this is currently the intended behavior, but after some debugging I discovered that the memory of every executable lying inisde the "/dev_flash/sys/" is not being released after it finalizes.
The proper way to do it is: whitelist only file under "/dev_flash/sys/external", of PRX type only and only if being done ingame.

* The second problem is that RPCS3 naively allows concurrent loads of executable PPU files and their entire LLVM workloads per CPU thread. This is not only a cause for massive memory usages during precompilation but is also not really needed as each files may get multiple threads to compile it as well depending on its size. So I added a limit which allows to load files of total sum of RAM size / 800. This  is not accurate but it does work nicely with the previousl limit for Overlay files of 2 with Metal Gear Solid 4 on 16GB of RAM.
This should protect from most memory shortages in the near future when CPUs have even more threads.

* Fix PPU LLVM memory cleanup of modules outside of /dev_flash/sys/external but inside /dev_flash even ingame, it turns out memory cleanup failed because the entry used to store the JIT instance uses a key that was different between creation access and removal access.

* Minor SPU LLVM worker memory optimization when SPU LLVM ingame workers are not active.
 
Fixes #15376 