### PR TITLE
Implement raw mouse hot swap

### DIFF
--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -219,7 +219,7 @@ raw_mouse_handler::raw_mouse_handler(bool ignore_config)
 
 raw_mouse_handler::~raw_mouse_handler()
 {
-	if (m_raw_mice.empty())
+	if (!m_registered_raw_input_devices)
 	{
 		return;
 	}

--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -265,14 +265,14 @@ void raw_mouse_handler::Init(const u32 max_connect)
 		connected_mice.insert(mouse.index());
 	}
 
-	for (u32 i = 0; i < now_connect; i++)
+	for (u32 i = 0; i < max_connect; i++)
 	{
 		m_mice.emplace_back(Mouse());
 	}
 
 	m_info = {};
 	m_info.max_connect = max_connect;
-	m_info.now_connect = std::min(::size32(m_mice), max_connect);
+	m_info.now_connect = std::min(now_connect, max_connect);
 	m_info.info = input::g_mice_intercepted ? CELL_MOUSE_INFO_INTERCEPTED : 0; // Ownership of mouse data: 0=Application, 1=System
 
 	for (u32 i = 0; i < m_info.now_connect; i++)

--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -5,6 +5,7 @@
 #include "Emu/RSX/RSXThread.h"
 #include "Emu/Io/interception.h"
 #include "Input/raw_mouse_config.h"
+#include "Utilities/Timer.h"
 
 #ifdef _WIN32
 #include <hidusage.h>
@@ -337,6 +338,8 @@ void raw_mouse_handler::enumerate_devices(u32 max_connect)
 		return;
 	}
 
+	Timer timer{};
+
 #ifdef _WIN32
 	u32 num_devices{};
 	u32 res = GetRawInputDeviceList(nullptr, &num_devices, sizeof(RAWINPUTDEVICELIST));
@@ -416,7 +419,7 @@ void raw_mouse_handler::enumerate_devices(u32 max_connect)
 	}
 #endif
 
-	input_log.notice("raw_mouse_handler: found %d devices", m_raw_mice.size());
+	input_log.notice("raw_mouse_handler: found %d devices in %f ms", m_raw_mice.size(), timer.GetElapsedTimeInMilliSec());
 }
 
 #ifdef _WIN32

--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -3,7 +3,7 @@
 #include "Emu/Io/MouseHandler.h"
 #include "Emu/RSX/display.h"
 #include "Utilities/Config.h"
-#include "Utilities/Mutex.h"
+#include "Utilities/mutex.h"
 #include "Utilities/Thread.h"
 
 #ifdef _WIN32
@@ -42,6 +42,7 @@ public:
 
 	const std::string& device_name() const { return m_device_name; }
 	u32 index() const { return m_index; }
+	void set_index(u32 index) { m_index = index; }
 
 private:
 	static std::pair<int, int> get_mouse_button(const cfg::string& button);
@@ -94,7 +95,7 @@ public:
 
 private:
 	u32 get_now_connect(std::set<u32>& connected_mice);
-	void enumerate_devices(u32 max_connect);
+	std::map<void*, raw_mouse> enumerate_devices(u32 max_connect);
 
 #ifdef _WIN32
 	void register_raw_input_devices();

--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -89,6 +89,11 @@ public:
 private:
 	void enumerate_devices(u32 max_connect);
 
+#ifdef _WIN32
+	void register_raw_input_devices();
+	bool m_registered_raw_input_devices = false;
+#endif
+
 	bool m_ignore_config = false;
 	std::map<void*, raw_mouse> m_raw_mice;
 	std::function<void(const std::string&, s32, bool)> m_mouse_press_callback;

--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -95,6 +95,7 @@ private:
 #endif
 
 	bool m_ignore_config = false;
+	std::mutex m_raw_mutex;
 	std::map<void*, raw_mouse> m_raw_mice;
 	std::function<void(const std::string&, s32, bool)> m_mouse_press_callback;
 };

--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -99,6 +99,7 @@ private:
 
 #ifdef _WIN32
 	void register_raw_input_devices();
+	void unregister_raw_input_devices();
 	bool m_registered_raw_input_devices = false;
 #endif
 

--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -64,7 +64,7 @@ private:
 class raw_mouse_handler final : public MouseHandlerBase
 {
 public:
-	raw_mouse_handler(bool ignore_config = false);
+	raw_mouse_handler(bool is_for_gui = false);
 	virtual ~raw_mouse_handler();
 
 	void Init(const u32 max_connect) override;
@@ -84,9 +84,13 @@ public:
 		}
 	}
 
+	void update_devices();
+
 #ifdef _WIN32
 	void handle_native_event(const MSG& msg);
 #endif
+
+	shared_mutex m_raw_mutex;
 
 private:
 	u32 get_now_connect(std::set<u32>& connected_mice);
@@ -97,8 +101,7 @@ private:
 	bool m_registered_raw_input_devices = false;
 #endif
 
-	bool m_ignore_config = false;
-	shared_mutex m_raw_mutex;
+	bool m_is_for_gui = false;
 	std::map<void*, raw_mouse> m_raw_mice;
 	std::function<void(const std::string&, s32, bool)> m_mouse_press_callback;
 

