### PR TITLE
SPU LLVM: Fix store elimination within common blocks and MFC commands

### DIFF
--- a/rpcs3/rpcs3qt/about_dialog.cpp
+++ b/rpcs3/rpcs3qt/about_dialog.cpp
@@ -19,7 +19,7 @@ about_dialog::about_dialog(QWidget* parent) : QDialog(parent), ui(new Ui::about_
 		R"(
 			<p style="white-space: nowrap;">
 				RPCS3 is an open-source Sony PlayStation 3 emulator and debugger.<br>
-				It is written in C++ for Windows, Linux, FreeBSD and MacOS funded with <a %0 href="https://www.patreon.com/Nekotekina">Patreon</a>.<br>
+				It is written in C++ for Windows, Linux, FreeBSD and MacOS funded with <a %0 href="https://rpcs3.net/patreon">Patreon</a>.<br>
 				Our developers and contributors are always working hard to ensure this project is the best that it can be.<br>
 				There are still plenty of implementations to make and optimizations to do.
 			</p>
@@ -28,9 +28,9 @@ about_dialog::about_dialog(QWidget* parent) : QDialog(parent), ui(new Ui::about_
 
 	// Events
 	connect(ui->gitHub, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://www.github.com/RPCS3")); });
-	connect(ui->website, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://www.rpcs3.net")); });
+	connect(ui->website, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://rpcs3.net")); });
 	connect(ui->forum, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://forums.rpcs3.net")); });
-	connect(ui->patreon, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://www.patreon.com/Nekotekina")); });
+	connect(ui->patreon, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://rpcs3.net/patreon")); });
 	connect(ui->discord, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://discord.me/RPCS3")); });
 	connect(ui->wiki, &QPushButton::clicked, [] { QDesktopServices::openUrl(QUrl("https://wiki.rpcs3.net/index.php?title=Main_Page")); });
 	connect(ui->close, &QPushButton::clicked, this, &QWidget::close);

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
@@ -15,6 +15,8 @@ constexpr auto qstr = QString::fromStdString;
 
 extern bool ppu_patch(u32 addr, u32 value);
 
+extern std::string format_spu_func_info(u32 addr, cpu_thread* spu);
+
 instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, CPUDisAsm* _disasm, std::function<cpu_thread*()> func)
 	: QDialog(parent)
 	, m_pc(_pc)
@@ -57,6 +59,16 @@ instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, C
 	vbox_right_panel->addWidget(new QLabel(qstr(fmt::format("%08x", m_pc))));
 	vbox_right_panel->addWidget(m_instr);
 	vbox_right_panel->addWidget(m_preview);
+
+	if (cpu && cpu->id_type() == 2)
+	{
+		// Print block information as if this instruction is its beginning
+		vbox_left_panel->addWidget(new QLabel(tr("Block Info:  ")));
+		m_func_info = new QLabel("", this);
+		vbox_right_panel->addWidget(m_func_info);
+
+		m_func_info->setText(qstr(format_spu_func_info(m_pc, cpu)));
+	}
 
 	if (cpu && cpu->id_type() == 2)
 	{

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.h
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.h
@@ -20,6 +20,7 @@ private:
 	std::shared_ptr<CPUDisAsm> m_disasm; // shared in order to allow an incomplete type
 	QLineEdit* m_instr;
 	QLabel* m_preview;
+	QLabel* m_func_info = nullptr;
 	QCheckBox* m_apply_for_spu_group = nullptr;
 
 	const std::function<cpu_thread*()> m_get_cpu;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3078,7 +3078,7 @@ void main_window::CreateConnects()
 
 	connect(ui->supportAct, &QAction::triggered, this, [this]
 	{
-		QDesktopServices::openUrl(QUrl("https://www.patreon.com/Nekotekina"));
+		QDesktopServices::openUrl(QUrl("https://rpcs3.net/patreon"));
 	});
 
 	connect(ui->aboutAct, &QAction::triggered, this, [this]

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -227,7 +227,7 @@ bool update_manager::handle_json(bool automatic, bool check_only, bool auto_acce
 			.arg(localized.GetVerboseTimeByMs(std::abs(diff_msec), true));
 	}
 
-	m_update_message = m_update_message.arg("<br>You can empower our project at <a href=\"https://patreon.com/Nekotekina\">RPCS3 Patreon</a><br>");
+	m_update_message = m_update_message.arg("<br>You can empower our project at <a href=\"https://rpcs3.net/patreon\">RPCS3 Patreon</a>.<br>");
 
 	m_request_url   = latest[os]["download"].toString().toStdString();
 	m_expected_hash = latest[os]["checksum"].toString().toStdString();

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -32,7 +32,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 		R"(
 			<p style="white-space: nowrap;">
 				RPCS3 is an open-source Sony PlayStation 3 emulator and debugger.<br>
-				It is written in C++ for Windows, Linux, FreeBSD and MacOS funded with <a %0 href="https://www.patreon.com/Nekotekina">Patreon</a>.<br>
+				It is written in C++ for Windows, Linux, FreeBSD and MacOS funded with <a %0 href="https://rpcs3.net/patreon">Patreon</a>.<br>
 				Our developers and contributors are always working hard to ensure this project is the best that it can be.<br>
 				There are still plenty of implementations to make and optimizations to do.
 			</p>


### PR DESCRIPTION
Should fix the last SPU crash with savestates.