### PR TITLE
cellGame: Enable disc insert/eject based on disc mount state

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.h
+++ b/rpcs3/Emu/Cell/Modules/cellGame.h
@@ -338,11 +338,12 @@ struct disc_change_manager
 
 	enum class eject_state
 	{
+		unknown,
 		inserted,
 		ejected,
 		busy
 	};
-	atomic_t<eject_state> state = eject_state::inserted;
+	atomic_t<eject_state> state = eject_state::unknown;
 
 	error_code register_callbacks(vm::ptr<CellGameDiscEjectCallback> func_eject, vm::ptr<CellGameDiscInsertCallback> func_insert);
 	error_code unregister_callbacks();


### PR DESCRIPTION
- Allow to insert a disc if no disc is mounted
- Only Allow to eject a disc if a disc is mounted
- Don't init the state as inserted. It may be an HDD game