### PR TITLE
PINE: Fix socket naming for Mac and Linux to match protocol specification

### DIFF
--- a/3rdparty/pine/pine_server.h
+++ b/3rdparty/pine/pine_server.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
+// IPC uses a concept of "slot" to be able to communicate with multiple
+// emulators at the same time, each slot should be unique to each emulator to
+// allow PnP and configurable by the end user so that several runs don't
+// conflict with each others
+#define IPC_DEFAULT_SLOT 28012
+
 //#include "Utilities/Thread.h"
 #include <string>
 #include "stdafx.h"
@@ -568,7 +574,9 @@ namespace pine
 				m_socket_name += "/rpcs3.sock";
 			}
 
-			m_socket_name = fmt::format("%s.%d", m_socket_name, Impl::get_port());
+			int slot = Impl::get_port();
+			if (slot != IPC_DEFAULT_SLOT)
+				m_socket_name = fmt::format("%s.%d", m_socket_name, slot);
 
 			struct sockaddr_un server;
 

--- a/3rdparty/pine/pine_server.h
+++ b/3rdparty/pine/pine_server.h
@@ -10,7 +10,6 @@
 // conflict with each others
 #define IPC_DEFAULT_SLOT 28012
 
-//#include "Utilities/Thread.h"
 #include <string>
 #include "stdafx.h"
 #include <stdio.h>
@@ -574,9 +573,11 @@ namespace pine
 				m_socket_name += "/rpcs3.sock";
 			}
 
-			int slot = Impl::get_port();
+			const int slot = Impl::get_port();
 			if (slot != IPC_DEFAULT_SLOT)
-				m_socket_name = fmt::format("%s.%d", m_socket_name, slot);
+			{
+				fmt::append(m_socket_name, ".%d", slot);
+			}
 
 			struct sockaddr_un server;
 


### PR DESCRIPTION
Hello! This small pull request aims to fix the PINE IPC socket file naming for Mac and Linux users. Essentially, the port is now only concatenated to the socket name if it is different than the default port.
This change was made to match with the specification of the [PINE protocol](https://github.com/GovanifY/pine/blob/master/standard/draft.dtd#L79-L115) and [the other emulators implementing it](https://github.com/PCSX2/pcsx2/blob/edeb0d7bd7258c58273cc4a88a9f9a823d71e48c/pcsx2/IPC.cpp#L95-L96).