### PR TITLE
Input GUI fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -835,10 +835,15 @@ void usb_handler_thread::disconnect_usb_device(std::shared_ptr<usb_device> dev, 
 
 void connect_usb_controller(u8 index, input::product_type type)
 {
-	bool already_connected = false;
-	auto& usbh = g_fxo->get<named_thread<usb_handler_thread>>();
+	auto usbh = g_fxo->try_get<named_thread<usb_handler_thread>>();
+	if (!usbh)
+	{
+		return;
+	}
 
-	if (const auto it = usbh.pad_to_usb.find(index); it != usbh.pad_to_usb.end())
+	bool already_connected = false;
+
+	if (const auto it = usbh->pad_to_usb.find(index); it != usbh->pad_to_usb.end())
 	{
 		if (it->second.first == type)
 		{
@@ -846,8 +851,8 @@ void connect_usb_controller(u8 index, input::product_type type)
 		}
 		else
 		{
-			usbh.disconnect_usb_device(it->second.second, true);
-			usbh.pad_to_usb.erase(it->first);
+			usbh->disconnect_usb_device(it->second.second, true);
+			usbh->pad_to_usb.erase(it->first);
 		}
 	}
 
@@ -859,9 +864,9 @@ void connect_usb_controller(u8 index, input::product_type type)
 		}
 
 		sys_usbd.success("Adding emulated GunCon3 (controller %d)", index);
-		std::shared_ptr<usb_device> dev = std::make_shared<usb_device_guncon3>(index, usbh.get_new_location());
-		usbh.connect_usb_device(dev, true);
-		usbh.pad_to_usb.emplace(index, std::pair(type, dev));
+		std::shared_ptr<usb_device> dev = std::make_shared<usb_device_guncon3>(index, usbh->get_new_location());
+		usbh->connect_usb_device(dev, true);
+		usbh->pad_to_usb.emplace(index, std::pair(type, dev));
 	}
 }
 

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -192,61 +192,6 @@ std::tuple<u16, u16> PadHandlerBase::ConvertToSquirclePoint(u16 inX, u16 inY, u3
 	return std::tuple<u16, u16>(newX, newY);
 }
 
