### PR TITLE
Pad settings: Ignore button press or stick values unless they increase

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -225,7 +225,7 @@ PadHandlerBase::connection PadHandlerBase::get_next_button_press(const std::stri
 	if (get_blacklist)
 		blacklist.clear();
 
-	if (first_call)
+	if (first_call || get_blacklist)
 		min_button_values.clear();
 
 	auto device = get_device(pad_id);

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -269,8 +269,6 @@ PadHandlerBase::connection PadHandlerBase::get_next_button_press(const std::stri
 			continue;
 		}
 
-		constexpr u16 touch_threshold = static_cast<u16>(255 * 0.9f);
-
 		const bool is_trigger = get_is_left_trigger(device, keycode) || get_is_right_trigger(device, keycode);
 		const bool is_stick   = !is_trigger && (get_is_left_stick(device, keycode) || get_is_right_stick(device, keycode));
 		const bool is_touch_motion = !is_trigger && !is_stick && get_is_touch_pad_motion(device, keycode);

--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -290,13 +290,13 @@ PadHandlerBase::connection PadHandlerBase::get_next_button_press(const std::stri
 
 	if (callback)
 	{
-		const pad_preview_values preview_values = get_preview_values(data);
+		pad_preview_values preview_values = get_preview_values(data);
 		const u32 battery_level = get_battery_level(pad_id);
 
 		if (pressed_button.value > 0)
-			callback(pressed_button.value, pressed_button.name, pad_id, battery_level, preview_values);
+			callback(pressed_button.value, pressed_button.name, pad_id, battery_level, std::move(preview_values));
 		else
-			callback(0, "", pad_id, battery_level, preview_values);
+			callback(0, "", pad_id, battery_level, std::move(preview_values));
 	}
 
 	return status;

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -112,6 +112,7 @@ protected:
 
 	static constexpr u32 MAX_GAMEPADS = 7;
 	static constexpr u16 button_press_threshold = 50;
+	static constexpr u16 touch_threshold = static_cast<u16>(255 * 0.9f);
 
 	std::array<bool, MAX_GAMEPADS> last_connection_status{{ false, false, false, false, false, false, false }};
 

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -111,13 +111,14 @@ protected:
 	};
 
 	static constexpr u32 MAX_GAMEPADS = 7;
+	static constexpr u16 button_press_threshold = 50;
 
 	std::array<bool, MAX_GAMEPADS> last_connection_status{{ false, false, false, false, false, false, false }};
 
 	std::string m_name_string;
 	usz m_max_devices = 0;
-	int m_trigger_threshold = 0;
-	int m_thumb_threshold = 0;
+	u32 m_trigger_threshold = 0;
+	u32 m_thumb_threshold = 0;
 
 	bool b_has_led = false;
 	bool b_has_rgb = false;
@@ -132,6 +133,7 @@ protected:
 	std::array<cfg_pad, MAX_GAMEPADS> m_pad_configs;
 	std::vector<pad_ensemble> m_bindings;
 	std::unordered_map<u32, std::string> button_list;
+	std::unordered_map<u32, u16> min_button_values;
 	std::set<u32> blacklist;
 
 	static std::set<u32> narrow_set(const std::set<u64>& src);
@@ -280,7 +282,7 @@ public:
 	// Binds a Pad to a device
 	virtual bool bindPadToDevice(std::shared_ptr<Pad> pad);
 	virtual void init_config(cfg_pad* cfg) = 0;
-	virtual connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons = {});
+	virtual connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons);
 	virtual void get_motion_sensors(const std::string& pad_id, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors);
 	virtual std::unordered_map<u32, std::string> get_motion_axis_list() const { return {}; }
 

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -297,10 +297,13 @@ std::shared_ptr<evdev_joystick_handler::EvdevDevice> evdev_joystick_handler::get
 	return evdev_device;
 }
 
-PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons)
 {
 	if (get_blacklist)
 		m_blacklist.clear();
+
+	if (first_call)
+		m_min_button_values.clear();
 
 	// Get our evdev device
 	std::shared_ptr<EvdevDevice> device = get_evdev_device(padId);
@@ -310,6 +313,7 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 			fail_callback(padId);
 		return connection::disconnected;
 	}
+
 	libevdev* dev = device->device;
 
 	// Try to fetch all new events from the joystick.
