### PR TITLE
input: Try to fix ingame pad connection updates

### DIFF
--- a/rpcs3/Emu/Io/Null/NullPadHandler.h
+++ b/rpcs3/Emu/Io/Null/NullPadHandler.h
@@ -5,7 +5,7 @@
 class NullPadHandler final : public PadHandlerBase
 {
 public:
-	NullPadHandler(bool emulation) : PadHandlerBase(pad_handler::null, emulation)
+	NullPadHandler() : PadHandlerBase(pad_handler::null)
 	{
 		b_has_pressure_intensity_button = false;
 	}

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -7,9 +7,7 @@
 
 cfg_input g_cfg_input;
 
-extern void pad_state_notify_state_change(usz index, u32 state);
-
-PadHandlerBase::PadHandlerBase(pad_handler type, bool emulation) : m_type(type), m_emulation(emulation)
+PadHandlerBase::PadHandlerBase(pad_handler type) : m_type(type)
 {
 }
 
@@ -747,11 +745,6 @@ void PadHandlerBase::process()
 
 				pad->m_port_status |= CELL_PAD_STATUS_CONNECTED + CELL_PAD_STATUS_ASSIGN_CHANGES;
 
-				if (m_emulation && !pad->is_fake_pad)
-				{
-					pad_state_notify_state_change(i, CELL_PAD_STATUS_CONNECTED);
-				}
-
 				last_connection_status[i] = true;
 				connected_devices++;
 			}
@@ -775,11 +768,6 @@ void PadHandlerBase::process()
 
 					pad->m_port_status |= CELL_PAD_STATUS_CONNECTED + CELL_PAD_STATUS_ASSIGN_CHANGES;
 
-					if (m_emulation && !pad->is_fake_pad)
-					{
-						pad_state_notify_state_change(i, CELL_PAD_STATUS_CONNECTED);
-					}
-
 					last_connection_status[i] = true;
 					connected_devices++;
 				}
@@ -792,11 +780,6 @@ void PadHandlerBase::process()
 
 				pad->m_port_status &= ~CELL_PAD_STATUS_CONNECTED;
 				pad->m_port_status |= CELL_PAD_STATUS_ASSIGN_CHANGES;
-
-				if (m_emulation)
-				{
-					pad_state_notify_state_change(i, CELL_PAD_STATUS_DISCONNECTED);
-				}
 
 				last_connection_status[i] = false;
 				connected_devices--;

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -248,7 +248,6 @@ public:
 
 	pad_handler m_type;
 	bool m_is_init = false;
-	bool m_emulation = false;
 
 	std::string name_string() const;
 	usz max_devices() const;
@@ -266,7 +265,7 @@ public:
 	void convert_stick_values(u16& x_out, u16& y_out, s32 x_in, s32 y_in, u32 deadzone, u32 anti_deadzone, u32 padsquircling) const;
 
 	virtual bool Init() { return true; }
-	PadHandlerBase(pad_handler type = pad_handler::null, bool emulation = false);
+	PadHandlerBase(pad_handler type = pad_handler::null);
 	virtual ~PadHandlerBase() = default;
 	// Sets window to config the controller(optional)
 	virtual void SetPadData(const std::string& /*padId*/, u8 /*player_id*/, u8 /*large_motor*/, u8 /*small_motor*/, s32 /*r*/, s32 /*g*/, s32 /*b*/, bool /*player_led*/, bool /*battery_led*/, u32 /*battery_led_brightness*/) {}

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -10,8 +10,8 @@ constexpr std::array<u8, 6> battery_capacity = {0, 1, 25, 50, 75, 100};
 
 constexpr id_pair SONY_DS3_ID_0 = {0x054C, 0x0268};
 
-ds3_pad_handler::ds3_pad_handler(bool emulation)
-    : hid_pad_handler(pad_handler::ds3, emulation, {SONY_DS3_ID_0})
+ds3_pad_handler::ds3_pad_handler()
+    : hid_pad_handler(pad_handler::ds3, {SONY_DS3_ID_0})
 {
 	button_list =
 	{

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -135,7 +135,7 @@ class ds3_pad_handler final : public hid_pad_handler<ds3_device>
 #endif
 
 public:
-	ds3_pad_handler(bool emulation);
+	ds3_pad_handler();
 	~ds3_pad_handler();
 
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -59,8 +59,8 @@ namespace
 	}*/
 }
 
