### PR TITLE
DS4/DualSense/SDL: Add touchpad support

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -261,9 +261,13 @@ PadHandlerBase::connection PadHandlerBase::get_next_button_press(const std::stri
 
 		const bool is_trigger = get_is_left_trigger(device, keycode) || get_is_right_trigger(device, keycode);
 		const bool is_stick   = !is_trigger && (get_is_left_stick(device, keycode) || get_is_right_stick(device, keycode));
-		const bool is_button = !is_trigger && !is_stick;
+		const bool is_touch_motion = !is_trigger && !is_stick && get_is_touch_pad_motion(device, keycode);
+		const bool is_button = !is_trigger && !is_stick && !is_touch_motion;
 
-		if ((is_trigger && (value > m_trigger_threshold)) || (is_stick && (value > m_thumb_threshold)) || (is_button && (value > 0)))
+		if ((is_trigger && (value > m_trigger_threshold)) ||
+			(is_stick && (value > m_thumb_threshold)) ||
+			(is_button && (value > 0)) ||
+			(is_touch_motion && (value > 255 * 0.9)))
 		{
 			if (get_blacklist)
 			{

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -290,6 +290,7 @@ private:
 	virtual bool get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
 	virtual bool get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
 	virtual bool get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
+	virtual bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
 	virtual PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& /*device*/) { return connection::disconnected; }
 	virtual void get_extended_info(const pad_ensemble& /*binding*/) {}
 	virtual void apply_pad_data(const pad_ensemble& /*binding*/) {}

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -19,6 +19,7 @@ namespace reports
 	constexpr u32 DS4_OUTPUT_REPORT_BLUETOOTH_SIZE = 78;
 	constexpr u32 DS4_TOUCHPAD_WIDTH = 1920;
 	constexpr u32 DS4_TOUCHPAD_HEIGHT = 942;
+	constexpr u32 DS4_TOUCH_POINT_INACTIVE = 0x80;
 
 	struct ds4_touch_point
 	{
@@ -33,7 +34,7 @@ namespace reports
 	struct ds4_touch_report
 	{
 		u8 timestamp;
-		ds4_touch_point points[2];
+		std::array<ds4_touch_point, 2> points;
 	};
 	static_assert(sizeof(ds4_touch_report) == 9);
 
@@ -61,7 +62,7 @@ namespace reports
 		u8 report_id;
 		ds4_input_report_common common;
 		u8 num_touch_reports;
-		ds4_touch_report touch_reports[3];
+		std::array<ds4_touch_report, 3> touch_reports;
 		u8 reserved[3];
 	};
 	static_assert(sizeof(ds4_input_report_usb) == DS4_INPUT_REPORT_USB_SIZE);
@@ -72,7 +73,7 @@ namespace reports
 		u8 reserved[2];
 		ds4_input_report_common common;
 		u8 num_touch_reports;
-		ds4_touch_report touch_reports[4];
+		std::array<ds4_touch_report, 4> touch_reports;
 		u8 reserved2[2];
 		u8 crc32[4];
 	};
@@ -150,6 +151,11 @@ class ds4_pad_handler final : public hid_pad_handler<DS4Device>
 		PSButton,
 		TouchPad,
 
+		Touch_L,
+		Touch_R,
+		Touch_U,
+		Touch_D,
+
 		L2,
 		R2,
 
@@ -184,6 +190,7 @@ private:
 	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -19,6 +19,7 @@ namespace reports
 	constexpr u32 DUALSENSE_INPUT_REPORT_GYRO_X_OFFSET = 15;
 	constexpr u32 DUALSENSE_TOUCHPAD_WIDTH  = 1920;
 	constexpr u32 DUALSENSE_TOUCHPAD_HEIGHT = 1080;
+	constexpr u32 DUALSENSE_TOUCH_POINT_INACTIVE = 0x80;
 
 	enum
 	{
@@ -82,7 +83,7 @@ namespace reports
 		le_t<u16, 1> accel[3];
 		le_t<u32, 1> sensor_timestamp;
 		u8 reserved2;
-		dualsense_touch_point points[2];
+		std::array<dualsense_touch_point, 2> points;
 		u8 reserved3[12];
 		u8 status;
 		u8 reserved4[10];
@@ -210,6 +211,11 @@ class dualsense_pad_handler final : public hid_pad_handler<DualSenseDevice>
 		Mic,
 		TouchPad,
 
+		Touch_L,
+		Touch_R,
+		Touch_U,
+		Touch_D,
+
 		L2,
 		R2,
 
@@ -247,6 +253,7 @@ private:
 	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
 	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
 	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;

--- a/rpcs3/Input/sdl_pad_handler.h
+++ b/rpcs3/Input/sdl_pad_handler.h
@@ -8,6 +8,20 @@
 class SDLDevice : public PadDevice
 {
 public:
+
+	struct touch_point
+	{
+		int index = 0;
+		int x = 0;
+		int y = 0;
+	};
+
+	struct touchpad
+	{
+		int index = 0;
+		std::vector<touch_point> fingers;
+	};
+
 	struct sdl_info
 	{
 		SDL_GameController* game_controller = nullptr;
@@ -37,6 +51,8 @@ public:
 
 		std::set<SDL_GameControllerButton> button_ids;
 		std::set<SDL_GameControllerAxis> axis_ids;
+
+		std::vector<touchpad> touchpads;
 	};
 
 	sdl_info sdl{};
@@ -81,6 +97,11 @@ class sdl_pad_handler : public PadHandlerBase
 		Paddle4,
 		Touchpad,
 
+		Touch_L,
+		Touch_R,
+		Touch_U,
+		Touch_D,
+
 		LT,
 		RT,
 
@@ -124,6 +145,7 @@ private:
 	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
 	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
 	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;
 


### PR DESCRIPTION
- Adds touchpad mapping support to the DualShock 4 handler.
- Adds touchpad mapping support to the DualSense handler.
- Adds touchpad mapping support to the SDL handler.

This allows you to map your touchpad to any button, stick or trigger.
You can for example use it to control to the fake ps move cursor.

See #15834