### PR TITLE
RSX/SPU: Import and improve RSX accurate reservations functionality

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -6698,6 +6698,12 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 			continue;
 		}
 
+		if (g_cfg.core.rsx_accurate_res_access)
+		{
+			// For now it is skipped completely in this case
+			continue;
+		}
+
 		union putllc16_info
 		{
 			u32 data;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -19,6 +19,7 @@
 #include "Emu/Cell/lv2/sys_event.h"
 #include "Emu/Cell/lv2/sys_time.h"
 #include "Emu/Cell/Modules/cellGcmSys.h"
+#include "Emu/Memory/vm_reservation.h"
 #include "util/serialization_ext.hpp"
 #include "Overlays/overlay_perf_metrics.h"
 #include "Overlays/overlay_debug_overlay.h"
@@ -3103,8 +3104,19 @@ namespace rsx
 			}
 		}
 
-		rsx::reservation_lock<true> lock(sink, 16);
-		vm::_ref<atomic_t<CellGcmReportData>>(sink).store({ timestamp(), value, 0});
+		CellGcmReportData report_data{ timestamp(), value, 0};
+
+		if (sink < label_addr || sink >= label_addr + sizeof(RsxReports::report))
+		{
+			vm::light_op<false>(vm::_ref<atomic_t<CellGcmReportData>>(sink), [&](atomic_t<CellGcmReportData>& data)
+			{
+				data.release(report_data);
+			});
+		}
+		else
+		{
+			vm::_ref<atomic_t<CellGcmReportData>>(sink).store(report_data);
+		}
 	}
 
 	u32 thread::copy_zcull_stats(u32 memory_range_start, u32 memory_range, u32 destination)


### PR DESCRIPTION
* Attempt to fix regressions with GOWA with #15429 while also improving accuracy by invalidating reservation timestamps.
* Partially import RSX accurate reservations functionality to default settings. The core part that was put in place for GOWA.
* Disable PUTLLC16 optimization when using accurate RSX reservations.