### PR TITLE
input: actually initialize midi drum notes and combos

### DIFF
--- a/rpcs3/Emu/Io/RB3MidiDrums.cpp
+++ b/rpcs3/Emu/Io/RB3MidiDrums.cpp
@@ -315,6 +315,9 @@ usb_device_rb3_midi_drums::Definition::Definition(std::string name, const std::s
 usb_device_rb3_midi_drums::usb_device_rb3_midi_drums(const std::array<u8, 7>& location, const std::string& device_name)
 	: usb_device_emulated(location)
 {
+	m_id_to_note_mapping = midi::create_id_to_note_mapping();
+	combo.reload_definitions();
+
 	UsbDeviceDescriptor descriptor{};
 	descriptor.bcdDevice = 0x0200;
 	descriptor.bDeviceClass = 0x00;


### PR DESCRIPTION
Hotfix for last commit.
Should fix initial midi drum button mapping.