### PR TITLE
USB: GunCon3 updates

### DIFF
--- a/rpcs3/Emu/Io/guncon3_config.h
+++ b/rpcs3/Emu/Io/guncon3_config.h
@@ -42,9 +42,9 @@ struct cfg_gc3 final : public emulated_pad_config<guncon3_btn>
 	cfg_pad_btn<guncon3_btn> bs_y{this, "B-stick Y-Axis", guncon3_btn::bs_y, pad_button::rs_y};
 };
 
-struct cfg_guncon3 final : public emulated_pads_config<cfg_gc3, 2>
+struct cfg_guncon3 final : public emulated_pads_config<cfg_gc3, 4>
 {
-	cfg_guncon3() : emulated_pads_config<cfg_gc3, 2>("guncon3") {};
+	cfg_guncon3() : emulated_pads_config<cfg_gc3, 4>("guncon3") {};
 };
 
 extern cfg_guncon3 g_cfg_guncon3;

--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -146,7 +146,9 @@ enum
 	CELL_PAD_PCLASS_TYPE_SKATEBOARD = 0x8001,
 
 	// these are used together with pad->is_fake_pad to capture input events for usbd/gem/move without conflicting with cellPad
+	CELL_PAD_FAKE_TYPE_FIRST        = 0xa000,
 	CELL_PAD_FAKE_TYPE_GUNCON3      = 0xa000,
+	CELL_PAD_FAKE_TYPE_LAST,
 
 	CELL_PAD_PCLASS_TYPE_MAX // last item
 };

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -190,7 +190,8 @@ void pad_thread::Init()
 				i, cfg->device.to_string(), m_pads[i]->m_pad_handler, m_pads[i]->m_vendor_id, m_pads[i]->m_product_id, m_pads[i]->m_class_type, m_pads[i]->m_class_profile);
 		}
 
-		m_pads[i]->is_fake_pad = (g_cfg.io.move == move_handler::fake && i >= (static_cast<u32>(CELL_PAD_MAX_PORT_NUM) - static_cast<u32>(CELL_GEM_MAX_NUM))) || m_pads[i]->m_class_type == CELL_PAD_FAKE_TYPE_GUNCON3;
+		m_pads[i]->is_fake_pad = (g_cfg.io.move == move_handler::fake && i >= (static_cast<u32>(CELL_PAD_MAX_PORT_NUM) - static_cast<u32>(CELL_GEM_MAX_NUM)))
+			|| (m_pads[i]->m_class_type >= CELL_PAD_FAKE_TYPE_FIRST && m_pads[i]->m_class_type <= CELL_PAD_FAKE_TYPE_LAST);
 		connect_usb_controller(i, input::get_product_by_vid_pid(m_pads[i]->m_vendor_id, m_pads[i]->m_product_id));
 	}
 }

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -191,7 +191,7 @@ void pad_thread::Init()
 		}
 
 		m_pads[i]->is_fake_pad = (g_cfg.io.move == move_handler::fake && i >= (static_cast<u32>(CELL_PAD_MAX_PORT_NUM) - static_cast<u32>(CELL_GEM_MAX_NUM)))
-			|| (m_pads[i]->m_class_type >= CELL_PAD_FAKE_TYPE_FIRST && m_pads[i]->m_class_type <= CELL_PAD_FAKE_TYPE_LAST);
+			|| (m_pads[i]->m_class_type >= CELL_PAD_FAKE_TYPE_FIRST && m_pads[i]->m_class_type < CELL_PAD_FAKE_TYPE_LAST);
 		connect_usb_controller(i, input::get_product_by_vid_pid(m_pads[i]->m_vendor_id, m_pads[i]->m_product_id));
 	}
 }


### PR DESCRIPTION
- Process the mouse buttons even when x/y_max aren't yet determined.
  - Allows to start the calibration without shaking the mouse before.
- Extend support to 4 players. The games can't use more than 2, but it allows more flexibility to mix DS3 and GC3.
- Avoid OOB for unsupported Pads

#### Configuration :white_check_mark: :
| Menu                                         | 1 Player (Basic)                               | 1 Player (Raw)                                 | 2 Players                                        |
|----------------------------------------------|------------------------------------------------|------------------------------------------------|--------------------------------------------------|
| Configuration - Input/Output - Mouse Handler | Basic                                          | Raw                                            | Raw                                              |
| Configuration - Emulator - Viewport - Ignore doubleclicks for Fullscreen | Checked | Checked | Checked |
| Configuration - Pads                         | Player3 = GunCon3<br/>Player1-2,4-7 = Disabled | Player3 = GunCon3<br/>Player1-2,4-7 = Disabled | Player3-4 = GunCon3<br/>Player1-2,5-7 = Disabled |
| Configuration - Mice - Basic Mouse           | Button 1-X                                     | -                                              | -                                                |
| Configuration - Mice - Raw Mouse             | -                                              | Player3 = <HID...><br/>- Button 1-X<br/>Player1-2,4 = Disabled | Player3-4 = <HID...><br/>- Button 1-X<br/>Player1-2 = Disabled |
| Configuration - USB Devices - GunCon 3       | Player3<br/>- Trigger = Mouse Button 1<br/>...   | Player3<br/>- Trigger = Mouse Button 1<br/>...   | Player3-4<br/>- Trigger = Mouse Button 1<br/>...   |