### PR TITLE
Add fallback CPU detection when llvm is not aware of the CPU model

### DIFF
--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -495,6 +495,7 @@ namespace llvm
 	class LLVMContext;
 	class ExecutionEngine;
 	class Module;
+	class StringRef;
 }
 
 // Temporary compiler interface
@@ -559,5 +560,7 @@ public:
 
 	bool add_sub_disk_space(ssz space);
 };
+
+llvm::StringRef fallback_cpu_detection();
 
 #endif // LLVM_AVAILABLE

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -751,10 +751,30 @@ llvm::StringRef fallback_cpu_detection()
 			return "znver5"; // Return newest known model here
 		}
 	}
-	else if (brand.startswith("Virtual Apple"))
+	else if (brand.contains("Intel"))
+	{
+		if (!utils::has_avx())
+		{
+			return "nehalem";
+		}
+		if (!utils::has_avx2())
+		{
+			return "ivybridge";
+		}
+		if (!utils::has_avx512())
+		{
+			return "skylake";
+		}
+		if (utils::has_avx512_icl())
+		{
+			return "cannonlake";
+		}
+		return "icelake-client";
+	}
+	else if (brand.startswith("VirtualApple"))
 	{
 		// No AVX. This will change in MacOS 15+, at which point we may revise this.
-		return "nehalem";
+		return utils::has_avx() ? "haswell" : "nehalem";
 	}
 
 #elif defined(ARCH_ARM64)

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -745,10 +745,11 @@ llvm::StringRef fallback_cpu_detection()
 				? "znver3"
 				: "znver4";
 		case 0x1a:
-			// Only one generation in family 1a so far
-			return "znver5";
+			// Only one generation in family 1a so far, zen5, which we do not support yet.
+			// Return zen4 as a workaround until the next LLVM upgrade.
+			return "znver4";
 		default:
-			return "znver5"; // Return newest known model here
+			return "znver4"; // Return newest known model here
 		}
 	}
 	else if (brand.contains("Intel"))

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -735,6 +735,11 @@ llvm::StringRef fallback_cpu_detection()
 	{
 		switch (family)
 		{
+		case 0x10:
+			return "amdfam10";
+		case 0x15:
+			// Bulldozer class, includes piledriver, excavator, steamroller, etc
+			return utils::has_avx2() ? "bdver4" : "bdver1";
 		case 0x17:
 		case 0x18:
 			// No major differences between znver1 and znver2, return the lesser
@@ -749,7 +754,9 @@ llvm::StringRef fallback_cpu_detection()
 			// Return zen4 as a workaround until the next LLVM upgrade.
 			return "znver4";
 		default:
-			return "znver4"; // Return newest known model here
+			return utils::has_avx512()
+				? "znver4"
+				: "znver3";
 		}
 	}
 	else if (brand.contains("Intel"))

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -440,6 +440,12 @@ std::string jit_compiler::cpu(const std::string& _cpu)
 	{
 		m_cpu = llvm::sys::getHostCPUName().str();
 
+		if (m_cpu == "generic")
+		{
+			// Try to detect a best match based on other criteria
+			m_cpu = fallback_cpu_detection();
+		}
+
 		if (m_cpu == "sandybridge" ||
 			m_cpu == "ivybridge" ||
 			m_cpu == "haswell" ||
@@ -715,6 +721,51 @@ void jit_compiler::fin()
 u64 jit_compiler::get(const std::string& name)
 {
 	return m_engine->getGlobalValueAddress(name);
+}
+
+llvm::StringRef fallback_cpu_detection()
+{
+#if defined (ARCH_X64)
+	// If we got here we either have a very old and outdated CPU or a new CPU that has not been seen by LLVM yet.
+	llvm::StringRef brand = utils::get_cpu_brand();
+	const auto family = utils::get_cpu_family();
+	const auto model = utils::get_cpu_model();
+
+	if (brand.startswith("AMD"))
+	{
+		switch (family)
+		{
+		case 0x17:
+		case 0x18:
+			// No major differences between znver1 and znver2, return the lesser
+			return "znver1";
+		case 0x19:
+			// Models 0-Fh are zen3 as are 20h-60h. The rest we can assume are zen4
+			return ((model >= 0x20 && model <= 0x60) || model < 0x10)
+				? "znver3"
+				: "znver4";
+		case 0x1a:
+			// Only one generation in family 1a so far
+			return "znver5";
+		default:
+			return "znver5"; // Return newest known model here
+		}
+	}
+	else if (brand.startswith("Virtual Apple"))
+	{
+		// No AVX. This will change in MacOS 15+, at which point we may revise this.
+		return "nehalem";
+	}
+
+#elif defined(ARCH_ARM64)
+	// TODO: Read the data from /proc/cpuinfo. ARM CPU registers are not accessible from usermode.
+	// This will be a pain when supporting snapdragon on windows but we'll cross that bridge when we get there.
+	// Require at least armv8-2a. Older chips are going to be useless anyway.
+	return "cortex-a78";
+#endif
+
+	// Failed to guess, use generic fallback
+	return "generic";
 }
 
 #endif // LLVM_AVAILABLE

--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -90,7 +90,13 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 	m_context = context;
 	m_engine = &engine;
 
-	const auto cpu = m_engine->getTargetMachine()->getTargetCPU();
+	auto cpu = m_engine->getTargetMachine()->getTargetCPU();
+
+	if (cpu == "generic")
+	{
+		// Detection failed, try to guess
+		cpu = fallback_cpu_detection();
+	}
 
 	// Test SSSE3 feature (TODO)
 	if (cpu == "generic" ||


### PR DESCRIPTION
Previously it was guessed that llvm would guess some recent version of the CPU e,g last generation intel or AMD, but instead it returns "generic" which can break the heurestics.
Adds a guessing framework to help detect CPUs better when llvm fails.