### PR TITLE
SPU Analyzer: Fix of Crysis

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -3266,6 +3266,8 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 			}
 			else
 			{
+				m_targets[pos].push_back(target);
+
 				if (g_cfg.core.spu_block_size == spu_block_size_type::giga)
 				{
 					spu_log.notice("[0x%x] At 0x%x: ignoring fixed tail call to 0x%x (SYNC)", entry_point, pos, target);

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -2638,6 +2638,14 @@ public:
 				fs::file(m_spurt->get_cache_path() + "spu-ir.log", fs::write + fs::append).write(log);
 			}
 
+			if (auto& cache = g_fxo->get<spu_cache>())
+			{
+				if (add_to_file)
+				{
+					cache.add(func);
+				}
+			}
+
 			fmt::throw_exception("Compilation failed");
 		}
 


### PR DESCRIPTION
Fixes #14147, turns out it was simply missing target registration. (the random freezing with the game is still present though)