### PR TITLE
Don't create perf map files in linux unless enabled

### DIFF
--- a/Utilities/JITASM.cpp
+++ b/Utilities/JITASM.cpp
@@ -19,6 +19,7 @@ LOG_CHANNEL(jit_log, "JIT");
 void jit_announce(uptr func, usz size, std::string_view name)
 {
 #ifdef __linux__
+#if 0
 	static const struct tmp_perf_map
 	{
 		std::string name{fmt::format("/tmp/perf-%d.map", getpid())};
@@ -44,6 +45,7 @@ void jit_announce(uptr func, usz size, std::string_view name)
 		fs::remove_file(s_map.name);
 		return;
 	}
+#endif
 #endif
 
 	if (!size)

--- a/rpcs3/Input/gui_pad_thread.cpp
+++ b/rpcs3/Input/gui_pad_thread.cpp
@@ -22,6 +22,7 @@
 #ifdef __linux__
 #include <linux/uinput.h>
 #include <fcntl.h>
+#include <unistd.h>
 #define CHECK_IOCTRL_RET(res) if (res == -1) { gui_log.error("gui_pad_thread: ioctl failed (errno=%d=%s)", res, strerror(errno)); }
 #elif defined(__APPLE__)
 #pragma GCC diagnostic push


### PR DESCRIPTION
Don't create perf map files unless specified.
This seems like a development feature anyway.

Also fixes some missing include for some linux code.

Fixes #15462
Fixes #15448
Fixes #15341