### PR TITLE
USB: If a Santroller device is in use elsewhere, don't send it commands

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -315,7 +315,9 @@ usb_handler_thread::usb_handler_thread()
 #endif
 				libusb_control_transfer(lusb_handle, +LIBUSB_ENDPOINT_IN | +LIBUSB_REQUEST_TYPE_CLASS | +LIBUSB_RECIPIENT_INTERFACE, 0x01, 0x03f2, 2, nullptr, 0, 5000);
 				libusb_close(lusb_handle);
-			} else {
+			}
+			else
+			{
 				sys_usbd.error("Unable to open Santroller device, make sure Santroller isn't open in the background.");
 			}
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -308,7 +308,8 @@ usb_handler_thread::usb_handler_thread()
 			sys_usbd.success("Found device: Santroller");
 			// Send the device a specific control transfer so that it jumps to a RPCS3 compatible mode
 			libusb_device_handle* lusb_handle;
-			if (libusb_open(list[index], &lusb_handle) == LIBUSB_SUCCESS) {
+			if (libusb_open(list[index], &lusb_handle) == LIBUSB_SUCCESS)
+			{
 #ifdef __linux__
 				libusb_set_auto_detach_kernel_driver(lusb_handle, true);
 				libusb_claim_interface(lusb_handle, 2);

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -308,13 +308,16 @@ usb_handler_thread::usb_handler_thread()
 			sys_usbd.success("Found device: Santroller");
 			// Send the device a specific control transfer so that it jumps to a RPCS3 compatible mode
 			libusb_device_handle* lusb_handle;
-			libusb_open(list[index], &lusb_handle);
+			if (libusb_open(list[index], &lusb_handle) == LIBUSB_SUCCESS) {
 #ifdef __linux__
-			libusb_set_auto_detach_kernel_driver(lusb_handle, true);
-			libusb_claim_interface(lusb_handle, 2);
+				libusb_set_auto_detach_kernel_driver(lusb_handle, true);
+				libusb_claim_interface(lusb_handle, 2);
 #endif
-			libusb_control_transfer(lusb_handle, +LIBUSB_ENDPOINT_IN | +LIBUSB_REQUEST_TYPE_CLASS | +LIBUSB_RECIPIENT_INTERFACE, 0x01, 0x03f2, 2, nullptr, 0, 5000);
-			libusb_close(lusb_handle);
+				libusb_control_transfer(lusb_handle, +LIBUSB_ENDPOINT_IN | +LIBUSB_REQUEST_TYPE_CLASS | +LIBUSB_RECIPIENT_INTERFACE, 0x01, 0x03f2, 2, nullptr, 0, 5000);
+				libusb_close(lusb_handle);
+			} else {
+				sys_usbd.error("Unable to open Santroller device, make sure Santroller isn't open in the background.");
+			}
 		}
 
 		// Top Shot Elite controllers


### PR DESCRIPTION
Currently, if a Santroller device is detected but it is already in use, RPCS3 crashes.

This fixes that by not trying to send control transfers to devices that can't be opened.