### PR TITLE
Qt/Logs: Fixing spaces, optimize string to html conversion

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -868,10 +868,10 @@ public:
 
 	~named_thread_group() noexcept
 	{
-		// Destroy all threads (it should join them)
-		for (u32 i = m_count - 1; i < m_count; i--)
+		// Destroy all threads in reverse order (it should join them)
+		for (u32 i = 0; i < m_count; i++)
 		{
-			std::launder(m_threads + i)->~Thread();
+			std::launder(m_threads + (m_count - i - 1))->~Thread();
 		}
 
 		::operator delete(static_cast<void*>(m_threads), std::align_val_t{alignof(Thread)});

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -137,6 +137,21 @@ struct cpu_prof
 			return results;
 		}
 
+		static f64 get_percent(u64 dividend, u64 divisor)
+		{
+			if (!dividend)
+			{
+				return 0;
+			}
+
+			if (dividend >= divisor)
+			{
+				return 100;
+			}
+
+			return 100. * dividend / divisor;
+		}
+
 		// Print info
 		void print(const std::shared_ptr<cpu_thread>& ptr)
 		{
@@ -144,7 +159,7 @@ struct cpu_prof
 			{
 				if (cpu_flag::exit - ptr->state)
 				{
-					profiler.notice("Thread \"%s\" [0x%08x]: %u samples (%.4f%% idle), %u new, %u reservation (%.4f%%): Not enough new samples have been collected since the last print.", ptr->get_name(), ptr->id, samples, 100. * idle / samples, new_samples, reservation_samples, 100. * reservation_samples / samples);
+					profiler.notice("Thread \"%s\" [0x%08x]: %u samples (%.4f%% idle), %u new, %u reservation (%.4f%%): Not enough new samples have been collected since the last print.", ptr->get_name(), ptr->id, samples, get_percent(idle, samples), new_samples, reservation_samples, get_percent(reservation_samples, samples - idle));
 				}
 
 				return;
@@ -160,7 +175,7 @@ struct cpu_prof
 
 			// Print results
 			const std::string results = format(chart, samples, idle);
-			profiler.notice("Thread \"%s\" [0x%08x]: %u samples (%.4f%% idle), %u new, %u reservation (%.4f%%):\n%s", ptr->get_name(), ptr->id, samples, 100. * idle / samples, new_samples, reservation_samples, 100. * reservation_samples / samples, results);
+			profiler.notice("Thread \"%s\" [0x%08x]: %u samples (%.4f%% idle), %u new, %u reservation (%.4f%%):\n%s", ptr->get_name(), ptr->id, samples, get_percent(idle, samples), new_samples, reservation_samples, get_percent(reservation_samples, samples - idle), results);
 
 			new_samples = 0;
 		}
@@ -203,7 +218,7 @@ struct cpu_prof
 
 			if (new_samples < min_print_all_samples && thread_ctrl::state() != thread_state::aborting)
 			{
-				profiler.notice("All Threads: %u samples (%.4f%% idle), %u new, %u reservation (%.4f%%): Not enough new samples have been collected since the last print.", samples, 100. * idle / samples, new_samples, reservation, 100. * reservation / samples);
+				profiler.notice("All Threads: %u samples (%.4f%% idle), %u new, %u reservation (%.4f%%): Not enough new samples have been collected since the last print.", samples, get_percent(idle, samples), new_samples, reservation, get_percent(reservation, samples - idle));
 				return;
 			}
 
@@ -213,7 +228,7 @@ struct cpu_prof
 			}
 
 			const std::string results = format(chart, samples, idle, true);
-			profiler.notice("All Threads: %u samples (%.4f%% idle), %u new, %u reservation (%.4f%%):%s", samples, 100. * idle / samples, new_samples, reservation, 100. * reservation / samples, results);
+			profiler.notice("All Threads: %u samples (%.4f%% idle), %u new, %u reservation (%.4f%%):%s", samples, get_percent(idle, samples), new_samples, reservation, get_percent(reservation, samples - idle), results);
 		}
 	};
 

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -2936,9 +2936,9 @@ struct llvm_calli
 
 	std::tuple<llvm_expr_t<A>...> a;
 
