### PR TITLE
Qt: Fix resolution dropdown if resolution flags of game are empty

### DIFF
--- a/rpcs3/rpcs3qt/config_adapter.cpp
+++ b/rpcs3/rpcs3qt/config_adapter.cpp
@@ -51,9 +51,9 @@ namespace cfg_adapter
 	QStringList get_options(const cfg_location& location)
 	{
 		QStringList values;
-		for (const auto& v : cfg_adapter::get_cfg(g_cfg, location.cbegin(), location.cend()).to_list())
+		for (const std::string& value : cfg_adapter::get_cfg(g_cfg, location.cbegin(), location.cend()).to_list())
 		{
-			values.append(QString::fromStdString(v));
+			values.append(QString::fromStdString(value));
 		}
 		return values;
 	}

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -275,7 +275,7 @@ void emu_settings::RestoreDefaults()
 	Q_EMIT RestoreDefaultsSignal();
 }
 
-void emu_settings::SaveSettings()
+void emu_settings::SaveSettings() const
 {
 	YAML::Emitter out;
 	emit_data(out, m_current_settings);
@@ -1345,6 +1345,7 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 		case xfloat_accuracy::relaxed: return tr("Relaxed XFloat");
 		case xfloat_accuracy::inaccurate: return tr("Inaccurate XFloat");
 		}
+		break;
 	default:
 		break;
 	}

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -104,7 +104,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
 	/** Writes the unsaved settings to file.  Used in settings dialog on accept.*/
-	void SaveSettings();
+	void SaveSettings() const;
 
 private:
 	YAML::Node m_default_settings; // The default settings as a YAML node.


### PR DESCRIPTION
- Fixes custom config creation error for games that have no resolution.
- Fixes empty dropdowns if resolution flags are 0 by adding all resolutions.
- Make sure to keep 720p as option if the dropdown would be empty after all.
- Adds some missing break and fixes some const correctness in the emu_settings class.