### PR TITLE
Remove check_state() inside thread notificatios

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -557,29 +557,6 @@ void cpu_thread::operator()()
 	// Register thread in g_cpu_array
 	s_cpu_counter++;
 
-	atomic_wait_engine::set_notify_callback(g_use_rtm || get_class() != thread_class::ppu ? nullptr : +[](const void*, u64 progress)
-	{
-		static thread_local bool wait_set = false;
-
-		cpu_thread* _cpu = get_current_cpu_thread();
-
-		// Wait flag isn't set asynchronously so this should be thread-safe
-		if (progress == 0 && _cpu->state.none_of(cpu_flag::wait + cpu_flag::temp))
-		{
-			// Operation just started and syscall is imminent
-			_cpu->state += cpu_flag::wait + cpu_flag::temp;
-			wait_set = true;
-			return;
-		}
-
-		if (progress == umax && std::exchange(wait_set, false))
-		{
-			// Operation finished: need to clean wait flag
-			ensure(!_cpu->check_state());
-			return;
-		}
-	});
-
 	static thread_local struct thread_cleanup_t
 	{
 		cpu_thread* _this = nullptr;
@@ -597,8 +574,6 @@ void cpu_thread::operator()()
 			{
 				ptr->compare_and_swap(_this, nullptr);
 			}
-
-			atomic_wait_engine::set_notify_callback(nullptr);
 
 			g_tls_log_control = [](const char*, u64){};
 

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -81,7 +81,7 @@ struct gui_listener : logs::listener
 
 			_new->msg += text;
 
-			queue.push(std::move(p));
+			queue.push<false>(std::move(p));
 		}
 	}
 

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -257,7 +257,6 @@ public:
 	static void notify_all(const void* data);
 
 	static void set_wait_callback(bool(*cb)(const void* data, u64 attempts, u64 stamp0));
-	static void set_notify_callback(void(*cb)(const void* data, u64 progress));
 	static void set_one_time_use_wait_callback(bool (*cb)(u64 progress));
 };
 


### PR DESCRIPTION
Do not call `cpu_thread::check_state()` in log utilities because it is dangerous and can cause deadlocks. After some consideration I removed imkplicit check_state() calls from all thread notification locations.Thanks to @Megamouse for debugging the randm freeze of and the bug associated.