-ds4_pad_handler::ds4_pad_handler(bool emulation)
-    : hid_pad_handler<DS4Device>(pad_handler::ds4, emulation, {SONY_DS4_ID_0, SONY_DS4_ID_1, SONY_DS4_ID_2, ZEROPLUS_ID_0})
+ds4_pad_handler::ds4_pad_handler()
+    : hid_pad_handler<DS4Device>(pad_handler::ds4, {SONY_DS4_ID_0, SONY_DS4_ID_1, SONY_DS4_ID_2, ZEROPLUS_ID_0})
 {
 	// Unique names for the config files and our pad settings dialog
 	button_list =

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -164,7 +164,7 @@ class ds4_pad_handler final : public hid_pad_handler<DS4Device>
 	};
 
 public:
-	ds4_pad_handler(bool emulation);
+	ds4_pad_handler();
 	~ds4_pad_handler();
 
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -25,8 +25,8 @@ namespace
 	constexpr id_pair SONY_DUALSENSE_ID_1 = {0x054C, 0x0DF2}; // DualSense Edge
 }
 
-dualsense_pad_handler::dualsense_pad_handler(bool emulation)
-    : hid_pad_handler<DualSenseDevice>(pad_handler::dualsense, emulation, {SONY_DUALSENSE_ID_0, SONY_DUALSENSE_ID_1})
+dualsense_pad_handler::dualsense_pad_handler()
+    : hid_pad_handler<DualSenseDevice>(pad_handler::dualsense, {SONY_DUALSENSE_ID_0, SONY_DUALSENSE_ID_1})
 {
 	// Unique names for the config files and our pad settings dialog
 	button_list =

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -229,7 +229,7 @@ class dualsense_pad_handler final : public hid_pad_handler<DualSenseDevice>
 	};
 
 public:
-	dualsense_pad_handler(bool emulation);
+	dualsense_pad_handler();
 	~dualsense_pad_handler();
 
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -19,8 +19,8 @@
 
 LOG_CHANNEL(evdev_log, "evdev");
 
-evdev_joystick_handler::evdev_joystick_handler(bool emulation)
-    : PadHandlerBase(pad_handler::evdev, emulation)
+evdev_joystick_handler::evdev_joystick_handler()
+    : PadHandlerBase(pad_handler::evdev)
 {
 	init_configs();
 

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -400,7 +400,7 @@ class evdev_joystick_handler final : public PadHandlerBase
 	};
 
 public:
-	evdev_joystick_handler(bool emulation);
+	evdev_joystick_handler();
 	~evdev_joystick_handler();
 
 	void init_config(cfg_pad* cfg) override;

--- a/rpcs3/Input/gui_pad_thread.cpp
+++ b/rpcs3/Input/gui_pad_thread.cpp
@@ -201,26 +201,26 @@ std::shared_ptr<PadHandlerBase> gui_pad_thread::GetHandler(pad_handler type)
 		// Makes no sense to use this if we are in the GUI anyway
 		return nullptr;
 	case pad_handler::ds3:
-		return std::make_shared<ds3_pad_handler>(false);
+		return std::make_shared<ds3_pad_handler>();
 	case pad_handler::ds4:
-		return std::make_shared<ds4_pad_handler>(false);
+		return std::make_shared<ds4_pad_handler>();
 	case pad_handler::dualsense:
-		return std::make_shared<dualsense_pad_handler>(false);
+		return std::make_shared<dualsense_pad_handler>();
 	case pad_handler::skateboard:
-		return std::make_shared<skateboard_pad_handler>(false);
+		return std::make_shared<skateboard_pad_handler>();
 #ifdef _WIN32
 	case pad_handler::xinput:
