### PR TITLE
Qt/input: add trigger step setting

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -23,6 +23,12 @@ public:
 	u8 player_id{0};
 	u8 large_motor{0};
 	u8 small_motor{0};
+	u8 l_trigger_step_index{0};
+	u8 r_trigger_step_index{0};
+	bool l_trigger_pressed{false};
+	bool r_trigger_pressed{false};
+	u16 l_trigger_value{0};
+	u16 r_trigger_value{0};
 	std::set<u64> trigger_code_left{};
 	std::set<u64> trigger_code_right{};
 	std::array<std::set<u64>, 4> axis_code_left{};
@@ -314,8 +320,9 @@ private:
 
 protected:
 	virtual std::array<std::set<u32>, PadHandlerBase::button::button_count> get_mapped_key_codes(const std::shared_ptr<PadDevice>& device, const cfg_pad* cfg);
-	virtual void get_mapping(const pad_ensemble& binding);
+	virtual void get_mapping(pad_ensemble& binding);
 	void TranslateButtonPress(const std::shared_ptr<PadDevice>& device, u64 keyCode, bool& pressed, u16& val, bool use_stick_multipliers, bool ignore_stick_threshold = false, bool ignore_trigger_threshold = false);
+	static inline void set_trigger_step(PadDevice& device, const Button& button, u16& value, bool& pressed);
 	void init_configs();
 	cfg_pad* get_config(const std::string& pad_id);
 };

--- a/rpcs3/Emu/Io/pad_config.h
+++ b/rpcs3/Emu/Io/pad_config.h
@@ -108,6 +108,11 @@ struct cfg_pad final : cfg::node
 	cfg::uint<0, 100> analog_lerp_factor{ this, "Analog Button Lerp Factor", 100 };
 	cfg::uint<0, 100> trigger_lerp_factor{ this, "Trigger Lerp Factor", 100 };
 
+	cfg::uint<0, 100> l_trigger_step_percent{ this, "Left Trigger Step Percent", 0 }; // 0 means that we don't step
+	cfg::uint<0, 100> r_trigger_step_percent{ this, "Right Trigger Step Percent", 0 }; // 0 means that we don't step
+	cfg::uint<0, 100> l_trigger_step_offset_percent{ this, "Left Trigger Step Offset Percent", 0 }; // our first step starts here
+	cfg::uint<0, 100> r_trigger_step_offset_percent{ this, "Right Trigger Step Offset Percent", 0 }; // our first step starts here
+
 	cfg::uint<CELL_PAD_PCLASS_TYPE_STANDARD, CELL_PAD_PCLASS_TYPE_MAX> device_class_type{ this, "Device Class Type", 0 };
 	cfg::uint<0, 65535> vendor_id{ this, "Vendor ID", 0 };
 	cfg::uint<0, 65535> product_id{ this, "Product ID", 0 };

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -439,7 +439,7 @@ private:
 
 protected:
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
-	void get_mapping(const pad_ensemble& binding) override;
+	void get_mapping(pad_ensemble& binding) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
 	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -985,6 +985,7 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad)
 		return false;
 
 	m_pad_configs[pad->m_player_id].from_string(player_config->config.to_string());
+
 	const cfg_pad* cfg = &m_pad_configs[pad->m_player_id];
 	if (cfg == nullptr)
 		return false;


### PR DESCRIPTION
There seem to be certain cases where multi-state-switches are reported as triggers, for example in guitars.
Therefore it shall be possible to also switch those states on any controller.

- Added config entries for left and right trigger step and trigger step offset (both in percent)
- The trigger step offset is the base position of the trigger
- The trigger step is the value that is added to the last value each time you press the button you mapped to the trigger
- Once we exceed 255 we reset the trigger to the step offset again (so the offset should be smaller or equal to the step size if you need the entire range of steps from 0 to 255)

I didn't bother with a GUI widget for now, since this seems like a special use case.

maybe fixes #12384