### PR TITLE
[WIP] SPU: Channel Loop Pattern Detection

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -7169,7 +7169,7 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 		{
 			//add_pattern(false, inst_attr::ch_lop, get_pc - result.entry_point);
 
-			spu_log.success("Channel Loop Pattern Detected! (read_pc=0x%x, branch_pc=0x%x, branch_target=0x%x, 0x%x-%s)", read_pc, pattern.branch_pc, pattern.branch_target, entry_point, func_hash);
+			spu_log.error("Channel Loop Pattern Detected! Report to developers! (read_pc=0x%x, branch_pc=0x%x, branch_target=0x%x, 0x%x-%s)", read_pc, pattern.branch_pc, pattern.branch_target, entry_point, func_hash);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -5275,7 +5275,7 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 							auto& entry = ::at32(reg_state_it, i);
 							const u32 entry_pc = entry.pc;
 
-							if (count == (state_it->atomic16.active ? 40 : 12))
+							if (count == (state_it->atomic16.active ? 25 : 12))
 							{
 								if (state_it->atomic16.active && !std::exchange(logged_block[target_pc / 4], true))
 								{
@@ -6929,7 +6929,7 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 			const auto ra = get_reg(op.ra);
 			const auto [af, av, at, ao, az, apc, ainst] = ra;
 
-			inherit_const_value(op.rt, ra, ra, av == op.si10, pos);
+			inherit_const_value(op.rt, ra, ra, av == op.si10 + 0u, pos);
 
 			if (rchcnt_loop.active)
 			{

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -7141,6 +7141,11 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 			value.reg2 = pattern.reg2;
 		}
 
+		if (true)
+		{
+			continue;
+		}
+
 		add_pattern(false, inst_attr::putllc16, pattern.put_pc - result.entry_point, value.data);
 
 		spu_log.success("PUTLLC16 Pattern Detected! (mem_count=%d, put_pc=0x%x, pc_rel=%d, offset=0x%x, const=%u, two_regs=%d, reg=%u, runtime=%d, 0x%x-%s) (putllc0=%d, putllc16+0=%d, all=%d)"

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1235,7 +1235,7 @@ class spu_llvm_recompiler : public spu_recompiler_base, public cpu_translator
 				rsx::reservation_lock rsx_lock(raddr, 128);
 
 				// Touch memory
-				vm::_ref<atomic_t<u8>>(dest ^ (4096 / 2)).compare_and_swap_test(0, 0);
+				utils::trigger_write_page_fault(vm::base(dest ^ (4096 / 2)));
 
 				auto [old_res, ok] = res.fetch_op([&](u64& rval)
 				{

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -209,6 +209,7 @@ public:
 		u32 known_ones{};
 		u32 known_zeroes{};
 		u32 origin = SPU_LS_SIZE;
+		bool is_instruction = false;
 
 		bool is_const() const;
 
@@ -242,7 +243,7 @@ public:
 		void invalidate_if_created(u32 current_pc);
 
 		template <usz Count = 1>
-		static std::conditional_t<Count == 1, reg_state_t, std::array<reg_state_t, Count>> make_unknown(u32 pc) noexcept
+		static std::conditional_t<Count == 1, reg_state_t, std::array<reg_state_t, Count>> make_unknown(u32 pc, u32 current_pc = SPU_LS_SIZE) noexcept
 		{
 			if constexpr (Count == 1)
 			{
@@ -250,6 +251,7 @@ public:
 				v.tag = alloc_tag();
 				v.flag = {};
 				v.origin = pc;
+				v.is_instruction = pc == current_pc;
 				return v;
 			}
 			else
@@ -258,12 +260,14 @@ public:
 
 				for (reg_state_t& state : result)
 				{
-					state = make_unknown<1>(pc);
+					state = make_unknown<1>(pc, current_pc);
 				}
 
 				return result;
 			}
 		}
+
+		bool compare_tags(const reg_state_t& rhs) const;
 
 		static reg_state_t from_value(u32 value) noexcept;
 		static u32 alloc_tag(bool reset = false) noexcept;


### PR DESCRIPTION
This is a draft, it does not do anything until later :)

This is an example of the pattern in the most simple form of it:

![image](https://github.com/RPCS3/rpcs3/assets/18193363/27d9cbe2-c267-4699-a509-b2fa7fd6e9a4)

It spins until the IN_MBOX channel has a value without side effects in the loop, in which case RPCS3 can use channel waiting to reduce CPU time.
Edit: I decided to merge it with only basic detection of the pattern without actual use because it has other commit s to solve regressions and that users would potentially respond to what games the pattern applies. (although the detection is yet to be tested)

* I also made the progress dialog's remaining time calculation much more stable
*  fixed some recent regressions.