### PR TITLE
Invalidate ds4/dualsense calibration instead of disabling the controller

### DIFF
--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -432,31 +432,12 @@ bool dualsense_pad_handler::get_calibration_data(DualSenseDevice* dualsense_devi
 	dualsense_device->calib_data[CalibIndex::YAW].bias   = read_s16(&buf[3]);
 	dualsense_device->calib_data[CalibIndex::ROLL].bias  = read_s16(&buf[5]);
 
-	s16 pitch_plus, pitch_minus, roll_plus, roll_minus, yaw_plus, yaw_minus;
-
-	// TODO: This was copied from DS4. Find out if it applies here.
-	// Check for calibration data format
-	// It's going to be either alternating +/- or +++---
-	if (read_s16(&buf[9]) < 0 && read_s16(&buf[7]) > 0)
-	{
-		// Wired mode for OEM controllers
-		pitch_plus  = read_s16(&buf[7]);
-		pitch_minus = read_s16(&buf[9]);
-		yaw_plus    = read_s16(&buf[11]);
-		yaw_minus   = read_s16(&buf[13]);
-		roll_plus   = read_s16(&buf[15]);
-		roll_minus  = read_s16(&buf[17]);
-	}
-	else
-	{
-		// Bluetooth mode and wired mode for some 3rd party controllers
-		pitch_plus  = read_s16(&buf[7]);
-		yaw_plus    = read_s16(&buf[9]);
-		roll_plus   = read_s16(&buf[11]);
-		pitch_minus = read_s16(&buf[13]);
-		yaw_minus   = read_s16(&buf[15]);
-		roll_minus  = read_s16(&buf[17]);
-	}
+	const s16 pitch_plus  = read_s16(&buf[7]);
+	const s16 pitch_minus = read_s16(&buf[9]);
+	const s16 yaw_plus    = read_s16(&buf[11]);
+	const s16 yaw_minus   = read_s16(&buf[13]);
+	const s16 roll_plus   = read_s16(&buf[15]);
+	const s16 roll_minus  = read_s16(&buf[17]);
 
 	// Confirm correctness. Need confirmation with dongle with no active controller
 	if (pitch_plus <= 0 || yaw_plus <= 0 || roll_plus <= 0 ||

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -8,9 +8,9 @@
 
 struct CalibData
 {
-	s16 bias;
-	s32 sens_numer;
-	s32 sens_denom;
+	s16 bias = 0;
+	s32 sens_numer = 0;
+	s32 sens_denom = 0;
 };
 
 enum CalibIndex
@@ -87,12 +87,12 @@ protected:
 	virtual int send_output_report(Device* device) = 0;
 	virtual DataStatus get_data(Device* device) = 0;
 
-	static s16 apply_calibration(s32 rawValue, const CalibData& calibData)
+	static s16 apply_calibration(s32 raw_value, const CalibData& calib_data)
 	{
-		const s32 biased = rawValue - calibData.bias;
-		const s32 quot   = calibData.sens_numer / calibData.sens_denom;
-		const s32 rem    = calibData.sens_numer % calibData.sens_denom;
-		const s32 output = (quot * biased) + ((rem * biased) / calibData.sens_denom);
+		const s32 biased = raw_value - calib_data.bias;
+		const s32 quot   = calib_data.sens_numer / calib_data.sens_denom;
+		const s32 rem    = calib_data.sens_numer % calib_data.sens_denom;
+		const s32 output = (quot * biased) + ((rem * biased) / calib_data.sens_denom);
 
 		return static_cast<s16>(std::clamp<s32>(output, s16{smin}, s16{smax}));
 	}


### PR DESCRIPTION
- Invalidate ds4/dualsense calibration instead of disabling the controller (same as linux kernel)
- Use same dualsense gyro calibration values as linux kernel

maybe fixes #15728