### PR TITLE
SPU LLVM: Avoid sinking stores out of non-loops

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -2340,6 +2340,7 @@ public:
 						}
 
 						bool has_gpr_barriers_in_the_way = false;
+						bool potential_loop = false;
 
 						for (auto [a2, b2] : sucs)
 						{
@@ -2351,6 +2352,7 @@ public:
 									break;
 								}
 
+								potential_loop = true;
 								continue;
 							}
 
@@ -2390,6 +2392,7 @@ public:
 									break;
 								}
 
+								potential_loop = true;
 								continue;
 							}
 
@@ -2421,6 +2424,12 @@ public:
 						if (has_gpr_barriers_in_the_way)
 						{
 							// Cannot sink store, has barriers in the way
+							continue;
+						}
+
+						if (!potential_loop)
+						{
+							spu_log.trace("Avoided postponing r%u store from block 0x%x (not loop)", i, block_q[bi].first);
 							continue;
 						}
 


### PR DESCRIPTION
Doing so in code not belonging to loops is non-beneficiary and may result in adverse effects on performance because the value has to be carried farther until the store. 