### PR TITLE
evdev: try to improve button mapping

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -256,6 +256,14 @@ public:
 	pad_handler m_type;
 	bool m_is_init = false;
 
+	enum class gui_call_type
+	{
+		normal,
+		get_connection,
+		reset_input,
+		blacklist
+	};
+
 	std::vector<pad_ensemble>& bindings() { return m_bindings; }
 	std::string name_string() const { return m_name_string; }
 	usz max_devices() const { return m_max_devices; }
@@ -287,7 +295,7 @@ public:
 	// Binds a Pad to a device
 	virtual bool bindPadToDevice(std::shared_ptr<Pad> pad);
 	virtual void init_config(cfg_pad* cfg) = 0;
-	virtual connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons);
+	virtual connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, gui_call_type call_type, const std::vector<std::string>& buttons);
 	virtual void get_motion_sensors(const std::string& pad_id, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors);
 	virtual std::unordered_map<u32, std::string> get_motion_axis_list() const { return {}; }
 

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
@@ -584,7 +584,7 @@ bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, con
 namespace rsx
 {
 #if defined(ARCH_X64) || defined(ARCH_ARM64)
-	static void write_fragment_constants_to_buffer_sse2(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize)
+	static inline void write_fragment_constants_to_buffer_sse2(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize)
 	{
 		f32* dst = buffer.data();
 		for (usz offset_in_fragment_program : offsets_cache)
@@ -610,9 +610,8 @@ namespace rsx
 			dst += 4;
 		}
 	}
-#endif
-
-	static void write_fragment_constants_to_buffer_fallback(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize)
+#else
+	static inline void write_fragment_constants_to_buffer_fallback(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize)
 	{
 		f32* dst = buffer.data();
 
@@ -638,6 +637,7 @@ namespace rsx
 			dst += 4;
 		}
 	}
+#endif
 
 	void write_fragment_constants_to_buffer(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize)
 	{

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -407,7 +407,7 @@ public:
 	bool Init() override;
 	std::vector<pad_list_entry> list_devices() override;
 	bool bindPadToDevice(std::shared_ptr<Pad> pad) override;
-	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons) override;
+	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, gui_call_type call_type, const std::vector<std::string>& buttons) override;
 	void get_motion_sensors(const std::string& padId, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors) override;
 	std::unordered_map<u32, std::string> get_motion_axis_list() const override;
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -84,7 +84,7 @@ public:
 
 	void init_config(cfg_pad* cfg) override;
 	std::vector<pad_list_entry> list_devices() override;
-	connection get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, bool /*first_call*/, bool /*get_blacklist*/, const std::vector<std::string>& /*buttons*/) override { return connection::connected; }
+	connection get_next_button_press(const std::string& /*padId*/, const pad_callback& /*callback*/, const pad_fail_callback& /*fail_callback*/, gui_call_type /*call_type*/, const std::vector<std::string>& /*buttons*/) override { return connection::connected; }
 	bool bindPadToDevice(std::shared_ptr<Pad> pad) override;
 	void process() override;
 

--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -114,7 +114,7 @@ public:
 	bool Init() override;
 
 	std::vector<pad_list_entry> list_devices() override;
-	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons) override;
+	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, gui_call_type call_type, const std::vector<std::string>& buttons) override;
 	void init_config(cfg_pad* cfg) override;
 
 private:

--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -763,14 +763,14 @@ void sdl_pad_handler::get_motion_sensors(const std::string& pad_id, const motion
 	PadHandlerBase::get_motion_sensors(pad_id, callback, fail_callback, preview_values, sensors);
 }
 
-PadHandlerBase::connection sdl_pad_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons)
+PadHandlerBase::connection sdl_pad_handler::get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, gui_call_type call_type, const std::vector<std::string>& buttons)
 {
 	if (!m_is_init)
 		return connection::disconnected;
 
 	SDL_PumpEvents();
 
-	return PadHandlerBase::get_next_button_press(padId, callback, fail_callback, first_call, get_blacklist, buttons);
+	return PadHandlerBase::get_next_button_press(padId, callback, fail_callback, call_type, buttons);
 }
 
 void sdl_pad_handler::apply_pad_data(const pad_ensemble& binding)

--- a/rpcs3/Input/sdl_pad_handler.h
+++ b/rpcs3/Input/sdl_pad_handler.h
@@ -128,7 +128,7 @@ public:
 	void SetPadData(const std::string& padId, u8 player_id, u8 large_motor, u8 small_motor, s32 r, s32 g, s32 b, bool player_led, bool battery_led, u32 battery_led_brightness) override;
 	u32 get_battery_level(const std::string& padId) override;
 	void get_motion_sensors(const std::string& pad_id, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors) override;
