### PR TITLE
Updater: Add RPCS3's Patreon link to update dialog

### DIFF
--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -201,7 +201,7 @@ bool update_manager::handle_json(bool automatic, bool check_only, bool auto_acce
 		if (diff_msec < 0)
 		{
 			// This usually means that the current version was marked as broken and won't be shipped anymore, so we need to downgrade to avoid certain bugs.
-			m_update_message = tr("A better version of RPCS3 is available!\n\nCurrent version: %0 (%1)\nBetter version: %2 (%3)\n\nDo you want to update?")
+			m_update_message = tr("A better version of RPCS3 is available!<br><br>Current version: %0 (%1)<br>Better version: %2 (%3)<br>%4<br>Do you want to update?")
 				.arg(current["version"].toString())
 				.arg(cur_str)
 				.arg(latest["version"].toString())
@@ -209,7 +209,7 @@ bool update_manager::handle_json(bool automatic, bool check_only, bool auto_acce
 		}
 		else
 		{
-			m_update_message = tr("A new version of RPCS3 is available!\n\nCurrent version: %0 (%1)\nLatest version: %2 (%3)\nYour version is %4 behind.\n\nDo you want to update?")
+			m_update_message = tr("A new version of RPCS3 is available!<br><br>Current version: %0 (%1)<br>Latest version: %2 (%3)<br>Your version is %4 behind.<br>%4<br>Do you want to update?")
 				.arg(current["version"].toString())
 				.arg(cur_str)
 				.arg(latest["version"].toString())
@@ -221,11 +221,13 @@ bool update_manager::handle_json(bool automatic, bool check_only, bool auto_acce
 	{
 		m_old_version = fmt::format("%s-%s-%s", rpcs3::get_full_branch(), rpcs3::get_branch(), rpcs3::get_version().to_string());
 
-		m_update_message = tr("You're currently using a custom or PR build.\n\nLatest version: %0 (%1)\nThe latest version is %2 old.\n\nDo you want to update to the latest official RPCS3 version?")
+		m_update_message = tr("You're currently using a custom or PR build.<br><br>Latest version: %0 (%1)<br>The latest version is %2 old.<br>%3<br>Do you want to update to the latest official RPCS3 version?")
 			.arg(latest["version"].toString())
 			.arg(lts_str)
 			.arg(localized.GetVerboseTimeByMs(std::abs(diff_msec), true));
 	}
+
+	m_update_message = m_update_message.arg("<br>You can empower our project at <a href=\"https://patreon.com/Nekotekina\">RPCS3 Patreon</a><br>");
 
 	m_request_url   = latest[os]["download"].toString().toStdString();
 	m_expected_hash = latest[os]["checksum"].toString().toStdString();
@@ -323,6 +325,7 @@ void update_manager::update(bool auto_accept)
 		}
 
 		QMessageBox mb(QMessageBox::Icon::Question, tr("Update Available"), m_update_message, QMessageBox::Yes | QMessageBox::No, m_downloader->get_progress_dialog() ? m_downloader->get_progress_dialog() : m_parent);
+		mb.setTextFormat(Qt::RichText);
 
 		if (!changelog_content.isEmpty())
 		{


### PR DESCRIPTION
Add a button that links to the Patreon on update successful dialog, nothing fancy.

![image](https://github.com/RPCS3/rpcs3/assets/18193363/52255d2d-b6f2-4ada-8a3d-c6ec735f8690)
