### PR TITLE
Fix sys_lwmutex_lock for SYS_SYNC_RETRY

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -521,6 +521,12 @@ error_code sys_event_queue_receive(ppu_thread& ppu, u32 equeue_id, vm::ptr<sys_e
 					continue;
 				}
 
+				if (!atomic_storage<ppu_thread*>::load(queue->pq))
+				{
+					// Waiters queue is empty, so the thread must have been signaled
+					break;
+				}
+
 				std::lock_guard lock(queue->mutex);
 
 				if (!queue->unqueue(queue->pq, &ppu))

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.cpp
@@ -240,6 +240,12 @@ error_code sys_event_flag_wait(ppu_thread& ppu, u32 id, u64 bitptn, u32 mode, vm
 					continue;
 				}
 
+				if (!atomic_storage<ppu_thread*>::load(flag->sq))
+				{
+					// Waiters queue is empty, so the thread must have been signaled
+					break;
+				}
+
 				std::lock_guard lock(flag->mutex);
 
 				if (!flag->unqueue(flag->sq, &ppu))

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -234,6 +234,12 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 					continue;
 				}
 
+				if (!mutex->load_sq())
+				{
+					// Sleep queue is empty, so the thread must have been signaled
+					break;
+				}
+
 				std::lock_guard lock(mutex->mutex);
 
 				bool success = false;

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -144,7 +144,7 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 	{
 		if (s32 signal = mutex.lv2_control.fetch_op([](auto& data)
 		{
-			if (data.signaled == 1)
+			if (data.signaled)
 			{
 				data.signaled = 0;
 				return true;
@@ -153,7 +153,7 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 			return false;
 		}).first.signaled)
 		{
-			if (signal == smin)
+			if (~signal & 1)
 			{
 				ppu.gpr[3] = CELL_EBUSY;
 			}
@@ -167,7 +167,7 @@ error_code _sys_lwmutex_lock(ppu_thread& ppu, u32 lwmutex_id, u64 timeout)
 
 		if (s32 signal = mutex.try_own(&ppu))
 		{
-			if (signal == smin)
+			if (~signal & 1)
 			{
 				ppu.gpr[3] = CELL_EBUSY;
 			}

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -255,6 +255,12 @@ error_code sys_mutex_lock(ppu_thread& ppu, u32 mutex_id, u64 timeout)
 					continue;
 				}
 
+				if (!atomic_storage<ppu_thread*>::load(mutex->control.raw().sq))
+				{
+					// Waiters queue is empty, so the thread must have been signaled
+					break;
+				}
+
 				std::lock_guard lock(mutex->mutex);
 
 				bool success = false;

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -196,6 +196,12 @@ error_code sys_rwlock_rlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 					continue;
 				}
 
+				if (!atomic_storage<ppu_thread*>::load(rwlock->rq))
+				{
+					// Waiters queue is empty, so the thread must have been signaled
+					break;
+				}
+
 				std::lock_guard lock(rwlock->mutex);
 
 				if (!rwlock->unqueue(rwlock->rq, &ppu))


### PR DESCRIPTION
It was missing signaled bit reset whenever _sys_lwmutex_unlock2 was used without a waiter.