### PR TITLE
Fix some warnings

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -297,7 +297,7 @@ fmt::base57_result fmt::base57_result::from_string(std::string_view str)
 		}
 	}
 
-	return std::move(result);
+	return result;
 }
 
 void fmt_class_string<const void*>::format(std::string& out, u64 arg)

--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -173,9 +173,6 @@ void fmt_class_string<fmt::base57>::format(std::string& out, u64 arg)
 
 fmt::base57_result fmt::base57_result::from_string(std::string_view str)
 {
-	// Precomputed tail sizes if input data is not multiple of 8
-	static constexpr u8 s_tail[8] = {0, 2, 3, 5, 6, 7, 9, 10};
-
 	fmt::base57_result result(str.size() / 11 * 8 + (str.size() % 11 ? 8 : 0));
 
 	// Each 11 chars of input produces 8 bytes of byte output

--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -17,6 +17,16 @@
 #include <errno.h>
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#elif defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 std::string wchar_to_utf8(std::wstring_view src)
 {
 #ifdef _WIN32
@@ -32,16 +42,6 @@ std::string wchar_to_utf8(std::wstring_view src)
 #endif
 }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 std::string utf16_to_utf8(std::u16string_view src)
 {
 	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter{};
@@ -53,13 +53,6 @@ std::u16string utf8_to_utf16(std::string_view src)
 	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> converter{};
 	return converter.from_bytes(src.data());
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#else
-#pragma GCC diagnostic pop
-#endif
 
 std::wstring utf8_to_wchar(std::string_view src)
 {
@@ -75,6 +68,13 @@ std::wstring utf8_to_wchar(std::string_view src)
 	return converter.from_bytes(src.data());
 #endif
 }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#elif defined(__clang__)
+#pragma clang diagnostic pop
+#else
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef _WIN32
 std::string fmt::win_error_to_string(unsigned long error, void* module_handle)

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -177,6 +177,7 @@ void LIBUSB_CALL callback_transfer(struct libusb_transfer* transfer)
 	usbh.transfer_complete(transfer);
 }
 
+#if LIBUSB_API_VERSION >= 0x0100010A
 static void LIBUSB_CALL log_cb(libusb_context* /*ctx*/, enum libusb_log_level level, const char* str)
 {
 	if (!str)
@@ -202,6 +203,7 @@ static void LIBUSB_CALL log_cb(libusb_context* /*ctx*/, enum libusb_log_level le
 		break;
 	}
 }
+#endif
 
 usb_handler_thread::usb_handler_thread()
 {


### PR DESCRIPTION
- Silence codecvt deprecation warnings on MacOs and FreeBSD
- Fix unused libusb log_cb on FreeBSD
- Fix std::move warning (don't move locals in return)
- Remove some unused variable