### PR TITLE
Remove Alipay link from FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
 patreon: Nekotekina
-custom: https://rpcs3.net/alipay


### PR DESCRIPTION
As mentioned in #15805 the Alipay link on project page is broken as we no longer use that platform for donations and the page for it on rpcs3.net has been deleted.