### PR TITLE
Qt: try to fix sound effects

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -606,11 +606,19 @@ void gui_application::InitializeCallbacks()
 		{
 			if (fs::is_file(path))
 			{
-				m_sound_effect.stop();
-				m_sound_effect.setSource(QUrl::fromLocalFile(qstr(path)));
-				m_sound_effect.setVolume(g_cfg.audio.volume * 0.01f);
-				m_sound_effect.setLoopCount(1);
-				m_sound_effect.play();
+				// Allow to play 3 sound effects at the same time
+				while (m_sound_effects.size() >= 3)
+				{
+					m_sound_effects.pop_front();
+				}
+
+				// Create a new sound effect. Re-using the same object seems to be broken for some users starting with Qt 6.6.3.
+				std::unique_ptr<QSoundEffect> sound_effect = std::make_unique<QSoundEffect>();
+				sound_effect->setSource(QUrl::fromLocalFile(qstr(path)));
+				sound_effect->setVolume(g_cfg.audio.volume * 0.01f);
+				sound_effect->play();
+
+				m_sound_effects.push_back(std::move(sound_effect));
 			}
 		});
 	};

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <functional>
+#include <deque>
 
 class gs_frame;
 class main_window;
@@ -96,7 +97,7 @@ private:
 	QTimer m_timer;
 	QElapsedTimer m_timer_playtime;
 
-	QSoundEffect m_sound_effect{};
+	std::deque<std::unique_ptr<QSoundEffect>> m_sound_effects{};
 
 	std::shared_ptr<emu_settings> m_emu_settings;
 	std::shared_ptr<gui_settings> m_gui_settings;


### PR DESCRIPTION
Don't re-use sound effect objects.
Allow 3 sounds simultaneously.

Maybe fixes #15478