-	std::array<usz, sizeof...(A)> order_equality_hint = []()
+	std::array<usz, std::max<usz>(sizeof...(A), 1)> order_equality_hint = []()
 	{
-		std::array<usz, sizeof...(A)> r{};
+		std::array<usz, std::max<usz>(sizeof...(A), 1)> r{};
 
 		for (usz i = 0; i < r.size(); i++)
 		{
@@ -2958,7 +2958,7 @@ struct llvm_calli
 	template <usz... I>
 	llvm::Value* eval(llvm::IRBuilder<>* ir, std::index_sequence<I...>) const
 	{
-		llvm::Value* v[sizeof...(A)]{std::get<I>(a).eval(ir)...};
+		llvm::Value* v[std::max<usz>(sizeof...(A), 1)]{std::get<I>(a).eval(ir)...};
 
 		if (c && (llvm::isa<llvm::Constant>(v[I]) || ...))
 		{

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -735,7 +735,9 @@ static auto ppu_load_exports(const ppu_module& _module, ppu_linkage_info* link, 
 			continue;
 		}
 
-		if (for_observing_callbacks)
+		const bool is_dummy_load = Emu.IsReady() && g_fxo->get<main_ppu_module>().segs.empty() && !Emu.DeserialManager();
+
+		if (!is_dummy_load && for_observing_callbacks)
 		{
 			continue;
 		}
@@ -759,7 +761,7 @@ static auto ppu_load_exports(const ppu_module& _module, ppu_linkage_info* link, 
 			ppu_loader.error("Unexpected num_tlsvar (%u)!", lib.num_tlsvar);
 		}
 
-		const bool should_load = ppu_register_library_lock(module_name, true);
+		const bool should_load = is_dummy_load || ppu_register_library_lock(module_name, true);
 
 		if (loaded_flags)
 		{

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -314,7 +314,7 @@ Function* PPUTranslator::GetSymbolResolver(const ppu_module& info)
 			continue;
 		}
 
-		vec_addrs.push_back(f.addr - base);
+		vec_addrs.push_back(static_cast<u32>(f.addr - base));
 		functions.push_back(cast<Function>(m_module->getOrInsertFunction(fmt::format("__0x%x", f.addr - base), ftype).getCallee()));
 	}
 

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -4427,6 +4427,8 @@ void spu_recompiler_base::dump(const spu_program& result, std::string& out)
 	SPUDisAsm dis_asm(cpu_disasm_mode::dump, reinterpret_cast<const u8*>(result.data.data()), result.lower_bound);
 
 	std::string hash;
+
+	if (!result.data.empty())
 	{
 		sha1_context ctx;
 		u8 output[20];
@@ -4435,6 +4437,10 @@ void spu_recompiler_base::dump(const spu_program& result, std::string& out)
 		sha1_update(&ctx, reinterpret_cast<const u8*>(result.data.data()), result.data.size() * 4);
 		sha1_finish(&ctx, output);
 		fmt::append(hash, "%s", fmt::base57(output));
+	}
+	else
+	{
+		hash = "N/A";
 	}
 
 	fmt::append(out, "========== SPU BLOCK 0x%05x (size %u, %s) ==========\n\n", result.entry_point, result.data.size(), hash);

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -1576,6 +1576,19 @@ void spu_thread::cpu_on_stop()
 		dump_all(ret);
 		spu_log.notice("thread context: %s", ret);
 	}
+
+	if (is_stopped(state - cpu_flag::stop))
+	{
+		if (stx == 0 && ftx == 0 && last_succ == 0 && last_fail == 0)
+		{
+			perf_log.notice("SPU thread perf stats are not available.");
+		}
+		else
+		{
+			perf_log.notice("Perf stats for transactions: success %u, failure %u", stx, ftx);
+			perf_log.notice("Perf stats for PUTLLC reload: success %u, failure %u", last_succ, last_fail);
+		}
+	}
 }
 
 void spu_thread::cpu_init()
@@ -1963,9 +1976,6 @@ spu_thread::~spu_thread()
 	shm->unmap(ls);
 	shm->unmap(ls - SPU_LS_SIZE);
 	utils::memory_release(ls - SPU_LS_SIZE * 2, SPU_LS_SIZE * 5);
-
-	perf_log.notice("Perf stats for transactions: success %u, failure %u", stx, ftx);
-	perf_log.notice("Perf stats for PUTLLC reload: success %u, failure %u", last_succ, last_fail);
 }
 
 u8* spu_thread::map_ls(utils::shm& shm, void* ptr)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3318,6 +3318,14 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 			set_progress_message("Commiting File");
 
