### PR TITLE
3rd Party: Bump MoltenVK to 1.2.10 (Vulkan SDK 1.3.290)

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -15,8 +15,8 @@ arch -x86_64 /usr/local/bin/brew reinstall -f --build-from-source gnutls freetyp
 arch -x86_64 /usr/local/bin/brew install llvm@16 glew cmake sdl2 vulkan-headers coreutils
 arch -x86_64 /usr/local/bin/brew link -f llvm@16 ffmpeg@5
 
-# moltenvk based on commit for 1.2.9 release
-wget https://raw.githubusercontent.com/Homebrew/homebrew-core/c117dde3198d62817371984d04d50e653ca88f7d/Formula/m/molten-vk.rb
+# moltenvk based on commit for 1.2.10 release
+wget https://raw.githubusercontent.com/Homebrew/homebrew-core/0d9f25fbd1658e975d00bd0e8cccd20a0c2cb74b/Formula/m/molten-vk.rb
 arch -x86_64 /usr/local/bin/brew install -f --overwrite ./molten-vk.rb
 #export MACOSX_DEPLOYMENT_TARGET=12.0
 export CXX=clang++

--- a/3rdparty/MoltenVK/CMakeLists.txt
+++ b/3rdparty/MoltenVK/CMakeLists.txt
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(moltenvk
 	GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-	GIT_TAG bf097ed
+	GIT_TAG edbdcf0
 	BUILD_IN_SOURCE 1
 	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK
 	CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK/fetchDependencies" --macos


### PR DESCRIPTION
Testing: 
- Ensure CI passes
- Ensure macOS build works without issue

Changelog: 

- Improvements to bindless resources and descriptor indexing:
    - Add support for Metal 3 argument buffers.
    - Support argument buffers on all platforms, when Metal 3 is available.
	- Support argument buffers on macOS when Metal 3 is not available.
	- Use Metal argument buffers by default when they are available.
	- Revert `MVKConfiguration::useMetalArgumentBuffers` and env var `MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS` to a boolean value, and enable it by default.
	- Support multiplanar images in Metal argument buffers.
	- Support a descriptor pool with less descriptors than the descriptor set layout, as long as the pool has enough descriptors for the variable descriptor count,
	- Update max number of bindless buffers and textures per stage to 1M, per Apple Docs.
	- Track `OpArrayLength` buffer-sizes buffer as an auxiliary buffer in each descriptor set argument buffer, as this is how SPIRV-Cross expects it.
- Add option to generate a GPU capture via a temporary named pipe from an external process.
- Fix shader conversion failure when using native texture atomics.
- MSL shader conversion, only pass resource bindings that apply to current shader stage.
- Graphics pipeline better support dynamic patch control points.
- Fix crash when `VkPipelineShaderStageCreateInfo::pTessellationState` is null.
- Update documentation for minimum runtime OS requirements to indicate macOS 10.15, iOS 13, or tvOS 13.
- Add support for Xcode 16, macOS 15 SDK, iOS 18 SDK, and MSL 3.2.
- Enforce barrier when sampling timestamps.
- Update Github CI versions to use Github's latest macOS and default Xcode, and update legacy CI support to macOS 12 and Xcode 13.4.1.
- Update dependency libraries to match Vulkan SDK 1.3.290.
- Update `MVK_PRIVATE_API_VERSION` to version `42`.
- Update to latest SPIRV-Cross:
	- MSL: Add option to force depth write in fragment shaders
	- MSL: Improve handling of padded descriptors with argument buffers
	- MSL: Support `ConstOffsets` on image gather.
	- MSL: Image gather `ConstOffsets` supports multiple address spaces.
	- MSL: Support a runtime array with dynamic offset in an argument buffer.
	- MSL: Support descriptor sets with recursive content when using argument buffers.
	- MSL: Don't bother supporting invalid multi-dimensional dynamic buffers.
	- MSL: Do not overwrite `rez_bind` when padding.
	- MSL: Only consider padding for non-aliased resources.
	- MSL: Always use layout-declared array size for argument buffers.
	- MSL: Allow UBO/SSBO resources to get the layout-derived size as well.
	- MSL: Improve handling of padded descriptors with argument buffers.
	- MSL: Fix invalid packing for pointer-to-vector.
	- MSL: Handle `OpPtrAccessChain` with ArrayStride
	- MSL: Consider pointer arithmetic for OpPtrAccessChain.
	- MSL: Cast to packed format when using unexpected stride.
	- MSL: Minor fix to resource type of `spvBufferSizeConstants` array indexes. 