### PR TITLE
input: use keyboard consumers to seperate cell and overlay logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ yaml-cpp.pc
 # miniupnp
 /3rdparty/miniupnp/x64/*
 
+# opencv
+/3rdparty/opencv/*
+
 # llvm
 /3rdparty/llvm/llvm_build
 

--- a/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
+++ b/rpcs3/Emu/Io/Null/NullKeyboardHandler.h
@@ -7,15 +7,18 @@ class NullKeyboardHandler final : public KeyboardHandlerBase
 	using KeyboardHandlerBase::KeyboardHandlerBase;
 
 public:
-	void Init(const u32 max_connect) override
+	void Init(keyboard_consumer& consumer, const u32 max_connect) override
 	{
-		m_info = {};
-		m_info.max_connect = max_connect;
-		m_info.is_null_handler = true;
-		m_keyboards.clear();
+		KbInfo& info = consumer.GetInfo();
+		std::vector<Keyboard>& keyboards = consumer.GetKeyboards();
+
+		info = {};
+		info.max_connect = max_connect;
+		info.is_null_handler = true;
+		keyboards.clear();
 		for (u32 i = 0; i < max_connect; i++)
 		{
-			m_keyboards.emplace_back(Keyboard());
+			keyboards.emplace_back(Keyboard());
 		}
 	}
 };

--- a/rpcs3/Input/basic_keyboard_handler.h
+++ b/rpcs3/Input/basic_keyboard_handler.h
@@ -11,14 +11,16 @@ class basic_keyboard_handler final : public KeyboardHandlerBase, public QObject
 	using KeyboardHandlerBase::KeyboardHandlerBase;
 
 public:
-	void Init(const u32 max_connect) override;
+	void Init(keyboard_consumer& consumer, const u32 max_connect) override;
 
 	void SetTargetWindow(QWindow* target);
 	bool eventFilter(QObject* watched, QEvent* event) override;
 	void keyPressEvent(QKeyEvent* event);
 	void keyReleaseEvent(QKeyEvent* event);
 	static s32 getUnmodifiedKey(QKeyEvent* event);
-	void LoadSettings();
+
 private:
+	void LoadSettings(Keyboard& keyboard);
+
 	QWindow* m_target = nullptr;
 };


### PR DESCRIPTION
Currently it is possible to initialize a basic keyboard handler in the overlay input loop, ignoring cellKb.
This can potentially cause bugs or unexpected behaviour if a game uses cellKb (like having key repeat active by mistake).

- Adds consumer subscription model to the basic keyboard handler.
- cellKb and the overlay input loop now each have their own subscription.
- This allows the overlay input loop to use key repeat by default without influencing cellKb behaviour.
- Properly ignore basic keyboard input in the osk if the pad handler is set to keyboard and pad input is disabled
- Added the caps lock and the meta key (windows key) to the basic keyboard handler
- Added opencv to gitignore for undisclosed reasons

Supersedes #15501 
Thanks for finding these issues @cipherxof 