### PR TITLE
sys_usbd: Allow 'Moving' figure to same slot on Dimensions Toypad

### DIFF
--- a/rpcs3/Emu/Io/Dimensions.cpp
+++ b/rpcs3/Emu/Io/Dimensions.cpp
@@ -403,7 +403,19 @@ bool dimensions_toypad::remove_figure(u8 pad, u8 index, bool save)
 
 bool dimensions_toypad::move_figure(u8 pad, u8 index, u8 old_pad, u8 old_index)
 {
-	// When moving figures between spaces on the portal, remove any figure from the space they are moving to,
+	if (old_index == index)
+	{
+		// Don't bother removing and loading again, just send response to the game
+		dimensions_figure& figure = get_figure_by_index(old_index);
+		std::array<u8, 32> figure_remove_response = {0x56, 0x0b, pad, 0x00, figure.index, 0x01};
+		figure_remove_response[13] = generate_checksum(figure_remove_response, 13);
+		std::array<u8, 32> figure_add_response = {0x56, 0x0b, pad, 0x00, figure.index, 0x00};
+		figure_add_response[13] = generate_checksum(figure_add_response, 13);
+		m_figure_added_removed_responses.push(figure_remove_response);
+		m_figure_added_removed_responses.push(figure_add_response);
+		return true;
+	}
+	// When moving figures between spaces on the toypad, remove any figure from the space they are moving to,
 	// then remove them from their current space, then load them to the space they are moving to
 	remove_figure(pad, index, true);
 

--- a/rpcs3/Emu/Io/Dimensions.cpp
+++ b/rpcs3/Emu/Io/Dimensions.cpp
@@ -406,15 +406,16 @@ bool dimensions_toypad::move_figure(u8 pad, u8 index, u8 old_pad, u8 old_index)
 	if (old_index == index)
 	{
 		// Don't bother removing and loading again, just send response to the game
-		dimensions_figure& figure = get_figure_by_index(old_index);
+		const dimensions_figure& figure = get_figure_by_index(old_index);
 		std::array<u8, 32> figure_remove_response = {0x56, 0x0b, pad, 0x00, figure.index, 0x01};
 		figure_remove_response[13] = generate_checksum(figure_remove_response, 13);
 		std::array<u8, 32> figure_add_response = {0x56, 0x0b, pad, 0x00, figure.index, 0x00};
 		figure_add_response[13] = generate_checksum(figure_add_response, 13);
-		m_figure_added_removed_responses.push(figure_remove_response);
-		m_figure_added_removed_responses.push(figure_add_response);
+		m_figure_added_removed_responses.push(std::move(figure_remove_response));
+		m_figure_added_removed_responses.push(std::move(figure_add_response));
 		return true;
 	}
+
 	// When moving figures between spaces on the toypad, remove any figure from the space they are moving to,
 	// then remove them from their current space, then load them to the space they are moving to
 	remove_figure(pad, index, true);

--- a/rpcs3/rpcs3qt/dimensions_dialog.cpp
+++ b/rpcs3/rpcs3qt/dimensions_dialog.cpp
@@ -543,19 +543,20 @@ void minifig_move_dialog::add_minifig_position(QGridLayout* grid_panel, u8 index
 	{
 		vbox_panel->addWidget(new QLabel(tr("None")));
 	}
-	if (old_index != index)
+	auto* btn_move = new QPushButton(tr("Move Here"), this);
+	if (old_index == index)
 	{
-		auto* btn_move = new QPushButton(tr("Move Here"), this);
-		vbox_panel->addWidget(btn_move);
-		connect(btn_move, &QAbstractButton::clicked, this, [this, index]
-			{
-				m_index = index;
-				m_pad = index == 1                             ? 1 :
-			            index == 0 || index == 3 || index == 4 ? 2 :
-			                                                     3;
-				accept();
-			});
+		btn_move->setText("Pick up and Place");
 	}
+	vbox_panel->addWidget(btn_move);
+	connect(btn_move, &QAbstractButton::clicked, this, [this, index]
+		{
+			m_index = index;
+			m_pad = index == 1                             ? 1 :
+		            index == 0 || index == 3 || index == 4 ? 2 :
+		                                                     3;
+			accept();
+		});
 
 	grid_panel->addLayout(vbox_panel, row, column);
 }
@@ -726,10 +727,13 @@ void dimensions_dialog::move_figure(u8 pad, u8 index)
 	if (move_dlg.exec() == Accepted)
 	{
 		g_dimensionstoypad.move_figure(move_dlg.get_new_pad(), move_dlg.get_new_index(), pad, index);
-		figure_slots[move_dlg.get_new_index()] = figure_slots[index];
-		m_edit_figures[move_dlg.get_new_index()]->setText(m_edit_figures[index]->text());
-		figure_slots[index] = std::nullopt;
-		m_edit_figures[index]->setText(tr("None"));
+		if (index != move_dlg.get_new_index())
+		{
+			figure_slots[move_dlg.get_new_index()] = figure_slots[index];
+			m_edit_figures[move_dlg.get_new_index()]->setText(m_edit_figures[index]->text());
+			figure_slots[index] = std::nullopt;
+			m_edit_figures[index]->setText(tr("None"));
+		}
 	}
 }
 

--- a/rpcs3/rpcs3qt/dimensions_dialog.cpp
+++ b/rpcs3/rpcs3qt/dimensions_dialog.cpp
@@ -546,7 +546,7 @@ void minifig_move_dialog::add_minifig_position(QGridLayout* grid_panel, u8 index
 	auto* btn_move = new QPushButton(tr("Move Here"), this);
 	if (old_index == index)
 	{
-		btn_move->setText("Pick up and Place");
+		btn_move->setText(tr("Pick up and Place"));
 	}
 	vbox_panel->addWidget(btn_move);
 	connect(btn_move, &QAbstractButton::clicked, this, [this, index]


### PR DESCRIPTION
Some sections of Lego Dimensions require figures to be picked up and placed in the same spot, so I have changed the button on the move dialog to represent this, and have the backend code changed to just send responses to the game when this happens, rather than the loading and moving of file pointers when moving to a new spot.