@@ -377,8 +381,8 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 		preview_values[5] = find_value(buttons[9]) - find_value(buttons[8]); // Right Stick Y
 	}
 
-	// return if nothing new has happened. ignore this to get the current state for blacklist
-	if (!get_blacklist && !has_new_event)
+	// return if nothing new has happened. ignore this to get the current state for blacklist or first_call
+	if (!get_blacklist && !first_call && !has_new_event)
 	{
 		if (callback)
 			callback(0, "", padId, 0, preview_values);
@@ -390,6 +394,17 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 		u16 value = 0;
 		std::string name;
 	} pressed_button{};
+
+	const auto set_button_press = [this, &pressed_button](const u16 value, const std::string& name)
+	{
+		const u16 min_value = m_min_button_values.contains(name) ? m_min_button_values[name] : 0;
+		const u16 diff = std::abs(min_value - value);
+
+		if (diff > button_press_threshold && value > pressed_button.value)
+		{
+			pressed_button = { .value = value, .name = name };
+		}
+	};
 
 	const bool is_xbox_360_controller = padId.find("Xbox 360") != umax;
 	const bool is_sony_controller = !is_xbox_360_controller && padId.find("Sony") != umax;
@@ -409,18 +424,25 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 			continue;
 
 		const u16 value = data[code].first;
-		if (value > 0)
+		u16& min_value = m_min_button_values[name];
+
+		if (first_call || value < min_value)
 		{
-			if (get_blacklist)
-			{
-				m_blacklist.insert(name);
-				evdev_log.error("Evdev Calibration: Added button [ %d = %s = %s ] to blacklist. Value = %d", code, libevdev_event_code_get_name(EV_KEY, code), name, value);
-			}
-			else if (value > pressed_button.value)
-			{
-				pressed_button = { value, name };
-			}
+			min_value = value;
+			return;
 		}
+
+		if (value <= 0)
+			continue;
+
+		if (get_blacklist)
+		{
+			m_blacklist.insert(name);
+			evdev_log.error("Evdev Calibration: Added button [ %d = %s = %s ] to blacklist. Value = %d", code, libevdev_event_code_get_name(EV_KEY, code), name, value);
+			continue;
+		}
+
+		set_button_press(value, name);
 	}
 
 	for (const auto& [code, name] : axis_list)
@@ -432,20 +454,27 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 			continue;
 
 		const u16 value = data[code].first;
-		if (value > 0 && value >= m_thumb_threshold)
+		u16& min_value = m_min_button_values[name];
+
+		if (first_call || value < min_value)
 		{
-			if (get_blacklist)
-			{
-				const int min = libevdev_get_abs_minimum(dev, code);
-				const int max = libevdev_get_abs_maximum(dev, code);
-				m_blacklist.insert(name);
-				evdev_log.error("Evdev Calibration: Added axis [ %d = %s = %s ] to blacklist. [ Value = %d ] [ Min = %d ] [ Max = %d ]", code, libevdev_event_code_get_name(EV_ABS, code), name, value, min, max);
-			}
-			else if (value > pressed_button.value)
-			{
-				pressed_button = { value, name };
-			}
+			min_value = value;
+			return;
 		}
+
+		if (value <= m_thumb_threshold)
+			continue;
+
+		if (get_blacklist)
+		{
+			const int min = libevdev_get_abs_minimum(dev, code);
+			const int max = libevdev_get_abs_maximum(dev, code);
+			m_blacklist.insert(name);
+			evdev_log.error("Evdev Calibration: Added axis [ %d = %s = %s ] to blacklist. [ Value = %d ] [ Min = %d ] [ Max = %d ]", code, libevdev_event_code_get_name(EV_ABS, code), name, value, min, max);
+			continue;
+		}
+
+		set_button_press(value, name);
 	}
 
 	for (const auto& [code, name] : rev_axis_list)
@@ -457,20 +486,32 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 			continue;
 
 		const u16 value = data[code].first;
