### PR TITLE
Improve keyboard modifier handling

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellKb.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellKb.cpp
@@ -11,7 +11,7 @@ error_code sys_config_stop(ppu_thread& ppu);
 
 extern bool is_input_allowed();
 
-LOG_CHANNEL(sys_io);
+LOG_CHANNEL(cellKb);
 
 template<>
 void fmt_class_string<CellKbError>::format(std::string& out, u64 arg)
@@ -77,7 +77,7 @@ void KeyboardHandlerBase::save(utils::serial& ar)
 
 error_code cellKbInit(ppu_thread& ppu, u32 max_connect)
 {
-	sys_io.warning("cellKbInit(max_connect=%d)", max_connect);
+	cellKb.warning("cellKbInit(max_connect=%d)", max_connect);
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
@@ -102,7 +102,7 @@ error_code cellKbInit(ppu_thread& ppu, u32 max_connect)
 
 error_code cellKbEnd(ppu_thread& ppu)
 {
-	sys_io.notice("cellKbEnd()");
+	cellKb.notice("cellKbEnd()");
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
@@ -123,7 +123,7 @@ error_code cellKbEnd(ppu_thread& ppu)
 
 error_code cellKbClearBuf(u32 port_no)
 {
-	sys_io.trace("cellKbClearBuf(port_no=%d)", port_no);
+	cellKb.trace("cellKbClearBuf(port_no=%d)", port_no);
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
@@ -158,7 +158,7 @@ error_code cellKbClearBuf(u32 port_no)
 
 u16 cellKbCnvRawCode(u32 arrange, u32 mkey, u32 led, u16 rawcode)
 {
-	sys_io.trace("cellKbCnvRawCode(arrange=%d, mkey=%d, led=%d, rawcode=0x%x)", arrange, mkey, led, rawcode);
+	cellKb.trace("cellKbCnvRawCode(arrange=%d, mkey=%d, led=%d, rawcode=0x%x)", arrange, mkey, led, rawcode);
 
 	// CELL_KB_RAWDAT
 	if (rawcode <= CELL_KEYC_E_UNDEF ||
@@ -308,7 +308,7 @@ u16 cellKbCnvRawCode(u32 arrange, u32 mkey, u32 led, u16 rawcode)
 
 error_code cellKbGetInfo(vm::ptr<CellKbInfo> info)
 {
-	sys_io.trace("cellKbGetInfo(info=*0x%x)", info);
+	cellKb.trace("cellKbGetInfo(info=*0x%x)", info);
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
@@ -340,7 +340,7 @@ error_code cellKbGetInfo(vm::ptr<CellKbInfo> info)
 
 error_code cellKbRead(u32 port_no, vm::ptr<CellKbData> data)
 {
-	sys_io.trace("cellKbRead(port_no=%d, data=*0x%x)", port_no, data);
+	cellKb.trace("cellKbRead(port_no=%d, data=*0x%x)", port_no, data);
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
@@ -397,7 +397,7 @@ error_code cellKbRead(u32 port_no, vm::ptr<CellKbData> data)
 
 error_code cellKbSetCodeType(u32 port_no, u32 type)
 {
-	sys_io.trace("cellKbSetCodeType(port_no=%d, type=%d)", port_no, type);
+	cellKb.trace("cellKbSetCodeType(port_no=%d, type=%d)", port_no, type);
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
@@ -425,7 +425,7 @@ error_code cellKbSetCodeType(u32 port_no, u32 type)
 
 error_code cellKbSetLEDStatus(u32 port_no, u8 led)
 {
-	sys_io.trace("cellKbSetLEDStatus(port_no=%d, led=%d)", port_no, led);
+	cellKb.trace("cellKbSetLEDStatus(port_no=%d, led=%d)", port_no, led);
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
@@ -454,7 +454,7 @@ error_code cellKbSetLEDStatus(u32 port_no, u8 led)
 
 error_code cellKbSetReadMode(u32 port_no, u32 rmode)
 {
-	sys_io.trace("cellKbSetReadMode(port_no=%d, rmode=%d)", port_no, rmode);
+	cellKb.trace("cellKbSetReadMode(port_no=%d, rmode=%d)", port_no, rmode);
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 
@@ -486,7 +486,7 @@ error_code cellKbSetReadMode(u32 port_no, u32 rmode)
 
 error_code cellKbGetConfiguration(u32 port_no, vm::ptr<CellKbConfig> config)
 {
-	sys_io.trace("cellKbGetConfiguration(port_no=%d, config=*0x%x)", port_no, config);
+	cellKb.trace("cellKbGetConfiguration(port_no=%d, config=*0x%x)", port_no, config);
 
 	auto& handler = g_fxo->get<KeyboardHandlerBase>();
 

--- a/rpcs3/Emu/Cell/Modules/cellMouse.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMouse.cpp
@@ -12,7 +12,7 @@ error_code sys_config_stop(ppu_thread& ppu);
 
 extern bool is_input_allowed();
 
-LOG_CHANNEL(sys_io);
+LOG_CHANNEL(cellMouse);
 
 template<>
 void fmt_class_string<CellMouseError>::format(std::string& out, u64 arg)
@@ -37,7 +37,7 @@ void fmt_class_string<CellMouseError>::format(std::string& out, u64 arg)
 
 error_code cellMouseInit(ppu_thread& ppu, u32 max_connect)
 {
-	sys_io.notice("cellMouseInit(max_connect=%d)", max_connect);
+	cellMouse.notice("cellMouseInit(max_connect=%d)", max_connect);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -60,7 +60,7 @@ error_code cellMouseInit(ppu_thread& ppu, u32 max_connect)
 
 error_code cellMouseClearBuf(u32 port_no)
 {
-	sys_io.trace("cellMouseClearBuf(port_no=%d)", port_no);
+	cellMouse.trace("cellMouseClearBuf(port_no=%d)", port_no);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -97,7 +97,7 @@ error_code cellMouseClearBuf(u32 port_no)
 
 error_code cellMouseEnd(ppu_thread& ppu)
 {
-	sys_io.notice("cellMouseEnd()");
+	cellMouse.notice("cellMouseEnd()");
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -113,7 +113,7 @@ error_code cellMouseEnd(ppu_thread& ppu)
 
 error_code cellMouseGetInfo(vm::ptr<CellMouseInfo> info)
 {
-	sys_io.trace("cellMouseGetInfo(info=*0x%x)", info);
+	cellMouse.trace("cellMouseGetInfo(info=*0x%x)", info);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -146,7 +146,7 @@ error_code cellMouseGetInfo(vm::ptr<CellMouseInfo> info)
 
 error_code cellMouseInfoTabletMode(u32 port_no, vm::ptr<CellMouseInfoTablet> info)
 {
-	sys_io.trace("cellMouseInfoTabletMode(port_no=%d, info=*0x%x)", port_no, info);
+	cellMouse.trace("cellMouseInfoTabletMode(port_no=%d, info=*0x%x)", port_no, info);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -183,7 +183,7 @@ error_code cellMouseInfoTabletMode(u32 port_no, vm::ptr<CellMouseInfoTablet> inf
 
 error_code cellMouseGetData(u32 port_no, vm::ptr<CellMouseData> data)
 {
-	sys_io.trace("cellMouseGetData(port_no=%d, data=*0x%x)", port_no, data);
+	cellMouse.trace("cellMouseGetData(port_no=%d, data=*0x%x)", port_no, data);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -233,7 +233,7 @@ error_code cellMouseGetData(u32 port_no, vm::ptr<CellMouseData> data)
 
 error_code cellMouseGetDataList(u32 port_no, vm::ptr<CellMouseDataList> data)
 {
-	sys_io.trace("cellMouseGetDataList(port_no=%d, data=0x%x)", port_no, data);
+	cellMouse.trace("cellMouseGetDataList(port_no=%d, data=0x%x)", port_no, data);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -288,7 +288,7 @@ error_code cellMouseGetDataList(u32 port_no, vm::ptr<CellMouseDataList> data)
 
 error_code cellMouseSetTabletMode(u32 port_no, u32 mode)
 {
-	sys_io.warning("cellMouseSetTabletMode(port_no=%d, mode=%d)", port_no, mode);
+	cellMouse.warning("cellMouseSetTabletMode(port_no=%d, mode=%d)", port_no, mode);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -324,7 +324,7 @@ error_code cellMouseSetTabletMode(u32 port_no, u32 mode)
 
 error_code cellMouseGetTabletDataList(u32 port_no, vm::ptr<CellMouseTabletDataList> data)
 {
-	sys_io.warning("cellMouseGetTabletDataList(port_no=%d, data=0x%x)", port_no, data);
+	cellMouse.warning("cellMouseGetTabletDataList(port_no=%d, data=0x%x)", port_no, data);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 
@@ -380,7 +380,7 @@ error_code cellMouseGetTabletDataList(u32 port_no, vm::ptr<CellMouseTabletDataLi
 
 error_code cellMouseGetRawData(u32 port_no, vm::ptr<CellMouseRawData> data)
 {
-	sys_io.trace("cellMouseGetRawData(port_no=%d, data=*0x%x)", port_no, data);
+	cellMouse.trace("cellMouseGetRawData(port_no=%d, data=*0x%x)", port_no, data);
 
 	auto& handler = g_fxo->get<MouseHandlerBase>();
 

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -14,7 +14,7 @@ error_code sys_config_stop(ppu_thread& ppu);
 
 extern bool is_input_allowed();
 
-LOG_CHANNEL(sys_io);
+LOG_CHANNEL(cellPad);
 
 template<>
 void fmt_class_string<CellPadError>::format(std::string& out, u64 arg)
@@ -148,7 +148,7 @@ extern void pad_state_notify_state_change(usz index, u32 state)
 
 error_code cellPadInit(ppu_thread& ppu, u32 max_connect)
 {
-	sys_io.warning("cellPadInit(max_connect=%d)", max_connect);
+	cellPad.warning("cellPadInit(max_connect=%d)", max_connect);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -182,7 +182,7 @@ error_code cellPadInit(ppu_thread& ppu, u32 max_connect)
 
 error_code cellPadEnd(ppu_thread& ppu)
 {
-	sys_io.notice("cellPadEnd()");
+	cellPad.notice("cellPadEnd()");
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -218,7 +218,7 @@ void clear_pad_buffer(const std::shared_ptr<Pad>& pad)
 
 error_code cellPadClearBuf(u32 port_no)
 {
-	sys_io.trace("cellPadClearBuf(port_no=%d)", port_no);
+	cellPad.trace("cellPadClearBuf(port_no=%d)", port_no);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -579,7 +579,7 @@ void pad_get_data(u32 port_no, CellPadData* data, bool get_periph_data = false)
 
 error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 {
-	sys_io.trace("cellPadGetData(port_no=%d, data=*0x%x)", port_no, data);
+	cellPad.trace("cellPadGetData(port_no=%d, data=*0x%x)", port_no, data);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -607,7 +607,7 @@ error_code cellPadGetData(u32 port_no, vm::ptr<CellPadData> data)
 
 error_code cellPadPeriphGetInfo(vm::ptr<CellPadPeriphInfo> info)
 {
-	sys_io.trace("cellPadPeriphGetInfo(info=*0x%x)", info);
+	cellPad.trace("cellPadPeriphGetInfo(info=*0x%x)", info);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -658,7 +658,7 @@ error_code cellPadPeriphGetInfo(vm::ptr<CellPadPeriphInfo> info)
 
 error_code cellPadPeriphGetData(u32 port_no, vm::ptr<CellPadPeriphData> data)
 {
-	sys_io.trace("cellPadPeriphGetData(port_no=%d, data=*0x%x)", port_no, data);
+	cellPad.trace("cellPadPeriphGetData(port_no=%d, data=*0x%x)", port_no, data);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -691,7 +691,7 @@ error_code cellPadPeriphGetData(u32 port_no, vm::ptr<CellPadPeriphData> data)
 
 error_code cellPadGetRawData(u32 port_no, vm::ptr<CellPadData> data)
 {
-	sys_io.todo("cellPadGetRawData(port_no=%d, data=*0x%x)", port_no, data);
+	cellPad.todo("cellPadGetRawData(port_no=%d, data=*0x%x)", port_no, data);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -720,7 +720,7 @@ error_code cellPadGetRawData(u32 port_no, vm::ptr<CellPadData> data)
 
 error_code cellPadGetDataExtra(u32 port_no, vm::ptr<u32> device_type, vm::ptr<CellPadData> data)
 {
-	sys_io.trace("cellPadGetDataExtra(port_no=%d, device_type=*0x%x, data=*0x%x)", port_no, device_type, data);
+	cellPad.trace("cellPadGetDataExtra(port_no=%d, device_type=*0x%x, data=*0x%x)", port_no, device_type, data);
 
 	// TODO: This is used just to get data from a BD/CEC remote,
 	// but if the port isnt a remote, device type is set to CELL_PAD_DEV_TYPE_STANDARD and just regular cellPadGetData is returned
@@ -744,7 +744,7 @@ error_code cellPadGetDataExtra(u32 port_no, vm::ptr<u32> device_type, vm::ptr<Ce
 
 error_code cellPadSetActDirect(u32 port_no, vm::ptr<CellPadActParam> param)
 {
-	sys_io.trace("cellPadSetActDirect(port_no=%d, param=*0x%x)", port_no, param);
+	cellPad.trace("cellPadSetActDirect(port_no=%d, param=*0x%x)", port_no, param);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -788,7 +788,7 @@ error_code cellPadSetActDirect(u32 port_no, vm::ptr<CellPadActParam> param)
 
 error_code cellPadGetInfo(vm::ptr<CellPadInfo> info)
 {
-	sys_io.trace("cellPadGetInfo(info=*0x%x)", info);
+	cellPad.trace("cellPadGetInfo(info=*0x%x)", info);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -833,7 +833,7 @@ error_code cellPadGetInfo(vm::ptr<CellPadInfo> info)
 
 error_code cellPadGetInfo2(vm::ptr<CellPadInfo2> info)
 {
-	sys_io.trace("cellPadGetInfo2(info=*0x%x)", info);
+	cellPad.trace("cellPadGetInfo2(info=*0x%x)", info);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -882,7 +882,7 @@ error_code cellPadGetInfo2(vm::ptr<CellPadInfo2> info)
 
 error_code cellPadGetCapabilityInfo(u32 port_no, vm::ptr<CellPadCapabilityInfo> info)
 {
-	sys_io.trace("cellPadGetCapabilityInfo(port_no=%d, data_addr:=0x%x)", port_no, info.addr());
+	cellPad.trace("cellPadGetCapabilityInfo(port_no=%d, data_addr:=0x%x)", port_no, info.addr());
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -913,7 +913,7 @@ error_code cellPadGetCapabilityInfo(u32 port_no, vm::ptr<CellPadCapabilityInfo> 
 
 error_code cellPadSetPortSetting(u32 port_no, u32 port_setting)
 {
-	sys_io.trace("cellPadSetPortSetting(port_no=%d, port_setting=0x%x)", port_no, port_setting);
+	cellPad.trace("cellPadSetPortSetting(port_no=%d, port_setting=0x%x)", port_no, port_setting);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -938,7 +938,7 @@ error_code cellPadSetPortSetting(u32 port_no, u32 port_setting)
 
 error_code cellPadInfoPressMode(u32 port_no)
 {
-	sys_io.trace("cellPadInfoPressMode(port_no=%d)", port_no);
+	cellPad.trace("cellPadInfoPressMode(port_no=%d)", port_no);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -965,7 +965,7 @@ error_code cellPadInfoPressMode(u32 port_no)
 
 error_code cellPadInfoSensorMode(u32 port_no)
 {
-	sys_io.trace("cellPadInfoSensorMode(port_no=%d)", port_no);
+	cellPad.trace("cellPadInfoSensorMode(port_no=%d)", port_no);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -992,7 +992,7 @@ error_code cellPadInfoSensorMode(u32 port_no)
 
 error_code cellPadSetPressMode(u32 port_no, u32 mode)
 {
-	sys_io.trace("cellPadSetPressMode(port_no=%d, mode=%d)", port_no, mode);
+	cellPad.trace("cellPadSetPressMode(port_no=%d, mode=%d)", port_no, mode);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -1026,7 +1026,7 @@ error_code cellPadSetPressMode(u32 port_no, u32 mode)
 
 error_code cellPadSetSensorMode(u32 port_no, u32 mode)
 {
-	sys_io.trace("cellPadSetSensorMode(port_no=%d, mode=%d)", port_no, mode);
+	cellPad.trace("cellPadSetSensorMode(port_no=%d, mode=%d)", port_no, mode);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -1060,7 +1060,7 @@ error_code cellPadSetSensorMode(u32 port_no, u32 mode)
 
 error_code cellPadLddRegisterController()
 {
-	sys_io.warning("cellPadLddRegisterController()");
+	cellPad.warning("cellPadLddRegisterController()");
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -1085,7 +1085,7 @@ error_code cellPadLddRegisterController()
 
 error_code cellPadLddDataInsert(s32 handle, vm::ptr<CellPadData> data)
 {
-	sys_io.trace("cellPadLddDataInsert(handle=%d, data=*0x%x)", handle, data);
+	cellPad.trace("cellPadLddDataInsert(handle=%d, data=*0x%x)", handle, data);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -1110,7 +1110,7 @@ error_code cellPadLddDataInsert(s32 handle, vm::ptr<CellPadData> data)
 
 error_code cellPadLddGetPortNo(s32 handle)
 {
-	sys_io.trace("cellPadLddGetPortNo(handle=%d)", handle);
+	cellPad.trace("cellPadLddGetPortNo(handle=%d)", handle);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -1134,7 +1134,7 @@ error_code cellPadLddGetPortNo(s32 handle)
 
 error_code cellPadLddUnregisterController(s32 handle)
 {
-	sys_io.warning("cellPadLddUnregisterController(handle=%d)", handle);
+	cellPad.warning("cellPadLddUnregisterController(handle=%d)", handle);
 
 	std::lock_guard lock(pad::g_pad_mutex);
 
@@ -1160,7 +1160,7 @@ error_code cellPadLddUnregisterController(s32 handle)
 
 error_code cellPadFilterIIRInit(vm::ptr<CellPadFilterIIRSos> pSos, s32 cutoff)
 {
-	sys_io.todo("cellPadFilterIIRInit(pSos=*0x%x, cutoff=%d)", pSos, cutoff);
+	cellPad.todo("cellPadFilterIIRInit(pSos=*0x%x, cutoff=%d)", pSos, cutoff);
 
 	if (!pSos) // TODO: does this check for cutoff > 2 ?
 	{
@@ -1172,7 +1172,7 @@ error_code cellPadFilterIIRInit(vm::ptr<CellPadFilterIIRSos> pSos, s32 cutoff)
 
 u32 cellPadFilterIIRFilter(vm::ptr<CellPadFilterIIRSos> pSos, u32 filterIn)
 {
-	sys_io.todo("cellPadFilterIIRFilter(pSos=*0x%x, filterIn=%d)", pSos, filterIn);
+	cellPad.todo("cellPadFilterIIRFilter(pSos=*0x%x, filterIn=%d)", pSos, filterIn);
 
 	// TODO: apply filter
 
@@ -1183,7 +1183,7 @@ s32 sys_io_3733EA3C(u32 port_no, vm::ptr<u32> device_type, vm::ptr<CellPadData> 
 {
 	// Used by the ps1 emulator built into the firmware
 	// Seems to call the same function that getdataextra does
-	sys_io.trace("sys_io_3733EA3C(port_no=%d, device_type=*0x%x, data=*0x%x)", port_no, device_type, data);
+	cellPad.trace("sys_io_3733EA3C(port_no=%d, device_type=*0x%x, data=*0x%x)", port_no, device_type, data);
 	return cellPadGetDataExtra(port_no, device_type, data);
 }
 

--- a/rpcs3/Emu/Io/KeyboardHandler.h
+++ b/rpcs3/Emu/Io/KeyboardHandler.h
@@ -22,6 +22,39 @@ enum QtKeys
 	Key_Super_R    = 0x01000054
 };
 
+// See https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
+enum native_key : u32
+{
+#ifdef _WIN32
+	ctrl_l = 0x001D,
+	ctrl_r = 0xE01D,
+	shift_l = 0x002A,
+	shift_r = 0x0036,
+	alt_l = 0x0038,
+	alt_r = 0xE038,
+	meta_l = 0xE05B,
+	meta_r = 0xE05C,
+#elif defined (__APPLE__)
+	ctrl_l = 0x3B,  // kVK_Control
+	ctrl_r = 0x3E,  // kVK_RightControl
+	shift_l = 0x38, // kVK_Shift
+	shift_r = 0x3C, // kVK_RightShift
+	alt_l = 0x3A,   // kVK_Option
+	alt_r = 0x3D,   // kVK_RightOption
+	meta_l = 0x37,  // kVK_Command
+	meta_r = 0x36,  // kVK_RightCommand
+#else
+	ctrl_l = 0x0025,
+	ctrl_r = 0x0069,
+	shift_l = 0x0032,
+	shift_r = 0x003E,
+	alt_l = 0x0040,
+	alt_r = 0x006C,
+	meta_l = 0x0085,
+	meta_r = 0x0086,
+#endif
+};
+
 struct KbInfo
 {
 	u32 max_connect = 0;
@@ -88,7 +121,7 @@ public:
 	keyboard_consumer() {}
 	keyboard_consumer(identifier id) : m_id(id) {}
 
-	bool ConsumeKey(u32 code, bool pressed, bool is_auto_repeat, const std::u32string& key);
+	bool ConsumeKey(u32 qt_code, u32 native_code, bool pressed, bool is_auto_repeat, const std::u32string& key);
 	void SetIntercepted(bool intercepted);
 
 	static bool IsMetaKey(u32 code);
@@ -103,6 +136,8 @@ public:
 	void ReleaseAllKeys();
 
 protected:
+	u32 get_out_key_code(u32 qt_code, u32 native_code, u32 out_key_code);
+
 	identifier m_id = identifier::unknown;
 	KbInfo m_info{};
 	std::vector<Keyboard> m_keyboards;
@@ -126,7 +161,7 @@ public:
 	keyboard_consumer& GetConsumer(keyboard_consumer::identifier id);
 	void RemoveConsumer(keyboard_consumer::identifier id);
 
-	bool HandleKey(u32 code, bool pressed, bool is_auto_repeat, const std::u32string& key);
+	bool HandleKey(u32 qt_code, u32 native_code, bool pressed, bool is_auto_repeat, const std::u32string& key);
 	void SetIntercepted(bool intercepted);
 
 	stx::init_mutex init;

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -110,7 +110,7 @@ void basic_keyboard_handler::keyPressEvent(QKeyEvent* keyEvent)
 
 	const int key = getUnmodifiedKey(keyEvent);
 
-	if (key < 0 || !HandleKey(static_cast<u32>(key), true, keyEvent->isAutoRepeat(), keyEvent->text().toStdU32String()))
+	if (key < 0 || !HandleKey(static_cast<u32>(key), keyEvent->nativeScanCode(), true, keyEvent->isAutoRepeat(), keyEvent->text().toStdU32String()))
 	{
 		keyEvent->ignore();
 	}
@@ -131,7 +131,7 @@ void basic_keyboard_handler::keyReleaseEvent(QKeyEvent* keyEvent)
 
 	const int key = getUnmodifiedKey(keyEvent);
 
-	if (key < 0 || !HandleKey(static_cast<u32>(key), false, keyEvent->isAutoRepeat(), keyEvent->text().toStdU32String()))
+	if (key < 0 || !HandleKey(static_cast<u32>(key), keyEvent->nativeScanCode(), false, keyEvent->isAutoRepeat(), keyEvent->text().toStdU32String()))
 	{
 		keyEvent->ignore();
 	}
@@ -182,11 +182,14 @@ void basic_keyboard_handler::LoadSettings(Keyboard& keyboard)
 	buttons.emplace_back(Qt::Key_Control, CELL_KB_MKEY_L_CTRL);
 	buttons.emplace_back(Qt::Key_Shift, CELL_KB_MKEY_L_SHIFT);
 	buttons.emplace_back(Qt::Key_Alt, CELL_KB_MKEY_L_ALT);
-	buttons.emplace_back(Qt::Key_Super_L, CELL_KB_MKEY_L_WIN);
+	buttons.emplace_back(Qt::Key_Meta, CELL_KB_MKEY_L_WIN);
 	//buttons.emplace_back(, CELL_KB_MKEY_R_CTRL);  // There is no way to know if it's left or right in Qt at the moment
 	//buttons.emplace_back(, CELL_KB_MKEY_R_SHIFT); // There is no way to know if it's left or right in Qt at the moment
 	//buttons.emplace_back(, CELL_KB_MKEY_R_ALT);   // There is no way to know if it's left or right in Qt at the moment
-	buttons.emplace_back(Qt::Key_Super_R, CELL_KB_MKEY_R_WIN);
+	//buttons.emplace_back(, CELL_KB_MKEY_R_WIN);   // There is no way to know if it's left or right in Qt at the moment
+
+	buttons.emplace_back(Qt::Key_Super_L, CELL_KB_MKEY_L_WIN); // The super keys are supposed to be the windows keys, but they trigger the meta key instead. Let's assign the windows keys to both.
+	buttons.emplace_back(Qt::Key_Super_R, CELL_KB_MKEY_R_WIN); // The super keys are supposed to be the windows keys, but they trigger the meta key instead. Let's assign the windows keys to both.
 
 	// CELL_KB_RAWDAT
 	//buttons.emplace_back(, CELL_KEYC_NO_EVENT); // Redundant, listed for completeness
@@ -222,7 +225,7 @@ void basic_keyboard_handler::LoadSettings(Keyboard& keyboard)
 	buttons.emplace_back(Qt::Key_Down, CELL_KEYC_DOWN_ARROW);
 	buttons.emplace_back(Qt::Key_Up, CELL_KEYC_UP_ARROW);
 	//buttons.emplace_back(, CELL_KEYC_NUM_LOCK);
-	buttons.emplace_back(Qt::Key_Meta, CELL_KEYC_APPLICATION);
+	//buttons.emplace_back(, CELL_KEYC_APPLICATION); // This is probably the PS key on the PS3 keyboard
 	buttons.emplace_back(Qt::Key_Kana_Shift, CELL_KEYC_KANA); // maybe Key_Kana_Lock
 	buttons.emplace_back(Qt::Key_Henkan, CELL_KEYC_HENKAN);
 	buttons.emplace_back(Qt::Key_Muhenkan, CELL_KEYC_MUHENKAN);

--- a/rpcs3/Input/basic_keyboard_handler.cpp
+++ b/rpcs3/Input/basic_keyboard_handler.cpp
@@ -179,17 +179,17 @@ void basic_keyboard_handler::LoadSettings(Keyboard& keyboard)
 	std::vector<KbButton> buttons;
 
 	// Meta Keys
-	//buttons.emplace_back(Qt::Key_Control, CELL_KB_MKEY_L_CTRL);
+	buttons.emplace_back(Qt::Key_Control, CELL_KB_MKEY_L_CTRL);
 	buttons.emplace_back(Qt::Key_Shift, CELL_KB_MKEY_L_SHIFT);
 	buttons.emplace_back(Qt::Key_Alt, CELL_KB_MKEY_L_ALT);
 	buttons.emplace_back(Qt::Key_Super_L, CELL_KB_MKEY_L_WIN);
-	//buttons.emplace_back(, CELL_KB_MKEY_R_CTRL);
-	//buttons.emplace_back(, CELL_KB_MKEY_R_SHIFT);
-	//buttons.emplace_back(, CELL_KB_MKEY_R_ALT);
+	//buttons.emplace_back(, CELL_KB_MKEY_R_CTRL);  // There is no way to know if it's left or right in Qt at the moment
+	//buttons.emplace_back(, CELL_KB_MKEY_R_SHIFT); // There is no way to know if it's left or right in Qt at the moment
+	//buttons.emplace_back(, CELL_KB_MKEY_R_ALT);   // There is no way to know if it's left or right in Qt at the moment
 	buttons.emplace_back(Qt::Key_Super_R, CELL_KB_MKEY_R_WIN);
 
 	// CELL_KB_RAWDAT
-	//buttons.emplace_back(, CELL_KEYC_NO_EVENT);
+	//buttons.emplace_back(, CELL_KEYC_NO_EVENT); // Redundant, listed for completeness
 	//buttons.emplace_back(, CELL_KEYC_E_ROLLOVER);
 	//buttons.emplace_back(, CELL_KEYC_E_POSTFAIL);
 	//buttons.emplace_back(, CELL_KEYC_E_UNDEF);
@@ -221,7 +221,7 @@ void basic_keyboard_handler::LoadSettings(Keyboard& keyboard)
 	buttons.emplace_back(Qt::Key_Left, CELL_KEYC_LEFT_ARROW);
 	buttons.emplace_back(Qt::Key_Down, CELL_KEYC_DOWN_ARROW);
 	buttons.emplace_back(Qt::Key_Up, CELL_KEYC_UP_ARROW);
-	//buttons.emplace_back(WXK_NUMLOCK, CELL_KEYC_NUM_LOCK);
+	//buttons.emplace_back(, CELL_KEYC_NUM_LOCK);
 	buttons.emplace_back(Qt::Key_Meta, CELL_KEYC_APPLICATION);
 	buttons.emplace_back(Qt::Key_Kana_Shift, CELL_KEYC_KANA); // maybe Key_Kana_Lock
 	buttons.emplace_back(Qt::Key_Henkan, CELL_KEYC_HENKAN);

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -1,6 +1,7 @@
 #include "keyboard_pad_handler.h"
 #include "pad_thread.h"
 #include "Emu/Io/pad_config.h"
+#include "Emu/Io/KeyboardHandler.h"
 #include "Input/product_info.h"
 #include "rpcs3qt/gs_frame.h"
 
@@ -821,12 +822,16 @@ u32 keyboard_pad_handler::GetKeyCode(const QString& keyName)
 
 int keyboard_pad_handler::native_scan_code_from_string([[maybe_unused]] const std::string& key)
 {
-	// NOTE: Qt throws a Ctrl key at us when using Alt Gr, so there is no point in distinguishing left and right Alt at the moment
+	// NOTE: Qt throws a Ctrl key at us when using Alt Gr first, so right Alt does not work at the moment
+	if (key == "Shift Left") return native_key::shift_l;
+	if (key == "Shift Right") return native_key::shift_r;
+	if (key == "Ctrl Left") return native_key::ctrl_l;
+	if (key == "Ctrl Right") return native_key::ctrl_r;
+	if (key == "Alt Left") return native_key::alt_l;
+	if (key == "Alt Right") return native_key::alt_r;
+	if (key == "Meta Left") return native_key::meta_l;
+	if (key == "Meta Right") return native_key::meta_r;
 #ifdef _WIN32
-	if (key == "Shift Left") return 42;
-	if (key == "Shift Right") return 54;
-	if (key == "Ctrl Left") return 29;
-	if (key == "Ctrl Right") return 285;
 	if (key == "Num+0" || key == "Num+Ins") return 82;
 	if (key == "Num+1" || key == "Num+End") return 79;
 	if (key == "Num+2" || key == "Num+Down") return 80;
@@ -851,15 +856,20 @@ int keyboard_pad_handler::native_scan_code_from_string([[maybe_unused]] const st
 
 std::string keyboard_pad_handler::native_scan_code_to_string(int native_scan_code)
 {
+	// NOTE: the other Qt function "nativeVirtualKey" does not distinguish between VK_SHIFT and VK_RSHIFT key in Qt at the moment
+	// NOTE: Qt throws a Ctrl key at us when using Alt Gr first, so right Alt does not work at the moment
+	// NOTE: for MacOs: nativeScanCode may not work
 	switch (native_scan_code)
 	{
+	case native_key::shift_l: return "Shift Left";
+	case native_key::shift_r: return "Shift Right";
+	case native_key::ctrl_l: return "Ctrl Left";
+	case native_key::ctrl_r: return "Ctrl Right";
+	case native_key::alt_l: return "Alt Left";
+	case native_key::alt_r: return "Alt Right";
+	case native_key::meta_l: return "Meta Left";
+	case native_key::meta_r: return "Meta Right";
 #ifdef _WIN32
-	// NOTE: the other Qt function "nativeVirtualKey" does not distinguish between VK_SHIFT and VK_RSHIFT key in Qt at the moment
-	// NOTE: Qt throws a Ctrl key at us when using Alt Gr, so there is no point in distinguishing left and right Alt at the moment
-	case 42: return "Shift Left";
-	case 54: return "Shift Right";
-	case 29: return "Ctrl Left";
-	case 285: return "Ctrl Right";
 	case 82: return "Num+0"; // Also "Num+Ins" depending on numlock
 	case 79: return "Num+1"; // Also "Num+End" depending on numlock
 	case 80: return "Num+2"; // Also "Num+Down" depending on numlock
@@ -878,7 +888,6 @@ std::string keyboard_pad_handler::native_scan_code_to_string(int native_scan_cod
 	case 284: return "Num+Enter";
 #else
 	// TODO
-	// NOTE for MacOs: nativeScanCode may not work
 #endif
 	default: return "";
 	}


### PR DESCRIPTION
- Adds missing Control key back to basic keyboard handler (this was a recent regression)
- Distinguish between left and right modifier keys by using native scan codes (Qt doesn't provide us with proper info)
- Use seperate log channels for cellPad, cellMouse and cellKb

NOTE: Alt Gr may not work properly, due to the way Qt passes it as "CTRL-Left" and then "ALT-Right"

fixes #15718
fixes #3393