### PR TITLE
cellMic: Wake up upon registering emulated SingStar microphone

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -149,6 +149,8 @@ void mic_context::load_config_and_init()
 			{
 				device.add_device(device_list[1]);
 			}
+
+			wake_up();
 		}
 		else
 		{


### PR DESCRIPTION
When using the emulated SingStar microphone, the device is only registered when initializing `cellMic`. However, the `mic_context` thread is only woken up when calling `register_device`. The registration happens before initializing `cellMic`, so the thread is never woken up after registering the device.

Add call to `wake_up` in `load_config_and_init` inside the emulated SingStar microphone specific code to fix this issue, allowing the thread to detect the device and update the microphone data.

This allows SingStar to receive the microphone data when using the emulated SingStar microphone that it previously wasn't receiving.
