### PR TITLE
vk: Dump diagnostic messages if device creation fails

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -129,6 +129,10 @@ namespace vk
 		u32 m_present_queue_family = 0;
 		u32 m_transfer_queue_family = 0;
 
+		void dump_debug_info(
+			const std::vector<const char*>& requested_extensions,
+			const VkPhysicalDeviceFeatures& requested_features) const;
+
 	public:
 		// Exported device endpoints
 		PFN_vkCmdBeginConditionalRenderingEXT _vkCmdBeginConditionalRenderingEXT = nullptr;


### PR DESCRIPTION
There are a few rare reports of device creation failing and crashing the application. Dump the requested extensions and enabled features if that happens.
We can't do much about missing features since we need some of them for proper emulation without ridiculous bugs, but with more information gathered we can identify reasonable workarounds.