### PR TITLE
Qt: fix camera id bugs

### DIFF
--- a/rpcs3/rpcs3qt/qt_camera_handler.cpp
+++ b/rpcs3/rpcs3qt/qt_camera_handler.cpp
@@ -298,13 +298,16 @@ void qt_camera_handler::update_camera_settings()
 	// Update camera if possible. We can only do this if it is already loaded.
 	if (m_camera && m_camera->isAvailable())
 	{
+		// Get camera id. Use camera id of Qt default if the "Default" camera is selected.
+		const std::string camera_id = (m_camera_id == g_cfg.io.camera_id.def) ? QMediaDevices::defaultVideoInput().id().toStdString() : m_camera_id;
+
 		// Load selected settings from config file
 		bool success = false;
-		cfg_camera::camera_setting cfg_setting = g_cfg_camera.get_camera_setting(m_camera_id, success);
+		cfg_camera::camera_setting cfg_setting = g_cfg_camera.get_camera_setting(camera_id, success);
 
 		if (success)
 		{
-			camera_log.notice("Found config entry for camera \"%s\"", m_camera_id);
+			camera_log.notice("Found config entry for camera \"%s\" (m_camera_id='%s')", camera_id, m_camera_id);
 
 			// List all available settings and choose the proper value if possible.
 			const double epsilon = 0.001;

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1181,7 +1181,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		for (const QCameraDevice& camera_info : QMediaDevices::videoInputs())
 		{
 			if (!camera_info.isNull())
-				ui->cameraIdBox->addItem(camera_info.description(), camera_info.id());
+			{
+				ui->cameraIdBox->addItem(camera_info.description(), QString(camera_info.id()));
+			}
 		}
 		if (const int index = ui->cameraIdBox->findData(qstr(selected_camera)); index >= 0)
 		{


### PR DESCRIPTION
- Fixes camera id string comparison in settings dialog IO tab
- Fixes "Default" camera id format selection in camera handler