### PR TITLE
Fix initial reload of mouse handler configs

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -914,22 +914,15 @@ static bool mouse_input_to_pad(const u32 mouse_no, be_t<u16>& digital_buttons, b
 		return false;
 	}
 
+	std::set<MouseButtonCodes> pressed_buttons;
 	const Mouse& mouse_data = ::at32(handler.GetMice(), mouse_no);
-	const auto is_pressed = [&mouse_data](MouseButtonCodes button) -> bool { return !!(mouse_data.buttons & button); };
+	const auto is_pressed = [&mouse_data, &pressed_buttons](MouseButtonCodes button) -> bool
+	{
+		// Only allow each button to be used for one action unless it's the combo button.
+		return (mouse_data.buttons & button) && (button == (CELL_MOUSE_BUTTON_3 + 0u/*fix warning*/) || pressed_buttons.insert(button).second);
+	};
 
 	digital_buttons = 0;
-
-	if (is_pressed(CELL_MOUSE_BUTTON_1))
-		digital_buttons |= CELL_GEM_CTRL_T;
-
-	if (is_pressed(CELL_MOUSE_BUTTON_2))
-		digital_buttons |= CELL_GEM_CTRL_MOVE;
-
-	if (is_pressed(CELL_MOUSE_BUTTON_4))
-		digital_buttons |= CELL_GEM_CTRL_CIRCLE;
-
-	if (is_pressed(CELL_MOUSE_BUTTON_5))
-		digital_buttons |= CELL_GEM_CTRL_CROSS;
 
 	if ((is_pressed(CELL_MOUSE_BUTTON_3) && is_pressed(CELL_MOUSE_BUTTON_1)) || is_pressed(CELL_MOUSE_BUTTON_6))
 		digital_buttons |= CELL_GEM_CTRL_SELECT;
@@ -942,6 +935,18 @@ static bool mouse_input_to_pad(const u32 mouse_no, be_t<u16>& digital_buttons, b
 
 	if (is_pressed(CELL_MOUSE_BUTTON_3) && is_pressed(CELL_MOUSE_BUTTON_5))
 		digital_buttons |= CELL_GEM_CTRL_SQUARE;
+
+	if (is_pressed(CELL_MOUSE_BUTTON_1))
+		digital_buttons |= CELL_GEM_CTRL_T;
+
+	if (is_pressed(CELL_MOUSE_BUTTON_2))
+		digital_buttons |= CELL_GEM_CTRL_MOVE;
+
+	if (is_pressed(CELL_MOUSE_BUTTON_4))
+		digital_buttons |= CELL_GEM_CTRL_CIRCLE;
+
+	if (is_pressed(CELL_MOUSE_BUTTON_5))
+		digital_buttons |= CELL_GEM_CTRL_CROSS;
 
 	analog_t = (mouse_data.buttons & CELL_MOUSE_BUTTON_1) ? 0xFFFF : 0;
 

--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -372,6 +372,8 @@ public:
 		{
 			cellGem.notice("Could not load gem config. Using defaults.");
 		}
+
+		cellGem.notice("Gem config=\n", g_cfg_gem.to_string());
 	};
 
 	SAVESTATE_INIT_POS(15);
@@ -395,10 +397,15 @@ public:
 	{
 		save(ar);
 
-		if (!ar.is_writing() && !g_cfg_gem.load())
+		if (ar.is_writing())
+			return;
+
+		if (!g_cfg_gem.load())
 		{
 			cellGem.notice("Could not load gem config. Using defaults.");
 		}
+
+		cellGem.notice("Gem config=\n", g_cfg_gem.to_string());
 	}
 };
 

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -423,6 +423,8 @@ usb_handler_thread::usb_handler_thread()
 
 		sys_usbd.notice("Adding emulated USIO");
 		usb_devices.push_back(std::make_shared<usb_device_usio>(get_new_location()));
+
+		sys_usbd.notice("USIO config=\n", g_cfg_usio.to_string());
 	}
 
 	const std::vector<std::string> devices_list = fmt::split(g_cfg.io.midi_devices.to_string(), { "@@@" });
@@ -449,7 +451,10 @@ usb_handler_thread::usb_handler_thread()
 			{
 				sys_usbd.notice("Could not load rb3drums config. Using defaults.");
 			}
+
 			usb_devices.push_back(std::make_shared<usb_device_rb3_midi_drums>(get_new_location(), device.name));
+
+			sys_usbd.notice("RB3 drums config=\n", g_cfg_rb3drums.to_string());
 			break;
 		}
 	}
@@ -463,11 +468,14 @@ usb_handler_thread::usb_handler_thread()
 
 		sys_usbd.notice("Adding emulated GHLtar (1 player)");
 		usb_devices.push_back(std::make_shared<usb_device_ghltar>(0, get_new_location()));
