### PR TITLE
Savestates: Some improvements

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -329,6 +329,13 @@ struct cpu_prof
 				continue;
 			}
 
+			if (!g_cfg.core.spu_debug)
+			{
+				// Reduce accuracy in favor of performance when enabled alone
+				thread_ctrl::wait_for(60, false);
+				continue;
+			}
+
 			// Wait, roughly for 20µs
 			thread_ctrl::wait_for(20, false);
 		}

--- a/rpcs3/Emu/Cell/Modules/cellSysutilAvc2.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutilAvc2.cpp
@@ -68,12 +68,33 @@ struct avc2_settings
 	avc2_settings(const avc2_settings&) = delete;
 	avc2_settings& operator=(const avc2_settings&) = delete;
 
+	SAVESTATE_INIT_POS(52);
+
 	vm::ptr<CellSysutilAvc2Callback> avc2_cb{};
 	vm::ptr<void> avc2_cb_arg{};
 	u32 streaming_mode = CELL_SYSUTIL_AVC2_STREAMING_MODE_NORMAL;
 	u8 mic_out_stream_sharing = 0;
 	u8 video_stream_sharing = 0;
 	u32 total_video_bitrate = 0;
+
+	avc2_settings(utils::serial& ar) noexcept
+	{
+		[[maybe_unused]] const s32 version = GET_SERIALIZATION_VERSION(cellSysutil);
+
+		if (version == 0)
+		{
+			return;
+		}
+
+		save(ar);
+	}
+
+	void save(utils::serial& ar)
+	{
+		GET_OR_USE_SERIALIZATION_VERSION(ar.is_writing(), cellSysutil);
+
+		ar(avc2_cb, avc2_cb_arg, streaming_mode, mic_out_stream_sharing, video_stream_sharing, total_video_bitrate);
+	}
 };
 
 error_code cellSysutilAvc2GetPlayerInfo(vm::cptr<SceNpMatching2RoomMemberId> player_id, vm::ptr<CellSysutilAvc2PlayerInfo> player_info)

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1842,7 +1842,7 @@ void spu_thread::cpu_work()
 		const u32 pos_at = pc / 4;
 		const u32 pos_bit = 1u << (pos_at % 8);
 
