### PR TITLE
sceNp: Fix sending partial results from sceNpScoreRecordGameData

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNp.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNp.cpp
@@ -5697,7 +5697,7 @@ error_code scenp_score_record_game_data(s32 transId, SceNpScoreBoardId boardId, 
 		return SCE_NP_COMMUNITY_ERROR_INSUFFICIENT_ARGUMENT;
 	}
 
-	auto [res, trans_ctx] = get_score_transaction_context(transId);
+	auto [res, trans_ctx] = get_score_transaction_context(transId, false);
 	if (res)
 		return *res;
 


### PR DESCRIPTION
`sceNpScoreRecordGameData` could be sending results in batches, but an error caused the transaction to reset every time, so those partial submissions would get corrupted.

Fixes Ghost Data in Ridge Racer 7.

![image](https://github.com/user-attachments/assets/38cd7464-fc39-425b-9001-47b9138915f0)
![image](https://github.com/user-attachments/assets/96ea2236-1aab-4da5-b942-efb71fd72ad6)