--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -3,6 +3,8 @@
 #include "Emu/Io/MouseHandler.h"
 #include "Emu/RSX/display.h"
 #include "Utilities/Config.h"
+#include "Utilities/Mutex.h"
+#include "Utilities/Thread.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -87,6 +89,7 @@ public:
 #endif
 
 private:
+	u32 get_now_connect(std::set<u32>& connected_mice);
 	void enumerate_devices(u32 max_connect);
 
 #ifdef _WIN32
@@ -95,7 +98,9 @@ private:
 #endif
 
 	bool m_ignore_config = false;
-	std::mutex m_raw_mutex;
+	shared_mutex m_raw_mutex;
 	std::map<void*, raw_mouse> m_raw_mice;
 	std::function<void(const std::string&, s32, bool)> m_mouse_press_callback;
+
+	std::unique_ptr<named_thread<std::function<void()>>> m_thread;
 };

--- a/rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp
@@ -220,7 +220,7 @@ bool basic_mouse_settings_dialog::eventFilter(QObject* object, QEvent* event)
 		if (m_button_id < 0)
 		{
 			QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
-			if (const auto button = qobject_cast<QPushButton*>(object); button && mouse_event->button() == Qt::RightButton)
+			if (const auto button = qobject_cast<QPushButton*>(object); button && button->isEnabled() && mouse_event->button() == Qt::RightButton)
 			{
 				if (const int button_id = m_buttons->id(button))
 				{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1026,7 +1026,7 @@ bool pad_settings_dialog::eventFilter(QObject* object, QEvent* event)
 		if (m_button_id == button_ids::id_pad_begin)
 		{
 			QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
-			if (const auto button = qobject_cast<QPushButton*>(object); button && mouse_event->button() == Qt::RightButton)
+			if (const auto button = qobject_cast<QPushButton*>(object); button && button->isEnabled() && mouse_event->button() == Qt::RightButton)
 			{
 				if (const int button_id = m_pad_buttons->id(button); m_cfg_entries.contains(button_id))
 				{

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
@@ -62,8 +62,10 @@ raw_mouse_settings_dialog::raw_mouse_settings_dialog(QWidget* parent)
 		cfg_log.notice("Could not load raw mouse config. Using defaults.");
 	}
 
+	constexpr u32 max_devices = 16;
+
 	g_raw_mouse_handler = std::make_unique<raw_mouse_handler>(true);
-	g_raw_mouse_handler->Init(::size32(g_cfg_raw_mouse.players));
+	g_raw_mouse_handler->Init(std::max(max_devices, ::size32(g_cfg_raw_mouse.players)));
 	g_raw_mouse_handler->set_mouse_press_callback([this](const std::string& device_name, s32 cell_code, bool pressed)
 	{
 		mouse_press(device_name, cell_code, pressed);

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
@@ -174,7 +174,7 @@ void raw_mouse_settings_dialog::update_combo_box(usz player)
 	combo->setCurrentIndex(std::max(0, combo->findData(current_device)));
 	combo->blockSignals(false);
 
-	if (player == m_tab_widget->currentIndex())
+	if (static_cast<int>(player) == m_tab_widget->currentIndex())
 	{
 		handle_device_change(device_name);
 	}

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
@@ -362,7 +362,7 @@ bool raw_mouse_settings_dialog::eventFilter(QObject* object, QEvent* event)
 		if (m_button_id < 0 && !m_disable_mouse_release_event)
 		{
 			QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
-			if (const auto button = qobject_cast<QPushButton*>(object); button && mouse_event->button() == Qt::RightButton)
+			if (const auto button = qobject_cast<QPushButton*>(object); button && button->isEnabled() && mouse_event->button() == Qt::RightButton)
 			{
 				if (const int button_id = m_buttons->id(button); button_id >= 0)
 				{

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.h
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.h
@@ -25,10 +25,10 @@ public:
 	virtual ~raw_mouse_settings_dialog();
 
 private:
+	void update_combo_box(usz player);
 	void add_tabs(QTabWidget* tabs);
-
+	void on_enumeration();
 	void reset_config();
-
 	void on_button_click(int id);
 	void mouse_press(const std::string& device_name, s32 cell_code, bool pressed);
 	void handle_device_change(const std::string& device_name);
@@ -55,6 +55,9 @@ private:
 	QTimer m_remap_timer;
 	QTimer m_mouse_release_timer;
 	bool m_disable_mouse_release_event = false;
+
+	// Update Timer
+	QTimer m_update_timer;
 
 protected:
 	bool eventFilter(QObject* object, QEvent* event) override;


### PR DESCRIPTION
- Adds device enumeration thread to the raw mouse handler (updates once per second)
- Adds device enumeration timer to the raw mouse config dialog (updates once per second)
- The enumeration only takes a couple of microseconds, so once a second should be fine
- Increases the max amount of devices in the dropdown to 16
- Ignore right click to clear input config button if the button is disabled (this seems to have been a bug since the beginning)