### PR TITLE
overlays/osk: Don't use meta out key code in the osk overlay

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -425,14 +425,14 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 			return;
 		}
 
-		bool is_kook_key = false;
+		bool is_hook_key = false;
 
 		switch (key_message.keycode)
 		{
 		case CELL_KEYC_NO_EVENT:
 		{
 			// Any shift/alt/ctrl key
-			is_kook_key = key_message.mkey > 0 && (info.hook_event_mode & CELL_OSKDIALOG_EVENT_HOOK_TYPE_ONLY_MODIFIER);
+			is_hook_key = key_message.mkey > 0 && (info.hook_event_mode & CELL_OSKDIALOG_EVENT_HOOK_TYPE_ONLY_MODIFIER);
 			break;
 		}
 		case CELL_KEYC_E_ROLLOVER:
@@ -473,18 +473,18 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 		case CELL_KEYC_MUHENKAN:
 		{
 			// Any function key or other special key like Delete
-			is_kook_key = (info.hook_event_mode & CELL_OSKDIALOG_EVENT_HOOK_TYPE_FUNCTION_KEY);
+			is_hook_key = (info.hook_event_mode & CELL_OSKDIALOG_EVENT_HOOK_TYPE_FUNCTION_KEY);
 			break;
 		}
 		default:
 		{
 			// Any regular ascii key
-			is_kook_key = (info.hook_event_mode & CELL_OSKDIALOG_EVENT_HOOK_TYPE_ASCII_KEY);
+			is_hook_key = (info.hook_event_mode & CELL_OSKDIALOG_EVENT_HOOK_TYPE_ASCII_KEY);
 			break;
 		}
 		}
 
-		if (!is_kook_key)
+		if (!is_hook_key)
 		{
 			cellOskDialog.notice("on_osk_key_input_entered: not a hook key: led=%d, mkey=%d, keycode=%d, hook_event_mode=%d", key_message.led, key_message.mkey, key_message.keycode, info.hook_event_mode.load());
 			return;

--- a/rpcs3/Emu/Io/GameTablet.cpp
+++ b/rpcs3/Emu/Io/GameTablet.cpp
@@ -156,7 +156,7 @@ void usb_device_gametablet::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endp
 		const auto gamepad_handler = pad::get_current_handler();
 		const auto& pads = gamepad_handler->GetPads();
 
-		const int pad_index = 1; // Player2
+		constexpr s32 pad_index = 1; // Player2
 		const auto& pad = ::at32(pads, pad_index);
 		if (pad->m_port_status & CELL_PAD_STATUS_CONNECTED)
 		{
@@ -244,7 +244,7 @@ void usb_device_gametablet::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endp
 
 	mouse_handler.Init(1);
 
-	const uint8_t mouse_index = 0;
+	constexpr u8 mouse_index = 0;
 	if (mouse_index >= mouse_handler.GetMice().size())
 	{
 		return;
@@ -256,20 +256,20 @@ void usb_device_gametablet::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endp
 		return;
 	}
 
-	static uint8_t noise_x = 0; // Toggle the LSB to simulate a noisy signal, Instant Artist dislikes a pen held perfectly still
-	static uint8_t noise_y = 0;
-	const int tablet_max_x = 1920;
-	const int tablet_max_y = 1080;
+	static u8 noise_x = 0; // Toggle the LSB to simulate a noisy signal, Instant Artist dislikes a pen held perfectly still
+	static u8 noise_y = 0;
+	constexpr s32 tablet_max_x = 1920;
+	constexpr s32 tablet_max_y = 1080;
 
-	const long tablet_x_pos = (mouse_data.x_pos * tablet_max_x / mouse_data.x_max) ^ noise_x;
-	const long tablet_y_pos = (mouse_data.y_pos * tablet_max_y / mouse_data.y_max) ^ noise_y;
-	noise_x = !noise_x;
-	noise_y = !noise_y;
+	const s32 tablet_x_pos = (mouse_data.x_pos * tablet_max_x / mouse_data.x_max) ^ noise_x;
+	const s32 tablet_y_pos = (mouse_data.y_pos * tablet_max_y / mouse_data.y_max) ^ noise_y;
+	noise_x ^= 0x1;
+	noise_y ^= 0x1;
 
 	buf[0x0b] = 0x40; // pen
 	buf[0x0d] = mouse_data.buttons & CELL_MOUSE_BUTTON_1 ? 0xbb : 0x72; // pressure
-	buf[0x0f] = tablet_x_pos / 0x100;
-	buf[0x10] = tablet_y_pos / 0x100;
-	buf[0x11] = tablet_x_pos % 0x100;
-	buf[0x12] = tablet_y_pos % 0x100;
+	buf[0x0f] = static_cast<u8>(tablet_x_pos / 0x100);
+	buf[0x10] = static_cast<u8>(tablet_y_pos / 0x100);
+	buf[0x11] = static_cast<u8>(tablet_x_pos % 0x100);
+	buf[0x12] = static_cast<u8>(tablet_y_pos % 0x100);
 }

--- a/rpcs3/Emu/RSX/RSXZCULL.h
+++ b/rpcs3/Emu/RSX/RSXZCULL.h
@@ -17,7 +17,7 @@ namespace rsx
 	static inline std::string_view location_tostring(u32 location)
 	{
 		ensure(location < 2);
-		const char* location_names[] = { "CELL_GCM_LOCATION_LOCAL", "CELL_GCM_LOCATION_MAIN" };
+		constexpr const char* location_names[2] = { "CELL_GCM_LOCATION_LOCAL", "CELL_GCM_LOCATION_MAIN" };
 		return location_names[location];
 	}
 


### PR DESCRIPTION
- Don't use meta out key code in the osk overlay.
The out key code is simply used to store the meta key ID. It is not meant to be a real key code.
- fix some warnings and typos