### PR TITLE
gl: Fixes for wayland (asahi linux, aarch64)

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -122,7 +122,7 @@ void GLGSRender::on_init_thread()
 	gl::init();
 	gl::set_command_context(gl_state);
 
-	//Enable adaptive vsync if vsync is requested
+	// Enable adaptive vsync if vsync is requested
 	gl::set_swapinterval(g_cfg.video.vsync ? -1 : 0);
 
 	if (g_cfg.video.debug_output)

--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -271,8 +271,8 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 
 	if (!image_to_flip || aspect_ratio.x1 || aspect_ratio.y1)
 	{
-		// Clear the window background to black
-		gl_state.clear_color(0, 0, 0, 0);
+		// Clear the window background to opaque black
+		gl_state.clear_color(0, 0, 0, 255);
 		gl::screen.clear(gl::buffers::color);
 	}
 
@@ -302,6 +302,7 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 
 		const areai screen_area = coordi({}, { static_cast<int>(buffer_width), static_cast<int>(buffer_height) });
 		const bool use_full_rgb_range_output = g_cfg.video.full_rgb_range_output.get();
+		const bool backbuffer_has_alpha = m_frame->has_alpha();
 
 		if (!m_upscaler || m_output_scaling != g_cfg.video.output_scaling)
 		{
@@ -322,7 +323,7 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 			}
 		}
 
-		if (use_full_rgb_range_output && rsx::fcmp(avconfig.gamma, 1.f) && avconfig.stereo_mode == stereo_render_mode_options::disabled)
+		if (!backbuffer_has_alpha && use_full_rgb_range_output && rsx::fcmp(avconfig.gamma, 1.f) && avconfig.stereo_mode == stereo_render_mode_options::disabled)
 		{
 			// Blit source image to the screen
 			m_upscaler->scale_output(cmd, image_to_flip, screen_area, aspect_ratio.flipped_vertical(), UPSCALE_AND_COMMIT | UPSCALE_DEFAULT_VIEW);

--- a/rpcs3/Emu/RSX/GL/glutils/fbo.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/fbo.cpp
@@ -75,6 +75,12 @@ namespace gl
 		DSA_CALL3(NamedFramebufferDrawBuffers, FramebufferDrawBuffers, m_id, 1, &buf);
 	}
 
+	void fbo::draw_buffer(swapchain_buffer buffer) const
+	{
+		GLenum buf = static_cast<GLenum>(buffer);
+		DSA_CALL3(NamedFramebufferDrawBuffers, FramebufferDrawBuffers, m_id, 1, &buf);
+	}
+
 	void fbo::draw_buffers(const std::initializer_list<attachment>& indexes) const
 	{
 		rsx::simple_array<GLenum> ids;
@@ -89,6 +95,12 @@ namespace gl
 	void fbo::read_buffer(const attachment& buffer) const
 	{
 		DSA_CALL3(NamedFramebufferReadBuffer, FramebufferReadBuffer, m_id, buffer.id());
+	}
+
+	void fbo::read_buffer(swapchain_buffer buffer) const
+	{
+		GLenum buf = static_cast<GLenum>(buffer);
+		DSA_CALL3(NamedFramebufferReadBuffer, FramebufferReadBuffer, m_id, buf);
 	}
 
 	void fbo::draw_arrays(GLenum mode, GLsizei count, GLint first) const

--- a/rpcs3/Emu/RSX/GL/glutils/fbo.h
+++ b/rpcs3/Emu/RSX/GL/glutils/fbo.h
@@ -181,6 +181,12 @@ namespace gl
 			draw_frame_buffer = GL_DRAW_FRAMEBUFFER
 		};
 
+		enum class swapchain_buffer
+		{
+			back = GL_BACK,
+			front = GL_FRONT
+		};
+
 		void create();
 		void bind() const;
 		void blit(const fbo& dst, areai src_area, areai dst_area, buffers buffers_ = buffers::color, filter filter_ = filter::nearest) const;
