### PR TITLE
input: add missing lock to keyboard handler ReleaseAllKeys

### DIFF
--- a/rpcs3/Emu/Io/KeyboardHandler.cpp
+++ b/rpcs3/Emu/Io/KeyboardHandler.cpp
@@ -306,6 +306,8 @@ void keyboard_consumer::SetIntercepted(bool intercepted)
 
 void KeyboardHandlerBase::ReleaseAllKeys()
 {
+	std::lock_guard<std::mutex> lock(m_mutex);
+
 	for (auto& [id, consumer] : m_consumers)
 	{
 		consumer.ReleaseAllKeys();


### PR DESCRIPTION
- This should fix a segfault I encountered when closing a game.
I think the consumers were removed while the window went out of focus.