### PR TITLE
Keyboard improvements

### DIFF
--- a/rpcs3/Emu/Io/KeyboardHandler.cpp
+++ b/rpcs3/Emu/Io/KeyboardHandler.cpp
@@ -46,17 +46,12 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed, const std::u32string& key)
 
 	for (Keyboard& keyboard : m_keyboards)
 	{
-		bool found_key = false;
-
 		KbData& data = keyboard.m_data;
-		KbConfig& config = keyboard.m_config;
+		const KbConfig& config = keyboard.m_config;
 
-		for (const KbButton& button : keyboard.m_buttons)
+		if (auto it = keyboard.m_keys.find(code); it != keyboard.m_keys.end())
 		{
-			if (button.m_keyCode != code)
-				continue;
-
-			found_key = true;
+			KbButton& button = it->second;
 
 			u16 kcode = CELL_KEYC_NO_EVENT;
 			bool is_meta_key = IsMetaKey(code);
@@ -156,8 +151,7 @@ void KeyboardHandlerBase::Key(u32 code, bool pressed, const std::u32string& key)
 				}
 			}
 		}
-
-		if (!found_key && !key.empty())
+		else if (!key.empty())
 		{
 			if (pressed)
 			{
@@ -205,14 +199,14 @@ void KeyboardHandlerBase::ReleaseAllKeys()
 {
 	for (Keyboard& keyboard : m_keyboards)
 	{
-		for (const KbButton& button : keyboard.m_buttons)
+		for (const auto& [key_code, button] : keyboard.m_keys)
 		{
 			Key(button.m_keyCode, false, {});
 		}
 
 		for (const std::u32string& key : keyboard.m_extra_data.pressed_keys)
 		{
-			Key(0, false, key);
+			Key(CELL_KEYC_NO_EVENT, false, key);
 		}
 
 		keyboard.m_extra_data.pressed_keys.clear();

--- a/rpcs3/Emu/Io/KeyboardHandler.h
+++ b/rpcs3/Emu/Io/KeyboardHandler.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <vector>
 #include <set>
+#include <unordered_map>
 
 #include "util/init_mutex.hpp"
 
@@ -71,7 +72,7 @@ struct Keyboard
 	KbData m_data{};
 	KbExtraData m_extra_data{};
 	KbConfig m_config{};
-	std::vector<KbButton> m_buttons;
+	std::unordered_map<u32, KbButton> m_keys;
 };
 
 class KeyboardHandlerBase
@@ -95,7 +96,6 @@ public:
 
 	KbInfo& GetInfo() { return m_info; }
 	std::vector<Keyboard>& GetKeyboards() { return m_keyboards; }
-	std::vector<KbButton>& GetButtons(const u32 keyboard) { return m_keyboards[keyboard].m_buttons; }
 	KbData& GetData(const u32 keyboard) { return m_keyboards[keyboard].m_data; }
 	KbExtraData& GetExtraData(const u32 keyboard) { return m_keyboards[keyboard].m_extra_data; }
 	KbConfig& GetConfig(const u32 keyboard) { return m_keyboards[keyboard].m_config; }

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -22,7 +22,7 @@ void basic_keyboard_handler::Init(const u32 max_connect)
 
 		kb.m_config.arrange = g_cfg.sys.keyboard_type;
 
-		m_keyboards.emplace_back();
+		m_keyboards.emplace_back(kb);
 	}
 
 	LoadSettings();

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -173,7 +173,7 @@ void basic_keyboard_handler::LoadSettings()
 		return;
 	}
 
-	std::vector<KbButton>& buttons = m_keyboards[0].m_buttons;
+	std::vector<KbButton> buttons;
 
 	// Meta Keys
 	//buttons.emplace_back(Qt::Key_Control, CELL_KB_MKEY_L_CTRL);
@@ -310,4 +310,12 @@ void basic_keyboard_handler::LoadSettings()
 	buttons.emplace_back(Qt::Key_ssharp, CELL_KEYC_SSHARP);
 	buttons.emplace_back(Qt::Key_QuoteLeft, CELL_KEYC_BACK_QUOTE);
 	buttons.emplace_back(Qt::Key_acute, CELL_KEYC_BACK_QUOTE);
+
+	// Fill our map
+	auto& keys = m_keyboards[0].m_keys;
+
+	for (const KbButton& button : buttons)
+	{
+		ensure(keys.try_emplace(button.m_keyCode, button).second);
+	}
 }

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -173,6 +173,8 @@ void basic_keyboard_handler::LoadSettings()
 		return;
 	}
 
