### PR TITLE
rsx: Properly implement signed normalized texture emulation

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -1134,6 +1134,29 @@ namespace rsx
 		fmt::throw_exception("Unknown format 0x%x", texture_format);
 	}
 
+	bool is_int8_remapped_format(u32 format)
+	{
+		switch (format)
+		{
+		case CELL_GCM_TEXTURE_DEPTH24_D8:
+		case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
+		case CELL_GCM_TEXTURE_DEPTH16:
+		case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
+		case CELL_GCM_TEXTURE_X16:
+		case CELL_GCM_TEXTURE_Y16_X16:
+		case CELL_GCM_TEXTURE_COMPRESSED_HILO8:
+		case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8:
+		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
+		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
+		case CELL_GCM_TEXTURE_X32_FLOAT:
+		case CELL_GCM_TEXTURE_Y16_X16_FLOAT:
+			// NOTE: Special data formats (XY, HILO, DEPTH) are not RGB formats
+			return false;
+		default:
+			return true;
+		}
+	}
+
 	/**
 	 * A texture is stored as an array of blocks, where a block is a pixel for standard texture
 	 * but is a structure containing several pixels for compressed format

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -255,6 +255,7 @@ namespace rsx
 	u8 get_format_sample_count(rsx::surface_antialiasing antialias);
 	u32 get_max_depth_value(rsx::surface_depth_format2 format);
 	bool is_depth_stencil_format(rsx::surface_depth_format2 format);
+	bool is_int8_remapped_format(u32 format); // Returns true if the format is treated as INT8 by the RSX remapper.
 
 	/**
 	 * Returns number of texel rows encoded in one pitch-length line of bytes

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -31,6 +31,8 @@ void GLFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 	int gl_version = 430;
 	std::vector<std::string> required_extensions;
 
+	required_extensions.push_back("GL_EXT_shader_integer_mix");
+
 	if (device_props.has_native_half_support)
 	{
 		const auto driver_caps = gl::get_driver_caps();

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -31,8 +31,6 @@ void GLFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 	int gl_version = 430;
 	std::vector<std::string> required_extensions;
 
-	required_extensions.push_back("GL_EXT_shader_integer_mix");
-
 	if (device_props.has_native_half_support)
 	{
 		const auto driver_caps = gl::get_driver_caps();

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
@@ -68,12 +68,12 @@ void FragmentProgramDecompiler::SetDst(std::string code, u32 flags)
 		if (dst.fp16 && device_props.has_native_half_support && !(flags & OPFLAGS::skip_type_cast))
 		{
 			// Cast to native data type
-			code = ClampValue(code, 1);
+			code = ClampValue(code, RSX_FP_PRECISION_HALF);
 		}
 
 		if (dst.saturate)
 		{
-			code = ClampValue(code, 4);
+			code = ClampValue(code, RSX_FP_PRECISION_SATURATE);
 		}
 		else if (dst.prec)
 		{

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -328,6 +328,10 @@ namespace glsl
 				{ "EXPAND_G_BIT" , rsx::texture_control_bits::EXPAND_G },
 				{ "EXPAND_B_BIT" , rsx::texture_control_bits::EXPAND_B },
 				{ "EXPAND_A_BIT" , rsx::texture_control_bits::EXPAND_A },
+				{ "SEXT_R_BIT" , rsx::texture_control_bits::SEXT_R },
+				{ "SEXT_G_BIT" , rsx::texture_control_bits::SEXT_G },
+				{ "SEXT_B_BIT" , rsx::texture_control_bits::SEXT_B },
+				{ "SEXT_A_BIT" , rsx::texture_control_bits::SEXT_A },
 
 				{ "ALPHAKILL    ", rsx::texture_control_bits::ALPHAKILL },
 				{ "RENORMALIZE  ", rsx::texture_control_bits::RENORMALIZE },

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.h
@@ -22,6 +22,10 @@ namespace rsx
 		EXPAND_R,
 		EXPAND_G,
 		EXPAND_B,
+		SEXT_A,
+		SEXT_R,
+		SEXT_G,
+		SEXT_B,
 		DEPTH_FLOAT,
 		DEPTH_COMPARE_OP,
 		DEPTH_COMPARE_1,
@@ -33,7 +37,9 @@ namespace rsx
 
 		GAMMA_CTRL_MASK = (1 << GAMMA_R) | (1 << GAMMA_G) | (1 << GAMMA_B) | (1 << GAMMA_A),
 		EXPAND_MASK = (1 << EXPAND_R) | (1 << EXPAND_G) | (1 << EXPAND_B) | (1 << EXPAND_A),
-		EXPAND_OFFSET = EXPAND_A
+		EXPAND_OFFSET = EXPAND_A,
+		SEXT_MASK = (1 << SEXT_R) | (1 << SEXT_G) | (1 << SEXT_B) | (1 << SEXT_A),
+		SEXT_OFFSET = SEXT_A
 	};
 
 	enum ROP_control_bits : u32

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureOps.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureOps.glsl
@@ -172,9 +172,9 @@ vec4 _texcoord_xform_shadow(const in vec4 coord4, const in sampler_info params)
 vec4 _sext_unorm8x4(const in vec4 x)
 {
 	// TODO: Handle clamped sign-extension
-	const ivec4 bits = ivec4(floor(fma(x, vec4(255.), vec4(0.5f))));
-	const bvec4 sign_check = lessThan(bits, ivec4(0x80));
-	const ivec4 ret = _select(bits - 256, bits, sign_check);
+	const vec4 bits = floor(fma(x, vec4(255.), vec4(0.5f)));
+	const bvec4 sign_check = lessThan(bits, vec4(128.f));
+	const vec4 ret = _select(bits - 256.f, bits, sign_check);
 	return ret / 127.f;
 }
 

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureOps.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureOps.glsl
@@ -172,7 +172,7 @@ vec4 _texcoord_xform_shadow(const in vec4 coord4, const in sampler_info params)
 vec4 _sext_unorm8x4(const in vec4 x)
 {
 	// TODO: Handle clamped sign-extension
-	const vec4 bits = floor(fma(x, vec4(255.), vec4(0.5f)));
+	const vec4 bits = floor(fma(x, vec4(255.f), vec4(0.5f)));
 	const bvec4 sign_check = lessThan(bits, vec4(128.f));
 	const vec4 ret = _select(bits - 256.f, bits, sign_check);
 	return ret / 127.f;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2599,75 +2599,55 @@ namespace rsx
 					}
 				}
 
-				// Special operations applied to 8-bit formats such as gamma correction and sign conversion
-				// NOTE: The unsigned_remap=bias flag being set flags the texture as being compressed normal (2n-1 / BX2) (UE3)
-				// NOTE: The ARGB8_signed flag means to reinterpret the raw bytes as signed. This is different than unsigned_remap=bias which does range decompression.
-				// This is a separate method of setting the format to signed mode without doing so per-channel
-				// Precedence = SNORM > GAMMA > UNSIGNED_REMAP (See Resistance 3 for GAMMA/BX2 relationship, UE3 for BX2 effect)
-
-				const u32 argb8_signed = tex.argb_signed(); // _SNROM
-				const u32 gamma = tex.gamma() & ~argb8_signed; // _SRGB
-				const u32 unsigned_remap = (tex.unsigned_remap() == CELL_GCM_TEXTURE_UNSIGNED_REMAP_NORMAL)? 0u : (~(gamma | argb8_signed) & 0xF); // _BX2
-				u32 argb8_convert = gamma;
-
-				// The options are mutually exclusive
-				ensure((argb8_signed & gamma) == 0);
-				ensure((argb8_signed & unsigned_remap) == 0);
-				ensure((gamma & unsigned_remap) == 0);
-
-				// Helper function to apply a per-channel mask based on an input mask
-				const auto apply_sign_convert_mask = [&](u32 mask, u32 bit_offset)
+				if (rsx::is_int8_remapped_format(format))
 				{
-					// TODO: Use actual remap mask to account for 0 and 1 overrides in default mapping
-					// TODO: Replace this clusterfuck of texture control with matrix transformation
-					const auto remap_ctrl = (tex.remap() >> 8) & 0xAA;
-					if (remap_ctrl == 0xAA)
+					// Special operations applied to 8-bit formats such as gamma correction and sign conversion
+					// NOTE: The unsigned_remap=bias flag being set flags the texture as being compressed normal (2n-1 / BX2) (UE3)
+					// NOTE: The ARGB8_signed flag means to reinterpret the raw bytes as signed. This is different than unsigned_remap=bias which does range decompression.
+					// This is a separate method of setting the format to signed mode without doing so per-channel
+					// Precedence = SNORM > GAMMA > UNSIGNED_REMAP (See Resistance 3 for GAMMA/BX2 relationship, UE3 for BX2 effect)
+
+					const u32 argb8_signed = tex.argb_signed(); // _SNROM
+					const u32 gamma = tex.gamma() & ~argb8_signed; // _SRGB
+					const u32 unsigned_remap = (tex.unsigned_remap() == CELL_GCM_TEXTURE_UNSIGNED_REMAP_NORMAL)? 0u : (~(gamma | argb8_signed) & 0xF); // _BX2
+					u32 argb8_convert = gamma;
+
+					// The options are mutually exclusive
+					ensure((argb8_signed & gamma) == 0);
+					ensure((argb8_signed & unsigned_remap) == 0);
+					ensure((gamma & unsigned_remap) == 0);
+
+					// Helper function to apply a per-channel mask based on an input mask
+					const auto apply_sign_convert_mask = [&](u32 mask, u32 bit_offset)
 					{
-						argb8_convert |= (mask & 0xFu) << bit_offset;
-						return;
+						// TODO: Use actual remap mask to account for 0 and 1 overrides in default mapping
+						// TODO: Replace this clusterfuck of texture control with matrix transformation
+						const auto remap_ctrl = (tex.remap() >> 8) & 0xAA;
+						if (remap_ctrl == 0xAA)
+						{
+							argb8_convert |= (mask & 0xFu) << bit_offset;
+							return;
+						}
+
+						if ((remap_ctrl & 0x03) == 0x02) argb8_convert |= (mask & 0x1u) << bit_offset;
+						if ((remap_ctrl & 0x0C) == 0x08) argb8_convert |= (mask & 0x2u) << bit_offset;
+						if ((remap_ctrl & 0x30) == 0x20) argb8_convert |= (mask & 0x4u) << bit_offset;
+						if ((remap_ctrl & 0xC0) == 0x80) argb8_convert |= (mask & 0x8u) << bit_offset;
+					};
+
+					if (argb8_signed)
+					{
+						// Apply integer sign extension from uint8 to sint8 and renormalize
+						apply_sign_convert_mask(argb8_signed, texture_control_bits::SEXT_OFFSET);
 					}
 
-					if ((remap_ctrl & 0x03) == 0x02) argb8_convert |= (mask & 0x1u) << bit_offset;
-					if ((remap_ctrl & 0x0C) == 0x08) argb8_convert |= (mask & 0x2u) << bit_offset;
-					if ((remap_ctrl & 0x30) == 0x20) argb8_convert |= (mask & 0x4u) << bit_offset;
-					if ((remap_ctrl & 0xC0) == 0x80) argb8_convert |= (mask & 0x8u) << bit_offset;
-				};
-
-				if (argb8_signed)
-				{
-					// Apply integer sign extension from uint8 to sint8 and renormalize
-					apply_sign_convert_mask(argb8_signed, texture_control_bits::SEXT_OFFSET);
-				}
-
-				if (unsigned_remap)
-				{
-					// Apply sign expansion, compressed normal-map style (2n - 1)
-					apply_sign_convert_mask(unsigned_remap, texture_control_bits::EXPAND_OFFSET);
-				}
-
-				if (argb8_convert)
-				{
-					switch (format)
+					if (unsigned_remap)
 					{
-					case CELL_GCM_TEXTURE_DEPTH24_D8:
-					case CELL_GCM_TEXTURE_DEPTH24_D8_FLOAT:
-					case CELL_GCM_TEXTURE_DEPTH16:
-					case CELL_GCM_TEXTURE_DEPTH16_FLOAT:
-					case CELL_GCM_TEXTURE_X16:
-					case CELL_GCM_TEXTURE_Y16_X16:
-					case CELL_GCM_TEXTURE_COMPRESSED_HILO8:
-					case CELL_GCM_TEXTURE_COMPRESSED_HILO_S8:
-					case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
-					case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
-					case CELL_GCM_TEXTURE_X32_FLOAT:
-					case CELL_GCM_TEXTURE_Y16_X16_FLOAT:
-						// Special data formats (XY, HILO, DEPTH) are not RGB formats
-						// Ignore gamma flags
-						break;
-					default:
-						texture_control |= argb8_convert;
-						break;
+						// Apply sign expansion, compressed normal-map style (2n - 1)
+						apply_sign_convert_mask(unsigned_remap, texture_control_bits::EXPAND_OFFSET);
 					}
+
+					texture_control |= argb8_convert;
 				}
 
 				current_fragment_program.texture_params[i].control = texture_control;

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2627,10 +2627,10 @@ namespace rsx
 						return;
 					}
 
-					if (remap_ctrl & 0x03) argb8_convert |= (mask & 0x1u) << bit_offset;
-					if (remap_ctrl & 0x0C) argb8_convert |= (mask & 0x2u) << bit_offset;
-					if (remap_ctrl & 0x30) argb8_convert |= (mask & 0x4u) << bit_offset;
-					if (remap_ctrl & 0xC0) argb8_convert |= (mask & 0x8u) << bit_offset;
+					if ((remap_ctrl & 0x03) == 0x02) argb8_convert |= (mask & 0x1u) << bit_offset;
+					if ((remap_ctrl & 0x0C) == 0x08) argb8_convert |= (mask & 0x2u) << bit_offset;
+					if ((remap_ctrl & 0x30) == 0x20) argb8_convert |= (mask & 0x4u) << bit_offset;
+					if ((remap_ctrl & 0xC0) == 0x80) argb8_convert |= (mask & 0x8u) << bit_offset;
 				};
 
 				if (argb8_signed)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2618,14 +2618,14 @@ namespace rsx
 					const auto remap_ctrl = (tex.remap() >> 8) & 0xAA;
 					if (remap_ctrl == 0xAA)
 					{
-						argb8_convert |= (unsigned_remap & 0xFu) << texture_control_bits::EXPAND_OFFSET;
+						argb8_convert |= (mask & 0xFu) << bit_offset;
 					}
 					else
 					{
-						if (remap_ctrl & 0x03) argb8_convert |= (unsigned_remap & 0x1u) << texture_control_bits::EXPAND_OFFSET;
-						if (remap_ctrl & 0x0C) argb8_convert |= (unsigned_remap & 0x2u) << texture_control_bits::EXPAND_OFFSET;
-						if (remap_ctrl & 0x30) argb8_convert |= (unsigned_remap & 0x4u) << texture_control_bits::EXPAND_OFFSET;
-						if (remap_ctrl & 0xC0) argb8_convert |= (unsigned_remap & 0x8u) << texture_control_bits::EXPAND_OFFSET;
+						if (remap_ctrl & 0x03) argb8_convert |= (mask & 0x1u) << bit_offset;
+						if (remap_ctrl & 0x0C) argb8_convert |= (mask & 0x2u) << bit_offset;
+						if (remap_ctrl & 0x30) argb8_convert |= (mask & 0x4u) << bit_offset;
+						if (remap_ctrl & 0xC0) argb8_convert |= (mask & 0x8u) << bit_offset;
 					}
 				};
 

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -29,28 +29,24 @@ std::string VKFragmentDecompilerThread::compareFunction(COMPARE f, const std::st
 
 void VKFragmentDecompilerThread::insertHeader(std::stringstream & OS)
 {
-	int version = 420;
 	std::vector<const char*> required_extensions;
 
 	if (device_props.has_native_half_support)
 	{
-		version = std::max(version, 450);
 		required_extensions.emplace_back("GL_EXT_shader_explicit_arithmetic_types_float16");
 	}
 
 	if (properties.multisampled_sampler_mask)
 	{
-		version = std::max(version, 450);
 		required_extensions.emplace_back("GL_ARB_shader_texture_image_samples");
 	}
 
 	if (m_prog.ctrl & RSX_SHADER_CONTROL_ATTRIBUTE_INTERPOLATION)
 	{
-		version = std::max(version, 450);
 		required_extensions.emplace_back("GL_EXT_fragment_shader_barycentric");
 	}
 
-	OS << "#version " << version << "\n";
+	OS << "#version 450\n";
 	for (const auto ext : required_extensions)
 	{
 		OS << "#extension " << ext << ": require\n";


### PR DESCRIPTION
Unlike desktop, PS3 has per-channel SNORM flags to toggle between UNORM and SNORM behavior. In the past I had attempted implementing this with true desktop SNORM formats, but the whole thing got messy very fast once we had titles with SNORM RGB and UNORM A configuration and others with SNORM, UNORM and sRGB flags all set. We moved to a software emulation model but the SNORM behavior was not correctly implemented, instead sharing code with the BX2 (sign expand) code which was incorrect.
This PR implements the sext behavior for SNORM textures properly.
It sorta fixes and breaks things at the same time and I don't have enough time to figure out all the corner cases, so I'm submitting this as-is as it is technically complete.