-	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, bool first_call, bool get_blacklist, const std::vector<std::string>& buttons) override;
+	connection get_next_button_press(const std::string& padId, const pad_callback& callback, const pad_fail_callback& fail_callback, gui_call_type call_type, const std::vector<std::string>& buttons) override;
 
 private:
 	// pseudo 'controller id' to keep track of unique controllers

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -560,7 +560,7 @@ void pad_settings_dialog::InitButtons()
 
 		while (thread_ctrl::state() != thread_state::aborting)
 		{
-			thread_ctrl::wait_for(1000);
+			thread_ctrl::wait_for(10000);
 
 			if (m_input_thread_state != input_thread_state::active)
 			{
@@ -796,7 +796,7 @@ void pad_settings_dialog::ReactivateButtons()
 	ui->chooseProduct->setFocusPolicy(Qt::WheelFocus);
 }
 
-void pad_settings_dialog::RepaintPreviewLabel(QLabel* l, int deadzone, int anti_deadzone, int desired_width, int x, int y, int squircle, double multiplier) const
+void pad_settings_dialog::RepaintPreviewLabel(QLabel* label, int deadzone, int anti_deadzone, int desired_width, int x, int y, int squircle, double multiplier) const
 {
 	desired_width = 100; // Let's keep a fixed size for these labels for now
 	const qreal deadzone_max = m_handler ? m_handler->thumb_max : 255; // 255 used as fallback. The deadzone circle shall be small.
@@ -884,7 +884,7 @@ void pad_settings_dialog::RepaintPreviewLabel(QLabel* l, int deadzone, int anti_
 
 	painter.end();
 
-	l->setPixmap(pixmap);
+	label->setPixmap(pixmap);
 }
 
 void pad_settings_dialog::keyPressEvent(QKeyEvent *keyEvent)
@@ -1624,7 +1624,7 @@ void pad_settings_dialog::ChangeHandler()
 	if (ui->chooseDevice->isEnabled() && ui->chooseDevice->currentIndex() >= 0)
 	{
 		start_input_thread();
-		m_timer_input.start(1);
+		m_timer_input.start(10);
 		m_timer_pad_refresh.start(1000);
 	}
 }

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -594,6 +594,7 @@ void pad_settings_dialog::InitButtons()
 			const u32 new_button_id = m_button_id;
 			const bool is_mapping = new_button_id > button_ids::id_pad_begin && new_button_id < button_ids::id_pad_end;
 			const bool first_call = std::exchange(button_id, new_button_id) != button_id && is_mapping;
+			const PadHandlerBase::gui_call_type call_type = first_call ? PadHandlerBase::gui_call_type::reset_input : PadHandlerBase::gui_call_type::normal;
 
 			const PadHandlerBase::connection status = m_handler->get_next_button_press(m_device_name,
 				[this, button_id](u16 val, std::string name, std::string pad_name, u32 battery_level, pad_preview_values preview_values)
@@ -616,7 +617,7 @@ void pad_settings_dialog::InitButtons()
 					m_input_callback_data.status = PadHandlerBase::connection::disconnected;
 					m_input_callback_data.button_id = button_id;
 				},
-				first_call, false, buttons);
+				call_type, buttons);
 
 			if (status == PadHandlerBase::connection::no_data)
 			{
@@ -642,7 +643,7 @@ void pad_settings_dialog::RefreshPads()
 		}
 
 		std::lock_guard lock(m_handler_mutex);
-		const PadHandlerBase::connection status = m_handler->get_next_button_press(info.name, nullptr, nullptr, false, false, {});
+		const PadHandlerBase::connection status = m_handler->get_next_button_press(info.name, nullptr, nullptr, PadHandlerBase::gui_call_type::get_connection, {});
 		switch_pad_info(i, info, status != PadHandlerBase::connection::disconnected);
 	}
 }
@@ -1327,7 +1328,7 @@ void pad_settings_dialog::OnPadButtonClicked(int id)
 	case button_ids::id_blacklist:
 	{
 		std::lock_guard lock(m_handler_mutex);
-		[[maybe_unused]] const PadHandlerBase::connection status = m_handler->get_next_button_press(m_device_name, nullptr, nullptr, false, true, {});
+		[[maybe_unused]] const PadHandlerBase::connection status = m_handler->get_next_button_press(m_device_name, nullptr, nullptr, PadHandlerBase::gui_call_type::blacklist, {});
 		return;
 	}
 	default:

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -207,7 +207,7 @@ private:
 	void ReloadButtons();
 
 	/** Repaints a stick deadzone preview label */
-	void RepaintPreviewLabel(QLabel* l, int deadzone, int anti_deadzone, int desired_width, int x, int y, int squircle, double multiplier) const;
+	void RepaintPreviewLabel(QLabel* label, int deadzone, int anti_deadzone, int desired_width, int x, int y, int squircle, double multiplier) const;
 
 	QString GetLocalizedPadHandler(const QString& original, pad_handler handler);
 	QString GetLocalizedPadName(pad_handler handler, const QString& original, usz index);


### PR DESCRIPTION
The latest button mapping changes that ignore already pressed buttons or axis when trying to remap a button do not to work properly due to the event based way evdev works.

We don't have all the events in the first call to get_next_button_press, so we have to set all the buttons that are not found in the first call to max in order to properly check them in the subsequent events.