### PR TITLE
cellMic: Fix CELLMIC_DEVATTR_CHANVOL handling

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -863,9 +863,9 @@ error_code cellMicGetDeviceAttr(s32 dev_num, CellMicDeviceAttr deviceAttributes,
 		switch (deviceAttributes)
 		{
 		case CELLMIC_DEVATTR_CHANVOL:
-			if (*arg1 > 2 || !arg2)
+			if (*arg1 == 0 || *arg1 > 2 || !arg2)
 				return CELL_MICIN_ERROR_PARAM;
-			*arg2 = ::at32(device.attr_chanvol, *arg1);
+			*arg2 = ::at32(device.attr_chanvol, *arg1 - 1);
 			break;
 		case CELLMIC_DEVATTR_LED: *arg1 = device.attr_led; break;
 		case CELLMIC_DEVATTR_GAIN: *arg1 = device.attr_gain; break;
@@ -897,9 +897,9 @@ error_code cellMicSetDeviceAttr(s32 dev_num, CellMicDeviceAttr deviceAttributes,
 	{
 	case CELLMIC_DEVATTR_CHANVOL:
 		// Used by SingStar to set the volume of each mic
-		if (arg1 > 2)
+		if (arg1 == 0 || arg1 > 2)
 			return CELL_MICIN_ERROR_PARAM;
-		::at32(device.attr_chanvol, arg1) = arg2;
+		::at32(device.attr_chanvol, arg1 - 1) = arg2;
 		break;
 	case CELLMIC_DEVATTR_LED: device.attr_led = arg1; break;
 	case CELLMIC_DEVATTR_GAIN: device.attr_gain = arg1; break;

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -8,6 +8,8 @@
 #include <Emu/IdManager.h>
 #include <Emu/Cell/lv2/sys_event.h>
 
+#include <numeric>
+
 LOG_CHANNEL(cellMic);
 
 template<>
@@ -863,9 +865,19 @@ error_code cellMicGetDeviceAttr(s32 dev_num, CellMicDeviceAttr deviceAttributes,
 		switch (deviceAttributes)
 		{
 		case CELLMIC_DEVATTR_CHANVOL:
-			if (*arg1 == 0 || *arg1 > 2 || !arg2)
+			if (*arg1 > 2 || !arg2)
 				return CELL_MICIN_ERROR_PARAM;
-			*arg2 = ::at32(device.attr_chanvol, *arg1 - 1);
+
+			if (*arg1 == 0)
+			{
+				// Calculate average volume of the channels
+				*arg2 = std::accumulate(device.attr_chanvol.begin(), device.attr_chanvol.end(), 0) / device.attr_chanvol.size();
+			}
+			else
+			{
+				*arg2 = ::at32(device.attr_chanvol, *arg1 - 1);
+			}
+
 			break;
 		case CELLMIC_DEVATTR_LED: *arg1 = device.attr_led; break;
 		case CELLMIC_DEVATTR_GAIN: *arg1 = device.attr_gain; break;
@@ -897,9 +909,18 @@ error_code cellMicSetDeviceAttr(s32 dev_num, CellMicDeviceAttr deviceAttributes,
 	{
 	case CELLMIC_DEVATTR_CHANVOL:
 		// Used by SingStar to set the volume of each mic
-		if (arg1 == 0 || arg1 > 2)
+		if (arg1 > 2)
 			return CELL_MICIN_ERROR_PARAM;
-		::at32(device.attr_chanvol, arg1 - 1) = arg2;
+
+		if (arg1 == 0)
+		{
+			device.attr_chanvol.fill(arg2);
+		}
+		else
+		{
+			::at32(device.attr_chanvol, arg1 - 1) = arg2;
+		}
+
 		break;
 	case CELLMIC_DEVATTR_LED: device.attr_led = arg1; break;
 	case CELLMIC_DEVATTR_GAIN: device.attr_gain = arg1; break;


### PR DESCRIPTION
The microphone index given in `arg1` is 1-indexed, so we have to subtract 1 from the index to access the proper value.

This wasn't caught up before since we were doing direct access of the array instead of using `::at32` which wouldn't check that the value is within bounds.

This allows the original SingStar game (with no updates installed) to boot up again, as it would otherwise crash then trying to set the volume to the second channel due to the index being out of bounds.