### PR TITLE
sys_net: properly return error in sendto

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
@@ -1037,9 +1037,9 @@ std::optional<s32> lv2_socket_native::sendto(s32 flags, const std::vector<u8>& b
 	}
 
 #ifdef _WIN32
-	get_last_error(!so_nbio && (flags & SYS_NET_MSG_DONTWAIT) == 0, connecting);
+	result = get_last_error(!so_nbio && (flags & SYS_NET_MSG_DONTWAIT) == 0, connecting);
 #else
-	get_last_error(!so_nbio && (flags & SYS_NET_MSG_DONTWAIT) == 0);
+	result = get_last_error(!so_nbio && (flags & SYS_NET_MSG_DONTWAIT) == 0);
 #endif
 
 	if (result)


### PR DESCRIPTION
In metal gear online, whenever a socket error occurred in sendto, the game would halt indefinitely spamming an infinite loop of errors. 

![image](https://github.com/RPCS3/rpcs3/assets/5994581/65c69568-d076-4313-977f-31153001487d)

It turns out sendto was never actually returning the error code.