### PR TITLE
rsx: Fix intra-draw-call barrier queueing

### DIFF
--- a/rpcs3/Emu/RSX/NV47/HW/common.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/common.cpp
@@ -30,11 +30,10 @@ namespace rsx
 			REGS(ctx)->register_vertex_info[attrib_index].data[channel_select] = value;
 		}
 
-		void push_draw_parameter_change(rsx::context* ctx, rsx::command_barrier_type /*type*/, u32 reg, u32 arg)
+		void push_draw_parameter_change(rsx::context* ctx, rsx::command_barrier_type type, u32 reg, u32 arg)
 		{
-			if (REGS(ctx)->latch == arg ||
-				!RSX(ctx)->in_begin_end ||
-				REGS(ctx)->current_draw_clause.empty())
+			// NOTE: We can't test against latch here, since a previous change may be buffered in a pending barrier.
+			if (!RSX(ctx)->in_begin_end || REGS(ctx)->current_draw_clause.empty())
 			{
 				return;
 			}
@@ -43,7 +42,7 @@ namespace rsx
 			REGS(ctx)->decode(reg, REGS(ctx)->latch);
 
 			// Insert barrier to reinsert the value later
-			REGS(ctx)->current_draw_clause.insert_command_barrier(index_base_modifier_barrier, arg);
+			REGS(ctx)->current_draw_clause.insert_command_barrier(type, arg);
 		}
 
 		u32 get_report_data_impl([[maybe_unused]] rsx::context* ctx, u32 offset)

--- a/rpcs3/Emu/RSX/NV47/HW/nv4097.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv4097.cpp
@@ -187,12 +187,12 @@ namespace rsx
 
 			if (REGS(ctx)->decode<NV4097_SET_COLOR_MASK>(arg).is_invalid()) [[ unlikely ]]
 			{
+				// Rollback
 				REGS(ctx)->decode(reg, REGS(ctx)->latch);
+				return;
 			}
-			else
-			{
-				set_surface_options_dirty_bit(ctx, reg, arg);
-			}
+
+			set_surface_options_dirty_bit(ctx, reg, arg);
 		}
 
 		void set_stencil_op(context* ctx, u32 reg, u32 arg)
@@ -202,15 +202,14 @@ namespace rsx
 				return;
 			}
 
-			const auto typed = to_stencil_op(arg);
-			if (typed) [[ likely ]]
+			if (to_stencil_op(arg)) [[ likely ]]
 			{
 				set_surface_options_dirty_bit(ctx, reg, arg);
+				return;
 			}
-			else
-			{
-				REGS(ctx)->decode(reg, REGS(ctx)->latch);
-			}
+
+			// Rollback
+			REGS(ctx)->decode(reg, REGS(ctx)->latch);
 		}
 
 		///// Draw call setup (vertex, etc)
@@ -415,11 +414,11 @@ namespace rsx
 				to_blend_equation((arg >> 16) & 0xFFFF)) [[ likely ]]
 			{
 				RSX(ctx)->m_graphics_state |= rsx::pipeline_config_dirty;
+				return;
 			}
-			else
-			{
-				REGS(ctx)->decode(reg, REGS(ctx)->latch);
-			}
+
+			// Rollback
+			REGS(ctx)->decode(reg, REGS(ctx)->latch);
 		}
 
 		void set_blend_factor(context* ctx, u32 reg, u32 arg)
@@ -433,11 +432,11 @@ namespace rsx
 				to_blend_factor((arg >> 16) & 0xFFFF)) [[ likely ]]
 			{
 				RSX(ctx)->m_graphics_state |= rsx::pipeline_config_dirty;
+				return;
 			}
-			else
-			{
-				REGS(ctx)->decode(reg, REGS(ctx)->latch);
-			}
+
+			// Rollback
+			REGS(ctx)->decode(reg, REGS(ctx)->latch);
 		}
 
 		///// Reports


### PR DESCRIPTION
### Changes
- Ignore latch since we may have another barrier queued. Barriers cost essentially nothing so there is no problem with extra pushes.
- Remove unnecessary use of "else" statements.

The real reason for the breakage was that latching optimizations were completely broken before and are now working properly after the refactor. The bug was always there, it just never triggered before now.

Fixes https://github.com/RPCS3/rpcs3/issues/15445