### PR TITLE
Fix locale on linux

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -64,6 +64,7 @@ std::unique_ptr<raw_mouse_handler> g_raw_mouse_handler;
 
 gui_application::gui_application(int& argc, char** argv) : QApplication(argc, argv)
 {
+	std::setlocale(LC_NUMERIC, "C"); // On linux Qt changes to system locale while initializing QCoreApplication
 }
 
 gui_application::~gui_application()


### PR DESCRIPTION
When launching emulator on linux, the following line appears in console:
> E CFG: cfg::try_to_float('0.000000'): invalid float

It happens because my systems locale uses comma as decimal separator while rpcs3 expects dot.

RPCS3 does try to set locale to C when launching:
https://github.com/RPCS3/rpcs3/blob/7e27e1420e9bf6545a6f642987f56ac335649bcd/rpcs3/main.cpp#L86-L91

But Qt sets this back to system default as documented [in here](https://doc.qt.io/qt-6/qcoreapplication.html):
> On Unix/Linux Qt is configured to use the system locale settings by default. This can cause a conflict when using POSIX functions, for instance, when converting between data types such as floats and strings, since the notation may differ between locales. To get around this problem, call the POSIX function setlocale(LC_NUMERIC,"C") right after initializing QApplication, QGuiApplication or QCoreApplication to reset the locale that is used for number formatting to "C"-locale.

This PR fixes the issue by changing locale back after application is initialized.