### PR TITLE
Add SPU usage for program dump, remove welcome dialog keyboard-shortcut

### DIFF
--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -372,7 +372,7 @@ public:
 			return;
 		}
 
-		jit_log.notice("LLVM: Created module: %s", _module->getName().data());
+		jit_log.trace("LLVM: Created module: %s", _module->getName().data());
 
 		// Restore space that was overestimated
 		ensure(m_compiler->add_sub_disk_space(max_size - module_file.size()));

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -320,18 +320,37 @@ namespace fmt
 		const uchar* data;
 		usz size;
 
+		base57() = default;
+
 		template <typename T>
-		base57(const T& arg)
-			: data(reinterpret_cast<const uchar*>(&arg))
+		base57(const T& arg) noexcept
+			: data(reinterpret_cast<const uchar*>(std::addressof(arg)))
 			, size(sizeof(T))
 		{
 		}
 
-		base57(const uchar* data, usz size)
+		base57(const uchar* data, usz size) noexcept
 			: data(data)
 			, size(size)
 		{
 		}
+	};
+
+	struct base57_result : public base57
+	{
+		std::unique_ptr<uchar[]> memory;
+
+		base57_result() noexcept = default;
+		base57_result(base57_result&&) = default;
+		base57_result& operator=(base57_result&&) = default;
+
+		explicit base57_result(usz size) noexcept
+			: base57(size ? new uchar[size] : nullptr, size)
+			, memory(const_cast<uchar*>(this->data))
+		{
+		}
+
+		static base57_result from_string(std::string_view str);
 	};
 
 	template <typename... Args>

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -73,14 +73,13 @@ void mic_context::operator()()
 	// Timestep in microseconds
 	constexpr u64 TIMESTEP = 256ull * 1'000'000ull / 48000ull;
 	u64 timeout = 0;
-	u32 oldvalue = 0;
 
 	while (thread_ctrl::state() != thread_state::aborting)
 	{
 		if (timeout != 0)
 		{
-			thread_ctrl::wait_on(wakey, oldvalue, timeout);
-			oldvalue = wakey;
+			thread_ctrl::wait_on(wakey, 0, timeout);
+			wakey.store(0);
 		}
 
 		std::lock_guard lock(mutex);
@@ -124,7 +123,7 @@ void mic_context::operator()()
 
 void mic_context::wake_up()
 {
-	wakey++;
+	wakey.store(1);
 	wakey.notify_one();
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -384,7 +384,9 @@ struct lv2_dir final : lv2_fs_object
 	// Read next
 	const fs::dir_entry* dir_read()
 	{
-		if (const u64 cur = pos++; cur < entries.size())
+		const u64 old_pos = pos;
+
+		if (const u64 cur = (old_pos < entries.size() ? pos++ : old_pos); cur < entries.size())
 		{
 			return &entries[cur];
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.cpp
@@ -92,7 +92,7 @@ void lv2_int_serv::join() const
 		std::bit_cast<u64>(&ppu_thread_exit)
 	});
 
-	thread->cmd_notify++;
+	thread->cmd_notify.store(1);
 	thread->cmd_notify.notify_one();
 	(*thread)();
 

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -581,7 +581,7 @@ error_code sys_ppu_thread_start(ppu_thread& ppu, u32 thread_id)
 	}
 	else
 	{
-		thread->cmd_notify++;
+		thread->cmd_notify.store(1);
 		thread->cmd_notify.notify_one();
 	}
 

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -933,7 +933,7 @@ namespace rsx
 					{ ppu_cmd::sleep, 0 }
 				});
 
-				intr_thread->cmd_notify++;
+				intr_thread->cmd_notify.store(1);
 				intr_thread->cmd_notify.notify_one();
 			}
 		}
@@ -3923,7 +3923,7 @@ namespace rsx
 					{ ppu_cmd::sleep, 0 }
 				});
 
-				intr_thread->cmd_notify++;
+				intr_thread->cmd_notify.store(1);
 				intr_thread->cmd_notify.notify_one();
 			}
 		}

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -57,7 +57,7 @@ namespace rsx
 				{ ppu_cmd::sleep, 0 }
 			});
 
-			RSX(ctx)->intr_thread->cmd_notify++;
+			RSX(ctx)->intr_thread->cmd_notify.store(1);
 			RSX(ctx)->intr_thread->cmd_notify.notify_one();
 		}
 