@@ -191,9 +197,11 @@ namespace gl
 
 		void recreate();
 		void draw_buffer(const attachment& buffer) const;
+		void draw_buffer(swapchain_buffer buffer) const;
 		void draw_buffers(const std::initializer_list<attachment>& indexes) const;
 
 		void read_buffer(const attachment& buffer) const;
+		void read_buffer(swapchain_buffer buffer) const;
 
 		void draw_arrays(GLenum mode, GLsizei count, GLint first = 0) const;
 		void draw_arrays(const buffer& buffer, GLenum mode, GLsizei count, GLint first = 0) const;

--- a/rpcs3/Emu/RSX/GSFrameBase.h
+++ b/rpcs3/Emu/RSX/GSFrameBase.h
@@ -25,6 +25,7 @@ public:
 	virtual void flip(draw_context_t ctx, bool skip_frame = false) = 0;
 	virtual int client_width() = 0;
 	virtual int client_height() = 0;
+	virtual bool has_alpha() = 0;
 
 	virtual display_handle_t handle() const = 0;
 

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/VideoOutCalibrationPass.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/VideoOutCalibrationPass.glsl
@@ -149,5 +149,6 @@ void main()
 	ocol = (limit_range == FALSE)
 		? color
 		: ((color * 220.) + 16.) / 255.;
+	ocol.a = 1.f;
 }
 )"

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -11,9 +11,11 @@ gl_gs_frame::gl_gs_frame(QScreen* screen, const QRect& geometry, const QIcon& ap
 {
 	setSurfaceType(QSurface::OpenGLSurface);
 
+	m_format.setRenderableType(QSurfaceFormat::OpenGL);
 	m_format.setMajorVersion(4);
 	m_format.setMinorVersion(3);
 	m_format.setProfile(QSurfaceFormat::CoreProfile);
+	m_format.setAlphaBufferSize(0);
 	m_format.setDepthBufferSize(0);
 	m_format.setSwapBehavior(QSurfaceFormat::SwapBehavior::DoubleBuffer);
 	if (g_cfg.video.debug_output)

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -113,8 +113,14 @@ gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon,
 	setScreen(screen);
 	setGeometry(geometry);
 	setTitle(qstr(m_window_title));
-	setVisibility(startup_visibility);
-	create();
+
+	if (g_cfg.video.renderer != video_renderer::opengl)
+	{
+		// Do not display the window before OpenGL is configured!
+		// This works fine in windows and X11 but wayland-egl will crash later.
+		setVisibility(startup_visibility);
+		create();
+	}
 
 	// TODO: enable in Qt6
 	//m_shortcut_handler = new shortcut_handler(gui::shortcuts::shortcut_handler_id::game_window, this, m_gui_settings);
@@ -1215,4 +1221,9 @@ void gs_frame::progress_increment(int delta)
 void gs_frame::progress_set_limit(int limit)
 {
 	m_progress_indicator->set_range(0, limit);
+}
+
+bool gs_frame::has_alpha()
+{
+	return format().hasAlpha();
 }

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -89,6 +89,7 @@ protected:
 	void flip(draw_context_t context, bool skip_frame = false) override;
 	int client_width() override;
 	int client_height() override;
+	bool has_alpha() override;
 
 	bool event(QEvent* ev) override;
 


### PR DESCRIPTION
This PR is part of the arm64 bringup series. I'm starting to merge these in.

Fixes:
1. Asahi linux (fedora version) has a full RGBA backbuffer for OpenGL by default when using Qt. Qt source code explictly sets 8 alpha bits on wayland-egl. By default when presenting to such a backbuffer, graphics get corrupted within a few seconds due to blending accumulation on the compositor. Fixed by detecting alpha on the backbuffer and using a fallback that forces alpha to 1.
2. We had double window creation for OpenGL. gs_frame calls create then gl_gs_frame calls create again. This is idempotent on windows but wayland doesn't like that at all.

Closes https://github.com/RPCS3/rpcs3/issues/15865