-		return std::make_shared<xinput_pad_handler>(false);
+		return std::make_shared<xinput_pad_handler>();
 	case pad_handler::mm:
-		return std::make_shared<mm_joystick_handler>(false);
+		return std::make_shared<mm_joystick_handler>();
 #endif
 #ifdef HAVE_SDL2
 	case pad_handler::sdl:
-		return std::make_shared<sdl_pad_handler>(false);
+		return std::make_shared<sdl_pad_handler>();
 #endif
 #ifdef HAVE_LIBEVDEV
 	case pad_handler::evdev:
-		return std::make_shared<evdev_joystick_handler>(false);
+		return std::make_shared<evdev_joystick_handler>();
 #endif
 	}
 

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -21,8 +21,8 @@ static std::mutex s_hid_mutex; // hid_pad_handler is created by pad_thread and p
 static u8 s_hid_instances{0};
 
 template <class Device>
-hid_pad_handler<Device>::hid_pad_handler(pad_handler type, bool emulation, std::vector<id_pair> ids)
-    : PadHandlerBase(type, emulation), m_ids(std::move(ids))
+hid_pad_handler<Device>::hid_pad_handler(pad_handler type, std::vector<id_pair> ids)
+    : PadHandlerBase(type), m_ids(std::move(ids))
 {
 	std::scoped_lock lock(s_hid_mutex);
 	ensure(s_hid_instances++ < 255);

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -51,7 +51,7 @@ template <class Device>
 class hid_pad_handler : public PadHandlerBase
 {
 public:
-	hid_pad_handler(pad_handler type, bool emulation, std::vector<id_pair> ids);
+	hid_pad_handler(pad_handler type, std::vector<id_pair> ids);
 	~hid_pad_handler();
 
 	bool Init() override;

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -16,9 +16,9 @@ bool keyboard_pad_handler::Init()
 	return true;
 }
 
-keyboard_pad_handler::keyboard_pad_handler(bool emulation)
+keyboard_pad_handler::keyboard_pad_handler()
 	: QObject()
-	, PadHandlerBase(pad_handler::keyboard, emulation)
+	, PadHandlerBase(pad_handler::keyboard)
 {
 	init_configs();
 

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -69,7 +69,7 @@ class keyboard_pad_handler final : public QObject, public PadHandlerBase
 public:
 	bool Init() override;
 
-	keyboard_pad_handler(bool emulation);
+	keyboard_pad_handler();
 
 	void SetTargetWindow(QWindow* target);
 	void processKeyEvent(QKeyEvent* event, bool pressed);

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -2,7 +2,7 @@
 #include "mm_joystick_handler.h"
 #include "Emu/Io/pad_config.h"
 
-mm_joystick_handler::mm_joystick_handler(bool emulation) : PadHandlerBase(pad_handler::mm, emulation)
+mm_joystick_handler::mm_joystick_handler() : PadHandlerBase(pad_handler::mm)
 {
 	init_configs();
 

--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -109,7 +109,7 @@ class mm_joystick_handler final : public PadHandlerBase
 	};
 
 public:
-	mm_joystick_handler(bool emulation);
+	mm_joystick_handler();
 
 	bool Init() override;
 

--- a/rpcs3/Input/pad_thread.h
+++ b/rpcs3/Input/pad_thread.h
@@ -44,18 +44,21 @@ protected:
 	void InitLddPad(u32 handle, const u32* port_status);
 
 	// List of all handlers
-	std::map<pad_handler, std::shared_ptr<PadHandlerBase>> handlers;
+	std::map<pad_handler, std::shared_ptr<PadHandlerBase>> m_handlers;
 
 	// Used for pad_handler::keyboard
 	void* m_curthread = nullptr;
 	void* m_curwindow = nullptr;
 
 	PadInfo m_info{ 0, 0, false };
-	std::array<std::shared_ptr<Pad>, CELL_PAD_MAX_PORT_NUM> m_pads;
+	std::array<std::shared_ptr<Pad>, CELL_PAD_MAX_PORT_NUM> m_pads{};
+	std::array<bool, CELL_PAD_MAX_PORT_NUM> m_pads_connected{};
 
 	u32 num_ldd_pad = 0;
 
 private:
+	void update_pad_states();
+
 	u32 m_mask_start_press_to_resume = 0;
 	u64 m_track_start_press_begin_timestamp = 0;
 	bool m_resume_emulation_flag = false;

--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -15,7 +15,7 @@ u32 g_sdl_handler_count = 0;
 constexpr u32 rumble_duration_ms = 500; // Some high number to keep rumble updates at a minimum.
 constexpr u32 rumble_refresh_ms = rumble_duration_ms - 100; // We need to keep updating the rumble. Choose a refresh timeout that is unlikely to run into missed rumble updates.
 
-sdl_pad_handler::sdl_pad_handler(bool emulation) : PadHandlerBase(pad_handler::sdl, emulation)
+sdl_pad_handler::sdl_pad_handler() : PadHandlerBase(pad_handler::sdl)
 {
 	button_list =
 	{

--- a/rpcs3/Input/sdl_pad_handler.h
+++ b/rpcs3/Input/sdl_pad_handler.h
@@ -95,7 +95,7 @@ class sdl_pad_handler : public PadHandlerBase
 	};
 
 public:
-	sdl_pad_handler(bool emulation);
+	sdl_pad_handler();
 	~sdl_pad_handler();
 
 	SDLDevice::sdl_info get_sdl_info(int i);

--- a/rpcs3/Input/skateboard_pad_handler.cpp
+++ b/rpcs3/Input/skateboard_pad_handler.cpp
@@ -37,8 +37,8 @@ namespace
 	static constexpr std::array<u8, sizeof(skateboard_input_report)> disconnected_state  = { 0x00, 0x00, 0x0F, 0x80, 0x80, 0x80, 0x80, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 }
 
-skateboard_pad_handler::skateboard_pad_handler(bool emulation)
-    : hid_pad_handler<skateboard_device>(pad_handler::skateboard, emulation, {SKATEBOARD_ID_0})
+skateboard_pad_handler::skateboard_pad_handler()
+    : hid_pad_handler<skateboard_device>(pad_handler::skateboard, {SKATEBOARD_ID_0})
 {
 	// Unique names for the config files and our pad settings dialog
 	button_list =

--- a/rpcs3/Input/skateboard_pad_handler.h
+++ b/rpcs3/Input/skateboard_pad_handler.h
@@ -171,7 +171,7 @@ class skateboard_pad_handler final : public hid_pad_handler<skateboard_device>
 	};
 
 public:
-	skateboard_pad_handler(bool emulation);
+	skateboard_pad_handler();
 	~skateboard_pad_handler();
 
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -14,7 +14,7 @@ namespace XINPUT_INFO
 	};
 } // namespace XINPUT_INFO
 
-xinput_pad_handler::xinput_pad_handler(bool emulation) : PadHandlerBase(pad_handler::xinput, emulation)
+xinput_pad_handler::xinput_pad_handler() : PadHandlerBase(pad_handler::xinput)
 {
 	// Unique names for the config files and our pad settings dialog
 	button_list =

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -102,7 +102,7 @@ class xinput_pad_handler final : public PadHandlerBase
 	};
 
 public:
-	xinput_pad_handler(bool emulation);
+	xinput_pad_handler();
 	~xinput_pad_handler();
 
 	bool Init() override;


### PR DESCRIPTION
I noticed that the pad connection state in games doesn't respond to pad settings changes properly anymore.
For instance, after switching from a disconnected DS4 handler to a connected xbox handler I had to first disconnect and then connect the controller again before I could control the game again.

I think it's best to move the pad_state_notify_state_change to a dedicated spot in the pad thread.
This has several advantages:
- The connection state notifications are now independent from the pad handlers and their settings
- The code now has a single point of failure. We had 3 spots before and the conditions didn't even match.
- Fixes an issue where the passed index was always based on the pad count in the individual handlers instead of the total pad count
- We can remove the "emulation" parameter from the handlers

Please compare this with the current release to confirm that this improves things.