### PR TITLE
PPU: Fix access violation on logging

### DIFF
--- a/rpcs3/Emu/Cell/PPUFunction.h
+++ b/rpcs3/Emu/Cell/PPUFunction.h
@@ -305,6 +305,16 @@ public:
 		return addr + index * 8 + (is_code_addr ? 4 : 0);
 	}
 
+	bool is_func(u32 cia) const
+	{
+		if (cia % 4 || !addr || cia < addr)
+		{
+			return false;
+		}
+
+		return (cia - addr) / 8 < access().size();
+	}
+
 	// Allocation address
 	u32 addr = 0;
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2760,7 +2760,7 @@ void ppu_thread::fast_call(u32 addr, u64 rtoc, bool is_thread_entry)
 
 		const auto cia = _this->cia;
 
-		if (_this->current_function && vm::read32(cia) != ppu_instructions::SC(0))
+		if (_this->current_function && g_fxo->get<ppu_function_manager>().is_func(cia))
 		{
 			return fmt::format("PPU[0x%x] Thread (%s) [HLE:0x%08x, LR:0x%08x]", _this->id, *name_cache.get(), cia, _this->lr);
 		}


### PR DESCRIPTION
Do not read from memory at CIA address, this can lead to unexpected access violations especially for RawSPU's PPU Interrupt thread handlers. 