### PR TITLE
PPU LLVM: Do not crash on linkage of garbage code

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -2646,7 +2646,7 @@ void PPUTranslator::SUBFC(ppu_opcode_t op)
 	SetGpr(op.rd, result);
 	SetCarry(m_ir->CreateICmpULE(result, b));
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__subfc_get_ov", a, b));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::ADDC(ppu_opcode_t op)
@@ -2657,7 +2657,7 @@ void PPUTranslator::ADDC(ppu_opcode_t op)
 	SetGpr(op.rd, result);
 	SetCarry(m_ir->CreateICmpULT(result, b));
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__addc_get_ov", a, b));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::MULHDU(ppu_opcode_t op)
@@ -2812,7 +2812,7 @@ void PPUTranslator::SUBF(ppu_opcode_t op)
 	const auto result = m_ir->CreateSub(b, a);
 	SetGpr(op.rd, result);
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__subf_get_ov", a, b));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::LDUX(ppu_opcode_t op)
@@ -2914,7 +2914,7 @@ void PPUTranslator::NEG(ppu_opcode_t op)
 	const auto result = m_ir->CreateNeg(reg);
 	SetGpr(op.rd, result);
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__neg_get_ov", reg));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::LBZUX(ppu_opcode_t op)
@@ -2947,7 +2947,7 @@ void PPUTranslator::SUBFE(ppu_opcode_t op)
 	SetGpr(op.rd, r2);
 	SetCarry(m_ir->CreateOr(m_ir->CreateICmpULT(r1, a), m_ir->CreateICmpULT(r2, r1)));
 	if (op.rc) SetCrFieldSignedCmp(0, r2, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__subfe_get_ov", a, b, c));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::ADDE(ppu_opcode_t op)
@@ -2960,7 +2960,7 @@ void PPUTranslator::ADDE(ppu_opcode_t op)
 	SetGpr(op.rd, r2);
 	SetCarry(m_ir->CreateOr(m_ir->CreateICmpULT(r1, a), m_ir->CreateICmpULT(r2, r1)));
 	if (op.rc) SetCrFieldSignedCmp(0, r2, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__adde_get_ov", a, b, c));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::MTOCRF(ppu_opcode_t op)
@@ -3079,7 +3079,7 @@ void PPUTranslator::ADDZE(ppu_opcode_t op)
 	SetGpr(op.rd, result);
 	SetCarry(m_ir->CreateICmpULT(result, a));
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__addze_get_ov", a, c));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::SUBFZE(ppu_opcode_t op)
@@ -3090,7 +3090,7 @@ void PPUTranslator::SUBFZE(ppu_opcode_t op)
 	SetGpr(op.rd, result);
 	SetCarry(m_ir->CreateICmpULT(result, a));
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__subfze_get_ov", a, c));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::STDCX(ppu_opcode_t op)
@@ -3119,7 +3119,7 @@ void PPUTranslator::SUBFME(ppu_opcode_t op)
 	SetGpr(op.rd, result);
 	SetCarry(m_ir->CreateOr(c, IsNotZero(a)));
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__subfme_get_ov", a, c));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::MULLD(ppu_opcode_t op)
@@ -3129,7 +3129,7 @@ void PPUTranslator::MULLD(ppu_opcode_t op)
 	const auto result = m_ir->CreateMul(a, b);
 	SetGpr(op.rd, result);
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__mulld_get_ov", a, b));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::ADDME(ppu_opcode_t op)
@@ -3140,7 +3140,7 @@ void PPUTranslator::ADDME(ppu_opcode_t op)
 	SetGpr(op.rd, result);
 	SetCarry(m_ir->CreateOr(c, IsNotZero(a)));
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__addme_get_ov", a, c));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::MULLW(ppu_opcode_t op)
@@ -3150,7 +3150,7 @@ void PPUTranslator::MULLW(ppu_opcode_t op)
 	const auto result = m_ir->CreateMul(a, b);
 	SetGpr(op.rd, result);
 	if (op.rc) SetCrFieldSignedCmp(0, result, m_ir->getInt64(0));
-	if (op.oe) SetOverflow(Call(GetType<bool>(), m_pure_attr, "__mullw_get_ov", a, b));
+	if (op.oe) UNK(op);
 }
 
 void PPUTranslator::DCBTST(ppu_opcode_t)


### PR DESCRIPTION
Seems to be a regression from #15477, causing detection of some garbage code.
Convert compile-time crash to runtime crash instead for unimplemented PPU features. (likely won't reach this code at runtime)
PPU cache needs to be cleaned for it to take affect.
Proper fixes would be added in the future.