### PR TITLE
SPU: Fix bug in GETLLAR, Enable PUTLLC16 if accurate reservations is off

### DIFF
--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -7133,8 +7133,9 @@ spu_program spu_recompiler_base::analyse(const be_t<u32>* ls, u32 entry_point, s
 			value.reg2 = pattern.reg2;
 		}
 
-		if (true)
+		if (g_cfg.core.spu_accurate_reservations)
 		{
+			// Because enabling it is a hack, as it turns out
 			continue;
 		}
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3541,6 +3541,13 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 							const u64 hash_val = read_from_ptr<be_t<u64>>(result.data) & -65536;
 							const f64 usage = get_cpu_program_usage_percent(hash_val);
+
+							if (usage == 0)
+							{
+								iter = index + 1;
+								continue;
+							}
+
 							const std::string text_append = fmt::format("usage %%%g, ", usage);
 							new_log.insert(new_log.begin() + seperator + out_added + 2, text_append.begin(), text_append.end());
 


### PR DESCRIPTION
Turns out PUTLLC16 optimization was not accurate due to data usage from GETLLAR after the atomic loop ends, but was compatible with a surprising number of games and had significant performance benefits for some such Metal Gear Solid Online.
So, I keep it, when SPU Accurate Reservations is off.

Fixes #15702
Fixes #15802
Fixes #15645
Fixes #15710 