### PR TITLE
Cirrus: Update to FreeBSD 13.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,7 +103,7 @@ freebsd_task:
   matrix:
     - name: Cirrus FreeBSD
       freebsd_instance:
-        image_family: freebsd-13-2
+        image_family: freebsd-13-3
         cpu: 8
         memory: 8G
   env:


### PR DESCRIPTION
FreeBSD 13.2 image was removed from freebsd-org-cloud-dev. 

As mentioned in https://cirrus-ci.org/guide/FreeBSD/, only _official FreeBSD VMs on Google Cloud Platform are supported_.

Security support for 13.2 ends at the end of the month (30 Jun 2024) too, so we will both switch to active 13.3 to keep up-to-date and fix the CI not working.

Fixes #15661.