### PR TITLE
SPU Analyzer: Do not terminate blocks on BRA

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -2925,7 +2925,6 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 			if (g_cfg.core.spu_block_size == spu_block_size_type::giga && !sync)
 			{
 				m_entry_info[target / 4] = true;
-				add_block(target);
 			}
 			else
 			{
@@ -2933,13 +2932,9 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 				{
 					spu_log.notice("[0x%x] At 0x%x: ignoring fixed tail call to 0x%x (SYNC)", entry_point, pos, target);
 				}
-
-				if (target > entry_point)
-				{
-					limit = std::min<u32>(limit, target);
-				}
 			}
 
+			add_block(target);
 			next_block();
 			break;
 		}
@@ -3528,10 +3523,6 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 					break;
 				case spu_itype::BRASL:
 					is_call = spu_branch_target(0, op.i16) != ia + 4;
-					break;
-				case spu_itype::BRA:
-					is_call = true;
-					is_tail = true;
 					break;
 				case spu_itype::BISL:
 				case spu_itype::BISLED:

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -503,8 +503,6 @@ class spu_llvm_recompiler : public spu_recompiler_base, public cpu_translator
 			return result;
 		}
 
-		ensure(!absolute);
-
 		auto& result = m_blocks[target].block;
 
 		if (!result)
@@ -7661,10 +7659,14 @@ public:
 			return;
 		}
 
+		const auto compiled_pos = m_ir->getInt32(m_pos);
 		const u32 target = spu_branch_target(0, op.i16);
 
 		m_block->block_end = m_ir->GetInsertBlock();
-		m_ir->CreateBr(add_block(target, true));
+		const auto real_pos = get_pc(m_pos);
+		value_t<u32> target_val;
+		target_val.value = m_ir->getInt32(target);
+		m_ir->CreateCondBr(m_ir->CreateICmpEQ(real_pos, compiled_pos), add_block(target, true), add_block_indirect({}, target_val));
 	}
 
 	void BRASL(spu_opcode_t op) //


### PR DESCRIPTION
Allow the SPU Analyzer to look for more instructions after encountering an absoulte-branch instruction.