### PR TITLE
Class "llvm:StringRef" has no member 'Startswith'

### DIFF
--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -731,7 +731,7 @@ llvm::StringRef fallback_cpu_detection()
 	const auto family = utils::get_cpu_family();
 	const auto model = utils::get_cpu_model();
 
-	if (brand.startswith("AMD"))
+	if (brand.starts_with("AMD"))
 	{
 		switch (family)
 		{
@@ -780,6 +780,7 @@ llvm::StringRef fallback_cpu_detection()
 		return "icelake-client";
 	}
 	else if (brand.startswith("VirtualApple"))
+	else if (brand.starts_with("VirtualApple"))
 	{
 		// No AVX. This will change in MacOS 15+, at which point we may revise this.
 		return utils::has_avx() ? "haswell" : "nehalem";

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -779,7 +779,6 @@ llvm::StringRef fallback_cpu_detection()
 		}
 		return "icelake-client";
 	}
-	else if (brand.startswith("VirtualApple"))
 	else if (brand.starts_with("VirtualApple"))
 	{
 		// No AVX. This will change in MacOS 15+, at which point we may revise this.

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -731,7 +731,7 @@ llvm::StringRef fallback_cpu_detection()
 	const auto family = utils::get_cpu_family();
 	const auto model = utils::get_cpu_model();
 
-	if (brand.starts_with("AMD"))
+	if (std::string_view(brand).starts_with("AMD"))
 	{
 		switch (family)
 		{
@@ -779,7 +779,7 @@ llvm::StringRef fallback_cpu_detection()
 		}
 		return "icelake-client";
 	}
-	else if (brand.starts_with("VirtualApple"))
+	else if (std::string_view(brand).starts_with("VirtualApple"))
 	{
 		// No AVX. This will change in MacOS 15+, at which point we may revise this.
 		return utils::has_avx() ? "haswell" : "nehalem";

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -727,7 +727,7 @@ llvm::StringRef fallback_cpu_detection()
 {
 #if defined (ARCH_X64)
 	// If we got here we either have a very old and outdated CPU or a new CPU that has not been seen by LLVM yet.
-	std::string brand = utils::get_cpu_brand();
+	const std::string brand = utils::get_cpu_brand();
 	const auto family = utils::get_cpu_family();
 	const auto model = utils::get_cpu_model();
 

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -731,7 +731,7 @@ llvm::StringRef fallback_cpu_detection()
 	const auto family = utils::get_cpu_family();
 	const auto model = utils::get_cpu_model();
 
-	if (std::string_view(brand).starts_with("AMD"))
+	if (brand.starts_with("AMD"))
 	{
 		switch (family)
 		{
@@ -759,7 +759,7 @@ llvm::StringRef fallback_cpu_detection()
 				: "znver3";
 		}
 	}
-	else if (brand.find("Intel"))
+	else if (brand.find("Intel") != std::string::npos)
 	{
 		if (!utils::has_avx())
 		{
@@ -779,7 +779,7 @@ llvm::StringRef fallback_cpu_detection()
 		}
 		return "icelake-client";
 	}
-	else if (std::string_view(brand).starts_with("VirtualApple"))
+	else if (brand.starts_with("VirtualApple"))
 	{
 		// No AVX. This will change in MacOS 15+, at which point we may revise this.
 		return utils::has_avx() ? "haswell" : "nehalem";

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -727,7 +727,7 @@ llvm::StringRef fallback_cpu_detection()
 {
 #if defined (ARCH_X64)
 	// If we got here we either have a very old and outdated CPU or a new CPU that has not been seen by LLVM yet.
-	llvm::StringRef brand = utils::get_cpu_brand();
+	std::string brand = utils::get_cpu_brand();
 	const auto family = utils::get_cpu_family();
 	const auto model = utils::get_cpu_model();
 
@@ -759,7 +759,7 @@ llvm::StringRef fallback_cpu_detection()
 				: "znver3";
 		}
 	}
-	else if (brand.contains("Intel"))
+	else if (brand.find("Intel"))
 	{
 		if (!utils::has_avx())
 		{


### PR DESCRIPTION
Following this example:
https://github.com/RPCS3/rpcs3/blob/master/Utilities%2FJITLLVM.cpp#L73

I resolved:
```
Class "llvm:StringRef" has no member 'Startswith'
if (brand.startswith("AMD"))
```
and
```
Class "llvm:StringRef" has no member 'Startswith'
else if (brand.startswith("VirtualApple"))
```
observed when checking out
LLVM 19.1.0-rc2

This resolves 1 problem with compilation on later versions of LLVM