### PR TITLE
Silence some warnings

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutilAvc2.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutilAvc2.cpp
@@ -523,10 +523,11 @@ error_code cellSysutilAvc2MicRead(vm::ptr<void> ptr, vm::ptr<u32> pSize)
 	// TODO: ringbuffer (holds 100ms of 16kHz single channel f32 samples)
 	std::vector<u8> buf{};
 
-	const u32 size_read = std::min<u32>(*pSize, ::size32(buf));
+	u32 size_read = 0;
 
-	if (size_read > 0)
+	if (u32 size_to_read = *pSize; size_to_read > 0 && !buf.empty())
 	{
+		size_read = std::min(size_to_read, ::size32(buf));
 		std::memcpy(ptr.get_ptr(), buf.data(), size_read);
 	}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -35,6 +35,7 @@
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wmissing-noreturn"
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 #include <llvm/IR/Verifier.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -35,6 +35,7 @@ const extern spu_decoder<spu_iflag> g_spu_iflag;
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wmissing-noreturn"
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 #include <llvm/ADT/PostOrderIterator.h>
 #include <llvm/Analysis/PostDominators.h>


### PR DESCRIPTION
- Silence some nonsensical nullptr deref warning in cellSysutilAvc2MicRead
- Silence llvm warning: dereferencing type-punned pointer might break strict-aliasing rules [-Wstrict-aliasing]