### PR TITLE
PPU LLVM: Support Unity games properly

### DIFF
--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -109,7 +109,7 @@ struct ppu_module
 		addr_to_seg_index = info.addr_to_seg_index;
 	}
 
-	bool analyse(u32 lib_toc, u32 entry, u32 end, const std::basic_string<u32>& applied, std::function<bool()> check_aborted = {});
+	bool analyse(u32 lib_toc, u32 entry, u32 end, const std::basic_string<u32>& applied, const std::vector<u32>& exported_funcs = std::vector<u32>{}, std::function<bool()> check_aborted = {});
 	void validate(u32 reloc);
 
 	template <typename T>

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -4230,7 +4230,7 @@ auto NEG()
 	const u64 RA = ppu.gpr[op.ra];
 	ppu.gpr[op.rd] = 0 - RA;
 	if constexpr (((Flags == has_oe) || ...))
-		ppu_ov_set(ppu, (~RA >> 63 == 0) && (~RA >> 63 != ppu.gpr[op.rd] >> 63));
+		ppu_ov_set(ppu, RA == (1ull << 63));
 	if constexpr (((Flags == has_rc) || ...))
 		ppu_cr_set<s64>(ppu, 0, ppu.gpr[op.rd], 0);
 	};

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4148,7 +4148,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 					}
 
 					// Participate in thread execution limitation (takes a long time)
-					if (std::lock_guard lock(g_fxo->get<jit_core_allocator>().sem); !ovlm->analyse(0, ovlm->entry, ovlm->seg0_code_end, ovlm->applied_patches, []()
+					if (std::lock_guard lock(g_fxo->get<jit_core_allocator>().sem); !ovlm->analyse(0, ovlm->entry, ovlm->seg0_code_end, ovlm->applied_patches, std::vector<u32>{}, []()
 					{
 						return Emu.IsStopped();
 					}))
@@ -4256,7 +4256,7 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 						break;
 					}
 
-					if (!_main.analyse(0, _main.elf_entry, _main.seg0_code_end, _main.applied_patches, [](){ return Emu.IsStopped(); }))
+					if (!_main.analyse(0, _main.elf_entry, _main.seg0_code_end, _main.applied_patches, std::vector<u32>{}, [](){ return Emu.IsStopped(); }))
 					{
 						g_fxo->get<spu_cache>() = std::move(current_cache);
 						break;
@@ -4308,7 +4308,7 @@ extern void ppu_initialize()
 	std::optional<scoped_progress_dialog> progr(std::in_place, "Analyzing PPU Executable...");
 
 	// Analyse executable
-	if (!_main.analyse(0, _main.elf_entry, _main.seg0_code_end, _main.applied_patches, [](){ return Emu.IsStopped(); }))
+	if (!_main.analyse(0, _main.elf_entry, _main.seg0_code_end, _main.applied_patches, std::vector<u32>{}, [](){ return Emu.IsStopped(); }))
 	{
 		return;
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -17,6 +17,8 @@
 #include "sys_memory.h"
 #include <span>
 
+extern void dump_executable(std::span<const u8> data, ppu_module* _main, std::string_view title_id);
+
 extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, bool virtual_load, const std::string&, s64, utils::serial* = nullptr);
 extern void ppu_unload_prx(const lv2_prx& prx);
 extern bool ppu_initialize(const ppu_module&, bool check_only = false, u64 file_size = 0);
@@ -270,6 +272,8 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 		return {CELL_PRX_ERROR_UNSUPPORTED_PRX_TYPE, +"Failed to decrypt file"};
 	}
 
+	const auto src_data = g_cfg.core.ppu_debug ? src.to_vector<u8>() : std::vector<u8>{};
+
 	ppu_prx_object obj = std::move(src);
 	src.close();
 
@@ -279,6 +283,11 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 	}
 
 	const auto prx = ppu_load_prx(obj, false, path, file_offset);
+
+	if (g_cfg.core.ppu_debug)
+	{
+		dump_executable({src_data.data(), src_data.size()}, prx.get(), Emu.GetTitleID());
+	}
 
 	obj.clear();
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -301,16 +301,18 @@ static void fixup_settings(const psf::registry* _psf)
 	}
 }
 