-		if (value > 0 && value >= m_thumb_threshold)
+		u16& min_value = m_min_button_values[name];
+
+		if (first_call || value < min_value)
 		{
-			if (get_blacklist)
-			{
-				const int min = libevdev_get_abs_minimum(dev, code);
-				const int max = libevdev_get_abs_maximum(dev, code);
-				m_blacklist.insert(name);
-				evdev_log.error("Evdev Calibration: Added rev axis [ %d = %s = %s ] to blacklist. [ Value = %d ] [ Min = %d ] [ Max = %d ]", code, libevdev_event_code_get_name(EV_ABS, code), name, value, min, max);
-			}
-			else if (value > pressed_button.value)
-			{
-				pressed_button = { value, name };
-			}
+			min_value = value;
+			return;
 		}
+
+		if (value <= m_thumb_threshold)
+			continue;
+
+		if (get_blacklist)
+		{
+			const int min = libevdev_get_abs_minimum(dev, code);
+			const int max = libevdev_get_abs_maximum(dev, code);
+			m_blacklist.insert(name);
+			evdev_log.error("Evdev Calibration: Added rev axis [ %d = %s = %s ] to blacklist. [ Value = %d ] [ Min = %d ] [ Max = %d ]", code, libevdev_event_code_get_name(EV_ABS, code), name, value, min, max);
+			continue;
+		}
+
+		set_button_press(value, name);
+	}
+
+	if (first_call)
+	{
+		return connection::no_data;
 	}
 
 	if (get_blacklist)

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -483,9 +483,9 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 	if (callback)
 	{
 		if (pressed_button.value > 0)
-			callback(pressed_button.value, pressed_button.name, padId, 0, preview_values);
+			callback(pressed_button.value, pressed_button.name, padId, 0, std::move(preview_values));
 		else
-			callback(0, "", padId, 0, preview_values);
+			callback(0, "", padId, 0, std::move(preview_values));
 	}
 
 	return connection::connected;

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -302,7 +302,7 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 	if (get_blacklist)
 		m_blacklist.clear();
 
-	if (first_call)
+	if (first_call || get_blacklist)
 		m_min_button_values.clear();
 
 	// Get our evdev device

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -407,7 +407,7 @@ public:
 	bool Init() override;
 	std::vector<pad_list_entry> list_devices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad) override;
-	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
+	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons) override;
 	void get_motion_sensors(const std::string& padId, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors) override;
 	std::unordered_map<u32, std::string> get_motion_axis_list() const override;
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
@@ -425,6 +425,7 @@ private:
 	positive_axis m_pos_axis_config;
 	std::set<u32> m_positive_axis;
 	std::set<std::string> m_blacklist;
+	std::unordered_map<std::string, u16> m_min_button_values;
 	std::unordered_map<std::string, std::shared_ptr<evdev_joystick_handler::EvdevDevice>> m_settings_added;
 	std::unordered_map<std::string, std::shared_ptr<evdev_joystick_handler::EvdevDevice>> m_motion_settings_added;
 	std::shared_ptr<EvdevDevice> m_dev;

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -84,7 +84,7 @@ public:
 
 	void init_config(cfg_pad* cfg) override;
 	std::vector<pad_list_entry> list_devices() override;
-	connection get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*get_blacklist*/ = false, const std::vector<std::string>& /*buttons*/ = {}) override { return connection::connected; }
+	connection get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*first_call*/, bool /*get_blacklist*/, const std::vector<std::string>& /*buttons*/) override { return connection::connected; }
 	bool bindPadToDevice(std::shared_ptr<Pad> pad) override;
 	void process() override;
 

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -226,7 +226,7 @@ PadHandlerBase::connection mm_joystick_handler::get_next_button_press(const std:
 	if (get_blacklist)
 		m_blacklist.clear();
 
-	if (first_call)
+	if (first_call || get_blacklist)
 		m_min_button_values.clear();
 
 	if (!Init())

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -379,9 +379,9 @@ PadHandlerBase::connection mm_joystick_handler::get_next_button_press(const std:
 			}
 
 			if (pressed_button.value > 0)
-				callback(pressed_button.value, pressed_button.name, padId, 0, preview_values);
+				callback(pressed_button.value, pressed_button.name, padId, 0, std::move(preview_values));
 			else
-				callback(0, "", padId, 0, preview_values);
+				callback(0, "", padId, 0, std::move(preview_values));
 		}
 
 		return connection::connected;

--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -114,7 +114,7 @@ public:
 	bool Init() override;
 
 	std::vector<pad_list_entry> list_devices() override;
