### PR TITLE
xinput: allow to map triggers as positive or negative

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1205,7 +1205,6 @@ class spu_llvm_recompiler : public spu_recompiler_base, public cpu_translator
 
 				const auto dest = raddr | (ls_dst & 127);
 				const auto _dest = vm::get_super_ptr<atomic_t<nse_t<v128>>>(dest);
-				using spu_rdata_t = decltype(spu_thread::rdata);
 
 				if (rdata == to_write || ((lsa ^ ls_dst) & (SPU_LS_SIZE - 128)))
 				{

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -121,6 +121,7 @@ protected:
 	usz m_max_devices = 0;
 	u32 m_trigger_threshold = 0;
 	u32 m_thumb_threshold = 0;
+	bool m_triggers_as_sticks_only = false;
 
 	bool b_has_led = false;
 	bool b_has_rgb = false;
@@ -281,6 +282,7 @@ public:
 
 	u16 NormalizeStickInput(u16 raw_value, s32 threshold, s32 multiplier, bool ignore_threshold = false) const;
 	void convert_stick_values(u16& x_out, u16& y_out, s32 x_in, s32 y_in, u32 deadzone, u32 anti_deadzone, u32 padsquircling) const;
+	void set_triggers_as_sticks_only(bool enabled) { m_triggers_as_sticks_only = enabled; }
 
 	virtual bool Init() { return true; }
 	PadHandlerBase(pad_handler type = pad_handler::null);

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -78,6 +78,11 @@ class xinput_pad_handler final : public PadHandlerBase
 		LT,
 		RT,
 
+		LT_Pos,
+		LT_Neg,
+		RT_Pos,
+		RT_Neg,
+
 		LSXNeg,
 		LSXPos,
 		LSYNeg,
@@ -120,8 +125,8 @@ private:
 	typedef DWORD (WINAPI * PFN_XINPUTGETBATTERYINFORMATION)(DWORD, BYTE, XINPUT_BATTERY_INFORMATION *);
 
 	int GetDeviceNumber(const std::string& padId);
-	static PadButtonValues get_button_values_base(const XINPUT_STATE& state);
-	static PadButtonValues get_button_values_scp(const SCP_EXTN& state);
+	static PadButtonValues get_button_values_base(const XINPUT_STATE& state, bool triggers_as_sticks_only);
+	static PadButtonValues get_button_values_scp(const SCP_EXTN& state, bool triggers_as_sticks_only);
 
 	HMODULE library{ nullptr };
 	PFN_XINPUTGETEXTENDED xinputGetExtended{ nullptr };

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1311,6 +1311,9 @@ void pad_settings_dialog::OnPadButtonClicked(int id)
 		m_enable_multi_binding = true;
 	}
 
+	// On alt+click or alt+space allow to handle triggers as the entire stick axis
+	m_handler->set_triggers_as_sticks_only(QApplication::keyboardModifiers() & Qt::KeyboardModifier::AltModifier);
+
 	for (auto but : m_pad_buttons->buttons())
 	{
 		but->setFocusPolicy(Qt::ClickFocus);

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -295,7 +295,7 @@ public:
 		const QString mouse_deadzones    = tr("The mouse deadzones represent the games' own deadzones on the x and y axes. Games usually enforce their own deadzones to filter out small unwanted stick movements. In consequence, mouse input feels unintuitive since it relies on immediate responsiveness. You can change these values temporarily during gameplay in order to find out the optimal values for your game (Alt+T and Alt+Y for x, Alt+U and Alt+I for y).");
 		const QString mouse_acceleration = tr("The mouse acceleration can be used to amplify your mouse movements on the x and y axes. Increase these values if your mouse movements feel too slow while playing a game. You can change these values temporarily during gameplay in order to find out the optimal values (Alt+G and Alt+H for x, Alt+J and Alt+K for y). Keep in mind that modern mice usually provide different modes and settings that can be used to change mouse movement speeds as well.");
 		const QString mouse_movement     = tr("The mouse movement mode determines how the mouse movement is translated to pad input.<br>Use the relative mode for traditional mouse movement.<br>Use the absolute mode to use the mouse's distance to the center of the screen as input value.");
-		const QString button_assignment  = tr("Left-click: remap this button.<br>Shift + Left-click: add an additional button mapping.<br>Right-click: clear this button mapping.");
+		const QString button_assignment  = tr("Left-click: remap this button.<br>Shift + Left-click: add an additional button mapping.<br>Alt + Left-click: differentiate between trigger press and release (only XInput for now).<br>Right-click: clear this button mapping.");
 
 	} gamepad_settings;
 };


### PR DESCRIPTION
By pressing ALT while clicking on a button in the pad settings, you can now enable a special mode for XInput.
This allows you to map the XInput triggers as positive or negative triggers.

We previously basically always treated XInput triggers as buttons. So you could only map pressing the trigger to a button.
The special mode will treat triggers that are pressed more than 50% as positive triggers and triggers that are pressed less than 50% as negative triggers.
You can therefore map a trigger to an entire stick axis, for example by mapping LT+ to LY+ and LT- to LY-.

This has only become feasible recently when I implemented that the initial state is ignored during a re-map.
In order to map a negative trigger, you will have to press the trigger before clicking one of the buttons in the pad settings dialog (with ALT). Then by releasing the trigger it will be recognized as negative.

You can still map the normal trigger behaviour to other buttons, even if it is already mapped as positive or negative trigger somewhere else.

The stick thresholds are ignored for these new trigger types. I can add them at a later point if needed.
Currently this is only useful for Rock Band guitar switches.

maybe fixes https://github.com/RPCS3/rpcs3/issues/12384