### PR TITLE
SPU: Utilize Operating System sleep in detected RCHCNT loop

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -150,6 +150,9 @@ public:
 	// Emit function call
 	void CallFunction(u64 target, llvm::Value* indirect = nullptr);
 
+	// Emit state check mid-block
+	void TestAborted();
+
 	// Initialize global for writing
 	llvm::Value* RegInit(llvm::Value*& local);
 

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -244,7 +244,14 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 
 	case SPU_In_MBox_offs:
 	{
-		ch_in_mbox.push(value);
+		if (!ch_in_mbox.push(value).op_done)
+		{
+			if (auto cpu = cpu_thread::get_current())
+			{
+				cpu->state += cpu_flag::again;
+			}
+		}
+
 		return true;
 	}
 

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -6253,10 +6253,15 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 					rchcnt_loop.ch_state = vregs[op.rt];
 					invalidate = false;
 				}
-				else if (rchcnt_loop.active && it != rchcnt_loop_all.end())
+				else if (rchcnt_loop.active)
 				{
 					// Success
-					it->second.active = false;
+					rchcnt_loop.active = false;
+
+					if (it == rchcnt_loop_all.end())
+					{
+						rchcnt_loop_all.emplace(pos, rchcnt_loop);
+					}
 				}
 
 				break;
@@ -7167,7 +7172,7 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 
 		if (inst_attr attr = m_inst_attrs[(read_pc - entry_point) / 4]; attr == inst_attr::none)
 		{
-			//add_pattern(false, inst_attr::ch_lop, get_pc - result.entry_point);
+			add_pattern(false, inst_attr::rchcnt_loop, read_pc - result.entry_point);
 
 			spu_log.error("Channel Loop Pattern Detected! Report to developers! (read_pc=0x%x, branch_pc=0x%x, branch_target=0x%x, 0x%x-%s)", read_pc, pattern.branch_pc, pattern.branch_target, entry_point, func_hash);
 		}

--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -390,6 +390,7 @@ protected:
 		omit,
 		putllc16,
 		putllc0,
+		rchcnt_loop,
 	};
 
 	std::vector<inst_attr> m_inst_attrs;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -176,6 +176,14 @@ enum : u32
 	SPU_FAKE_BASE_ADDR  = 0xE8000000,
 };
 