-extern void dump_executable(std::span<const u8> data, ppu_module* _main, std::string_view title_id)
+extern void dump_executable(std::span<const u8> data, ppu_module* _module, std::string_view title_id)
 {
+	const std::string_view filename = _module->path.substr(_module->path.find_last_of('/') + 1);
+
 	// Format filename and directory name
 	// Make each directory for each file so tools like IDA can work on it cleanly
-	const std::string dir_path = fs::get_cache_dir() + "ppu_progs/" + std::string{!title_id.empty() ? title_id : "untitled"} + fmt::format("-%s-%s", fmt::base57(_main->sha1), _main->path.substr(_main->path.find_last_of('/') + 1))  + '/';
-	const std::string filename = dir_path + "exec.elf";
+	const std::string dir_path = fs::get_cache_dir() + "ppu_progs/" + std::string{!title_id.empty() ? title_id : "untitled"} + fmt::format("-%s-%s", fmt::base57(_module->sha1), filename)  + '/';
+	const std::string file_path = dir_path + (fmt::to_lower(filename).ends_with(".prx") || fmt::to_lower(filename).ends_with(".sprx") ? "prog.prx" : "exec.elf");
 
 	if (fs::create_dir(dir_path) || fs::g_tls_error == fs::error::exist)
 	{
-		if (fs::file out{filename, fs::create + fs::write})
+		if (fs::file out{file_path, fs::create + fs::write})
 		{
 			if (out.size() == data.size())
 			{

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -301,7 +301,7 @@ static void fixup_settings(const psf::registry* _psf)
 	}
 }
 
-void dump_executable(std::span<const u8> data, main_ppu_module* _main, std::string_view title_id)
+extern void dump_executable(std::span<const u8> data, ppu_module* _main, std::string_view title_id)
 {
 	// Format filename and directory name
 	// Make each directory for each file so tools like IDA can work on it cleanly

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1681,7 +1681,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 			{
 				if (auto& _main = *ensure(g_fxo->try_get<main_ppu_module>()); !_main.path.empty())
 				{
-					if (!_main.analyse(0, _main.elf_entry, _main.seg0_code_end, _main.applied_patches, [](){ return Emu.IsStopped(); }))
+					if (!_main.analyse(0, _main.elf_entry, _main.seg0_code_end, _main.applied_patches, std::vector<u32>{}, [](){ return Emu.IsStopped(); }))
 					{
 						return;
 					}

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -210,9 +210,15 @@ void progress_dialog_server::operator()()
 						const u64 remaining_usec = pdone ? utils::rational_mul<u64>(passed_usec, static_cast<u64>(ptotal) - pdone, pdone) : (passed_usec * ptotal);
 
 						// Only show compile notification if we estimate at least 100ms
-						if (remaining_usec >= 100'000ULL && (!ppu_cue_refs || !*ppu_cue_refs))
+						if (remaining_usec >= 100'000ULL)
 						{
-							ppu_cue_refs = rsx::overlays::show_ppu_compile_notification();
+							if (!ppu_cue_refs || !*ppu_cue_refs)
+							{
+								ppu_cue_refs = rsx::overlays::show_ppu_compile_notification();
+							}
+
+							// Make sure to update any pending messages. PPU compilation may freeze the image.
+							rsx::overlays::refresh_message_queue();
 						}
 					}
 
@@ -222,6 +228,8 @@ void progress_dialog_server::operator()()
 						{
 							*ppu_cue_refs = 0;
 							ppu_cue_refs.reset();
+
+							rsx::overlays::refresh_message_queue();
 						}
 					}
 


### PR DESCRIPTION
* Use exported functions as the baseline for function analysis if none other is found. (PRX)
* Implement SUBFO, ADDCO and NEGO instruction forms. (setting overflow bit)
* Fix fallback function analysis with conditional link branches.
* Fix Branches with link to the next instruction, this is apparently how DOT.NET's PS3 SPRX files resolve relative addresses for data within PRX. They never heard of TOC which is also why function analysis used to not detect a single function of it.
* Dump decrypted PRX when PPU debug is enabled

Fixes #15524, while also properly supporting LLVM for them. (they used slower interpreter fallback)