-std::string PadHandlerBase::name_string() const
-{
-	return m_name_string;
-}
-
-usz PadHandlerBase::max_devices() const
-{
-	return m_max_devices;
-}
-
-bool PadHandlerBase::has_config() const
-{
-	return b_has_config;
-}
-
-bool PadHandlerBase::has_rumble() const
-{
-	return b_has_rumble;
-}
-
-bool PadHandlerBase::has_motion() const
-{
-	return b_has_motion;
-}
-
-bool PadHandlerBase::has_deadzones() const
-{
-	return b_has_deadzones;
-}
-
-bool PadHandlerBase::has_led() const
-{
-	return b_has_led;
-}
-
-bool PadHandlerBase::has_rgb() const
-{
-	return b_has_rgb;
-}
-
-bool PadHandlerBase::has_player_led() const
-{
-	return b_has_player_led;
-}
-
-bool PadHandlerBase::has_battery() const
-{
-	return b_has_battery;
-}
-
-bool PadHandlerBase::has_pressure_intensity_button() const
-{
-	return b_has_pressure_intensity_button;
-}
-
 void PadHandlerBase::init_configs()
 {
 	for (u32 i = 0; i < MAX_GAMEPADS; i++)

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -123,6 +123,7 @@ protected:
 	bool b_has_rgb = false;
 	bool b_has_player_led = false;
 	bool b_has_battery = false;
+	bool b_has_battery_led = false;
 	bool b_has_deadzones = false;
 	bool b_has_rumble = false;
 	bool b_has_motion = false;
@@ -249,17 +250,19 @@ public:
 	pad_handler m_type;
 	bool m_is_init = false;
 
-	std::string name_string() const;
-	usz max_devices() const;
-	bool has_config() const;
-	bool has_rumble() const;
-	bool has_motion() const;
-	bool has_deadzones() const;
-	bool has_led() const;
-	bool has_rgb() const;
-	bool has_player_led() const;
-	bool has_battery() const;
-	bool has_pressure_intensity_button() const;
+	std::vector<pad_ensemble>& bindings() { return m_bindings; }
+	std::string name_string() const { return m_name_string; }
+	usz max_devices() const { return m_max_devices; }
+	bool has_config() const { return b_has_config; }
+	bool has_rumble() const { return b_has_rumble; }
+	bool has_motion() const { return b_has_motion; }
+	bool has_deadzones() const { return b_has_deadzones; }
+	bool has_led() const { return b_has_led; }
+	bool has_rgb() const { return b_has_rgb; }
+	bool has_player_led() const { return b_has_player_led; }
+	bool has_battery() const { return b_has_battery; }
+	bool has_battery_led() const { return b_has_battery_led; }
+	bool has_pressure_intensity_button() const { return b_has_pressure_intensity_button; }
 
 	u16 NormalizeStickInput(u16 raw_value, s32 threshold, s32 multiplier, bool ignore_threshold = false) const;
 	void convert_stick_values(u16& x_out, u16& y_out, s32 x_in, s32 y_in, u32 deadzone, u32 anti_deadzone, u32 padsquircling) const;

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -53,6 +53,7 @@ ds3_pad_handler::ds3_pad_handler()
 	b_has_motion = true;
 	b_has_deadzones = true;
 	b_has_battery = true;
+	b_has_battery_led = true;
 	b_has_led = true;
 	b_has_rgb = false;
 	b_has_player_led = true;

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -113,6 +113,7 @@ ds4_pad_handler::ds4_pad_handler()
 	b_has_led = true;
 	b_has_rgb = true;
 	b_has_battery = true;
+	b_has_battery_led = true;
 
 	m_name_string = "DS4 Pad #";
 	m_max_devices = CELL_PAD_MAX_PORT_NUM;

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -85,6 +85,7 @@ dualsense_pad_handler::dualsense_pad_handler()
 	b_has_rgb = true;
 	b_has_player_led = true;
 	b_has_battery = true;
+	b_has_battery_led = true;
 
 	m_name_string = "DualSense Pad #";
 	m_max_devices = CELL_PAD_MAX_PORT_NUM;

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -363,7 +363,10 @@ void pad_thread::operator()()
 			}
 		}
 
-		update_pad_states();
+		if (Emu.IsRunning())
+		{
+			update_pad_states();
+		}
 
 		m_info.now_connect = connected_devices + num_ldd_pad;
 

--- a/rpcs3/Input/pad_thread.h
+++ b/rpcs3/Input/pad_thread.h
@@ -34,6 +34,8 @@ public:
 
 	void open_home_menu();
 
+	std::map<pad_handler, std::shared_ptr<PadHandlerBase>>& get_handlers() { return m_handlers; }
+
 	static std::shared_ptr<PadHandlerBase> GetHandler(pad_handler type);
 	static void InitPadConfig(cfg_pad& cfg, pad_handler type, std::shared_ptr<PadHandlerBase>& handler);
 

--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -170,6 +170,7 @@ sdl_pad_handler::sdl_pad_handler() : PadHandlerBase(pad_handler::sdl)
 	b_has_led = true;
 	b_has_rgb = true;
 	b_has_battery = true;
+	b_has_battery_led = true;
 
 	m_trigger_threshold = trigger_max / 2;
 	m_thumb_threshold = thumb_max / 2;

--- a/rpcs3/Input/skateboard_pad_handler.cpp
+++ b/rpcs3/Input/skateboard_pad_handler.cpp
@@ -81,6 +81,7 @@ skateboard_pad_handler::skateboard_pad_handler()
 	b_has_rgb = false;
 	b_has_player_led = false;
 	b_has_battery = false;