+	Keyboard& keyboard = m_keyboards[0];
+
 	std::vector<KbButton> buttons;
 
 	// Meta Keys
@@ -289,20 +291,28 @@ void basic_keyboard_handler::LoadSettings()
 	buttons.emplace_back(Qt::Key_Minus, CELL_KEYC_MINUS);
 	buttons.emplace_back(Qt::Key_Equal, CELL_KEYC_EQUAL_101);
 	buttons.emplace_back(Qt::Key_AsciiCircum, CELL_KEYC_ACCENT_CIRCONFLEX_106);
-	buttons.emplace_back(Qt::Key_BracketLeft, CELL_KEYC_LEFT_BRACKET_101);
 	buttons.emplace_back(Qt::Key_At, CELL_KEYC_ATMARK_106);
-	buttons.emplace_back(Qt::Key_BracketRight, CELL_KEYC_RIGHT_BRACKET_101);
-	buttons.emplace_back(Qt::Key_BracketLeft, CELL_KEYC_LEFT_BRACKET_106);
-	buttons.emplace_back(Qt::Key_Backslash, CELL_KEYC_BACKSLASH_101);
-	buttons.emplace_back(Qt::Key_BracketRight, CELL_KEYC_RIGHT_BRACKET_106);
 	buttons.emplace_back(Qt::Key_Semicolon, CELL_KEYC_SEMICOLON);
 	buttons.emplace_back(Qt::Key_Apostrophe, CELL_KEYC_QUOTATION_101);
 	buttons.emplace_back(Qt::Key_Colon, CELL_KEYC_COLON_106);
 	buttons.emplace_back(Qt::Key_Comma, CELL_KEYC_COMMA);
 	buttons.emplace_back(Qt::Key_Period, CELL_KEYC_PERIOD);
 	buttons.emplace_back(Qt::Key_Slash, CELL_KEYC_SLASH);
-	buttons.emplace_back(Qt::Key_Backslash, CELL_KEYC_BACKSLASH_106);
 	buttons.emplace_back(Qt::Key_yen, CELL_KEYC_YEN_106);
+
+	// Some buttons share the same key code on different layouts
+	if (keyboard.m_config.arrange == CELL_KB_MAPPING_106)
+	{
+		buttons.emplace_back(Qt::Key_Backslash, CELL_KEYC_BACKSLASH_106);
+		buttons.emplace_back(Qt::Key_BracketLeft, CELL_KEYC_LEFT_BRACKET_106);
+		buttons.emplace_back(Qt::Key_BracketRight, CELL_KEYC_RIGHT_BRACKET_106);
+	}
+	else
+	{
+		buttons.emplace_back(Qt::Key_Backslash, CELL_KEYC_BACKSLASH_101);
+		buttons.emplace_back(Qt::Key_BracketLeft, CELL_KEYC_LEFT_BRACKET_101);
+		buttons.emplace_back(Qt::Key_BracketRight, CELL_KEYC_RIGHT_BRACKET_101);
+	}
 
 	// Made up helper buttons
 	buttons.emplace_back(Qt::Key_Less, CELL_KEYC_LESS);
@@ -312,10 +322,11 @@ void basic_keyboard_handler::LoadSettings()
 	buttons.emplace_back(Qt::Key_acute, CELL_KEYC_BACK_QUOTE);
 
 	// Fill our map
-	auto& keys = m_keyboards[0].m_keys;
-
 	for (const KbButton& button : buttons)
 	{
-		ensure(keys.try_emplace(button.m_keyCode, button).second);
+		if (!keyboard.m_keys.try_emplace(button.m_keyCode, button).second)
+		{
+			input_log.error("basic_keyboard_handler failed to set key code %d", button.m_keyCode);
+		}
 	}
 }


### PR DESCRIPTION
- Use unordered_map to store the keys. This may improve latency ever so slightly.
- Separates US and Japanese backslash and bracket mapping
- This together fixes those keys in the osk dialog and maybe also in cellKb in general since the US key was replaced by the japanese key due to the loop missign a break (now only one can be selected due to the map)
- Set the arrange value (keyboard type) properly.
This was apparently forgotten to add during some other refactoring and may fix some cellKb issues with non-US keyboards.