### PR TITLE
PPU Loader: Fix unload of HLEd PRX modules

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3717,6 +3717,12 @@ extern fs::file make_file_view(fs::file&& _file, u64 offset, u64 max_size = umax
 
 extern void ppu_finalize(const ppu_module& info, bool force_mem_release)
 {
+	if (info.segs.empty())
+	{
+		// HLEd modules
+		return;
+	}
+
 	if (!force_mem_release && info.name.empty())
 	{
 		// Don't remove main module from memory


### PR DESCRIPTION
It worked before because all dev_flash modules already skipped unload process. So technically you could have reproduced this bug on older builds if you have attempted to HLE and game's PRX file for example because it is outside of dev_flash.

Fixes #15382 