@@ -84,7 +84,7 @@ namespace rsx
 				{ ppu_cmd::sleep, 0 }
 			});
 
-			RSX(ctx)->intr_thread->cmd_notify++;
+			RSX(ctx)->intr_thread->cmd_notify.store(1);
 			RSX(ctx)->intr_thread->cmd_notify.notify_one();
 		}
 	}

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -65,7 +65,7 @@ extern std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu)
 }
 
 debugger_frame::debugger_frame(std::shared_ptr<gui_settings> gui_settings, QWidget *parent)
-	: custom_dock_widget(tr("Debugger"), parent)
+	: custom_dock_widget(tr("Debugger [Press F1 for help]"), parent)
 	, m_gui_settings(std::move(gui_settings))
 {
 	setContentsMargins(0, 0, 0, 0);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -354,12 +354,6 @@ void main_window::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const Q
 
 	switch (shortcut_key)
 	{
-	case gui::shortcuts::shortcut::mw_welcome_dialog:
-	{
-		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);
-		welcome->open();
-		break;
-	}
 	case gui::shortcuts::shortcut::mw_toggle_fullscreen:
 	{
 		ui->toolbar_fullscreen->trigger();

--- a/rpcs3/rpcs3qt/shortcut_settings.cpp
+++ b/rpcs3/rpcs3qt/shortcut_settings.cpp
@@ -16,7 +16,6 @@ void fmt_class_string<gui::shortcuts::shortcut>::format(std::string& out, u64 ar
 		case shortcut::mw_toggle_fullscreen: return "mw_toggle_fullscreen";
 		case shortcut::mw_exit_fullscreen: return "mw_exit_fullscreen";
 		case shortcut::mw_refresh: return "mw_refresh";
-		case shortcut::mw_welcome_dialog: return "mw_welcome_dialog";
 		case shortcut::gw_toggle_fullscreen: return "gw_toggle_fullscreen";
 		case shortcut::gw_exit_fullscreen: return "gw_exit_fullscreen";
 		case shortcut::gw_log_mark: return "gw_log_mark";
@@ -44,7 +43,6 @@ shortcut_settings::shortcut_settings()
 		{ shortcut::mw_toggle_fullscreen, shortcut_info{ "main_window_toggle_fullscreen", tr("Toggle Fullscreen"), "Alt+Return", shortcut_handler_id::main_window } },
 		{ shortcut::mw_exit_fullscreen, shortcut_info{ "main_window_exit_fullscreen", tr("Exit Fullscreen"), "Esc", shortcut_handler_id::main_window } },
 		{ shortcut::mw_refresh, shortcut_info{ "main_window_refresh", tr("Refresh"), "Ctrl+F5", shortcut_handler_id::main_window } },
-		{ shortcut::mw_welcome_dialog, shortcut_info{ "main_window_welcome_dialog", tr("Show Welcome Dialog"), "F1", shortcut_handler_id::main_window } },
 		{ shortcut::gw_toggle_fullscreen, shortcut_info{ "game_window_toggle_fullscreen", tr("Toggle Fullscreen"), "Alt+Return", shortcut_handler_id::game_window } },
 		{ shortcut::gw_exit_fullscreen, shortcut_info{ "game_window_exit_fullscreen", tr("Exit Fullscreen"), "Esc", shortcut_handler_id::game_window } },
 		{ shortcut::gw_log_mark, shortcut_info{ "game_window_log_mark", tr("Add Log Mark"), "Alt+L", shortcut_handler_id::game_window } },

--- a/rpcs3/rpcs3qt/shortcut_settings.h
+++ b/rpcs3/rpcs3qt/shortcut_settings.h
@@ -23,7 +23,6 @@ namespace gui
 			mw_toggle_fullscreen,
 			mw_exit_fullscreen,
 			mw_refresh,
-			mw_welcome_dialog,
 
 			gw_toggle_fullscreen,
 			gw_exit_fullscreen,


### PR DESCRIPTION
* When SPU Debug is option is enabled, percent of usage of SPU programs is added to the log when dumping SPU code.
* Remove welcome dialog shortcut and add description in debugger that F1 invokes the help dialog. Fixes #15839
* Fix some minor bugs regarding potential overflows.