### PR TITLE
Fix changelog size hack

### DIFF
--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -336,10 +336,15 @@ void update_manager::update(bool auto_accept)
 
 			// Smartass hack to make the unresizeable message box wide enough for the changelog
 			const int changelog_width = QLabel(changelog_content).sizeHint().width();
-			while (QLabel(m_update_message).sizeHint().width() < changelog_width)
+			if (QLabel(m_update_message).sizeHint().width() < changelog_width)
 			{
-				m_update_message += "          ";
+				m_update_message += " &nbsp;";
+				while (QLabel(m_update_message).sizeHint().width() < changelog_width)
+				{
+					m_update_message += "&nbsp;";
+				}
 			}
+
 			mb.setText(m_update_message);
 		}
 


### PR DESCRIPTION
QLabel auto detects if the text is html so adding spaces to it didn't lengthen it, needed to use \&nbsp; to actually add spaces.

An extra space is added the first time otherwise it considers the word update and all the spaces as a single word and puts it on a new line.