+	b_has_battery_led = false;
 	b_has_pressure_intensity_button = false;
 
 	m_name_string = "Skateboard #";

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -59,6 +59,7 @@ xinput_pad_handler::xinput_pad_handler() : PadHandlerBase(pad_handler::xinput)
 	b_has_rumble = true;
 	b_has_deadzones = true;
 	b_has_battery = true;
+	b_has_battery_led = false;
 
 	m_name_string = "XInput Pad #";
 	m_max_devices = XUSER_MAX_COUNT;

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.cpp
@@ -5,7 +5,7 @@
 #include <QPixmap>
 #include <QPainterPath>
 
-pad_led_settings_dialog::pad_led_settings_dialog(QDialog* parent, int colorR, int colorG, int colorB, bool has_rgb, bool has_player_led, bool player_led_enabled, bool has_battery, bool led_low_battery_blink, bool led_battery_indicator, int led_battery_indicator_brightness)
+pad_led_settings_dialog::pad_led_settings_dialog(QDialog* parent, int colorR, int colorG, int colorB, bool has_rgb, bool has_player_led, bool player_led_enabled, bool has_battery, bool has_battery_led, bool led_low_battery_blink, bool led_battery_indicator, int led_battery_indicator_brightness)
     : QDialog(parent)
     , ui(new Ui::pad_led_settings_dialog)
     , m_initial{colorR, colorG, colorB, player_led_enabled, led_low_battery_blink, led_battery_indicator, led_battery_indicator_brightness}
@@ -23,8 +23,8 @@ pad_led_settings_dialog::pad_led_settings_dialog(QDialog* parent, int colorR, in
 
 	ui->gb_player_led->setEnabled(has_player_led);
 	ui->gb_led_color->setEnabled(has_rgb);
-	ui->gb_battery_status->setEnabled(has_battery);
-	ui->gb_indicator_brightness->setEnabled(has_battery && has_rgb); // Let's restrict this to rgb capable devices for now
+	ui->gb_battery_status->setEnabled(has_battery && has_battery_led);
+	ui->gb_indicator_brightness->setEnabled(has_battery && has_battery_led && has_rgb); // Let's restrict this to rgb capable devices for now
 
 	connect(ui->bb_dialog_buttons, &QDialogButtonBox::clicked, [this](QAbstractButton* button)
 	{
@@ -61,8 +61,18 @@ pad_led_settings_dialog::pad_led_settings_dialog(QDialog* parent, int colorR, in
 				redraw_color_sample();
 			}
 		});
-		connect(ui->hs_indicator_brightness, &QAbstractSlider::valueChanged, this, &pad_led_settings_dialog::update_slider_label);
-		connect(ui->cb_led_indicate, &QCheckBox::toggled, this, &pad_led_settings_dialog::battery_indicator_checked);
+
+		if (ui->gb_battery_status->isEnabled())
+		{
+			connect(ui->hs_indicator_brightness, &QAbstractSlider::valueChanged, this, &pad_led_settings_dialog::update_slider_label);
+		}
+
+		if (ui->cb_led_indicate->isEnabled())
+		{
+			connect(ui->cb_led_indicate, &QCheckBox::toggled, this, &pad_led_settings_dialog::battery_indicator_checked);
+		}
+
+		battery_indicator_checked(ui->cb_led_indicate->isChecked());
 	}
 
 	// Draw color sample after showing the dialog, in order to have proper dimensions

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.h
@@ -14,7 +14,7 @@ class pad_led_settings_dialog : public QDialog
 	Q_OBJECT
 
 public:
-	explicit pad_led_settings_dialog(QDialog* parent, int colorR, int colorG, int colorB, bool has_rgb, bool has_player_led, bool player_led_enabled, bool has_battery, bool led_low_battery_blink, bool led_battery_indicator, int led_battery_indicator_brightness);
+	explicit pad_led_settings_dialog(QDialog* parent, int colorR, int colorG, int colorB, bool has_rgb, bool has_player_led, bool player_led_enabled, bool has_battery, bool has_battery_led, bool led_low_battery_blink, bool led_battery_indicator, int led_battery_indicator_brightness);
 	~pad_led_settings_dialog();
 
 	struct led_settings

--- a/rpcs3/rpcs3qt/pad_led_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_led_settings_dialog.ui
@@ -46,7 +46,7 @@
    <item>
     <widget class="QGroupBox" name="gb_player_led">
      <property name="title">
-      <string>GroupBox</string>
+      <string>Player LED</string>
      </property>
      <layout class="QVBoxLayout" name="gb_player_led_layout">
       <item>

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -404,7 +404,7 @@ void pad_settings_dialog::InitButtons()
 		ensure(m_handler);
 		const cfg_pad& cfg = GetPlayerConfig();
 		SetPadData(0, 0, cfg.led_battery_indicator.get());
-		pad_led_settings_dialog dialog(this, cfg.colorR, cfg.colorG, cfg.colorB, m_handler->has_rgb(), m_handler->has_player_led(), cfg.player_led_enabled.get(), m_handler->has_battery(), cfg.led_low_battery_blink.get(), cfg.led_battery_indicator.get(), cfg.led_battery_indicator_brightness);
+		pad_led_settings_dialog dialog(this, cfg.colorR, cfg.colorG, cfg.colorB, m_handler->has_rgb(), m_handler->has_player_led(), cfg.player_led_enabled.get(), m_handler->has_battery(), m_handler->has_battery_led(), cfg.led_low_battery_blink.get(), cfg.led_battery_indicator.get(), cfg.led_battery_indicator_brightness);
 		connect(&dialog, &pad_led_settings_dialog::pass_led_settings, this, [this](const pad_led_settings_dialog::led_settings& settings)
 		{
 			ensure(m_handler);
@@ -1220,6 +1220,7 @@ void pad_settings_dialog::UpdateLabels(bool is_reset)
 
 		// Apply stored/default LED settings to the device
 		m_enable_led = m_handler->has_led();
+		m_enable_battery_led = m_handler->has_battery_led();
 		SetPadData(0, 0);
 
 		// Enable battery and LED group box

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -118,6 +118,7 @@ private:
 	bool m_enable_deadzones{ false };
 	bool m_enable_led{ false };
 	bool m_enable_battery{ false };
+	bool m_enable_battery_led{ false };
 	bool m_enable_motion{ false };
 	bool m_enable_pressure_intensity_button{ true };
 

--- a/rpcs3/rpcs3qt/qt_camera_video_sink.cpp
+++ b/rpcs3/rpcs3qt/qt_camera_video_sink.cpp
@@ -103,10 +103,6 @@ bool qt_camera_video_sink::present(const QVideoFrame& frame)
 
 		switch (m_format)
 		{
-		case CELL_CAMERA_JPG:
-			break;
-		case CELL_CAMERA_RGBA:
-			break;
 		case CELL_CAMERA_RAW8: // The game seems to expect BGGR
 		{
 			// Let's use a very simple algorithm to convert the image to raw BGGR
@@ -233,6 +229,8 @@ bool qt_camera_video_sink::present(const QVideoFrame& frame)
 			synchronizer.waitForFinished();
 			break;
 		}
+		case CELL_CAMERA_JPG:
+		case CELL_CAMERA_RGBA:
 		case CELL_CAMERA_RAW10:
 		case CELL_CAMERA_YUV420:
 		case CELL_CAMERA_FORMAT_UNKNOWN:


### PR DESCRIPTION
- Fix player LED groupbox label
- Fix initial battery indicator checkbox state
- Disable battery LED settings if the pad handler doesn't support it
- Allow running pad thread without emulation (useful if you need to access pads in GUI dialogs)
- Copy JPG and RGBA camera data if needed