### PR TITLE
CELL: More efficient reservation notificatins

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -262,7 +262,8 @@ public:
 	u64 rtime{0};
 	alignas(64) std::byte rdata[128]{}; // Reservation data
 	bool use_full_rdata{};
-	u32 res_notify{};
+	u32 res_notify{0};
+	u64 res_notify_time{0};
 
 	union ppu_prio_t
 	{

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -446,10 +446,10 @@ waitpkg_func static void __tpause(u32 cycles, u32 cstate)
 
 static std::array<atomic_t<u8>, 128> g_resrv_waiters_count;
 
-static inline atomic_t<u8>& get_resrv_waiters_count(u32 raddr)
+extern atomic_t<u8>& get_resrv_waiters_count(u32 raddr)
 {
 	// Storage efficient method to distinguish different nearby addresses (which are likely)
-	 return g_resrv_waiters_count[std::popcount(raddr) + ((raddr / 128) % 4) * 32];
+	 return g_resrv_waiters_count[std::popcount(raddr & -512) + ((raddr / 128) % 4) * 32];
 }
 
 void do_cell_atomic_128_store(u32 addr, const void* to_write);

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1333,9 +1333,12 @@ bool lv2_obj::sleep(cpu_thread& cpu, const u64 timeout)
 		{
 			static_cast<ppu_thread&>(cpu).res_notify = 0;
 
-			const usz notify_later_idx = std::basic_string_view<const void*>{g_to_notify, std::size(g_to_notify)}.find_first_of(std::add_pointer_t<const void>{});
-
-			if (notify_later_idx != umax)
+			if (static_cast<ppu_thread&>(cpu).res_notify_time != (vm::reservation_acquire(addr) & -128))
+			{
+				// Ignore outdated notification request
+			}
+			else if (usz notify_later_idx = std::basic_string_view<const void*>{g_to_notify, std::size(g_to_notify)}.find_first_of(std::add_pointer_t<const void>{});
+				notify_later_idx != umax)
 			{
 				g_to_notify[notify_later_idx] = &vm::reservation_notifier(addr);
 
@@ -1384,9 +1387,12 @@ bool lv2_obj::awake(cpu_thread* thread, s32 prio)
 		{
 			ppu->res_notify = 0;
 
-			const usz notify_later_idx = std::basic_string_view<const void*>{g_to_notify, std::size(g_to_notify)}.find_first_of(std::add_pointer_t<const void>{});
-
-			if (notify_later_idx != umax)
+			if (ppu->res_notify_time != (vm::reservation_acquire(addr) & -128))
+			{
+				// Ignore outdated notification request
+			}
+			else if (usz notify_later_idx = std::basic_string_view<const void*>{g_to_notify, std::size(g_to_notify)}.find_first_of(std::add_pointer_t<const void>{});
+				notify_later_idx != umax)
 			{
 				g_to_notify[notify_later_idx] = &vm::reservation_notifier(addr);
 


### PR DESCRIPTION
* Exclude most notifications related to reservations residing on identical reservation metadata.
* Discard pending but outdated reservation notification requests. (another reservation update has been made since) 