### PR TITLE
HLE: use original filename for media exports

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMusicExport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicExport.cpp
@@ -226,16 +226,16 @@ error_code cellMusicExportFromFile(vm::cptr<char> srcHddDir, vm::cptr<char> srcH
 		return { CELL_MUSIC_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
-	std::string filename = param->title.get_ptr();
+	std::string filename;
+
+	if (srcHddFile)
+	{
+		fmt::append(filename, "%s", srcHddFile.get_ptr());
+	}
 
 	if (filename.empty())
 	{
-		return { CELL_MUSIC_EXPORT_UTIL_ERROR_PARAM, "title empty" };
-	}
-
-	if (const std::string extension = get_file_extension(file_path); !extension.empty())
-	{
-		fmt::append(filename, ".%s", extension);
+		return { CELL_MUSIC_EXPORT_UTIL_ERROR_PARAM, "filename empty" };
 	}
 
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32

--- a/rpcs3/Emu/Cell/Modules/cellPhotoExport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoExport.cpp
@@ -197,16 +197,11 @@ error_code cellPhotoRegistFromFile(vm::cptr<char> path, vm::cptr<char> photo_tit
 		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
-	std::string filename = photo_title.get_ptr();
+	const std::string filename = file_path.substr(file_path.find_last_of('/') + 1);
 
 	if (filename.empty())
 	{
-		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "title empty" };
-	}
-
-	if (const std::string extension = get_file_extension(file_path); !extension.empty())
-	{
-		fmt::append(filename, ".%s", extension);
+		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "filename empty" };
 	}
 
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32
@@ -340,16 +335,16 @@ error_code cellPhotoExportFromFile(vm::cptr<char> srcHddDir, vm::cptr<char> srcH
 		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
-	std::string filename = param->photo_title.get_ptr();
+	std::string filename;
+
+	if (srcHddFile)
+	{
+		fmt::append(filename, "%s", srcHddFile.get_ptr());
+	}
 
 	if (filename.empty())
 	{
-		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "title empty" };
-	}
-
-	if (const std::string extension = get_file_extension(file_path); !extension.empty())
-	{
-		fmt::append(filename, ".%s", extension);
+		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "filename empty" };
 	}
 
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32
@@ -414,16 +409,16 @@ error_code cellPhotoExportFromFileWithCopy(vm::cptr<char> srcHddDir, vm::cptr<ch
 		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
-	std::string filename = param->photo_title.get_ptr();
+	std::string filename;
+
+	if (srcHddFile)
+	{
+		fmt::append(filename, "%s", srcHddFile.get_ptr());
+	}
 
 	if (filename.empty())
 	{
-		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "title empty" };
-	}
-
-	if (const std::string extension = get_file_extension(file_path); !extension.empty())
-	{
-		fmt::append(filename, ".%s", extension);
+		return { CELL_PHOTO_EXPORT_UTIL_ERROR_PARAM, "filename empty" };
 	}
 
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32

--- a/rpcs3/Emu/Cell/Modules/cellVideoExport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoExport.cpp
@@ -237,16 +237,16 @@ error_code cellVideoExportFromFileWithCopy(vm::cptr<char> srcHddDir, vm::cptr<ch
 		return { CELL_VIDEO_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
-	std::string filename = param->title.get_ptr();
+	std::string filename;
+
+	if (srcHddFile)
+	{
+		fmt::append(filename, "%s", srcHddFile.get_ptr());
+	}
 
 	if (filename.empty())
 	{
-		return { CELL_VIDEO_EXPORT_UTIL_ERROR_PARAM, "title empty" };
-	}
-
-	if (const std::string extension = get_file_extension(file_path); !extension.empty())
-	{
-		fmt::append(filename, ".%s", extension);
+		return { CELL_VIDEO_EXPORT_UTIL_ERROR_PARAM, "filename empty" };
 	}
 
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32
@@ -301,16 +301,16 @@ error_code cellVideoExportFromFile(vm::cptr<char> srcHddDir, vm::cptr<char> srcH
 		return { CELL_VIDEO_EXPORT_UTIL_ERROR_PARAM, file_path };
 	}
 
-	std::string filename = param->title.get_ptr();
+	std::string filename;
+
+	if (srcHddFile)
+	{
+		fmt::append(filename, "%s", srcHddFile.get_ptr());
+	}
 
 	if (filename.empty())
 	{
-		return { CELL_VIDEO_EXPORT_UTIL_ERROR_PARAM, "title empty" };
-	}
-
-	if (const std::string extension = get_file_extension(file_path); !extension.empty())
-	{
-		fmt::append(filename, ".%s", extension);
+		return { CELL_VIDEO_EXPORT_UTIL_ERROR_PARAM, "filename empty" };
 	}
 
 	sysutil_register_cb([=](ppu_thread& ppu) -> s32


### PR DESCRIPTION
No idea what's the real logic here.
I was just winging it with the title before.
It's most likely just meant for metadata.

probably fixes #15547