### PR TITLE
Input: Reload viewport gui settings when changing visibility or active state of the game window

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -93,11 +93,12 @@ protected:
 	bool event(QEvent* ev) override;
 
 private:
+	void load_gui_settings();
 	void hide_on_close();
 	void toggle_recording();
 	void toggle_mouselock();
 	void update_cursor();
-	void handle_cursor(QWindow::Visibility visibility, bool from_event, bool start_idle_timer);
+	void handle_cursor(QWindow::Visibility visibility, bool visibility_changed, bool active_changed, bool start_idle_timer);
 
 private Q_SLOTS:
 	void mouse_hide_timeout();


### PR DESCRIPTION
- Reload Viewport gui settings when changing visibility or active state of the game window
![image](https://github.com/user-attachments/assets/df5a5a90-c299-43e5-9369-82ef1e6344b8)

- Log used pad config

It's been increasingly annoying to read log files of input issues and not being able to see what pad config was actually used.