### PR TITLE
[macOS] Fix compilation with Apple Clang

### DIFF
--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -1182,7 +1182,7 @@ namespace utils
 			{
 				av.video.context->codec_id = av.format_context->oformat->video_codec;
 				av.video.context->codec_type = AVMEDIA_TYPE_VIDEO;
-				av.video.context->frame_number = 0;
+				av.video.context->frame_num = 0;
 				av.video.context->bit_rate = m_video_bitrate_bps;
 				av.video.context->width = static_cast<int>(m_out_format.width);
 				av.video.context->height = static_cast<int>(m_out_format.height);


### PR DESCRIPTION
Compilation was failing with the following error: 
```
/Applications/Games/Emulators/Playstation 3/rpcs3/rpcs3/util/media_utils.cpp:1185:23: error: no member named 'frame_number' in 'AVCodecContext'; did you mean 'frame_num'?
                                av.video.context->frame_number = 0;
                                                  ^~~~~~~~~~~~
                                                  frame_num
/opt/homebrew/include/libavcodec/avcodec.h:2030:13: note: 'frame_num' declared here
    int64_t frame_num;
            ^
```

This PR blindly follows the compiler's suggestion and renames `frame_number` to `frame_num`, which allows the build to complete. 

This function is related to audio recording from PR #14817. 
@Megamouse could you confirm if this change is correct or not? 