### PR TITLE
gl: Fix OpenGL behavior under wayland-egl

### DIFF
--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -30,6 +30,7 @@ if(UNIX AND NOT APPLE)
     find_package(Wayland)
     if(WAYLAND_FOUND)
         add_definitions(-DHAVE_WAYLAND)
+        set(ADDITIONAL_LIBS ${ADDITIONAL_LIBS} "EGL")
     endif()
 endif()
 

--- a/rpcs3/Emu/RSX/GL/OpenGL.cpp
+++ b/rpcs3/Emu/RSX/GL/OpenGL.cpp
@@ -1,6 +1,10 @@
 #include "stdafx.h"
 #include "OpenGL.h"
 
+#if defined(HAVE_WAYLAND)
+#include <EGL/egl.h>
+#endif
+
 #ifdef _WIN32
 
 extern "C"
@@ -53,6 +57,14 @@ void gl::set_swapinterval(int interval)
 			return;
 		}
 	}
+
+#ifdef HAVE_WAYLAND
+	if (auto egl_display = eglGetCurrentDisplay(); egl_display != EGL_NO_DISPLAY)
+	{
+		eglSwapInterval(egl_display, interval);
+		return;
+	}
+#endif
 
 	//No existing drawable or missing swap extension, EGL?
 	rsx_log.error("Failed to set swap interval");

--- a/rpcs3/rpcs3qt/gl_gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gl_gs_frame.cpp
@@ -18,12 +18,14 @@ gl_gs_frame::gl_gs_frame(QScreen* screen, const QRect& geometry, const QIcon& ap
 	m_format.setAlphaBufferSize(0);
 	m_format.setDepthBufferSize(0);
 	m_format.setSwapBehavior(QSurfaceFormat::SwapBehavior::DoubleBuffer);
+	m_format.setSwapInterval(0);
 	if (g_cfg.video.debug_output)
 	{
 		m_format.setOption(QSurfaceFormat::FormatOption::DebugContext);
 	}
 	setFormat(m_format);
 	create();
+	show();
 }
 
 draw_context_t gl_gs_frame::make_context()


### PR DESCRIPTION
1. Do not force vsync on by default. Some of the poor opengl performance observed in rpcs3 is actually just caused by this bug.
2. Do not use glxSwapInterval under wayland. We should use eglSwapInterval instead.
3. Show the OGL window after creation. This solves so many weird problems in wayland such as invisible game window or crashes with a wayland error in the log.