### PR TITLE
lv2_socket: reset queue after move

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -1735,6 +1735,7 @@ error_code lv2_socket::abort_socket(s32 flags)
 		}
 
 		qcopy = std::move(queue);
+		queue = {};
 		events.store({});
 	}
 


### PR DESCRIPTION
- Reset queue member after move (moved containers are in an undefined state)