### PR TITLE
raw_mouse: Fix button map out of bounds access

### DIFF
--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -42,7 +42,7 @@ public:
 
 	const std::string& device_name() const { return m_device_name; }
 	u32 index() const { return m_index; }
-	void set_index(u32 index) { m_index = index; }
+	void set_index(u32 index);
 	void request_reload() { reload_requested = true; }
 
 private:


### PR DESCRIPTION
Fixes button map out of bounds access in the raw mouse handler.

- Reload the mouse config when the index changes.
- Clear the button map before reloading the config.
- Check if the button really is in the map.

Probably fixes #15832