### PR TITLE
Don't crash the game if only a LDD controller is present

### DIFF
--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1595,7 +1595,7 @@ void pad_settings_dialog::ChangeConfig(const QString& config_file)
 	}
 	else
 	{
-		cfg_log.fatal("Handler '%s' not found in handler dropdown.", handler);
+		cfg_log.error("Handler '%s' not found in handler dropdown.", handler);
 	}
 
 	// Force Refresh


### PR DESCRIPTION
Don't crash the game if only a LDD controller is present
Steps to reproduce:
- Disconnect all the controllers
- Start a game which connect a LDD controller
- Open the Pads window

![Untitled](https://github.com/RPCS3/rpcs3/assets/2995486/4221f76d-430e-4cf0-8f87-1ac88c32d31e)