+			fs::file to_close_file;
+			{
+				auto reset = init_mtx->reset();
+				to_close_file = std::move(file.file);
+				reset.set_init();
+			}
+			to_close_file.close();
+
 			if (!file.commit() || !fs::get_stat(path, file_stat))
 			{
 				sys_log.error("Failed to write savestate to file! (path='%s', %s)", path, fs::g_tls_error);

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -154,7 +154,7 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 	{
 		utils::attach_console(utils::console_stream::std_err, true);
 
-		std::cerr << fmt::format("RPCS3: %s\n", text);
+		utils::output_stderr(fmt::format("RPCS3: %s\n", text));
 #ifdef __linux__
 		jit_announce(0, 0, "");
 #endif
@@ -174,7 +174,7 @@ LOG_CHANNEL(q_debug, "QDEBUG");
 	}
 	else
 	{
-		std::cerr << fmt::format("RPCS3: %s\n", text);
+		utils::output_stderr(fmt::format("RPCS3: %s\n", text));
 	}
 
 	static auto show_report = [is_html, include_help_text](std::string_view text)
@@ -277,7 +277,7 @@ struct fatal_error_listener final : logs::listener
 			utils::attach_console(utils::console_stream::std_err, false);
 
 			// Output to error stream as is
-			std::cerr << _msg;
+			utils::output_stderr(_msg);
 
 #ifdef _WIN32
 			if (IsDebuggerPresent())
@@ -401,7 +401,7 @@ QCoreApplication* create_application(int& argc, char* argv[])
 				{
 					const std::string msg = fmt::format("The command line value %s for %s is not allowed. Please use a valid value for Qt::HighDpiScaleFactorRoundingPolicy.", arg_val, arg_rounding);
 					sys_log.error("%s", msg); // Don't exit with fatal error. The resulting dialog might be unreadable with dpi problems.
-					std::cerr << msg << std::endl;
+					utils::output_stderr(msg, true);
 				}
 			}
 		}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -545,6 +545,7 @@ void main_window::BootElf()
 		"SELF files (EBOOT.BIN *.self);;"
 		"BOOT files (*BOOT.BIN);;"
 		"BIN files (*.bin);;"
+		"All executable files (*.SAVESTAT.gz *.SAVESTAT *.sprx *.SPRX *.self *.SELF *.bin *.BIN *.prx *.PRX *.elf *.ELF *.o *.O);;"
 		"All files (*.*)"),
 		Q_NULLPTR, QFileDialog::DontResolveSymlinks);
 

--- a/rpcs3/util/console.cpp
+++ b/rpcs3/util/console.cpp
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #endif
 
+#include <iostream>
+
 namespace utils
 {
 	void attach_console([[maybe_unused]] int stream, [[maybe_unused]] bool open_console)
@@ -34,6 +36,26 @@ namespace utils
 		{
 			[[maybe_unused]] const auto con_in = freopen("CONIN$", "r", stdin);
 		}
+#endif
+	}
+
+	void output_stderr(std::string_view str, bool with_endline)
+	{
+		if (with_endline)
+		{
+#ifdef _WIN32
+			std::clog << str;
+#else
+			std::cerr << str;
+#endif
+			str = "\n";
+		}
+
+#ifdef _WIN32
+		// Flush seems broken on Windows (deadlocks)
+		std::clog << str;
+#else
+		std::cerr << str;
 #endif
 	}
 }

--- a/rpcs3/util/console.h
+++ b/rpcs3/util/console.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 namespace utils
 {
 	enum console_stream
@@ -10,4 +12,6 @@ namespace utils
 	};
 
 	void attach_console(int stream, bool open_console);
+
+	void output_stderr(std::string_view str, bool with_endline = false);
 }


### PR DESCRIPTION
Every time that more than one space was repeated in a log message, the Qt log frame would display it as one. Replace it with non-breaking space.
Also: Remove two redundant copies of the `QString` on HTML escaping when not needed. The first was being done by `QString::toHtmlEscaped()`, and the second was done as an unfortunate result of `QString::replace()` return lvalue reference, which creates a copy upon rvalue conversion. (this matters mostly for huge log messages)

Misc commits:
* Fixup SPU profiler floating point inaccuracies on bounds.
* Fix potential nullptr deference in savestates on saving. (race condition)
* Debugging improvements, add SPRX booting option and always log its function exports.