### PR TITLE
[Testers Needed #3] SPU: Use AI for GETLLAR spin detection

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -2309,6 +2309,12 @@ public:
 
 				for (u32 i = 0; i <= s_reg_127; i++)
 				{
+					if (i == s_reg_sp)
+					{
+						// If we postpone R1 store we lose effortless meta-analytical capabilities for little gain
+						continue;
+					}
+
 					// If store isn't erased, try to sink it
 					if (auto& bs = bqbi->store[i]; bs && bqbi->bb->targets.size() > 1 && !bqbi->does_gpr_barrier_proceed_last_store(i))
 					{
@@ -2447,7 +2453,7 @@ public:
 										}
 									}
 
-									spu_log.trace("Postoned r%u store from block 0x%x (single)", i, block_q[bi].first);
+									spu_log.trace("Postponed r%u store from block 0x%x (single)", i, block_q[bi].first);
 								}
 								else
 								{
@@ -2488,7 +2494,7 @@ public:
 										pdt.recalculate(*m_function);
 										dt.recalculate(*m_function);
 
-										spu_log.trace("Postoned r%u store from block 0x%x (multiple)", i, block_q[bi].first);
+										spu_log.trace("Postponed r%u store from block 0x%x (multiple)", i, block_q[bi].first);
 									}
 
 									ins = edge->getTerminator();

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -798,8 +798,10 @@ public:
 	u64 last_gtsc = 0;
 	u32 last_getllar = umax; // LS address of last GETLLAR (if matches current GETLLAR we can let the thread rest)
 	u32 last_getllar_id = umax;
+	u32 last_getllar_addr = umax;
 	u32 getllar_spin_count = 0;
 	u32 getllar_busy_waiting_switch = umax; // umax means the test needs evaluation, otherwise it's a boolean
+	u64 getllar_evaluate_time = 0;
 
 	std::vector<mfc_cmd_dump> mfc_history;
 	u64 mfc_dump_idx = 0;
@@ -823,6 +825,8 @@ public:
 	u32 current_bp_pc = umax;
 	bool stop_flag_removal_protection = false;
 
+	std::array<std::array<u8, 4>, SPU_LS_SIZE / 32> getllar_wait_time{};
+ 
 	void push_snr(u32 number, u32 value);
 	static void do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8* ls);
 	bool do_dma_check(const spu_mfc_cmd& args);
@@ -892,6 +896,7 @@ public:
 	static atomic_t<u32> g_raw_spu_ctr;
 	static atomic_t<u32> g_raw_spu_id[5];
 	static atomic_t<u32> g_spu_work_count;
+	static atomic_t<u8> g_reservation_waiters[32];
 
 	static u32 find_raw_spu(u32 id)
 	{

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -896,7 +896,7 @@ public:
 	static atomic_t<u32> g_raw_spu_ctr;
 	static atomic_t<u32> g_raw_spu_id[5];
 	static atomic_t<u32> g_spu_work_count;
-	static atomic_t<u8> g_reservation_waiters[32];
+	static atomic_t<u8> g_reservation_waiters[128];
 
 	static u32 find_raw_spu(u32 id)
 	{

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -677,7 +677,6 @@ public:
 
 	// MFC command data
 	spu_mfc_cmd ch_mfc_cmd;
-	u32 mfc_cmd_id = 0;
 
 	// MFC command queue
 	spu_mfc_cmd mfc_queue[16]{};
@@ -797,7 +796,7 @@ public:
 	u64 last_succ = 0;
 	u64 last_gtsc = 0;
 	u32 last_getllar = umax; // LS address of last GETLLAR (if matches current GETLLAR we can let the thread rest)
-	u32 last_getllar_id = umax;
+	u32 last_getllar_gpr1 = umax;
 	u32 last_getllar_addr = umax;
 	u32 getllar_spin_count = 0;
 	u32 getllar_busy_waiting_switch = umax; // umax means the test needs evaluation, otherwise it's a boolean
@@ -896,7 +895,6 @@ public:
 	static atomic_t<u32> g_raw_spu_ctr;
 	static atomic_t<u32> g_raw_spu_id[5];
 	static atomic_t<u32> g_spu_work_count;
-	static atomic_t<u8> g_reservation_waiters[128];
 
 	static u32 find_raw_spu(u32 id)
 	{

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -33,7 +33,7 @@ struct cfg_root : cfg::node
 		cfg::_bool set_daz_and_ftz{ this, "Set DAZ and FTZ", false };
 		cfg::_enum<spu_decoder_type> spu_decoder{ this, "SPU Decoder", spu_decoder_type::llvm };
 		cfg::uint<0, 100> spu_reservation_busy_waiting_percentage{ this, "SPU Reservation Busy Waiting Percentage", 0, true };
-		cfg::uint<0, 100> spu_getllar_busy_waiting_percentage{ this, "SPU GETLLAR Busy Waiting Percentage", 100, true };
+		cfg::uint<0, 101> spu_getllar_busy_waiting_percentage{ this, "SPU GETLLAR Busy Waiting Percentage", 100, true };
 		cfg::_bool spu_debug{ this, "SPU Debug" };
 		cfg::_bool mfc_debug{ this, "MFC Debug" };
 		cfg::_int<0, 6> preferred_spu_threads{ this, "Preferred SPU Threads", 0, true }; // Number of hardware threads dedicated to heavy simultaneous spu tasks


### PR DESCRIPTION
You got fooled.. click-baited.. hoodwinked.. The reason being I want you test this.
What this pr does is to detect long GETLLAR loops using data from the past to determine if operating system sleep need to be involved. This is related to #12523 but brings GETLLAR wait detection into the masses by carefully observing the time it takes for the reservation data change to come through before deciding to opt for CPU sleep.

Edit: In addition, I have added detection for concurrent waiting on the same data between multiple threads, so each thread can notify the others in the case of the data change. That is what (hopefully) prevented most of performance regressions, allowing mostly improvements. 

What to compare:
* CPU and SPU usage.
* Performance difference, especially on lower threaded CPUs.

Note: Do not use the SPURS limit setting when testing the pr because it alters the results.

## Improved games (see comments):

https://github.com/RPCS3/rpcs3/pull/15623#issuecomment-2170589725
https://github.com/RPCS3/rpcs3/pull/15623#issuecomment-2170021693