### PR TITLE
Savestates: Fixup

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutilAvc2.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutilAvc2.cpp
@@ -77,6 +77,11 @@ struct avc2_settings
 	u8 video_stream_sharing = 0;
 	u32 total_video_bitrate = 0;
 
+	static bool saveable(bool is_writing) noexcept
+	{
+		return GET_SERIALIZATION_VERSION(cellSysutil) != 0;
+	}
+
 	avc2_settings(utils::serial& ar) noexcept
 	{
 		[[maybe_unused]] const s32 version = GET_SERIALIZATION_VERSION(cellSysutil);

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -802,6 +802,9 @@ void spu_cache::initialize(bool build_existing_cache)
 
 		compiler->init();
 
+		// Counter for error reporting
+		u32 logged_error = 0;
+
 		// How much every thread compiled
 		uint result = 0;
 
@@ -861,6 +864,14 @@ void spu_cache::initialize(bool build_existing_cache)
 			if (func2 != func)
 			{
 				spu_log.error("[0x%05x] SPU Analyser failed, %u vs %u", func2.entry_point, func2.data.size(), size0);
+
+				if (logged_error < 2)
+				{
+					std::string log;
+					compiler->dump(func, log);
+					spu_log.notice("[0x%05x] Function: %s", func.entry_point, log);
+					logged_error++;
+				}
 			}
 			else if (!compiler->compile(std::move(func2)))
 			{


### PR DESCRIPTION
Skip serialization tagging on missing cellSysutilAvc2 object from save file. Fixes #15444 
Ironically this tagging mechanism is what enables such good debugging of savestate load failures.