-	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist = false, const std::vector<std::string>& buttons = {}) override;
+	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons) override;
 	void init_config(cfg_pad* cfg) override;
 
 private:
@@ -127,6 +127,7 @@ private:
 	bool m_is_init = false;
 
 	std::set<u64> m_blacklist;
+	std::unordered_map<u64, u16> m_min_button_values;
 	std::map<std::string, std::shared_ptr<MMJOYDevice>> m_devices;
 
 	template <typename T>

--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -762,14 +762,14 @@ void sdl_pad_handler::get_motion_sensors(const std::string& pad_id, const motion
 	PadHandlerBase::get_motion_sensors(pad_id, callback, fail_callback, preview_values, sensors);
 }
 
-PadHandlerBase::connection sdl_pad_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons)
+PadHandlerBase::connection sdl_pad_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons)
 {
 	if (!m_is_init)
 		return connection::disconnected;
 
 	SDL_PumpEvents();
 
-	return PadHandlerBase::get_next_button_press(padId, callback, fail_callback, get_blacklist, buttons);
+	return PadHandlerBase::get_next_button_press(padId, callback, fail_callback, first_call, get_blacklist, buttons);
 }
 
 void sdl_pad_handler::apply_pad_data(const pad_ensemble& binding)

--- a/rpcs3/Input/sdl_pad_handler.h
+++ b/rpcs3/Input/sdl_pad_handler.h
@@ -128,7 +128,7 @@ public:
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void get_motion_sensors(const std::string& pad_id, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors) override;
-	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool get_blacklist, const std::vector<std::string>& buttons) override;
+	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons) override;
 
 private:
 	// pseudo 'controller id' to keep track of unique controllers

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -575,9 +575,15 @@ void pad_settings_dialog::InitButtons()
 
 			const std::vector<std::string> buttons =
 			{
-				m_cfg_entries[button_ids::id_pad_l2].keys, m_cfg_entries[button_ids::id_pad_r2].keys, m_cfg_entries[button_ids::id_pad_lstick_left].keys,
-				m_cfg_entries[button_ids::id_pad_lstick_right].keys, m_cfg_entries[button_ids::id_pad_lstick_down].keys, m_cfg_entries[button_ids::id_pad_lstick_up].keys,
-				m_cfg_entries[button_ids::id_pad_rstick_left].keys, m_cfg_entries[button_ids::id_pad_rstick_right].keys, m_cfg_entries[button_ids::id_pad_rstick_down].keys,
+				m_cfg_entries[button_ids::id_pad_l2].keys,
+				m_cfg_entries[button_ids::id_pad_r2].keys,
+				m_cfg_entries[button_ids::id_pad_lstick_left].keys,
+				m_cfg_entries[button_ids::id_pad_lstick_right].keys,
+				m_cfg_entries[button_ids::id_pad_lstick_down].keys,
+				m_cfg_entries[button_ids::id_pad_lstick_up].keys,
+				m_cfg_entries[button_ids::id_pad_rstick_left].keys,
+				m_cfg_entries[button_ids::id_pad_rstick_right].keys,
+				m_cfg_entries[button_ids::id_pad_rstick_down].keys,
 				m_cfg_entries[button_ids::id_pad_rstick_up].keys
 			};
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -124,7 +124,7 @@ private:
 
 	// Button Mapping
 	QButtonGroup* m_pad_buttons = nullptr;
-	u32 m_button_id = id_pad_begin;
+	atomic_t<u32> m_button_id = button_ids::id_pad_begin;
 	std::map<int /*id*/, pad_button /*info*/> m_cfg_entries;
 	std::map<int /*id*/, std::string> m_duplicate_buttons;
 
@@ -166,6 +166,7 @@ private:
 	{
 		PadHandlerBase::connection status = PadHandlerBase::connection::disconnected;
 		bool has_new_data = false;
+		u32 button_id = button_ids::id_pad_begin;
 		u16 val = 0;
 		std::string name;
 		std::string pad_name;


### PR DESCRIPTION
- Pad settings: Ignore button press or stick values unless they increase

This basically means that already pressed buttons or sticks won't trigger a remap unless you release them and press them again.
This hopefully improves mapping your buttons and sticks in the pad settings dialog.

fixes #15086