### PR TITLE
Dimensions: Try to fix out of bounds array access

### DIFF
--- a/rpcs3/Emu/Io/Dimensions.cpp
+++ b/rpcs3/Emu/Io/Dimensions.cpp
@@ -34,7 +34,7 @@ void dimensions_figure::save()
 	dim_file.write(data.data(), 0x2D * 0x04);
 }
 
-u8 dimensions_toypad::generate_checksum(const std::array<u8, 32>& data, u32 num_of_bytes) const
+u8 dimensions_toypad::generate_checksum(const std::array<u8, 32>& data, u32 num_of_bytes)
 {
 	int checksum = 0;
 	ensure(num_of_bytes <= data.size());
@@ -90,7 +90,7 @@ void dimensions_toypad::initialize_rng(u32 seed)
 
 u32 dimensions_toypad::get_next()
 {
-	u32 e = random_a - std::rotl(random_b, 21);
+	const u32 e = random_a - std::rotl(random_b, 21);
 	random_a = random_b ^ std::rotl(random_c, 19);
 	random_b = random_c + std::rotl(random_d, 6);
 	random_c = random_d + e;
@@ -237,9 +237,9 @@ std::array<u8, 4> dimensions_toypad::dimensions_randomize(const std::vector<u8> 
 
 u32 dimensions_toypad::get_figure_id(const std::array<u8, 0x2D * 0x04>& buf)
 {
-	std::array<u8, 16> figure_key = generate_figure_key(buf);
+	const std::array<u8, 16> figure_key = generate_figure_key(buf);
 
-	std::array<u8, 8> decrypted = decrypt(&buf[36 * 4], figure_key);
+	const std::array<u8, 8> decrypted = decrypt(&buf[36 * 4], figure_key);
 
 	const u32 fig_num = read_from_ptr<le_t<u32>>(decrypted);
 	// Characters have their model number encrypted in page 36
@@ -295,7 +295,7 @@ void dimensions_toypad::query_block(u8 index, u8 page, std::array<u8, 32>& reply
 	std::lock_guard lock(dimensions_mutex);
 
 	// Index from game begins at 1 rather than 0, so minus 1 here
-	dimensions_figure& figure = get_figure_by_index(index - 1);
+	const dimensions_figure& figure = get_figure_by_index(index - 1);
 
 	reply_buf[0] = 0x55;
 	reply_buf[1] = 0x12;
@@ -341,7 +341,7 @@ void dimensions_toypad::get_model(const u8* buf, u8 sequence, std::array<u8, 32>
 	const u8 index = value[0];
 	const u32 conf = read_from_ptr<be_t<u32>>(value, 4);
 	// Index from game begins at 1 rather than 0, so minus 1 here
-	dimensions_figure& figure = get_figure_by_index(index - 1);
+	const dimensions_figure& figure = get_figure_by_index(index - 1);
 	std::array<u8, 8> value_to_encrypt = {};
 	// Response is the figure's id (little endian) followed by the confirmation from payload
 	write_to_ptr<le_t<u32>>(value_to_encrypt, figure.id);

--- a/rpcs3/Emu/Io/Dimensions.h
+++ b/rpcs3/Emu/Io/Dimensions.h
@@ -37,7 +37,7 @@ public:
 
 protected:
 	shared_mutex m_dimensions_mutex;
-	std::array<dimensions_figure, dimensions_figure_count> m_figures;
+	std::array<dimensions_figure, dimensions_figure_count> m_figures{};
 
 private:
 	static void random_uid(u8* uid_buffer);

--- a/rpcs3/Emu/Io/Dimensions.h
+++ b/rpcs3/Emu/Io/Dimensions.h
@@ -6,6 +6,8 @@
 #include <optional>
 #include <queue>
 
+static constexpr size_t dimensions_figure_count = 7;
+
 struct dimensions_figure
 {
 	fs::file dim_file;
@@ -35,7 +37,7 @@ public:
 
 protected:
 	shared_mutex m_dimensions_mutex;
-	std::array<dimensions_figure, 7> m_figures;
+	std::array<dimensions_figure, dimensions_figure_count> m_figures;
 
 private:
 	static void random_uid(u8* uid_buffer);

--- a/rpcs3/Emu/Io/Dimensions.h
+++ b/rpcs3/Emu/Io/Dimensions.h
@@ -19,7 +19,7 @@ struct dimensions_figure
 class dimensions_toypad
 {
 public:
-	void get_blank_response(u8 type, u8 sequence, std::array<u8, 32>& reply_buf);
+	static void get_blank_response(u8 type, u8 sequence, std::array<u8, 32>& reply_buf);
 	void generate_random_number(const u8* buf, u8 sequence, std::array<u8, 32>& reply_buf);
 	void initialize_rng(u32 seed);
 	void get_challenge_response(const u8* buf, u8 sequence, std::array<u8, 32>& reply_buf);
@@ -31,22 +31,22 @@ public:
 	bool remove_figure(u8 pad, u8 index, bool save);
 	u32 load_figure(const std::array<u8, 0x2D * 0x04>& buf, fs::file in_file, u8 pad, u8 index);
 	bool move_figure(u8 pad, u8 index, u8 old_pad, u8 old_index);
-	bool create_blank_character(std::array<u8, 0x2D * 0x04>& buf, u16 id);
+	static bool create_blank_character(std::array<u8, 0x2D * 0x04>& buf, u16 id);
 
 protected:
 	shared_mutex dimensions_mutex;
 	std::array<dimensions_figure, 7> m_figures;
 
 private:
-	void random_uid(u8* uid_buffer);
-	u8 generate_checksum(const std::array<u8, 32>& data, u32 num_of_bytes) const;
-	std::array<u8, 8> decrypt(const u8* buf, std::optional<std::array<u8, 16>> key);
-	std::array<u8, 8> encrypt(const u8* buf, std::optional<std::array<u8, 16>> key);
-	std::array<u8, 16> generate_figure_key(const std::array<u8, 0x2D * 0x04>& buf);
-	u32 scramble(const std::array<u8, 7>& uid, u8 count);
-	std::array<u8, 4> pwd_generate(const std::array<u8, 7>& uid);
-	std::array<u8, 4> dimensions_randomize(const std::vector<u8> key, u8 count);
-	u32 get_figure_id(const std::array<u8, 0x2D * 0x04>& buf);
+	static void random_uid(u8* uid_buffer);
+	static u8 generate_checksum(const std::array<u8, 32>& data, u32 num_of_bytes);
+	static std::array<u8, 8> decrypt(const u8* buf, std::optional<std::array<u8, 16>> key);
+	static std::array<u8, 8> encrypt(const u8* buf, std::optional<std::array<u8, 16>> key);
+	static std::array<u8, 16> generate_figure_key(const std::array<u8, 0x2D * 0x04>& buf);
+	static u32 scramble(const std::array<u8, 7>& uid, u8 count);
+	static std::array<u8, 4> pwd_generate(const std::array<u8, 7>& uid);
+	static std::array<u8, 4> dimensions_randomize(const std::vector<u8> key, u8 count);
+	static u32 get_figure_id(const std::array<u8, 0x2D * 0x04>& buf);
 	u32 get_next();
 	dimensions_figure& get_figure_by_index(u8 index);
 

--- a/rpcs3/Emu/Io/Dimensions.h
+++ b/rpcs3/Emu/Io/Dimensions.h
@@ -28,13 +28,13 @@ public:
 	void get_model(const u8* buf, u8 sequence, std::array<u8, 32>& reply_buf);
 	std::optional<std::array<u8, 32>> pop_added_removed_response();
 
-	bool remove_figure(u8 pad, u8 index, bool save);
-	u32 load_figure(const std::array<u8, 0x2D * 0x04>& buf, fs::file in_file, u8 pad, u8 index);
+	bool remove_figure(u8 pad, u8 index, bool save, bool lock);
+	u32 load_figure(const std::array<u8, 0x2D * 0x04>& buf, fs::file in_file, u8 pad, u8 index, bool lock);
 	bool move_figure(u8 pad, u8 index, u8 old_pad, u8 old_index);
 	static bool create_blank_character(std::array<u8, 0x2D * 0x04>& buf, u16 id);
 
 protected:
-	shared_mutex dimensions_mutex;
+	shared_mutex m_dimensions_mutex;
 	std::array<dimensions_figure, 7> m_figures;
 
 private:
@@ -50,10 +50,10 @@ private:
 	u32 get_next();
 	dimensions_figure& get_figure_by_index(u8 index);
 
-	u32 random_a;
-	u32 random_b;
-	u32 random_c;
-	u32 random_d;
+	u32 m_random_a{};
+	u32 m_random_b{};
+	u32 m_random_c{};
+	u32 m_random_d{};
 
 	u8 m_figure_order = 0;
 	std::queue<std::array<u8, 32>> m_figure_added_removed_responses;
@@ -72,6 +72,6 @@ public:
 	void isochronous_transfer(UsbTransfer* transfer) override;
 
 protected:
-	shared_mutex query_mutex;
+	shared_mutex m_query_mutex;
 	std::queue<std::array<u8, 32>> m_queries;
 };

--- a/rpcs3/Emu/Io/Infinity.cpp
+++ b/rpcs3/Emu/Io/Infinity.cpp
@@ -276,26 +276,26 @@ bool infinity_base::remove_figure(u8 position)
 	std::lock_guard lock(infinity_mutex);
 	infinity_figure& figure = figures[position];
 
-	if (figure.present)
+	if (!figure.present)
 	{
-		position = derive_figure_position(position);
-		if (position == 0)
-		{
-			return false;
-		}
-
-		figure.present = false;
-
-		std::array<u8, 32> figure_change_response = {0xab, 0x04, position, 0x09, figure.order_added,
-			0x01};
-		figure_change_response[6] = generate_checksum(figure_change_response, 6);
-		m_figure_added_removed_responses.push(figure_change_response);
-
-		figure.save();
-		figure.inf_file.close();
-		return true;
+		return false;
 	}
-	return false;
+
+	position = derive_figure_position(position);
+	if (position == 0)
+	{
+		return false;
+	}
+
+	figure.present = false;
+
+	std::array<u8, 32> figure_change_response = {0xab, 0x04, position, 0x09, figure.order_added, 0x01};
+	figure_change_response[6] = generate_checksum(figure_change_response, 6);
+	m_figure_added_removed_responses.push(figure_change_response);
+
+	figure.save();
+	figure.inf_file.close();
+	return true;
 }
 
 u32 infinity_base::load_figure(const std::array<u8, 0x14 * 0x10>& buf, fs::file in_file, u8 position)

--- a/rpcs3/rpcs3qt/dimensions_dialog.cpp
+++ b/rpcs3/rpcs3qt/dimensions_dialog.cpp
@@ -690,7 +690,7 @@ void dimensions_dialog::clear_figure(u8 pad, u8 index)
 
 	if (figure_slots[index])
 	{
-		g_dimensionstoypad.remove_figure(pad, index, true);
+		g_dimensionstoypad.remove_figure(pad, index, true, true);
 		figure_slots[index] = std::nullopt;
 		m_edit_figures[index]->setText(tr("None"));
 	}
@@ -755,7 +755,7 @@ void dimensions_dialog::load_figure_path(u8 pad, u8 index, const QString& path)
 
 	clear_figure(pad, index);
 
-	const u32 fig_num = g_dimensionstoypad.load_figure(data, std::move(dim_file), pad, index);
+	const u32 fig_num = g_dimensionstoypad.load_figure(data, std::move(dim_file), pad, index, true);
 
 	figure_slots[index] = fig_num;
 	const auto name = list_minifigs.find(fig_num);


### PR DESCRIPTION
- Do not try to fetch figures if the index in the request is out of bounds. Just ignore the read/write instead
- Add lock to pop_added_removed_response
- Add lock to move_figure (somewhat recursive)
- Make some functions static

maybe fixes #15886