-	}
-	if (g_cfg.io.ghltar == ghltar_handler::two_controllers)
-	{
-		sys_usbd.notice("Adding emulated GHLtar (2 players)");
-		usb_devices.push_back(std::make_shared<usb_device_ghltar>(1, get_new_location()));
+
+		if (g_cfg.io.ghltar == ghltar_handler::two_controllers)
+		{
+			sys_usbd.notice("Adding emulated GHLtar (2 players)");
+			usb_devices.push_back(std::make_shared<usb_device_ghltar>(1, get_new_location()));
+		}
+
+		sys_usbd.notice("Ghltar config=\n", g_cfg_ghltar.to_string());
 	}
 
 	if (g_cfg.io.turntable == turntable_handler::one_controller || g_cfg.io.turntable == turntable_handler::two_controllers)
@@ -479,11 +487,14 @@ usb_handler_thread::usb_handler_thread()
 
 		sys_usbd.notice("Adding emulated turntable (1 player)");
 		usb_devices.push_back(std::make_shared<usb_device_turntable>(0, get_new_location()));
-	}
-	if (g_cfg.io.turntable == turntable_handler::two_controllers)
-	{
-		sys_usbd.notice("Adding emulated turntable (2 players)");
-		usb_devices.push_back(std::make_shared<usb_device_turntable>(1, get_new_location()));
+
+		if (g_cfg.io.turntable == turntable_handler::two_controllers)
+		{
+			sys_usbd.notice("Adding emulated turntable (2 players)");
+			usb_devices.push_back(std::make_shared<usb_device_turntable>(1, get_new_location()));
+		}
+
+		sys_usbd.notice("Turntable config=\n", g_cfg_turntable.to_string());
 	}
 
 	if (g_cfg.io.buzz == buzz_handler::one_controller || g_cfg.io.buzz == buzz_handler::two_controllers)
@@ -495,13 +506,16 @@ usb_handler_thread::usb_handler_thread()
 
 		sys_usbd.notice("Adding emulated Buzz! buzzer (1-4 players)");
 		usb_devices.push_back(std::make_shared<usb_device_buzz>(0, 3, get_new_location()));
-	}
-	if (g_cfg.io.buzz == buzz_handler::two_controllers)
-	{
-		// The current buzz emulation piggybacks on the pad input.
-		// Since there can only be 7 pads connected on a PS3 the 8th player is currently not supported
-		sys_usbd.notice("Adding emulated Buzz! buzzer (5-7 players)");
-		usb_devices.push_back(std::make_shared<usb_device_buzz>(4, 6, get_new_location()));
+
+		if (g_cfg.io.buzz == buzz_handler::two_controllers)
+		{
+			// The current buzz emulation piggybacks on the pad input.
+			// Since there can only be 7 pads connected on a PS3 the 8th player is currently not supported
+			sys_usbd.notice("Adding emulated Buzz! buzzer (5-7 players)");
+			usb_devices.push_back(std::make_shared<usb_device_buzz>(4, 6, get_new_location()));
+		}
+
+		sys_usbd.notice("Buzz config=\n", g_cfg_buzz.to_string());
 	}
 }
 
@@ -885,6 +899,8 @@ void connect_usb_controller(u8 index, input::product_type type)
 			std::shared_ptr<usb_device> dev = std::make_shared<usb_device_guncon3>(index, usbh->get_new_location());
 			usbh->connect_usb_device(dev, true);
 			usbh->pad_to_usb.emplace(index, std::pair(type, dev));
+
+			sys_usbd.notice("GunCon3 config=\n", g_cfg_guncon3.to_string());
 			break;
 		}
 		case input::product_type::top_shot_elite:
@@ -898,6 +914,8 @@ void connect_usb_controller(u8 index, input::product_type type)
 			std::shared_ptr<usb_device> dev = std::make_shared<usb_device_topshotelite>(index, usbh->get_new_location());
 			usbh->connect_usb_device(dev, true);
 			usbh->pad_to_usb.emplace(index, std::pair(type, dev));
+
+			sys_usbd.notice("Top shot elite config=\n", g_cfg_topshotelite.to_string());
 			break;
 		}
 		case input::product_type::top_shot_fearmaster:
@@ -911,6 +929,8 @@ void connect_usb_controller(u8 index, input::product_type type)
 			std::shared_ptr<usb_device> dev = std::make_shared<usb_device_topshotfearmaster>(index, usbh->get_new_location());
 			usbh->connect_usb_device(dev, true);
 			usbh->pad_to_usb.emplace(index, std::pair(type, dev));
+
+			sys_usbd.notice("Top shot fearmaster config=\n", g_cfg_topshotfearmaster.to_string());
 			break;
 		}
 		case input::product_type::udraw_gametablet:

