### PR TITLE
aarch64/cpu: Add LLVM support

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -387,6 +387,7 @@ target_link_libraries(rpcs3_emu
 target_sources(rpcs3_emu PRIVATE
     CPU/CPUThread.cpp
     CPU/CPUTranslator.cpp
+    CPU/Backends/AArch64JIT.cpp
 )
 
 target_link_libraries(rpcs3_emu

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -387,8 +387,13 @@ target_link_libraries(rpcs3_emu
 target_sources(rpcs3_emu PRIVATE
     CPU/CPUThread.cpp
     CPU/CPUTranslator.cpp
-    CPU/Backends/AArch64JIT.cpp
 )
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+    target_sources(rpcs3_emu PRIVATE
+        CPU/Backends/AArch64JIT.cpp
+    )
+endif()
 
 target_link_libraries(rpcs3_emu
     PUBLIC 3rdparty::llvm 3rdparty::asmjit)

--- a/rpcs3/Emu/CPU/Backends/AArch64JIT.cpp
+++ b/rpcs3/Emu/CPU/Backends/AArch64JIT.cpp
@@ -21,21 +21,6 @@ LOG_CHANNEL(jit_log, "JIT");
 
 namespace aarch64
 {
-    // FIXME: This really should be part of fmt
-    static std::string join_strings(const std::vector<std::string>& v, const char* delim)
-    {
-        std::string result;
-        for (const auto& s : v)
-        {
-            if (!result.empty())
-            {
-                result += delim;
-            }
-            result += s;
-        }
-        return result;
-    }
-
     using instruction_info_t = GHC_frame_preservation_pass::instruction_info_t;
     using function_info_t = GHC_frame_preservation_pass::function_info_t;
 
@@ -414,7 +399,7 @@ namespace aarch64
                     }
 
                     // Emit the branch
-                    llvm_asm(irb, exit_fn, args, join_strings(constraints, ","), f.getContext());
+                    llvm_asm(irb, exit_fn, args, fmt::merge(constraints, ","), f.getContext());
 
                     // Delete original call instruction
                     bit = ci->eraseFromParent();

--- a/rpcs3/Emu/CPU/Backends/AArch64JIT.cpp
+++ b/rpcs3/Emu/CPU/Backends/AArch64JIT.cpp
@@ -23,7 +23,7 @@ namespace aarch64
     using function_info_t = GHC_frame_preservation_pass::function_info_t;
 
     GHC_frame_preservation_pass::GHC_frame_preservation_pass(
-        gprs base_reg,
+        gpr base_reg,
         u32 hv_ctx_offset,
         std::function<bool(const std::string&)> exclusion_callback)
     {
@@ -226,7 +226,7 @@ namespace aarch64
             "add x30, x%u, x30;\n"     // Add to base register
             "ldr x30, [x30];\n",       // Load x30
             execution_context.hypervisor_context_offset,
-            execution_context.base_register);
+            static_cast<u32>(execution_context.base_register));
 
         if (function_info.stack_frame_size > 0)
         {

--- a/rpcs3/Emu/CPU/Backends/AArch64JIT.cpp
+++ b/rpcs3/Emu/CPU/Backends/AArch64JIT.cpp
@@ -1,0 +1,347 @@
+#include "stdafx.h"
+#include "AArch64JIT.h"
+#include "../Hypervisor.h"
+
+namespace aarch64
+{
+    // FIXME: This really should be part of fmt
+    static std::string join_strings(const std::vector<std::string>& v, const char* delim)
+    {
+        std::string result;
+        for (const auto& s : v)
+        {
+            if (!result.empty())
+            {
+                result += delim;
+            }
+            result += s;
+        }
+        return result;
+    }
+
+    using instruction_info_t = GHC_frame_preservation_pass::instruction_info_t;
+    using function_info_t = GHC_frame_preservation_pass::function_info_t;
+
+    GHC_frame_preservation_pass::GHC_frame_preservation_pass(
+        gprs base_reg,
+        u32 hv_ctx_offset,
+        std::function<bool(const std::string&)> exclusion_callback)
+    {
+        execution_context.base_register = base_reg;
+        execution_context.hypervisor_context_offset = hv_ctx_offset;
+        this->exclusion_callback = exclusion_callback;
+    }
+
+    void GHC_frame_preservation_pass::reset()
+    {
+        visited_functions.clear();
+    }
+
+    void GHC_frame_preservation_pass::force_tail_call_terminators(llvm::Function& f)
+    {
+        // GHC functions are not call-stack preserving and can therefore never return if they make any external calls at all.
+        // Replace every terminator clause with a tail call explicitly. This is already done for X64 to work, but better safe than sorry.
+        for (auto& bb : f)
+        {
+            auto bit = bb.begin(), prev = bb.end();
+            for (; bit != bb.end(); prev = bit, ++bit)
+            {
+                if (prev == bb.end())
+                {
+                    continue;
+                }
+
+                if (auto ri = llvm::dyn_cast<llvm::ReturnInst>(&*bit))
+                {
+                    if (auto ci = llvm::dyn_cast<llvm::CallInst>(&*prev))
+                    {
+                        // This is a "ret" that is coming after a "call" to another funciton.
+                        // Enforce that it must be a tail call.
+                        if (!ci->isTailCall())
+                        {
+                            ci->setTailCall();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    function_info_t GHC_frame_preservation_pass::preprocess_function(llvm::Function& f)
+    {
+        function_info_t result{};
+        result.instruction_count = f.getInstructionCount();
+
+        // Blanket exclusions. Stubs or dispatchers that do not compute anything themselves.
+        if (f.getName() == "__spu-null")
+        {
+            // Don't waste the effort processing this stub. It has no points of concern
+            return result;
+        }
+
+        // Stack frame estimation. SPU code can be very long and consumes several KB of stack.
+        u32 stack_frame_size = 128u;
+        // Actual ratio is usually around 1:4
+        const u32 expected_compiled_instr_count = f.getInstructionCount() * 4;
+        // Because GHC doesn't preserve stack (all stack is scratch), we know we'll start to spill once we go over the number of actual regs.
+        // We use a naive allocator that just assumes each instruction consumes a register slot. We "spill" every 32 instructions.
+        // FIXME: Aggressive spill is only really a thing with vector operations. We can detect those instead.
+        // A proper fix is to port this to a MF pass, but I have PTSD from working at MF level.
+        const u32 spill_pages = (expected_compiled_instr_count + 127u) / 128u;
+        stack_frame_size *= std::min(spill_pages, 32u); // 128 to 4k dynamic. It is unlikely that any frame consumes more than 4096 bytes
+
+        result.stack_frame_size = stack_frame_size;
+        result.instruction_count = f.getInstructionCount();
+        result.num_external_calls = 0;
+
+        // The LR is not spared by LLVM in cases where there is a lot of spilling.
+        // This is another thing to be moved to a MachineFunction pass.
+        result.clobbers_x30 = result.instruction_count > 32;
+
+        for (auto& bb : f)
+        {
+            for (auto& inst : bb)
+            {
+                if (auto ci = llvm::dyn_cast<llvm::CallInst>(&inst))
+                {
+                    result.num_external_calls++;
+                    result.clobbers_x30 |= (!ci->isTailCall());
+                }
+            }
+        }
+
+        return result;
+    }
+
+    instruction_info_t GHC_frame_preservation_pass::decode_instruction(llvm::Function& f, llvm::Instruction* i)
+    {
+        instruction_info_t result{};
+        if (auto ci = llvm::dyn_cast<llvm::CallInst>(i))
+        {
+            result.is_call_inst = true;
+            result.is_returning = true;
+            result.preserve_stack = !ci->isTailCall();
+            result.callee = ci->getCalledFunction();
+            result.is_tail_call = ci->isTailCall();
+
+            if (!result.callee)
+            {
+                // TODO: What are these?????? Patchpoints maybe? Need to check again
+                result.is_call_inst = f.getName() == "__spu-null";
+            }
+            else
+            {
+                result.callee_is_GHC = result.callee->getCallingConv() == llvm::CallingConv::GHC;
+            }
+            return result;
+        }
+
+        if (auto bi = llvm::dyn_cast<llvm::BranchInst>(i))
+        {
+            // More likely to jump out via an unconditional...
+            if (!bi->isConditional())
+            {
+                ensure(bi->getNumSuccessors() == 1);
+                auto targetbb = bi->getSuccessor(0);
+
+                result.callee = targetbb->getParent();
+                result.is_call_inst = result.callee->getName() != f.getName();
+            }
+
+            return result;
+        }
+
+        if (auto bi = llvm::dyn_cast<llvm::IndirectBrInst>(i))
+        {
+            // Very unlikely to be the same function. Can be considered a function exit.
+            ensure(bi->getNumDestinations() == 1);
+            auto targetbb = bi->getSuccessor(0);
+
+            result.callee = targetbb->getParent();
+            result.is_call_inst = result.callee->getName() != f.getName();
+            return result;
+        }
+
+        if (auto bi = llvm::dyn_cast<llvm::CallBrInst>(i))
+        {
+            ensure(bi->getNumSuccessors() == 1);
+            auto targetbb = bi->getSuccessor(0);
+
+            result.callee = targetbb->getParent();
+            result.is_call_inst = result.callee->getName() != f.getName();
+            return result;
+        }
+
+        if (auto bi = llvm::dyn_cast<llvm::InvokeInst>(i))
+        {
+            ensure(bi->getNumSuccessors() == 2);
+            auto targetbb = bi->getSuccessor(0);
+
+            result.callee = targetbb->getParent();
+            result.is_call_inst = result.callee->getName() != f.getName();
+            return result;
+        }
+
+        return result;
+    }
+
+    void GHC_frame_preservation_pass::run(llvm::IRBuilder<>* irb, llvm::Function& f)
+    {
+        if (f.getCallingConv() != llvm::CallingConv::GHC)
+        {
+            // If we're not doing GHC, the calling conv will have stack fixup on its own via prologue/epilogue
+            return;
+        }
+
+        if (f.getInstructionCount() == 0)
+        {
+            // Nothing to do. Happens with placeholder functions such as branch patchpoints
+            return;
+        }
+
+        const auto this_name = f.getName().str();
+        if (exclusion_callback && exclusion_callback(this_name))
+        {
+            // Function is explicitly excluded
+            return;
+        }
+
+        // Preprocessing.
+        auto function_info = preprocess_function(f);
+        if (function_info.num_external_calls == 0 && function_info.stack_frame_size == 0)
+        {
+            // No stack frame injection and no external calls to patch up. This is a leaf function, nothing to do.
+            return;
+        }
+
+        // Force tail calls on all terminators
+        force_tail_call_terminators(f);
+
+        // Asm snippets for patching stack frame
+        std::string frame_prologue, frame_epilogue;
+
+        // Return address reload on exit. This is safer than trying to stuff things into the stack frame since the size is largely just guesswork at this time.
+        std::string x30_tail_restore = fmt::format(
+            "mov x30, #%u;\n"          // Load offset to last gateway exit
+            "add x30, x%u, x30;\n"     // Add to base register
+            "ldr x30, [x30];\n",       // Load x30
+            execution_context.hypervisor_context_offset,
+            execution_context.base_register);
+
+        if (function_info.stack_frame_size > 0)
+        {
+            // NOTE: The stack frame here is purely optional, we can pre-allocate scratch on the gateway.
+            // However, that is an optimization for another time, this helps make debugging easier.
+            frame_prologue = fmt::format("sub sp, sp, #%u;", function_info.stack_frame_size);
+            frame_epilogue = fmt::format("add sp, sp, #%u;", function_info.stack_frame_size);
+
+            // Emit the frame prologue
+            LLVM_ASM_0(frame_prologue, irb, f.getContext());
+        }
+
+        // Now we start processing
+        bool terminator_found = false;
+        for (auto& bb : f)
+        {
+            for (auto bit = bb.begin(); bit != bb.end();)
+            {
+                const auto instruction_info = decode_instruction(f, &(*bit));
+                if (!instruction_info.is_call_inst)
+                {
+                    ++bit;
+                    continue;
+                }
+
+                std::string callee_name = "__unknown";
+                if (const auto cf = instruction_info.callee)
+                {
+                    callee_name = cf->getName().str();
+                    if (cf->hasFnAttribute(llvm::Attribute::AlwaysInline) || callee_name.starts_with("llvm."))
+                    {
+                        // Always inlined call. Likely inline Asm. Skip
+                        // log("Function %s will ignore call to intrinsic function %s\n", this_name.c_str(), callee_name.c_str());
+                        ++bit;
+                        continue;
+                    }
+
+                    // Technically We should also ignore any host functions linked in, usually starting with ppu_ or spu_ prefix.
+                    // However, there is not much guarantee that those are safe with only rare exceptions, and it doesn't hurt to patch the frame around them that much anyway.
+                }
+
+                terminator_found |= instruction_info.is_tail_call;
+
+                if (!instruction_info.preserve_stack)
+                {
+                    // Now we patch the call if required. For normal calls that 'return' (i.e calls to C/C++ ABI), we do not patch them as they will manage the stack themselves (callee-managed)
+                    llvm::Instruction* original_inst = llvm::dyn_cast<llvm::Instruction>(bit);
+                    irb->SetInsertPoint(ensure(llvm::dyn_cast<llvm::Instruction>(bit)));
+
+                    if (function_info.stack_frame_size > 0)
+                    {
+                        // 1. Nuke all scratch
+                        LLVM_ASM_0(frame_epilogue, irb, f.getContext());
+                    }
+
+                    if (function_info.clobbers_x30)
+                    {
+                        // 2. Restore the gateway as the current return address
+                        LLVM_ASM_0(x30_tail_restore, irb, f.getContext());
+                    }
+
+                    // 3. We're about to make a tail call. This means after this call, we're supposed to return immediately. In that case, don't link, lower to branch only.
+                    // Note that branches have some undesirable side-effects. For one, we lose the argument inputs, which the callee is expecting.
+                    // This means we burn some cycles on every exit, but in return we do not require one instruction on the prologue + the ret chain is eliminated.
+                    // No ret-chain also means two BBs can call each other indefinitely without running out of stack without relying on llvm to optimize that away.
+
+                    std::string exit_fn;
+                    auto ci = ensure(llvm::dyn_cast<llvm::CallInst>(original_inst));
+                    auto operand_count = ci->getNumOperands();
+                    std::vector<std::string> constraints;
+                    std::vector<llvm::Value*> args;
+
+                    // We now load the callee args.
+                    // FIXME: This is often times redundant and wastes cycles, we'll clean this up in a MachineFunction pass later.
+                    int base_reg = execution_context.base_register;
+                    for (unsigned i = 0; i < operand_count; ++i)
+                    {
+                        args.push_back(ci->getOperand(i));
+                        exit_fn += fmt::format("mov x%d, $%u;\n", base_reg++, i);
+                        constraints.push_back("r");
+                    }
+
+                    std::copy(ci->operands().begin(), ci->operands().end(), args.begin());
+                    auto target = ensure(ci->getCalledOperand());
+                    args.push_back(target);
+
+                    if (ci->isIndirectCall())
+                    {
+                        constraints.push_back("r");
+                        exit_fn += fmt::format(
+                            "mov x15, $%u;\n"
+                            "br x15",
+                            operand_count);
+                    }
+                    else
+                    {
+                        constraints.push_back("i");
+                        exit_fn += fmt::format("b $%u;\n", operand_count);
+                    }
+
+                    // Emit the branch
+                    LLVM_ASM(exit_fn, args, join_strings(constraints, ","), irb, f.getContext());
+
+                    // Delete original call instruction
+                    bit = ci->eraseFromParent();
+                }
+
+                // Next
+                if (bit != bb.end())
+                {
+                    ++bit;
+                }
+            }
+        }
+
+        ensure(terminator_found, "Could not find terminator for function!");
+    }
+}

--- a/rpcs3/Emu/CPU/Backends/AArch64JIT.h
+++ b/rpcs3/Emu/CPU/Backends/AArch64JIT.h
@@ -54,11 +54,9 @@ namespace aarch64
         };
 
     protected:
-        std::unordered_set<std::string> visited_functions;
+        std::unordered_set<std::string> m_visited_functions;
 
-        config_t execution_context;
-
-        std::function<bool(const std::string&)> exclusion_callback;
+        config_t m_config;
 
         void force_tail_call_terminators(llvm::Function& f);
 

--- a/rpcs3/Emu/CPU/Backends/AArch64JIT.h
+++ b/rpcs3/Emu/CPU/Backends/AArch64JIT.h
@@ -11,7 +11,7 @@
 
 namespace aarch64
 {
-    enum gprs : s32
+    enum gpr : s32
     {
         x0 = 0,
         x1, x2, x3, x4, x5, x6, x7, x8, x9,
@@ -21,7 +21,7 @@ namespace aarch64
 
     // On non-x86 architectures GHC runs stackless. SP is treated as a pointer to scratchpad memory.
     // This pass keeps this behavior intact while preserving the expectations of the host's C++ ABI.
-    class GHC_frame_preservation_pass : translator_pass
+    class GHC_frame_preservation_pass : public translator_pass
     {
     public:
         struct function_info_t
@@ -46,7 +46,7 @@ namespace aarch64
 
         struct
         {
-            gprs base_register;
+            gpr base_register;
             u32  hypervisor_context_offset;
         } execution_context;
 
@@ -60,7 +60,7 @@ namespace aarch64
     public:
 
         GHC_frame_preservation_pass(
-            gprs base_reg,
+            gpr base_reg,
             u32 hv_ctx_offset,
             std::function<bool(const std::string&)> exclusion_callback = {});
         ~GHC_frame_preservation_pass() = default;

--- a/rpcs3/Emu/CPU/Backends/AArch64JIT.h
+++ b/rpcs3/Emu/CPU/Backends/AArch64JIT.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#ifndef ARCH_ARM64
+#error "You have included an arm-only header"
+#endif
+
+#include <util/types.hpp>
+#include "../CPUTranslator.h"
+
+#include <unordered_set>
+
+namespace aarch64
+{
+    enum gprs : s32
+    {
+        x0 = 0,
+        x1, x2, x3, x4, x5, x6, x7, x8, x9,
+        x10, x11, x12, x13, x14, x15, x16, x17, x18, x19,
+        x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, x30
+    };
+
+    // On non-x86 architectures GHC runs stackless. SP is treated as a pointer to scratchpad memory.
+    // This pass keeps this behavior intact while preserving the expectations of the host's C++ ABI.
+    class GHC_frame_preservation_pass : translator_pass
+    {
+    public:
+        struct function_info_t
+        {
+            u32 instruction_count;
+            u32 num_external_calls;
+            u32 stack_frame_size;     // Guessing this properly is critical for vector-heavy functions where spilling is a lot more common
+            bool clobbers_x30;
+        };
+
+        struct instruction_info_t
+        {
+            bool is_call_inst;        // Is a function call. This includes a branch to external code.
+            bool preserve_stack;      // Preserve the stack around this call.
+            bool is_returning;        // This instruction "returns" to the next instruction (typically just llvm::CallInst*)
+            bool callee_is_GHC;       // The other function is GHC
+            bool is_tail_call;        // Tail call. Assume it is an exit/terminator.
+            llvm::Function* callee;   // Callee if any
+        };
+    protected:
+        std::unordered_set<std::string> visited_functions;
+
+        struct
+        {
+            gprs base_register;
+            u32  hypervisor_context_offset;
+        } execution_context;
+
+        std::function<bool(const std::string&)> exclusion_callback;
+
+        void force_tail_call_terminators(llvm::Function& f);
+
+        function_info_t preprocess_function(llvm::Function& f);
+
+        instruction_info_t decode_instruction(llvm::Function& f, llvm::Instruction* i);
+    public:
+
+        GHC_frame_preservation_pass(
+            gprs base_reg,
+            u32 hv_ctx_offset,
+            std::function<bool(const std::string&)> exclusion_callback = {});
+        ~GHC_frame_preservation_pass() = default;
+
+        void run(llvm::IRBuilder<>* irb, llvm::Function& f) override;
+        void reset() override;
+    };
+}

--- a/rpcs3/Emu/CPU/Backends/AArch64JIT.h
+++ b/rpcs3/Emu/CPU/Backends/AArch64JIT.h
@@ -39,14 +39,16 @@ namespace aarch64
             bool is_returning;        // This instruction "returns" to the next instruction (typically just llvm::CallInst*)
             bool callee_is_GHC;       // The other function is GHC
             bool is_tail_call;        // Tail call. Assume it is an exit/terminator.
+            bool is_indirect;         // Indirect call. Target is the first operand.
             llvm::Function* callee;   // Callee if any
+            std::string callee_name;  // Name of the callee.
         };
     protected:
         std::unordered_set<std::string> visited_functions;
 
         struct
         {
-            gpr base_register;
+            std::vector<std::pair<std::string, gpr>> base_register_lookup;
             u32  hypervisor_context_offset;
         } execution_context;
 
@@ -57,11 +59,13 @@ namespace aarch64
         function_info_t preprocess_function(llvm::Function& f);
 
         instruction_info_t decode_instruction(llvm::Function& f, llvm::Instruction* i);
+
+        gpr get_base_register_for_call(const std::string& callee_name);
     public:
 
         GHC_frame_preservation_pass(
-            gpr base_reg,
             u32 hv_ctx_offset,
+            const std::vector<std::pair<std::string, gpr>>& base_register_lookup = {},
             std::function<bool(const std::string&)> exclusion_callback = {});
         ~GHC_frame_preservation_pass() = default;
 

--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -392,6 +392,17 @@ void cpu_translator::replace_intrinsics(llvm::Function& f)
 	}
 }
 
+void cpu_translator::run_transforms(llvm::Function& f)
+{
+	// This pass must run first because the other passes may depend on resolved names.
+	replace_intrinsics(f);
+
+	for (auto& pass : m_transform_passes)
+	{
+		pass->run(m_ir, f);
+	}
+}
+
 void cpu_translator::erase_stores(llvm::ArrayRef<llvm::Value*> args)
 {
 	for (auto v : args)

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3938,7 +3938,7 @@ llvm::InlineAsm* compile_inline_asm(
 static inline
 llvm::CallInst* llvm_asm(
 	llvm::IRBuilder<>* irb,
-	std::string& asm_,
+	const std::string& asm_,
 	llvm::ArrayRef<llvm::Value*> args,
 	const std::string& constraints,
 	llvm::LLVMContext& context)

--- a/rpcs3/Emu/CPU/Hypervisor.h
+++ b/rpcs3/Emu/CPU/Hypervisor.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <util/types.hpp>
+
+namespace rpcs3
+{
+	union alignas(16) hypervisor_context_t
+	{
+		u64 regs[16];
+
+		struct
+		{
+			u64 pc;
+			u64 sp;
+
+			u64 x18;
+			u64 x19;
+			u64 x20;
+			u64 x21;
+			u64 x22;
+			u64 x23;
+			u64 x24;
+			u64 x25;
+			u64 x26;
+			u64 x27;
+			u64 x28;
+			u64 x29;
+			u64 x30;
+
+			// x0-x17 unused
+		} aarch64;
+
+		struct
+		{
+			u64 sp;
+
+			// Other regs unused
+		} x86;
+	};
+}

--- a/rpcs3/Emu/CPU/Hypervisor.h
+++ b/rpcs3/Emu/CPU/Hypervisor.h
@@ -4,6 +4,18 @@
 
 namespace rpcs3
 {
+#if defined(ARCH_x64)
+	union hypervisor_context_t
+	{
+		u64 regs[1];
+		struct
+		{
+			u64 rsp;
+		} x86;
+	};
+
+	static_assert(sizeof(hypervisor_context_t) == 8);
+#else
 	union alignas(16) hypervisor_context_t
 	{
 		u64 regs[16];
@@ -29,12 +41,6 @@ namespace rpcs3
 
 			// x0-x17 unused
 		} aarch64;
-
-		struct
-		{
-			u64 sp;
-
-			// Other regs unused
-		} x86;
 	};
+#endif
 }

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -222,7 +222,7 @@ const auto ppu_gateway = build_function_asm<void(*)(ppu_thread*)>("ppu_gateway",
 #endif
 
 	// Save native stack pointer for longjmp emulation
-	c.mov(x86::qword_ptr(args[0], ::offset32(&ppu_thread::saved_native_sp)), x86::rsp);
+	c.mov(x86::qword_ptr(args[0], ::offset32(&ppu_thread::hv_ctx, &rpcs3::hypervisor_context_t::regs)), x86::rsp);
 
 	// Initialize args
 	c.mov(x86::r13, x86::qword_ptr(reinterpret_cast<u64>(&vm::g_exec_addr)));
@@ -291,37 +291,48 @@ const auto ppu_gateway = build_function_asm<void(*)(ppu_thread*)>("ppu_gateway",
 	// and https://developer.arm.com/documentation/den0024/a/The-ABI-for-ARM-64-bit-Architecture/Register-use-in-the-AArch64-Procedure-Call-Standard/Parameters-in-general-purpose-registers
 	// for AArch64 calling convention
 
-	// Save sp for native longjmp emulation
-	Label native_sp_offset = c.newLabel();
-	c.ldr(a64::x10, arm::Mem(native_sp_offset));
-	// sp not allowed to be used in load/stores directly
-	c.mov(a64::x15, a64::sp);
-	c.str(a64::x15, arm::Mem(args[0], a64::x10));
-
-	// Push callee saved registers to the stack
+	// Push callee saved registers to the hv context
+	// Assume our LLVM compiled code is unsafe and can clobber our stack. GHC on aarch64 treats stack as scratch.
+	// We also want to store the register context at a fixed place so we can read the hypervisor state from any lcoation.
 	// We need to save x18-x30 = 13 x 8B each + 8 bytes for 16B alignment = 112B
-	c.sub(a64::sp, a64::sp, Imm(112));
-	c.stp(a64::x18, a64::x19, arm::Mem(a64::sp));
-	c.stp(a64::x20, a64::x21, arm::Mem(a64::sp, 16));
-	c.stp(a64::x22, a64::x23, arm::Mem(a64::sp, 32));
-	c.stp(a64::x24, a64::x25, arm::Mem(a64::sp, 48));
-	c.stp(a64::x26, a64::x27, arm::Mem(a64::sp, 64));
-	c.stp(a64::x28, a64::x29, arm::Mem(a64::sp, 80));
-	c.str(a64::x30, arm::Mem(a64::sp, 96));
+
+	// Pre-context save
+	// Layout:
+	// pc, sp
+	// x18, x19...x30
+	// NOTE: Do not touch x19..x30 before saving the registers!
+	const u64 hv_register_array_offset = ::offset32(&ppu_thread::hv_ctx, &rpcs3::hypervisor_context_t::regs);
+	Label hv_ctx_pc = c.newLabel(); // Used to hold the far jump return address
+
+	// Sanity
+	ensure(hv_register_array_offset < 4096); // Imm10
+
+	c.mov(a64::x15, args[0]);
+	c.add(a64::x14, a64::x15, Imm(hv_register_array_offset));  // Per-thread context save
+
+	c.adr(a64::x15, hv_ctx_pc); // x15 = pc
+	c.mov(a64::x13, a64::sp);   // x16 = sp
+
+	c.stp(a64::x15, a64::x13, arm::Mem(a64::x14));
+	c.stp(a64::x18, a64::x19, arm::Mem(a64::x14, 16));
+	c.stp(a64::x20, a64::x21, arm::Mem(a64::x14, 32));
+	c.stp(a64::x22, a64::x23, arm::Mem(a64::x14, 48));
+	c.stp(a64::x24, a64::x25, arm::Mem(a64::x14, 64));
+	c.stp(a64::x26, a64::x27, arm::Mem(a64::x14, 80));
+	c.stp(a64::x28, a64::x29, arm::Mem(a64::x14, 96));
+	c.str(a64::x30, arm::Mem(a64::x14, 112));
 
 	// Load REG_Base - use absolute jump target to bypass rel jmp range limits
-	Label exec_addr = c.newLabel();
-	c.ldr(a64::x19, arm::Mem(exec_addr));
+	c.mov(a64::x19, Imm(reinterpret_cast<u64>(&vm::g_exec_addr)));
 	c.ldr(a64::x19, arm::Mem(a64::x19));
 	// Load PPUThread struct base -> REG_Sp
 	const arm::GpX ppu_t_base = a64::x20;
 	c.mov(ppu_t_base, args[0]);
 	// Load PC
 	const arm::GpX pc = a64::x15;
-	Label cia_offset = c.newLabel();
 	const arm::GpX cia_addr_reg = a64::x11;
 	// Load offset value
-	c.ldr(cia_addr_reg, arm::Mem(cia_offset));
+	c.mov(cia_addr_reg, Imm(static_cast<u64>(::offset32(&ppu_thread::cia))));
 	// Load cia
 	c.ldr(a64::w15, arm::Mem(ppu_t_base, cia_addr_reg));
 	// Multiply by 2 to index into ptr table
@@ -343,44 +354,45 @@ const auto ppu_gateway = build_function_asm<void(*)(ppu_thread*)>("ppu_gateway",
 	c.lsr(call_target, call_target, Imm(16));
 
 	// Load registers
-	Label base_addr = c.newLabel();
-	c.ldr(a64::x22, arm::Mem(base_addr));
+	c.mov(a64::x22, Imm(reinterpret_cast<u64>(&vm::g_base_addr)));
 	c.ldr(a64::x22, arm::Mem(a64::x22));
 
-	Label gpr_addr_offset = c.newLabel();
 	const arm::GpX gpr_addr_reg = a64::x9;
-	c.ldr(gpr_addr_reg, arm::Mem(gpr_addr_offset));
+	c.mov(gpr_addr_reg, Imm(static_cast<u64>(::offset32(&ppu_thread::gpr))));
 	c.add(gpr_addr_reg, gpr_addr_reg, ppu_t_base);
 	c.ldr(a64::x23, arm::Mem(gpr_addr_reg));
 	c.ldr(a64::x24, arm::Mem(gpr_addr_reg, 8));
 	c.ldr(a64::x25, arm::Mem(gpr_addr_reg, 16));
 
+	// GHC frame for the guest. This seems dodgy but the only thing stored on stack is actually registers before making calls to C++ code.
+	// Injected stack frames also work, but are not free and are completely unnecessary.
+	c.sub(a64::sp, a64::sp, Imm(4096));
+
 	// Execute LLE call
 	c.blr(call_target);
 
-	// Restore registers from the stack
-	c.ldp(a64::x18, a64::x19, arm::Mem(a64::sp));
-	c.ldp(a64::x20, a64::x21, arm::Mem(a64::sp, 16));
-	c.ldp(a64::x22, a64::x23, arm::Mem(a64::sp, 32));
-	c.ldp(a64::x24, a64::x25, arm::Mem(a64::sp, 48));
-	c.ldp(a64::x26, a64::x27, arm::Mem(a64::sp, 64));
-	c.ldp(a64::x28, a64::x29, arm::Mem(a64::sp, 80));
-	c.ldr(a64::x30, arm::Mem(a64::sp, 96));
-	// Restore stack ptr
-	c.add(a64::sp, a64::sp, Imm(112));
-	// Return
-	c.ret(a64::x30);
+	// Return address after far jump. Reset sp and start unwinding...
+	c.bind(hv_ctx_pc);
 
-	c.bind(exec_addr);
-	c.embedUInt64(reinterpret_cast<u64>(&vm::g_exec_addr));
-	c.bind(base_addr);
-	c.embedUInt64(reinterpret_cast<u64>(&vm::g_base_addr));
-	c.bind(cia_offset);
-	c.embedUInt64(static_cast<u64>(::offset32(&ppu_thread::cia)));
-	c.bind(gpr_addr_offset);
-	c.embedUInt64(static_cast<u64>(::offset32(&ppu_thread::gpr)));
-	c.bind(native_sp_offset);
-	c.embedUInt64(static_cast<u64>(::offset32(&ppu_thread::saved_native_sp)));
+	// Execution guard undo (unneded since we're going to hard-reset the SP)
+	//c.add(a64::sp, a64::sp, Imm(4096));
+
+	// We either got here through normal "ret" which keeps our x20 intact, or we jumped here and the escape reset our x20 reg
+	// Either way, x20 contains our thread base and we forcefully reset the stack pointer
+	c.add(a64::x14, a64::x20, Imm(hv_register_array_offset));  // Per-thread context save
+
+	c.ldr(a64::x15, arm::Mem(a64::x14, 8));
+	c.ldp(a64::x18, a64::x19, arm::Mem(a64::x14, 16));
+	c.ldp(a64::x20, a64::x21, arm::Mem(a64::x14, 32));
+	c.ldp(a64::x22, a64::x23, arm::Mem(a64::x14, 48));
+	c.ldp(a64::x24, a64::x25, arm::Mem(a64::x14, 64));
+	c.ldp(a64::x26, a64::x27, arm::Mem(a64::x14, 80));
+	c.ldp(a64::x28, a64::x29, arm::Mem(a64::x14, 96));
+	c.ldr(a64::x30, arm::Mem(a64::x14, 112));
+
+	// Return
+	c.mov(a64::sp, a64::x15);
+	c.ret(a64::x30);
 #endif
 });
 
@@ -390,11 +402,20 @@ const extern auto ppu_escape = build_function_asm<void(*)(ppu_thread*)>("ppu_esc
 
 #if defined(ARCH_X64)
 	// Restore native stack pointer (longjmp emulation)
-	c.mov(x86::rsp, x86::qword_ptr(args[0], ::offset32(&ppu_thread::saved_native_sp)));
+	c.mov(x86::rsp, x86::qword_ptr(args[0], ::offset32(&ppu_thread::hv_ctx, &rpcs3::hypervisor_context_t::regs)));
 
 	// Return to the return location
 	c.sub(x86::rsp, 8);
 	c.ret();
+#else
+	// We really shouldn't be using this, but an implementation shoudln't hurt
+	// Far jump return. Only clobbers x30.
+	const arm::GpX ppu_t_base = a64::x20;
+	const u64 hv_register_array_offset = ::offset32(&ppu_thread::hv_ctx, &rpcs3::hypervisor_context_t::regs);
+	c.mov(ppu_t_base, args[0]);
+	c.mov(a64::x30, Imm(hv_register_array_offset));
+	c.ldr(a64::x30, arm::Mem(ppu_t_base, a64::x30));
+	c.ret(a64::x30);
 #endif
 });
 
@@ -2265,6 +2286,9 @@ void ppu_thread::exec_task()
 {
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::_static)
 	{
+		// HVContext push to allow recursion. This happens with guest callback invocations.
+		const auto old_hv_ctx = hv_ctx;
+
 		while (true)
 		{
 			if (state) [[unlikely]]
@@ -2276,6 +2300,8 @@ void ppu_thread::exec_task()
 			ppu_gateway(this);
 		}
 
+		// HVContext pop
+		hv_ctx = old_hv_ctx;
 		return;
 	}
 
@@ -2313,6 +2339,8 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 	, ppu_tname(make_single<std::string>(name))
 {
 	prio.raw().prio = _prio;
+
+	memset(&hv_ctx, 0, sizeof(hv_ctx));
 
 	gpr[1] = stack_addr + stack_size - ppu_stack_start_offset;
 
@@ -3502,7 +3530,7 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 
 			if (notify)
 			{
-				bool notified = false;
+bool notified = false;
 
 				if (ppu.res_notify_time == (vm::reservation_acquire(notify) & -128))
 				{
@@ -5277,12 +5305,14 @@ static void ppu_initialize2(jit_compiler& jit, const ppu_module& module_part, co
 				// Translate
 				if (const auto func = translator.Translate(module_part.funcs[fi]))
 				{
+#ifdef ARCH_X64 // TODO
 					// Run optimization passes
 #if LLVM_VERSION_MAJOR < 17
 					pm.run(*func);
 #else
 					fpm.run(*func, fam);
 #endif
+#endif // ARCH_X64
 				}
 				else
 				{
@@ -5297,12 +5327,14 @@ static void ppu_initialize2(jit_compiler& jit, const ppu_module& module_part, co
 		{
 			if (const auto func = translator.GetSymbolResolver(whole_module))
 			{
+#ifdef ARCH_X64 // TODO
 				// Run optimization passes
 #if LLVM_VERSION_MAJOR < 17
 				pm.run(*func);
 #else
 				fpm.run(*func, fam);
 #endif
+#endif // ARCH_X64
 			}
 			else
 			{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -381,7 +381,7 @@ const auto ppu_gateway = build_function_asm<void(*)(ppu_thread*)>("ppu_gateway",
 
 	// GHC scratchpad mem. If managed correctly (i.e no returns ever), GHC functions should never require a stack frame.
 	// We allocate a slab to use for all functions as they tail-call into each other.
-	c.sub(a64::sp, a64::sp, Imm(4096));
+	c.sub(a64::sp, a64::sp, Imm(8192));
 
 	// Execute LLE call
 	c.blr(call_target);
@@ -390,7 +390,7 @@ const auto ppu_gateway = build_function_asm<void(*)(ppu_thread*)>("ppu_gateway",
 	c.bind(hv_ctx_pc);
 
 	// Clear scratchpad allocation
-	c.add(a64::sp, a64::sp, Imm(4096));
+	c.add(a64::sp, a64::sp, Imm(8192));
 
 	c.ldr(a64::x20, arm::Mem(a64::sp));
 	c.add(a64::sp, a64::sp, Imm(16));

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -291,6 +291,13 @@ const auto ppu_gateway = build_function_asm<void(*)(ppu_thread*)>("ppu_gateway",
 	// and https://developer.arm.com/documentation/den0024/a/The-ABI-for-ARM-64-bit-Architecture/Register-use-in-the-AArch64-Procedure-Call-Standard/Parameters-in-general-purpose-registers
 	// for AArch64 calling convention
 
+	// PPU function argument layout:
+	// x19 = m_exec
+	// x20 = m_thread,
+	// x21 = seg0
+	// x22 = m_base
+	// x23 - x25 = gpr[0] - gpr[3]
+
 	// Push callee saved registers to the hv context
 	// Assume our LLVM compiled code is unsafe and can clobber our stack. GHC on aarch64 treats stack as scratch.
 	// We also want to store the register context at a fixed place so we can read the hypervisor state from any lcoation.

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3548,7 +3548,7 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 
 			if (notify)
 			{
-bool notified = false;
+				bool notified = false;
 
 				if (ppu.res_notify_time == (vm::reservation_acquire(notify) & -128))
 				{

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../CPU/CPUThread.h"
+#include "../CPU/Hypervisor.h"
 #include "../Memory/vm_ptr.h"
 #include "Utilities/lockless.h"
 #include "Utilities/BitField.h"
@@ -162,6 +163,9 @@ public:
 	void save(utils::serial& ar);
 
 	using cpu_thread::operator=;
+
+	// Hypervisor context data
+	alignas(16) rpcs3::hypervisor_context_t hv_ctx; // HV context for gate enter exit. Keep at a low struct offset.
 
 	u64 gpr[32] = {}; // General-Purpose Registers
 	f64 fpr[32] = {}; // Floating Point Registers

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -164,9 +164,6 @@ public:
 
 	using cpu_thread::operator=;
 
-	// Hypervisor context data
-	alignas(16) rpcs3::hypervisor_context_t hv_ctx; // HV context for gate enter exit. Keep at a low struct offset.
-
 	u64 gpr[32] = {}; // General-Purpose Registers
 	f64 fpr[32] = {}; // Floating Point Registers
 	v128 vr[32] = {}; // Vector Registers
@@ -307,7 +304,8 @@ public:
 	// Thread name
 	atomic_ptr<std::string> ppu_tname;
 
-	u64 saved_native_sp = 0; // Host thread's stack pointer for emulated longjmp
+	// Hypervisor context data
+	rpcs3::hypervisor_context_t hv_ctx; // HV context for gate enter exit. Keep at a low struct offset.
 
 	u64 last_ftsc = 0;
 	u64 last_ftime = 0;

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -269,7 +269,7 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 		}
 	}
 
-	replace_intrinsics(*m_function);
+	run_transforms(*m_function);
 	return m_function;
 }
 
@@ -321,7 +321,7 @@ Function* PPUTranslator::GetSymbolResolver(const ppu_module& info)
 	{
 		// Possible special case for no functions (allowing the do-while optimization)
 		m_ir->CreateRetVoid(); // FIXME: Aarch64. It should work fine as long as there is no callchain beyond this function with a ret path.
-		replace_intrinsics(*m_function);
+		run_transforms(*m_function);
 		return m_function;
 	}
 
@@ -379,7 +379,7 @@ Function* PPUTranslator::GetSymbolResolver(const ppu_module& info)
 
 	m_ir->CreateRetVoid(); // FIXME: Aarch64 - Should be ok as long as no ret-based callchain proceeds from here
 
-	replace_intrinsics(*m_function);
+	run_transforms(*m_function);
 	return m_function;
 }
 
@@ -5375,7 +5375,7 @@ void PPUTranslator::build_interpreter()
 		op.vc = 3; \
 		this->i(op); \
 		VMEscape(); \
-		replace_intrinsics(*m_function); \
+		run_transforms(*m_function); \
 	}
 
 	BUILD_VEC_INST(VADDCUW);

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -49,7 +49,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_mo
 		aarch64::GHC_frame_preservation_pass::config_t config =
 		{
 			.debug_info = false,         // Set to "true" to insert debug frames on x27
-			.use_stack_frames = false,   // GW allocates 4k of scratch on the stack
+			.use_stack_frames = false,   // We don't need this since the PPU GW allocates global scratch on the stack
 			.hypervisor_context_offset = ::offset32(&ppu_thread::hv_ctx),
 			.exclusion_callback = {},    // Unused, we don't have special exclusion functions on PPU
 			.base_register_lookup = base_reg_lookup

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -150,6 +150,9 @@ public:
 	// Emit function call
 	void CallFunction(u64 target, llvm::Value* indirect = nullptr);
 
+	// Emit escape sequence back to hypervisor
+	void VMEscape(llvm::CallInst* tail_call = nullptr, bool skip_flush = false);
+
 	// Emit state check mid-block
 	void TestAborted();
 

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -150,9 +150,6 @@ public:
 	// Emit function call
 	void CallFunction(u64 target, llvm::Value* indirect = nullptr);
 
-	// Emit escape sequence back to hypervisor
-	void VMEscape(llvm::CallInst* tail_call = nullptr, bool skip_flush = false);
-
 	// Emit state check mid-block
 	void TestAborted();
 

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -2605,7 +2605,7 @@ public:
 
 		for (auto& f : *m_module)
 		{
-			replace_intrinsics(f);
+			run_transforms(f);
 		}
 
 		for (const auto& func : m_functions)
@@ -3089,7 +3089,7 @@ public:
 
 		for (auto& f : *_module)
 		{
-			replace_intrinsics(f);
+			run_transforms(f);
 		}
 
 		std::string log;

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1493,12 +1493,17 @@ public:
 			// Initialize transform passes
 #ifdef ARCH_ARM64
 			{
+				auto should_exclude_function = [](const std::string& fn_name)
+				{
+					return fn_name.starts_with("spu_") || fn_name.starts_with("tr_");
+				};
+
 				aarch64::GHC_frame_preservation_pass::config_t config =
 				{
 					.debug_info = false,         // Set to "true" to insert debug frames on x27
 					.use_stack_frames = false,   // We don't need this since the SPU GW allocates global scratch on the stack
 					.hypervisor_context_offset = ::offset32(&spu_thread::hv_ctx),
-					.exclusion_callback = {},    // Unused
+					.exclusion_callback = should_exclude_function,
 					.base_register_lookup = {}   // Unused, always x19 on SPU
 				};
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2062,6 +2062,8 @@ spu_thread::spu_thread(lv2_spu_group* group, u32 index, std::string_view name, u
 	}
 
 	range_lock = vm::alloc_range_lock();
+
+	memset(&hv_ctx, 0, sizeof(hv_ctx));
 }
 
 void spu_thread::serialize_common(utils::serial& ar)

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Emu/CPU/CPUThread.h"
+#include "Emu/CPU/Hypervisor.h"
 #include "Emu/Cell/SPUInterpreter.h"
 #include "Emu/Memory/vm.h"
 #include "MFC.h"
@@ -778,7 +779,7 @@ public:
 	u64 block_recover = 0;
 	u64 block_failure = 0;
 
-	u64 saved_native_sp = 0; // Host thread's stack pointer for emulated longjmp
+	alignas(16) rpcs3::hypervisor_context_t hv_ctx; // NOTE: The offset within the class must be within the first 1MiB
 
 	u64 ftx = 0; // Failed transactions
 	u64 stx = 0; // Succeeded transactions (pure counters)

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -779,7 +779,7 @@ public:
 	u64 block_recover = 0;
 	u64 block_failure = 0;
 
-	alignas(16) rpcs3::hypervisor_context_t hv_ctx; // NOTE: The offset within the class must be within the first 1MiB
+	rpcs3::hypervisor_context_t hv_ctx; // NOTE: The offset within the class must be within the first 1MiB
 
 	u64 ftx = 0; // Failed transactions
 	u64 stx = 0; // Succeeded transactions (pure counters)

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -536,6 +536,7 @@
     <ClInclude Include="Emu\Cell\Modules\libfs_utility_init.h" />
     <ClInclude Include="Emu\Cell\Modules\sys_crashdump.h" />
     <ClInclude Include="Emu\config_mode.h" />
+    <ClInclude Include="Emu\CPU\Hypervisor.h" />
     <ClInclude Include="Emu\CPU\sse2neon.h" />
     <ClInclude Include="Emu\games_config.h" />
     <ClInclude Include="Emu\Io\Buzz.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2569,8 +2569,8 @@
     <ClInclude Include="Emu\RSX\NV47\FW\GRAPH_backend.h">
       <Filter>Emu\GPU\RSX\NV47\FW</Filter>
     </ClInclude>
-    <ClInclude Include="Emu\Io\mouse_config.h">
-      <Filter>Emu\Io</Filter>
+    <ClInclude Include="Emu\CPU\Hypervisor.h">
+      <Filter>Emu\CPU</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/util/simd.hpp
+++ b/rpcs3/util/simd.hpp
@@ -25,6 +25,14 @@
 #include <math.h>
 #include <cfenv>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 namespace asmjit
 {
 	struct vec_builder;
@@ -541,7 +549,7 @@ namespace asmjit
 	}
 #define FOR_X64(f, ...) do { using enum asmjit::x86::Inst::Id; return asmjit::f(__VA_ARGS__); } while (0)
 #elif defined(ARCH_ARM64)
-#define FOR_X64(...) do {} while (0)
+#define FOR_X64(...) do { fmt::throw_exception("Unimplemented for this architecture!"); } while (0)
 #endif
 }
 
@@ -3098,3 +3106,9 @@ inline auto gv_shuffle_right(A&& a)
 {
 	FOR_X64(unary_op, kIdPsrldq, kIdVpsrldq, std::forward<A>(a), Count);
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Adds support for arm64 LLVM JIT.
Closes https://github.com/RPCS3/rpcs3/issues/15867
Closes https://github.com/RPCS3/rpcs3/issues/15868

### Supported Platforms
Only linux has been tested so far. MacOS should work though may require some fiddling, that is work for later.

### Overview
The implementation presented here uses a post-processing method on the LLVM IR as it was the most flexible approach (you can see remnants of the original idea in the first commit). Previous ideas like x86-ifying the IR also worked but were slow likely due to all the stack management and pushng/popping of return addresses and the like. Previous attempts (all worked to some degree) include.
- Stack-based call/ret management. Clumsy and slow. Often crashed if anything misbehaved.
- Custom LLVM. First approach I used, not scalable.
- Explicit "gates" for entry and exit to/from the hypervisor. This required very extensive code changes to the PPU and SPU translator codebase and was guaranteed to break whenever other contributors made any changes. Technically this is the fastest option as code generated is very explicit, but it is difficult to work with and I don't want to be trapped in a maintenance nightmare.

### What works
Most games will not work if they don't work with interpreters but chances are good that if interpreter gets somewhere then LLVM also will. However, I have observed plenty of graphical glitches so some RSX work may be needed to make this usable.