### PR TITLE
VSH cache

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3756,11 +3756,13 @@ extern void ppu_finalize(const ppu_module& info, bool force_mem_release)
 	// Get cache path for this executable
 	std::string cache_path = fs::get_cache_dir() + "cache/";
 
-	if (Emu.IsVsh())
+	const bool in_dev_flash = info.path.starts_with(dev_flash);
+
+	if (in_dev_flash && !info.path.starts_with(dev_flash + "sys/external/"))
 	{
 		cache_path += "vsh/";
 	}
-	else if (!info.path.starts_with(dev_flash) && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
+	else if (!in_dev_flash && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
 	{
 		cache_path += Emu.GetTitleID();
 		cache_path += '/';
@@ -4264,7 +4266,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 					obj.clear(), src.close(); // Clear decrypted file and elf object memory
 
 					_main.name = ' '; // Make ppu_finalize work
-					Emu.ConfigurePPUCache(!Emu.IsPathInsideDir(_main.path, g_cfg_vfs.get_dev_flash()));
+					Emu.ConfigurePPUCache();
 					ppu_initialize(_main, false, file_size);
 					spu_cache::initialize(false);
 					ppu_finalize(_main, true);
@@ -4528,12 +4530,14 @@ bool ppu_initialize(const ppu_module& info, bool check_only, u64 file_size)
 
 		const std::string dev_flash = vfs::get("/dev_flash/");
 
-		if (Emu.IsVsh())
+		const bool in_dev_flash = info.path.starts_with(dev_flash);
+
+		if (in_dev_flash && !info.path.starts_with(dev_flash + "sys/external/"))
 		{
 			// Add prefix for vsh
 			cache_path += "vsh/";
 		}
-		else if (!info.path.starts_with(dev_flash) && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
+		else if (!in_dev_flash && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
 		{
 			// Add prefix for anything except dev_flash files, standalone elfs or PS1 classics
 			cache_path += Emu.GetTitleID();

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3756,7 +3756,11 @@ extern void ppu_finalize(const ppu_module& info, bool force_mem_release)
 	// Get cache path for this executable
 	std::string cache_path = fs::get_cache_dir() + "cache/";
 
-	if (!info.path.starts_with(dev_flash) && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
+	if (Emu.IsVsh())
+	{
+		cache_path += "vsh/";
+	}
+	else if (!info.path.starts_with(dev_flash) && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
 	{
 		cache_path += Emu.GetTitleID();
 		cache_path += '/';
@@ -4524,7 +4528,12 @@ bool ppu_initialize(const ppu_module& info, bool check_only, u64 file_size)
 
 		const std::string dev_flash = vfs::get("/dev_flash/");
 
-		if (!info.path.starts_with(dev_flash) && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
+		if (Emu.IsVsh())
+		{
+			// Add prefix for vsh
+			cache_path += "vsh/";
+		}
+		else if (!info.path.starts_with(dev_flash) && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
 		{
 			// Add prefix for anything except dev_flash files, standalone elfs or PS1 classics
 			cache_path += Emu.GetTitleID();

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3754,19 +3754,7 @@ extern void ppu_finalize(const ppu_module& info, bool force_mem_release)
 	}
 
 	// Get cache path for this executable
-	std::string cache_path = fs::get_cache_dir() + "cache/";
-
-	const bool in_dev_flash = info.path.starts_with(dev_flash);
-
-	if (in_dev_flash && !info.path.starts_with(dev_flash + "sys/external/"))
-	{
-		cache_path += "vsh/";
-	}
-	else if (!in_dev_flash && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
-	{
-		cache_path += Emu.GetTitleID();
-		cache_path += '/';
-	}
+	std::string cache_path = rpcs3::utils::get_cache_dir(info.path);
 
 	// Add PPU hash and filename
 	fmt::append(cache_path, "ppu-%s-%s/", fmt::base57(info.sha1), info.path.substr(info.path.find_last_of('/') + 1));
@@ -4526,23 +4514,7 @@ bool ppu_initialize(const ppu_module& info, bool check_only, u64 file_size)
 	else
 	{
 		// New PPU cache location
-		cache_path = fs::get_cache_dir() + "cache/";
-
-		const std::string dev_flash = vfs::get("/dev_flash/");
-
-		const bool in_dev_flash = info.path.starts_with(dev_flash);
-
-		if (in_dev_flash && !info.path.starts_with(dev_flash + "sys/external/"))
-		{
-			// Add prefix for vsh
-			cache_path += "vsh/";
-		}
-		else if (!in_dev_flash && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
-		{
-			// Add prefix for anything except dev_flash files, standalone elfs or PS1 classics
-			cache_path += Emu.GetTitleID();
-			cache_path += '/';
-		}
+		cache_path = rpcs3::utils::get_cache_dir(info.path);
 
 		// Add PPU hash and filename
 		fmt::append(cache_path, "ppu-%s-%s/", fmt::base57(info.sha1), info.path.substr(info.path.find_last_of('/') + 1));

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3701,10 +3701,17 @@ void Emulator::ConfigurePPUCache(bool with_title_id) const
 
 	_main.cache = rpcs3::utils::get_cache_dir();
 
-	if (with_title_id && !m_title_id.empty() && m_cat != "1P")
+	if (with_title_id)
 	{
-		_main.cache += GetTitleID();
-		_main.cache += '/';
+		if (IsVsh())
+		{
+			_main.cache += "vsh/";
+		}
+		else if (!m_title_id.empty() && m_cat != "1P")
+		{
+			_main.cache += GetTitleID();
+			_main.cache += '/';
+		}
 	}
 
 	fmt::append(_main.cache, "ppu-%s-%s/", fmt::base57(_main.sha1), _main.path.substr(_main.path.find_last_of('/') + 1));

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3699,20 +3699,7 @@ void Emulator::ConfigurePPUCache() const
 {
 	auto& _main = g_fxo->get<main_ppu_module>();
 
-	_main.cache = rpcs3::utils::get_cache_dir();
-
-	const std::string dev_flash = vfs::get("/dev_flash/");
-	const bool in_dev_flash = _main.path.starts_with(dev_flash);
-
-	if (in_dev_flash && !_main.path.starts_with(dev_flash + "sys/external/"))
-	{
-		_main.cache += "vsh/";
-	}
-	else if (!in_dev_flash && !m_title_id.empty() && m_cat != "1P")
-	{
-		_main.cache += GetTitleID();
-		_main.cache += '/';
-	}
+	_main.cache = rpcs3::utils::get_cache_dir(_main.path);
 
 	fmt::append(_main.cache, "ppu-%s-%s/", fmt::base57(_main.sha1), _main.path.substr(_main.path.find_last_of('/') + 1));
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3695,23 +3695,23 @@ s32 error_code::error_report(s32 result, const logs::message* channel, const cha
 	return result;
 }
 
-void Emulator::ConfigurePPUCache(bool with_title_id) const
+void Emulator::ConfigurePPUCache() const
 {
 	auto& _main = g_fxo->get<main_ppu_module>();
 
 	_main.cache = rpcs3::utils::get_cache_dir();
 
-	if (with_title_id)
+	const std::string dev_flash = vfs::get("/dev_flash/");
+	const bool in_dev_flash = _main.path.starts_with(dev_flash);
+
+	if (in_dev_flash && !_main.path.starts_with(dev_flash + "sys/external/"))
 	{
-		if (IsVsh())
-		{
-			_main.cache += "vsh/";
-		}
-		else if (!m_title_id.empty() && m_cat != "1P")
-		{
-			_main.cache += GetTitleID();
-			_main.cache += '/';
-		}
+		_main.cache += "vsh/";
+	}
+	else if (!in_dev_flash && !m_title_id.empty() && m_cat != "1P")
+	{
+		_main.cache += GetTitleID();
+		_main.cache += '/';
 	}
 
 	fmt::append(_main.cache, "ppu-%s-%s/", fmt::base57(_main.sha1), _main.path.substr(_main.path.find_last_of('/') + 1));

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -377,7 +377,7 @@ public:
 
 	std::string GetFormattedTitle(double fps) const;
 
-	void ConfigurePPUCache(bool with_title_id = true) const;
+	void ConfigurePPUCache() const;
 
 	std::set<std::string> GetGameDirs() const;
 	u32 AddGamesFromDir(const std::string& path);

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -3,6 +3,7 @@
 #include "system_config.h"
 #include "vfs_config.h"
 #include "Emu/Io/pad_config.h"
+#include "Emu/System.h"
 #include "util/sysinfo.hpp"
 #include "Utilities/File.h"
 #include "Utilities/StrUtil.h"
@@ -119,6 +120,28 @@ namespace rpcs3::utils
 	std::string get_cache_dir()
 	{
 		return fs::get_cache_dir() + "cache/";
+	}
+
+	std::string get_cache_dir(std::string_view module_path)
+	{
+		std::string cache_dir = get_cache_dir();
+
+		const std::string dev_flash = g_cfg_vfs.get_dev_flash();
+		const bool in_dev_flash = Emu.IsPathInsideDir(module_path, dev_flash);
+
+		if (in_dev_flash && !Emu.IsPathInsideDir(module_path, dev_flash + "sys/external/"))
+		{
+			// Add prefix for vsh
+			cache_dir += "vsh/";
+		}
+		else if (!in_dev_flash && !Emu.GetTitleID().empty() && Emu.GetCat() != "1P")
+		{
+			// Add prefix for anything except dev_flash files, standalone elfs or PS1 classics
+			cache_dir += Emu.GetTitleID();
+			cache_dir += '/';
+		}
+
+		return cache_dir;
 	}
 
 	std::string get_rap_file_path(const std::string_view& rap)

--- a/rpcs3/Emu/system_utils.hpp
+++ b/rpcs3/Emu/system_utils.hpp
@@ -17,6 +17,7 @@ namespace rpcs3::utils
 	std::string get_hdd0_dir();
 	std::string get_hdd1_dir();
 	std::string get_cache_dir();
+	std::string get_cache_dir(std::string_view module_path);
 
 	std::string get_rap_file_path(const std::string_view& rap);
 	bool verify_c00_unlock_edat(const std::string_view& content_id, bool fast = false);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -286,7 +286,7 @@ bool game_list_frame::IsEntryVisible(const game_info& game, bool search_fallback
 
 std::string game_list_frame::GetCacheDirBySerial(const std::string& serial)
 {
-	return rpcs3::utils::get_cache_dir() + serial;
+	return rpcs3::utils::get_cache_dir() + (serial == "vsh.self" ? "vsh" : serial);
 }
 
 std::string game_list_frame::GetDataDirBySerial(const std::string& serial)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2032,10 +2032,13 @@ void game_list_frame::BatchRemovePPUCaches()
 	}
 
 	std::set<std::string> serials;
+	serials.emplace("vsh");
+
 	for (const auto& game : m_game_data)
 	{
 		serials.emplace(game->info.serial);
 	}
+
 	const u32 total = ::size32(serials);
 
 	if (total == 0)
@@ -2086,10 +2089,13 @@ void game_list_frame::BatchRemoveSPUCaches()
 	}
 
 	std::set<std::string> serials;
+	serials.emplace("vsh");
+
 	for (const auto& game : m_game_data)
 	{
 		serials.emplace(game->info.serial);
 	}
+
 	const u32 total = ::size32(serials);
 
 	if (total == 0)
@@ -2248,10 +2254,13 @@ void game_list_frame::BatchRemoveShaderCaches()
 	}
 
 	std::set<std::string> serials;
+	serials.emplace("vsh");
+
 	for (const auto& game : m_game_data)
 	{
 		serials.emplace(game->info.serial);
 	}
+
 	const u32 total = ::size32(serials);
 
 	if (total == 0)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1031,7 +1031,7 @@ void game_list_frame::ShowContextMenu(const QPoint &pos)
 
 	static const auto is_game_running = [](const std::string& serial)
 	{
-		return Emu.GetStatus(false) != system_state::stopped && serial == Emu.GetTitleID();
+		return Emu.GetStatus(false) != system_state::stopped && (serial == Emu.GetTitleID() || (serial == "vsh.self" && Emu.IsVsh()));
 	};
 
 	const bool is_current_running_game = is_game_running(current_game.serial);


### PR DESCRIPTION
- Move vsh cache to "/cache/vsh/". I don't know if this is the best way, but it's certainly clean.
- Add "/cache/vsh/" to batch removal operations
- Allow to remove vsh cache in context menu
- Disable vsh removal options if vsh is running (this was a bug anyway)

fixes #15531