### PR TITLE
PPU LLVM: Fix crash in Unity games (regression)

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5055,11 +5055,18 @@ bool ppu_initialize(const ppu_module& info, bool check_only, u64 file_size)
 	// Try to patch all single and unregistered BLRs with the same function (TODO: Maybe generalize it into PIC code detection and patching)
 	ppu_intrp_func_t BLR_func = nullptr;
 
-	const bool is_first = jit && !jit_mod.init;
-
 	const bool showing_only_apply_stage = !g_progr.load() && !g_progr_ptotal && !g_progr_ftotal && g_progr_ptotal.compare_and_swap_test(0, 1);
 
 	progr = "Applying PPU Code...";
+
+	if (!jit)
+	{
+		// No functions - nothing to do
+		ensure(info.funcs.empty());
+		return compiled_new;
+	}
+
+	const bool is_first = !jit_mod.init;
 
 	if (is_first)
 	{

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -2314,6 +2314,12 @@ std::vector<u32> spu_thread::discover_functions(u32 base_addr, std::span<const u
 			continue;
 		}
 
+		if (std::count(calls.begin(), calls.end(), func))
+		{
+			// Cannot call another call instruction (link is overwritten)
+			continue;
+		}
+
 		addrs.push_back(func);
 
 		// Detect an "arguments passing" block, possible queue another function

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -323,8 +323,8 @@ bool boot_last_savestate(bool testing)
 bool load_and_check_reserved(utils::serial& ar, usz size)
 {
 	u8 bytes[4096];
+	ensure(size < std::size(bytes));
 	std::memset(&bytes[size & (0 - sizeof(v128))], 0, sizeof(v128));
-	ensure(size <= std::size(bytes));
 
 	const usz old_pos = ar.pos;
 	ar(std::span<u8>(bytes, size));


### PR DESCRIPTION
Seeing on discord, https://discord.com/channels/272035812277878785/277227681836302338/1230390083736047667
This happend because JIT instance was not initialized due to a failure to find functions.
I fixed that and also added an experimental fallback to find PPU functions using callers like in SPU precompilation.