### PR TITLE
allow the disabling of the ZCULL write report optimization

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -344,7 +344,8 @@ struct cfg_root : cfg::node
 		cfg::string gdb_server{ this, "GDB Server", "127.0.0.1:2345" };
 		cfg::_bool silence_all_logs{ this, "Silence All Logs", false, true };
 		cfg::string title_format{ this, "Window Title Format", "FPS: %F | %R | %V | %T [%t]", true };
-		cfg::_bool pause_during_home_menu{this, "Pause Emulation During Home Menu", false, false };
+		cfg::_bool pause_during_home_menu{ this, "Pause Emulation During Home Menu", false, false };
+		cfg::_bool disable_zcull_write_report_optimization{ this, "Disable ZCULL Write Report Optimization", false, true };
 
 	} misc{ this };
 


### PR DESCRIPTION
As noted in issue https://github.com/RPCS3/rpcs3/issues/15754 (and likely issue https://github.com/RPCS3/rpcs3/issues/15645 as well), one of the optimizations added in pull request https://github.com/RPCS3/rpcs3/pull/15618 causes some games to consistently freeze at various points.  This change introduces an internal miscellaneous custom option that allows for the disabling of this optimization, allowing a workaround for the freeze issue.