### PR TITLE
Fixed compilation

### DIFF
--- a/rpcs3/Emu/Io/Dimensions.h
+++ b/rpcs3/Emu/Io/Dimensions.h
@@ -3,6 +3,7 @@
 #include "Emu/Io/usb_device.h"
 #include "Utilities/mutex.h"
 #include <array>
+#include <optional>
 #include <queue>
 
 struct dimensions_figure


### PR DESCRIPTION
missing optional header (from commmit 500bf0f3f5422b31ea4c2b70e2b0b19329deac7f).

This was caught when compiling rpcs3 from this repo: https://github.com/second-reality/linux-emulation/.
Since there is no build error through RPCS3 repo, I guess different flags must have been used. Anyway, the include is still missing.