--- a/rpcs3/Emu/Io/mouse_config.cpp
+++ b/rpcs3/Emu/Io/mouse_config.cpp
@@ -19,9 +19,14 @@ bool mouse_config::exist() const
 
 bool mouse_config::load()
 {
+	g_cfg_mouse.from_default();
+
 	if (fs::file cfg_file{cfg_name, fs::read})
 	{
-		return from_string(cfg_file.to_string());
+		if (const std::string content = cfg_file.to_string(); !content.empty())
+		{
+			return from_string(content);
+		}
 	}
 
 	return false;

--- a/rpcs3/Input/basic_mouse_handler.cpp
+++ b/rpcs3/Input/basic_mouse_handler.cpp
@@ -20,8 +20,12 @@ void basic_mouse_handler::Init(const u32 max_connect)
 		return;
 	}
 
-	g_cfg_mouse.from_default();
-	g_cfg_mouse.load();
+	if (!g_cfg_mouse.load())
+	{
+		input_log.notice("basic_mouse_handler: Could not load basic mouse config. Using defaults.");
+	}
+
+	g_cfg_mouse.reload_requested = true;
 
 	reload_config();
 

--- a/rpcs3/Input/basic_mouse_handler.cpp
+++ b/rpcs3/Input/basic_mouse_handler.cpp
@@ -47,6 +47,8 @@ void basic_mouse_handler::Init(const u32 max_connect)
 
 void basic_mouse_handler::reload_config()
 {
+	input_log.notice("Basic mouse config=\n%s", g_cfg_mouse.to_string());
+
 	m_buttons[CELL_MOUSE_BUTTON_1] = get_mouse_button(g_cfg_mouse.mouse_button_1);
 	m_buttons[CELL_MOUSE_BUTTON_2] = get_mouse_button(g_cfg_mouse.mouse_button_2);
 	m_buttons[CELL_MOUSE_BUTTON_3] = get_mouse_button(g_cfg_mouse.mouse_button_3);

--- a/rpcs3/Input/basic_mouse_handler.cpp
+++ b/rpcs3/Input/basic_mouse_handler.cpp
@@ -25,8 +25,6 @@ void basic_mouse_handler::Init(const u32 max_connect)
 		input_log.notice("basic_mouse_handler: Could not load basic mouse config. Using defaults.");
 	}
 
-	g_cfg_mouse.reload_requested = true;
-
 	reload_config();
 
 	m_mice.clear();
@@ -82,6 +80,12 @@ void basic_mouse_handler::SetTargetWindow(QWindow* target)
 
 bool basic_mouse_handler::eventFilter(QObject* target, QEvent* ev)
 {
+	if (m_info.max_connect == 0)
+	{
+		// Not initialized
+		return false;
+	}
+
 	if (!ev)
 	{
 		return false;

--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -267,8 +267,6 @@ void raw_mouse_handler::Init(const u32 max_connect)
 		input_log.notice("raw_mouse_handler: Could not load raw mouse config. Using defaults.");
 	}
 
-	g_cfg_raw_mouse.reload_requested = true;
-
 	m_mice.clear();
 	m_mice.resize(max_connect);
 
@@ -559,6 +557,12 @@ std::map<void*, raw_mouse> raw_mouse_handler::enumerate_devices(u32 max_connect)
 #ifdef _WIN32
 void raw_mouse_handler::handle_native_event(const MSG& msg)
 {
+	if (m_info.max_connect == 0)
+	{
+		// Not initialized
+		return;
+	}
+
 	if (msg.message != WM_INPUT)
 	{
 		return;

--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -267,6 +267,8 @@ void raw_mouse_handler::Init(const u32 max_connect)
 		input_log.notice("raw_mouse_handler: Could not load raw mouse config. Using defaults.");
 	}
 
+	g_cfg_raw_mouse.reload_requested = true;
+
 	m_mice.clear();
 	m_mice.resize(max_connect);
 

--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -51,6 +51,8 @@ void raw_mouse::reload_config()
 	{
 		if (const auto& player = ::at32(g_cfg_raw_mouse.players, m_index))
 		{
+			input_log.notice("Raw mouse config for player %d=\n%s", m_index, player->to_string());
+
 			m_mouse_acceleration = static_cast<float>(player->mouse_acceleration.get()) / 100.0f;
 
 			m_buttons[CELL_MOUSE_BUTTON_1] = get_mouse_button(player->mouse_button_1);


### PR DESCRIPTION
- Fix initial reload of mouse handler configs. Ignore mouse events while the handler isn't initialized.
- Log any input config file contents if in use
- Only allow each move mouse handler button to be used for one action unless it's the combo button.