### PR TITLE
overlays/osk: allow repeating keys and caps lock

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -161,11 +161,6 @@ namespace rsx
 					std::lock_guard<std::mutex> lock(handler.m_mutex);
 					std::vector<Keyboard>& keyboards = handler.GetKeyboards();
 
-					if (!keyboards.empty())
-					{
-						keyboards[0].m_key_repeat = false;
-					}
-
 					if (!keyboards.empty() && handler.GetInfo().status[0] == CELL_KB_STATUS_CONNECTED)
 					{
 						keyboards[0].m_key_repeat = true;

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -151,6 +151,8 @@ namespace rsx
 					continue;
 				}
 
+				bool ignore_gamepad_input = false;
+
 				// Get keyboard input if supported by the overlay and activated by the game.
 				// Ignored if a keyboard pad handler is active in order to prevent double input.
 				if (m_keyboard_input_enabled && !m_keyboard_pad_handler_active && input::g_keyboards_intercepted)
@@ -211,12 +213,10 @@ namespace rsx
 
 				if (!rinfo.now_connect || !input::g_pads_intercepted)
 				{
-					m_keyboard_pad_handler_active = false;
-					refresh();
-					continue;
+					ignore_gamepad_input = true;
 				}
 
-				bool keyboard_pad_handler_active = false;
+				m_keyboard_pad_handler_active = false;
 
 				int pad_index = -1;
 				for (const auto& pad : handler->GetPads())
@@ -249,6 +249,11 @@ namespace rsx
 					if (pad->m_pad_handler == pad_handler::keyboard)
 					{
 						m_keyboard_pad_handler_active = true;
+					}
+
+					if (ignore_gamepad_input)
+					{
+						continue;
 					}
 
 					for (const Button& button : pad->m_buttons)
@@ -368,8 +373,6 @@ namespace rsx
 							break;
 					}
 				}
-
-				m_keyboard_pad_handler_active = keyboard_pad_handler_active;
 
 				refresh();
 			}

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -157,9 +157,17 @@ namespace rsx
 				{
 					auto& handler = g_fxo->get<KeyboardHandlerBase>();
 					std::lock_guard<std::mutex> lock(handler.m_mutex);
+					std::vector<Keyboard>& keyboards = handler.GetKeyboards();
 
-					if (!handler.GetKeyboards().empty() && handler.GetInfo().status[0] == CELL_KB_STATUS_CONNECTED)
+					if (!keyboards.empty())
 					{
+						keyboards[0].m_key_repeat = false;
+					}
+
+					if (!keyboards.empty() && handler.GetInfo().status[0] == CELL_KB_STATUS_CONNECTED)
+					{
+						keyboards[0].m_key_repeat = true;
+
 						KbData& current_data = handler.GetData(0);
 						KbExtraData& extra_data = handler.GetExtraData(0);
 
@@ -191,7 +199,6 @@ namespace rsx
 						handler.Init(1);
 
 						// Enable key repeat
-						std::vector<Keyboard>& keyboards = handler.GetKeyboards();
 						ensure(!keyboards.empty());
 						::at32(keyboards, 0).m_key_repeat = true;
 					}

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -194,7 +194,7 @@ void basic_keyboard_handler::LoadSettings()
 	//buttons.emplace_back(, CELL_KEYC_E_UNDEF);
 	buttons.emplace_back(Qt::Key_Escape, CELL_KEYC_ESCAPE);
 	buttons.emplace_back(Qt::Key_Kanji, CELL_KEYC_106_KANJI);
-	//buttons.emplace_back(Qt::Key_CapsLock, CELL_KEYC_CAPS_LOCK);
+	buttons.emplace_back(Qt::Key_CapsLock, CELL_KEYC_CAPS_LOCK);
 	buttons.emplace_back(Qt::Key_F1, CELL_KEYC_F1);
 	buttons.emplace_back(Qt::Key_F2, CELL_KEYC_F2);
 	buttons.emplace_back(Qt::Key_F3, CELL_KEYC_F3);


### PR DESCRIPTION
- allow repeating keys (i.e, holding backspace to delete input)
- previously the keyboard handler was only ignored when the larger osk was visible. now it's ignored even with the smaller popup osk
- enable the caps lock key