### PR TITLE
USB: Allow UsbPspCm passthrough

### DIFF
--- a/rpcs3/Emu/Io/usb_device.cpp
+++ b/rpcs3/Emu/Io/usb_device.cpp
@@ -85,7 +85,7 @@ void usb_device_passthrough::send_libusb_transfer(libusb_transfer* transfer)
 		case LIBUSB_ERROR_BUSY: continue;
 		default:
 		{
-			sys_usbd.error("Unexpected error from libusb_submit_transfer: %d", res);
+			sys_usbd.error("Unexpected error from libusb_submit_transfer: %d(%s)", res, libusb_error_name(res));
 			return;
 		}
 		}
@@ -114,7 +114,7 @@ void usb_device_passthrough::read_descriptors()
 		int ssize = libusb_control_transfer(lusb_handle, +LIBUSB_ENDPOINT_IN | +LIBUSB_REQUEST_TYPE_STANDARD | +LIBUSB_RECIPIENT_DEVICE, LIBUSB_REQUEST_GET_DESCRIPTOR, 0x0200 | index, 0, buf, 1000, 0);
 		if (ssize < 0)
 		{
-			sys_usbd.fatal("Couldn't get the config from the device: %d", ssize);
+			sys_usbd.fatal("Couldn't get the config from the device: %d(%s)", ssize, libusb_error_name(ssize));
 			continue;
 		}
 

--- a/rpcs3/Emu/Io/usb_device.h
+++ b/rpcs3/Emu/Io/usb_device.h
@@ -88,6 +88,7 @@ struct UsbDeviceHID
 
 struct UsbTransfer
 {
+	u32 assigned_number = 0;
 	u32 transfer_id = 0;
 
 	s32 result = 0;


### PR DESCRIPTION
#### USB: Allow UsbPspCm passthrough
Steps:
- Launch the PSP game on a physical PSP  or [PSVita](https://github.com/isage/adrenaline_usb_enabler).
- Connect the USB cable between PSP/PSVita and PC.
- Find the menu which enables the PS3 connection - sometimes it is enabled automatically.
  - A new USB device should connect with VendorID=0x054c, ProductID=**[0x01cb](https://github.com/RPCS3/rpcs3/assets/2995486/c2496620-a712-4f62-ad79-b6e519327fc1)**.
- Follow the [cellUsbd Set-up Instructions](https://wiki.rpcs3.net/index.php?title=Help:Peripherals_and_accessories#cellUsbd_Set-up_Instructions)
- Always start the PS3 game only after the Device=0x01cb is attached because USB hotplug isn't supported (#15074).



![PSP-PS3](https://github.com/RPCS3/rpcs3/assets/2995486/24f9238b-cf3f-4d8d-bcfe-07a81e7a8a07)
