### PR TITLE
Fix midi drum config loading order

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -6747,7 +6747,7 @@ auto FCFID()
 
 	static const auto exec = [](ppu_thread& ppu, auto&& d, auto&& b)
 	{
-		f64 r = std::bit_cast<s64>(b);
+		f64 r = static_cast<f64>(std::bit_cast<s64>(b));
 		d = r;
 		ppu_set_fpcc<Flags...>(ppu, r, 0.);
 	};

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -1736,7 +1736,7 @@ error_code lv2_socket::abort_socket(s32 flags)
 		lv2_obj::append(ppu.get());
 	}
 
-	const u32 num_waiters = qcopy.size();
+	const u32 num_waiters = ::size32(qcopy);
 	if (num_waiters && (type == SYS_NET_SOCK_STREAM || type == SYS_NET_SOCK_DGRAM))
 	{
 		auto& nc = g_fxo->get<network_context>();

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -240,7 +240,6 @@ usb_handler_thread::usb_handler_thread()
 	bool found_skylander = false;
 	bool found_infinity  = false;
 	bool found_usj       = false;
-	bool found_rb3drums  = false;
 
 	for (ssize_t index = 0; index < ndev; index++)
 	{
@@ -426,17 +425,12 @@ usb_handler_thread::usb_handler_thread()
 			usb_devices.push_back(std::make_shared<usb_device_rb3_midi_keyboard>(get_new_location(), device.name));
 			break;
 		case midi_device_type::drums:
-			found_rb3drums = true;
+			if (!g_cfg_rb3drums.load())
+			{
+				sys_usbd.notice("Could not load rb3drums config. Using defaults.");
+			}
 			usb_devices.push_back(std::make_shared<usb_device_rb3_midi_drums>(get_new_location(), device.name));
 			break;
-		}
-	}
-
-	if (found_rb3drums)
-	{
-		if (!g_cfg_rb3drums.load())
-		{
-			sys_usbd.notice("Could not load rb3drums config. Using defaults.");
 		}
 	}
 

--- a/rpcs3/Emu/Io/MouseHandler.cpp
+++ b/rpcs3/Emu/Io/MouseHandler.cpp
@@ -105,7 +105,7 @@ void MouseHandlerBase::Scroll(u32 index, s8 x, s8 y)
 	}
 }
 
-void MouseHandlerBase::Move(u32 index, s32 x_pos_new, s32 y_pos_new, s32 x_max, s32 y_max, const bool is_relative, s32 x_delta, s32 y_delta)
+void MouseHandlerBase::Move(u32 index, s32 x_pos_new, s32 y_pos_new, s32 x_max, s32 y_max, bool is_relative, s32 x_delta, s32 y_delta)
 {
 	std::lock_guard lock(mutex);
 

--- a/rpcs3/Emu/Io/MouseHandler.h
+++ b/rpcs3/Emu/Io/MouseHandler.h
@@ -145,7 +145,7 @@ public:
 
 	void Button(u32 index, u8 button, bool pressed);
 	void Scroll(u32 index, s8 x, s8 y);
-	void Move(u32 index, s32 x_pos_new, s32 y_pos_new, s32 x_max, s32 y_max, const bool is_relative = false, s32 x_delta = 0, s32 y_delta = 0);
+	void Move(u32 index, s32 x_pos_new, s32 y_pos_new, s32 x_max, s32 y_max, bool is_relative = false, s32 x_delta = 0, s32 y_delta = 0);
 
 	void SetIntercepted(bool intercepted);
 

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1252,7 +1252,9 @@
     <ClCompile Include="Emu\Io\mouse_config.cpp">
       <Filter>Emu\Io</Filter>
     </ClCompile>
-    <ClCompile Include="Emu\Io\MouseHandler.cpp" />
+    <ClCompile Include="Emu\Io\MouseHandler.cpp">
+      <Filter>Emu\Io</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -138,31 +138,28 @@ EmuCallbacks main_application::CreateCallbacks()
 
 	callbacks.init_mouse_handler = [this]()
 	{
-		switch (g_cfg.io.mouse.get())
-		{
-		case mouse_handler::null:
+		mouse_handler handler = g_cfg.io.mouse;
+
+		if (handler == mouse_handler::null)
 		{
 			switch (g_cfg.io.move)
 			{
 			case move_handler::mouse:
-			{
-				basic_mouse_handler* ret = g_fxo->init<MouseHandlerBase, basic_mouse_handler>(Emu.DeserialManager());
-				ret->moveToThread(get_thread());
-				ret->SetTargetWindow(m_game_window);
+				handler = mouse_handler::basic;
 				break;
-			}
 			case move_handler::raw_mouse:
-			{
-				g_fxo->init<MouseHandlerBase, raw_mouse_handler>(Emu.DeserialManager());
+				handler = mouse_handler::raw;
 				break;
-			}
 			default:
-			{
-				g_fxo->init<MouseHandlerBase, NullMouseHandler>(Emu.DeserialManager());
 				break;
 			}
-			}
+		}
 
+		switch (handler)
+		{
+		case mouse_handler::null:
+		{
+			g_fxo->init<MouseHandlerBase, NullMouseHandler>(Emu.DeserialManager());
 			break;
 		}
 		case mouse_handler::basic:

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -1070,10 +1070,22 @@ void gs_frame::take_screenshot(std::vector<u8> data, u32 sshot_width, u32 sshot_
 
 void gs_frame::mouseDoubleClickEvent(QMouseEvent* ev)
 {
-	if (m_disable_mouse || g_cfg.io.move == move_handler::mouse) return;
+	if (m_disable_mouse)
+	{
+		return;
+	}
+
+	switch (g_cfg.io.move)
+	{
+	case move_handler::mouse:
+	case move_handler::raw_mouse:
 #ifdef HAVE_LIBEVDEV
-	if (g_cfg.io.move == move_handler::gun) return;
+	case move_handler::gun:
 #endif
+		return;
+	default:
+		break;
+	}
 
 	if (ev->button() == Qt::LeftButton)
 	{


### PR DESCRIPTION
- Load midi drum config before creating the objects. This should fix initial note overrides and combos.
- Ignore raw mouse double click when used as move handler (just to be consistent with the other mouse handler. I was considering removing it, but I guess it's just annoying to have to set the option manually)
- Simplify mouse handler initialization
- Fix some warnings