-		if (local_breakpoints[pos_at] & pos_bit)
+		if (local_breakpoints[pos_at / 8] & pos_bit)
 		{
 			// Ignore repeatations until a different instruction is issued
 			if (pc != current_bp_pc)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3022,11 +3022,14 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 	*join_thread = make_ptr(new named_thread("Emulation Join Thread"sv, [join_thread, savestate, allow_autoexit, this]() mutable
 	{
 		fs::pending_file file;
-		std::shared_ptr<stx::init_mutex> init_mtx = std::make_shared<stx::init_mutex>();
-		std::shared_ptr<bool> join_ended = std::make_shared<bool>(false);
-		atomic_ptr<utils::serial> to_ar;
 
-		named_thread stop_watchdog("Stop Watchdog"sv, [&to_ar, init_mtx, join_ended, this]()
+		auto verbose_message = std::make_shared<atomic_ptr<std::string>>();
+		auto init_mtx = std::make_shared<stx::init_mutex>();
+		auto join_ended = std::make_shared<bool>(false);
+		auto to_ar = std::make_shared<atomic_ptr<utils::serial>>();
+
+		auto stop_watchdog = make_ptr(new named_thread("Stop Watchdog"sv,
+			[to_ar, init_mtx, join_ended, verbose_message, this]()
 		{
 			const auto closed_sucessfully = std::make_shared<atomic_t<bool>>(false);
 
@@ -3058,10 +3061,10 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 			while (thread_ctrl::state() != thread_state::aborting)
 			{
-				if (auto ar_ptr = to_ar.load())
+				if (auto ar_ptr = to_ar->load())
 				{
 					// Total amount of waiting: about 10s
-					GetCallbacks().on_save_state_progress(closed_sucessfully, ar_ptr, init_mtx);
+					GetCallbacks().on_save_state_progress(closed_sucessfully, ar_ptr, verbose_message.get(), init_mtx);
 
 					while (thread_ctrl::state() != thread_state::aborting)
 					{
@@ -3076,7 +3079,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 
 			*closed_sucessfully = true;
-		});
+		}));
 
 		// Join threads
 		for (const auto& [type, data] : *g_fxo)
@@ -3097,8 +3100,15 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 		static_cast<void>(init_mtx->init());
 
+		auto set_progress_message = [&](std::string_view text)
+		{
+			*verbose_message = stx::make_single<std::string>(text);
+		};
+
 		while (savestate)
 		{
+			set_progress_message("Creating File");
+
 			path = get_savestate_file(m_title_id, m_path, 0, 0);
 
 			// The function is meant for reading files, so if there is no GZ file it would not return compressed file path
@@ -3124,7 +3134,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 			auto serial_ptr = stx::make_single<utils::serial>();
 			serial_ptr->m_file_handler = make_compressed_serialization_file_handler(file.file);
-			to_ar = std::move(serial_ptr);
+			*to_ar = std::move(serial_ptr);
 
 			signal_system_cache_can_stay();
 			break;
@@ -3142,7 +3152,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 					return fmt::format("Emu State Capture Thread: '%s'", g_tls_serialize_name);
 				};
 
-				auto& ar = *to_ar.load();
+				auto& ar = *to_ar->load();
 
 				read_used_savestate_versions(); // Reset version data
 				USING_SERIALIZATION_VERSION(global_version);
@@ -3217,6 +3227,8 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 					ar(std::string{});
 				};
 
+				set_progress_message("Creating Header");
+
 				ar("RPCS3SAV"_u64);
 				ar(std::endian::native == std::endian::little);
 				ar(g_cfg.savestate.state_inspection_mode.get());
@@ -3256,11 +3268,21 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 				ar(klic.empty() ? std::array<u8, 16>{} : std::bit_cast<std::array<u8, 16>>(klic[0]));
 				ar(m_game_dir);
+
+				set_progress_message("Saving HDD1");
 				save_hdd1();
+				set_progress_message("Saving HDD0");
 				save_hdd0();
+
 				ar(std::array<u8, 32>{}); // Reserved for future use
+
+				set_progress_message("Saving VMemory");
 				vm::save(ar);
+
+				set_progress_message("Saving FXO");
 				g_fxo->save(ar);
+
+				set_progress_message("Finalizing File");
 
 				bs_t<SaveStateExtentionFlags1> extension_flags{SaveStateExtentionFlags1::SupportsMenuOpenResume};
 
@@ -3285,17 +3307,16 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 			if (emu_state_cap_thread == thread_state::errored)
 			{
 				sys_log.error("Saving savestate failed due to fatal error!");
-				to_ar.reset();
+				to_ar->reset();
 				savestate = false;
 			}
 		}
 
-		stop_watchdog = thread_state::finished;
-		static_cast<void>(init_mtx->reset());
-
 		if (savestate)
 		{
 			fs::stat_t file_stat{};
+
+			set_progress_message("Commiting File");
 
 			if (!file.commit() || !fs::get_stat(path, file_stat))
 			{
@@ -3394,8 +3415,10 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 			}
 		}
 
+		set_progress_message("Resetting Objects");
+
 		// Final termination from main thread (move the last ownership of join thread in order to destroy it)
-		CallFromMainThread([join_thread = std::move(join_thread), allow_autoexit, this]() mutable
+		CallFromMainThread([join_thread = std::move(join_thread), verbose_message, stop_watchdog, init_mtx, allow_autoexit, this]()
 		{
 			cpu_thread::cleanup();
 
@@ -3406,6 +3429,9 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 			sys_log.notice("Objects cleared...");
 
 			vm::close();
+
+			*stop_watchdog = thread_state::finished;
+			static_cast<void>(init_mtx->reset());
 
 			jit_runtime::finalize();
 

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -64,7 +64,7 @@ struct EmuCallbacks
 	std::function<void()> on_ready;
 	std::function<bool()> on_missing_fw;
 	std::function<void(std::shared_ptr<atomic_t<bool>>, int)> on_emulation_stop_no_response;
-	std::function<void(std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, std::shared_ptr<void>)> on_save_state_progress;
+	std::function<void(std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, stx::atomic_ptr<std::string>*, std::shared_ptr<void>)> on_save_state_progress;
 	std::function<void(bool enabled)> enable_disc_eject;
 	std::function<void(bool enabled)> enable_disc_insert;
 	std::function<bool(bool, std::function<void()>)> try_to_quit; // (force_quit, on_exit) Try to close RPCS3

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -196,9 +196,9 @@ bool is_savestate_version_compatible(const std::vector<version_entry>& data, boo
 		}
 		else
 		{
-			for (auto [identifier, _] : data)
+			for (auto& entry : s_serial_versions)
 			{
-				s_serial_versions[identifier].current_version = 0;
+				entry.current_version = 0;
 			}
 		}
 	}

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -25,7 +25,7 @@ struct serial_ver_t
 	std::set<u16> compatible_versions;
 };
 
-static std::array<serial_ver_t, 26> s_serial_versions;
+static std::array<serial_ver_t, 27> s_serial_versions;
 
 #define SERIALIZATION_VER(name, identifier, ...) \
 \
@@ -85,6 +85,8 @@ SERIALIZATION_VER(sys_io, 23,                                   2)
 // Misc versions for HLE/LLE not included so main version would not invalidated
 SERIALIZATION_VER(LLE, 24,                                      1)
 SERIALIZATION_VER(HLE, 25,                                      1)
+
+SERIALIZATION_VER(cellSysutil, 26,                              1)
 
 template <>
 void fmt_class_string<std::remove_cvref_t<decltype(s_serial_versions)>>::format(std::string& out, u64 arg)

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -19,6 +19,7 @@ LOG_CHANNEL(sys_log, "SYS");
 
 struct serial_ver_t
 {
+	std::string ver_name;
 	bool used = false;
 	u16 current_version = 0;
 	std::set<u16> compatible_versions;
@@ -28,7 +29,7 @@ static std::array<serial_ver_t, 26> s_serial_versions;
 
 #define SERIALIZATION_VER(name, identifier, ...) \
 \
-	const bool s_##name##_serialization_fill = []() { if (::s_serial_versions[identifier].compatible_versions.empty()) ::s_serial_versions[identifier].compatible_versions = {__VA_ARGS__}; return true; }();\
+	const bool s_##name##_serialization_fill = []() { auto& e = ::s_serial_versions[identifier]; if (e.compatible_versions.empty()) { e.compatible_versions = {__VA_ARGS__}; e.ver_name = #name; } return true; }();\
 \
 	extern void using_##name##_serialization()\
 	{\
@@ -85,6 +86,32 @@ SERIALIZATION_VER(sys_io, 23,                                   2)
 SERIALIZATION_VER(LLE, 24,                                      1)
 SERIALIZATION_VER(HLE, 25,                                      1)
 
+template <>
+void fmt_class_string<std::remove_cvref_t<decltype(s_serial_versions)>>::format(std::string& out, u64 arg)
+{
+	bool is_first = true;
+
+	const auto& serials = get_object(arg);
+
+	out += "{ ";
+
+	for (auto& entry : serials)
+	{
+		if (entry.current_version)
+		{
+			if (!is_first)
+			{
+				out += ", ";
+			}
+
+			is_first = false;
+			fmt::append(out, "%s=%d", entry.ver_name, entry.current_version);
+		}
+	}
+
+	out += " }";
+}
+
 std::vector<version_entry> get_savestate_versioning_data(fs::file&& file, std::string_view filepath)
 {
 	if (!file)
@@ -132,16 +159,27 @@ bool is_savestate_version_compatible(const std::vector<version_entry>& data, boo
 
 	bool ok = true;
 
+	if (is_boot_check)
+	{
+		for (auto& entry : s_serial_versions)
+		{
+			// Version 0 means that the entire constructor using the version should be skipped
+			entry.current_version = 0;
+		}
+	}
+
+	auto& channel = (is_boot_check ? sys_log.error : sys_log.trace);
+
 	for (auto [identifier, version] : data)
 	{
 		if (identifier >= s_serial_versions.size())
 		{
-			(is_boot_check ? sys_log.error : sys_log.trace)("Savestate version identifier is unknown! (category=%u, version=%u)", identifier, version);
+			channel("Savestate version identifier is unknown! (category=%u, version=%u)", identifier, version);
 			ok = false; // Log all mismatches
 		}
 		else if (!s_serial_versions[identifier].compatible_versions.count(version))
 		{
-			(is_boot_check ? sys_log.error : sys_log.trace)("Savestate version is not supported. (category=%u, version=%u)", identifier, version);
+			channel("Savestate version is not supported. (category=%u, version=%u)", identifier, version);
 			ok = false;
 		}
 		else if (is_boot_check)
@@ -150,11 +188,18 @@ bool is_savestate_version_compatible(const std::vector<version_entry>& data, boo
 		}
 	}
 
-	if (!ok && is_boot_check)
+	if (is_boot_check)
 	{
-		for (auto [identifier, _] : data)
+		if (ok)
 		{
-			s_serial_versions[identifier].current_version = 0;
+			sys_log.success("Savestate versions: %s", s_serial_versions);
+		}
+		else
+		{
+			for (auto [identifier, _] : data)
+			{
+				s_serial_versions[identifier].current_version = 0;
+			}
 		}
 	}
 

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -148,7 +148,7 @@ void headless_application::InitializeCallbacks()
 		}
 	};
 
-	callbacks.on_save_state_progress = [](std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, std::shared_ptr<void>)
+	callbacks.on_save_state_progress = [](std::shared_ptr<atomic_t<bool>>, stx::shared_ptr<utils::serial>, stx::atomic_ptr<std::string>*, std::shared_ptr<void>)
 	{
 	};
 

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -151,7 +151,7 @@ void debugger_list::ShowAddress(u32 addr, bool select_addr, bool direct)
 			const u32 pos_at = pc / 4;
 			const u32 pos_bit = 1u << (pos_at % 8);
 
-			return !!((*spu_bps_list)[pos_at] & pos_bit);
+			return !!((*spu_bps_list)[pos_at / 8] & pos_bit);
 		}
 		default: return false;
 		}

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -51,6 +51,7 @@ enum class emu_settings_type
 	AccuratePPUVNAN,
 	AccuratePPUFPCC,
 	MaxPreemptCount,
+	SPUProfiler,
 
 	// Graphics
 	Renderer,
@@ -237,6 +238,7 @@ inline static const QMap<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::AccuratePPUVNAN,          { "Core", "PPU Accurate Vector NaN Values"}},
 	{ emu_settings_type::AccuratePPUFPCC,          { "Core", "PPU Set FPCC Bits"}},
 	{ emu_settings_type::MaxPreemptCount,          { "Core", "Max CPU Preempt Count"}},
+	{ emu_settings_type::SPUProfiler,              { "Core", "SPU Profiler"}},
 
 	// Graphics Tab
 	{ emu_settings_type::Renderer,                   { "Video", "Renderer"}},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1477,6 +1477,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->compatibleSavestates, emu_settings_type::CompatibleEmulationSavestateMode);
 	SubscribeTooltip(ui->compatibleSavestates, tooltips.settings.compatible_savestates);
 
+	m_emu_settings->EnhanceCheckBox(ui->spuProfiler, emu_settings_type::SPUProfiler);
+	SubscribeTooltip(ui->spuProfiler, tooltips.settings.spu_profiler);
+
 	m_emu_settings->EnhanceCheckBox(ui->silenceAllLogs, emu_settings_type::SilenceAllLogs);
 	SubscribeTooltip(ui->silenceAllLogs, tooltips.settings.silence_all_logs);
 

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2441,6 +2441,13 @@
                 </widget>
                </item>
                <item>
+                <widget class="QCheckBox" name="spuProfiler">
+                 <property name="text">
+                  <string>SPU Profiler</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QCheckBox" name="silenceAllLogs">
                  <property name="text">
                   <string>Silence All Logs</string>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -55,6 +55,7 @@ public:
 		const QString suspend_savestates           = tr("When this mode is on, emulation exits when saving and the savestate file is concealed after loading it, preventing reuse by RPCS3.\nThis mode is like hibernation of emulation: if you don't want to be able to cheat using savestates when playing the game, consider using this mode.\nDo note that the savestate file is not gone completely, just ignored by RPCS3. You can manually relaunch it if needed.");
 		const QString compatible_savestates        = tr("When this mode is on, SPU emulation prioritizes savestate compatibility, however, it may reduce performance slightly.\nWhen this mode is off, some games may not allow making a savestate and show an SPU pause error in the log.");
 		const QString paused_savestates            = tr("When this mode is on, savestates are loaded and paused on the first frame.\nThis allows players to prepare for gameplay without being thrown into the action immediately.");
+		const QString spu_profiler                 = tr("When enabled, SPU performance is measured at runtime.\nEnable only at a developr's request because when enabled it reduces performance a bit by itself.");
 
 		// audio
 


### PR DESCRIPTION
* If the savestate file does not contain a version supported, ensure it is 0 so the serialization can be skipped entirely later.
* Log sub-versions supported by the savestate file on load.
* Fix out-of-range access bug when encountering a savestate with versions unknown. (from newer builds)
* Add names for the saving stages for the save progress dialog.
* Add SPU Profiler setting to UI in advanced tab.