+struct spu_channel_op_state
+{
+	u8 old_count;
+	u8 count;
+	bool notify;
+	bool op_done;
+};
+
 struct alignas(16) spu_channel
 {
 	// Low 32 bits contain value
@@ -186,8 +194,10 @@ struct alignas(16) spu_channel
 
 public:
 	static constexpr u32 off_wait  = 32;
+	static constexpr u32 off_occupy = 32;
 	static constexpr u32 off_count = 63;
 	static constexpr u64 bit_wait  = 1ull << off_wait;
+	static constexpr u64 bit_occupy = 1ull << off_occupy;
 	static constexpr u64 bit_count = 1ull << off_count;
 
 	// Returns true on success
@@ -207,20 +217,21 @@ public:
 
 	// Push unconditionally, may require notification
 	// Performing bitwise OR with previous value if specified, otherwise overwiting it
-	bool push(u32 value, bool to_or = false)
+	// Returns old count and new count
+	spu_channel_op_state push(u32 value, bool to_or = false, bool postpone_notify = false)
 	{
 		while (true)
 		{
 			const auto [old, pushed_to_data] = data.fetch_op([&](u64& data)
 			{
-				if (data == bit_wait)
+				if (data & bit_occupy)
 				{
 					return false;
 				}
 
 				if (to_or)
 				{
-					data |= bit_count | value;
+					data = bit_count | (static_cast<u32>(data) | value);
 				}
 				else
 				{
@@ -233,26 +244,42 @@ public:
 			if (!pushed_to_data)
 			{
 				// Insert the pending value in special storage for waiting SPUs, leave no time in which the channel has data
-				if (!jostling_value.compare_and_swap_test(bit_wait, value))
+				if (!jostling_value.compare_and_swap_test(bit_occupy, value))
 				{
 					// Other thread has inserted a value through jostling_value, retry
 					continue;
 				}
+			}
 
+			if (old & bit_wait)
+			{
 				// Turn off waiting bit manually (must succeed because waiting bit can only be resetted by the thread pushed to jostling_value)
-				ensure(this->data.bit_test_reset(off_wait));
-				utils::bless<atomic_t<u32>>(&data)[1].notify_one();
+				if (!this->data.bit_test_reset(off_wait))
+				{
+					// Could be fatal or at emulation stopping, to be checked by the caller
+					return { (old & bit_count) == 0, 0, false, false };
+				}
+
+				if (!postpone_notify)
+				{
+					utils::bless<atomic_t<u32>>(&data)[1].notify_one();
+				}
 			}
 
 			// Return true if count has changed from 0 to 1, this condition is considered satisfied even if we pushed a value directly to the special storage for waiting SPUs
-			return !pushed_to_data || (old & bit_count) == 0;
+			return { (old & bit_count) == 0, 1, (old & bit_wait) != 0, true };
 		}
+	}
+
+	void notify()
+	{
+		utils::bless<atomic_t<u32>>(&data)[1].notify_one();
 	}
 
 	// Returns true on success
 	bool try_pop(u32& out)
 	{
-		return data.fetch_op([&](u64& data)
+		return data.fetch_op([&out](u64& data)
 		{
 			if (data & bit_count) [[likely]]
 			{
@@ -284,7 +311,7 @@ public:
 	u32 pop()
 	{
 		// Value is not cleared and may be read again
-		constexpr u64 mask = bit_count | bit_wait;
+		constexpr u64 mask = bit_count | bit_occupy;
 
 		const u64 old = data.fetch_op([&](u64& data)
 		{
@@ -295,10 +322,10 @@ public:
 				return;
 			}
 
-			data &= ~mask;
+			data &= ~(mask | bit_wait);
 		});
 
-		if ((old & mask) == mask)
+		if (old & bit_wait)
 		{
 			utils::bless<atomic_t<u32>>(&data)[1].notify_one();
 		}
@@ -324,7 +351,7 @@ public:
 
 	u32 get_count() const
 	{
-		return static_cast<u32>(data >> off_count);
+		return (data & bit_count) ? 1 : 0;
 	}
 };
 
@@ -344,59 +371,26 @@ struct spu_channel_4_t
 	atomic_t<u64> jostling_value;
 	atomic_t<u32> value3;
 
-	static constexpr u32 off_wait  = 32;
+	static constexpr u32 off_wait  = 0;
+	static constexpr u32 off_occupy = 7;
 	static constexpr u64 bit_wait  = 1ull << off_wait;
+	static constexpr u64 bit_occupy = 1ull << off_occupy;
+	static constexpr u64 jostling_flag = 1ull << 63;
 
 	void clear()
 	{
 		values.release({});
+		jostling_value.release(0);
+		value3.release(0);
 	}
 
 	// push unconditionally (overwriting latest value), returns true if needs signaling
-	void push(u32 value)
+	// returning if could be aborted (operation failed unexpectedly)
+	spu_channel_op_state push(u32 value, bool postpone_notify = false);
+
+	void notify()
 	{
-		while (true)
-		{
-			value3.release(value);
-			const auto [old, pushed_to_data] = values.fetch_op([&](sync_var_t& data)
-			{
-				if (data.waiting)
-				{
-					return false;
-				}
-
-				switch (data.count++)
-				{
-				case 0: data.value0 = value; break;
-				case 1: data.value1 = value; break;
-				case 2: data.value2 = value; break;
-				default:
-				{
-					data.count = 4;
-					data.value3_inval++; // Ensure the SPU reads the most recent value3 write in try_pop by re-loading
-					break;
-				}
-				}
-
-				return true;
-			});
-
-			if (!pushed_to_data)
-			{
-				// Insert the pending value in special storage for waiting SPUs, leave no time in which the channel has data
-				if (!jostling_value.compare_and_swap_test(bit_wait, value))
-				{
-					// Other thread has inserted a value through jostling_value, retry
-					continue;
-				}
-
-				// Turn off waiting bit manually (must succeed because waiting bit can only be resetted by the thread pushing to jostling_value)
-				ensure(atomic_storage<u8>::exchange(values.raw().waiting, 0));
-				utils::bless<atomic_t<u32>>(&values)[0].notify_one();
-			}
-
-			return;
-		}
+		utils::bless<atomic_t<u32>>(&values)[0].notify_one();
 	}
 
 	// returns non-zero value on success: queue size before removal
@@ -422,7 +416,7 @@ struct spu_channel_4_t
 	}
 
 	// Returns [previous count, value] (if aborted 0 count is returned)
-	std::pair<u32, u32> pop_wait(cpu_thread& spu);
+	std::pair<u32, u32> pop_wait(cpu_thread& spu, bool pop_value = true);
 
 	// returns current queue size without modification
 	uint try_read(u32 (&out)[4]) const
@@ -443,7 +437,7 @@ struct spu_channel_4_t
 
 	u32 get_count() const
 	{
-		return std::as_const(values).raw().count;
+		return atomic_storage<u8>::load(std::as_const(values).raw().count);
 	}
 
 	void set_values(u32 count, u32 value0, u32 value1 = 0, u32 value2 = 0, u32 value3 = 0)

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1749,9 +1749,23 @@ error_code sys_spu_thread_write_spu_mb(ppu_thread& ppu, u32 id, u32 value)
 		return CELL_ESRCH;
 	}
 
-	std::lock_guard lock(group->mutex);
+	spu_channel_op_state state{};
+	{
+		std::lock_guard lock(group->mutex);
 
-	thread->ch_in_mbox.push(value);
+		state = thread->ch_in_mbox.push(value, true);
+	}
+
+	if (!state.op_done)
+	{
+		ppu.state += cpu_flag::again;
+		return {};
+	}
+
+	if (state.notify)
+	{
+		thread->ch_in_mbox.notify();
+	}
 
 	return CELL_OK;
 }


### PR DESCRIPTION
Affects perhaps less thqan 100 games, if no "Channel pattern loop" message appears then no affect on games.
Makes RCHCNT busy loops waiting for channel to be accessible with no side effects in games, use operating system sleep and thread notifications to save CPU time.