### PR TITLE
Improve patch.yml value validation

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -87,7 +87,7 @@ void fmt_class_string<patch_type>::format(std::string& out, u64 arg)
 	});
 }
 
-void patch_engine::patch_config_value::set_and_check_value(f64 new_value, const std::string& name)
+void patch_engine::patch_config_value::set_and_check_value(f64 new_value, std::string_view name)
 {
 	switch (type)
 	{
@@ -147,7 +147,7 @@ std::string patch_engine::get_imported_patch_path()
 	return get_patches_path() + "imported_patch.yml";
 }
 
-static void append_log_message(std::stringstream* log_messages, const std::string& message, const logs::message* channel = nullptr)
+static void append_log_message(std::stringstream* log_messages, std::string_view message, const logs::message* channel = nullptr)
 {
 	if (channel)
 	{
@@ -593,13 +593,13 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 
 			if (const auto patch_node = patches_entry.second[patch_key::patch])
 			{
-				if (!read_patch_node(info, patch_node, root, log_messages))
+				if (!read_patch_node(info, patch_node, root, path, log_messages))
 				{
 					for (const auto& it : patches_entry.second)
 					{
 						if (it.first.Scalar() == patch_key::patch)
 						{
-							append_log_message(log_messages, fmt::format("Skipping invalid patch node %s: (key: %s, location: %s)", info.description, main_key, get_yaml_node_location(it.first)), &patch_log.error);
+							append_log_message(log_messages, fmt::format("Skipping invalid patch node %s: (key: %s, location: %s, file: %s)", info.description, main_key, get_yaml_node_location(it.first), path), &patch_log.error);
 							break;
 						}
 					}
@@ -634,7 +634,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 	return is_valid;
 }
 
-patch_type patch_engine::get_patch_type(const std::string& text)
+patch_type patch_engine::get_patch_type(std::string_view text)
 {
 	u64 type_val = 0;
 
@@ -656,11 +656,11 @@ patch_type patch_engine::get_patch_type(YAML::Node node)
 	return get_patch_type(node.Scalar());
 }
 
-bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifier, const YAML::Node& root, std::stringstream* log_messages)
+bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifier, const YAML::Node& root, std::string_view path, std::stringstream* log_messages)
 {
 	if (!node || !node.IsSequence())
 	{
-		append_log_message(log_messages, fmt::format("Skipping invalid patch node %s. (key: %s, location: %s)", info.description, info.hash, get_yaml_node_location(node)), &patch_log.error);
+		append_log_message(log_messages, fmt::format("Skipping invalid patch node %s. (key: %s, location: %s, file: %s)", info.description, info.hash, get_yaml_node_location(node), path), &patch_log.error);
 		return false;
 	}
 
@@ -673,7 +673,7 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 	if (type == patch_type::invalid)
 	{
 		const auto type_str = type_node && type_node.IsScalar() ? type_node.Scalar() : "";
-		append_log_message(log_messages, fmt::format("Skipping patch node %s: type '%s' is invalid. (key: %s, location: %s)", info.description, type_str, info.hash, get_yaml_node_location(node)), &patch_log.error);
+		append_log_message(log_messages, fmt::format("Skipping patch node %s: type '%s' is invalid. (key: %s, location: %s, file: %s)", info.description, type_str, info.hash, get_yaml_node_location(node), path), &patch_log.error);
 		return false;
 	}
 
@@ -684,7 +684,7 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 		// Check if the anchor was resolved.
 		if (const auto yml_type = addr_node.Type(); yml_type != YAML::NodeType::Sequence)
 		{
-			append_log_message(log_messages, fmt::format("Skipping patch node %s: expected Sequence, found %s (key: %s, location: %s)", info.description, yml_type, info.hash, get_yaml_node_location(node)), &patch_log.error);
+			append_log_message(log_messages, fmt::format("Skipping patch node %s: expected Sequence, found %s (key: %s, location: %s, file: %s)", info.description, yml_type, info.hash, get_yaml_node_location(node), path), &patch_log.error);
 			return false;
 		}
 
@@ -695,7 +695,7 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 
 		for (const auto& item : addr_node)
 		{
-			if (!add_patch_data(item, info, mod, root, log_messages))
+			if (!add_patch_data(item, info, mod, root, path, log_messages))
 			{
 				is_valid = false;
 			}
@@ -706,13 +706,13 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 
 	if (const auto yml_type = value_node.Type(); yml_type != YAML::NodeType::Scalar)
 	{
-		append_log_message(log_messages, fmt::format("Skipping patch node %s. Value element has wrong type %s. (key: %s, location: %s)", info.description, yml_type, info.hash, get_yaml_node_location(node)), &patch_log.error);
+		append_log_message(log_messages, fmt::format("Skipping patch node %s. Value element has wrong type %s. (key: %s, location: %s, file: %s)", info.description, yml_type, info.hash, get_yaml_node_location(node), path), &patch_log.error);
 		return false;
 	}
 
 	if (patch_type_uses_hex_offset(type) && !addr_node.Scalar().starts_with("0x"))
 	{
-		append_log_message(log_messages, fmt::format("Skipping patch node %s. Address element has wrong format %s. (key: %s, location: %s)", info.description, addr_node.Scalar(), info.hash, get_yaml_node_location(node)), &patch_log.error);
+		append_log_message(log_messages, fmt::format("Skipping patch node %s. Address element has wrong format %s. (key: %s, location: %s, file: %s)", info.description, addr_node.Scalar(), info.hash, get_yaml_node_location(node), path), &patch_log.error);
 		return false;
 	}
 
@@ -738,15 +738,15 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 		[[maybe_unused]] const u32 offset = get_yaml_node_value<u32>(addr_node, error_message);
 		if (!error_message.empty())
 		{
-			error_message = fmt::format("Skipping patch data entry: [ %s, 0x%.8x, %s ] (key: %s, location: %s) Invalid patch offset '%s' (not a valid u32 or overflow)",
-				p_data.type, p_data.offset, p_data.original_value.empty() ? "?" : p_data.original_value, info.hash, get_yaml_node_location(node), p_data.original_offset);
+			error_message = fmt::format("Skipping patch data entry: [ %s, 0x%.8x, %s ] (key: %s, location: %s, file: %s) Invalid patch offset '%s' (not a valid u32 or overflow)",
+				p_data.type, p_data.offset, p_data.original_value.empty() ? "?" : p_data.original_value, info.hash, get_yaml_node_location(node), path, p_data.original_offset);
 			append_log_message(log_messages, error_message, &patch_log.error);
 			return false;
 		}
 		if ((0xFFFFFFFF - modifier) < p_data.offset)
 		{
-			error_message = fmt::format("Skipping patch data entry: [ %s, 0x%.8x, %s ] (key: %s, location: %s) Invalid combination of patch offset 0x%.8x and modifier 0x%.8x (overflow)",
-				p_data.type, p_data.offset, p_data.original_value.empty() ? "?" : p_data.original_value, info.hash, get_yaml_node_location(node), p_data.offset, modifier);
+			error_message = fmt::format("Skipping patch data entry: [ %s, 0x%.8x, %s ] (key: %s, location: %s, file: %s) Invalid combination of patch offset 0x%.8x and modifier 0x%.8x (overflow)",
+				p_data.type, p_data.offset, p_data.original_value.empty() ? "?" : p_data.original_value, info.hash, get_yaml_node_location(node), path, p_data.offset, modifier);
 			append_log_message(log_messages, error_message, &patch_log.error);
 			return false;
 		}
@@ -815,8 +815,8 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 
 	if (!error_message.empty())
 	{
-		error_message = fmt::format("Skipping patch data entry: [ %s, 0x%.8x, %s ] (key: %s, location: %s) %s",
-			p_data.type, p_data.offset, p_data.original_value.empty() ? "?" : p_data.original_value, info.hash, get_yaml_node_location(node), error_message);
+		error_message = fmt::format("Skipping patch data entry: [ %s, 0x%.8x, %s ] (key: %s, location: %s, file: %s) %s",
+			p_data.type, p_data.offset, p_data.original_value.empty() ? "?" : p_data.original_value, info.hash, get_yaml_node_location(node), path, error_message);
 		append_log_message(log_messages, error_message, &patch_log.error);
 		return false;
 	}
@@ -826,7 +826,7 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 	return true;
 }
 
-bool patch_engine::read_patch_node(patch_info& info, YAML::Node node, const YAML::Node& root, std::stringstream* log_messages)
+bool patch_engine::read_patch_node(patch_info& info, YAML::Node node, const YAML::Node& root, std::string_view path, std::stringstream* log_messages)
 {
 	if (!node)
 	{
@@ -844,7 +844,7 @@ bool patch_engine::read_patch_node(patch_info& info, YAML::Node node, const YAML
 
 	for (auto patch : node)
 	{
-		if (!add_patch_data(patch, info, 0, root, log_messages))
+		if (!add_patch_data(patch, info, 0, root, path, log_messages))
 		{
 			is_valid = false;
 		}
@@ -862,7 +862,7 @@ void patch_engine::append_global_patches()
 	load(m_map, get_imported_patch_path());
 }
 
-void patch_engine::append_title_patches(const std::string& title_id)
+void patch_engine::append_title_patches(std::string_view title_id)
 {
 	if (title_id.empty())
 	{
@@ -870,7 +870,7 @@ void patch_engine::append_title_patches(const std::string& title_id)
 	}
 
 	// Regular patch.yml
-	load(m_map, get_patches_path() + title_id + "_patch.yml");
+	load(m_map, fmt::format("%s%s_patch.yml", get_patches_path(), title_id));
 }
 
 void ppu_register_range(u32 addr, u32 size);
@@ -1703,7 +1703,7 @@ void patch_engine::save_config(const patch_map& patches_map)
 	}
 }
 
-static void append_patches(patch_engine::patch_map& existing_patches, const patch_engine::patch_map& new_patches, usz& count, usz& total, std::stringstream* log_messages)
+static void append_patches(patch_engine::patch_map& existing_patches, const patch_engine::patch_map& new_patches, usz& count, usz& total, std::stringstream* log_messages, std::string_view path)
 {
 	for (const auto& [hash, new_container] : new_patches)
 	{
@@ -1734,13 +1734,13 @@ static void append_patches(patch_engine::patch_map& existing_patches, const patc
 
 			if (!ok)
 			{
-				append_log_message(log_messages, fmt::format("Failed to compare patch versions ('%s' vs '%s') for %s: %s", new_info.patch_version, info.patch_version, hash, description), &patch_log.error);
+				append_log_message(log_messages, fmt::format("Failed to compare patch versions ('%s' vs '%s') for %s: %s (file: %s)", new_info.patch_version, info.patch_version, hash, description, path), &patch_log.error);
 				continue;
 			}
 
 			if (!version_is_bigger)
 			{
-				append_log_message(log_messages, fmt::format("A higher or equal patch version already exists ('%s' vs '%s') for %s: %s", new_info.patch_version, info.patch_version, hash, description), &patch_log.error);
+				append_log_message(log_messages, fmt::format("A higher or equal patch version already exists ('%s' vs '%s') for %s: %s (file: %s)", new_info.patch_version, info.patch_version, hash, description, path), &patch_log.error);
 				continue;
 			}
 
@@ -1894,7 +1894,7 @@ bool patch_engine::import_patches(const patch_engine::patch_map& patches, const 
 
 	if (load(existing_patches, path, "", true, log_messages))
 	{
-		append_patches(existing_patches, patches, count, total, log_messages);
+		append_patches(existing_patches, patches, count, total, log_messages, path);
 		return count == 0 || save_patches(existing_patches, path, log_messages);
 	}
 

--- a/Utilities/bin_patch.h
+++ b/Utilities/bin_patch.h
@@ -113,7 +113,7 @@ public:
 			return value == other.value && min == other.min && max == other.max && type == other.type && allowed_values == other.allowed_values;
 		}
 
-		void set_and_check_value(f64 new_value, const std::string& name);
+		void set_and_check_value(f64 new_value, std::string_view name);
 	};
 
 	struct patch_config_values
@@ -182,16 +182,16 @@ public:
 	static bool load(patch_map& patches, const std::string& path, std::string content = "", bool importing = false, std::stringstream* log_messages = nullptr);
 
 	// Read and add a patch node to the patch info
-	static bool read_patch_node(patch_info& info, YAML::Node node, const YAML::Node& root, std::stringstream* log_messages = nullptr);
+	static bool read_patch_node(patch_info& info, YAML::Node node, const YAML::Node& root, std::string_view path, std::stringstream* log_messages = nullptr);
 
 	// Get the patch type from a string
-	static patch_type get_patch_type(const std::string& text);
+	static patch_type get_patch_type(std::string_view text);
 
 	// Get the patch type of a patch node
 	static patch_type get_patch_type(YAML::Node node);
 
 	// Add the data of a patch node
-	static bool add_patch_data(YAML::Node node, patch_info& info, u32 modifier, const YAML::Node& root, std::stringstream* log_messages = nullptr);
+	static bool add_patch_data(YAML::Node node, patch_info& info, u32 modifier, const YAML::Node& root, std::string_view path, std::stringstream* log_messages = nullptr);
 
 	// Save to patch_config.yml
 	static void save_config(const patch_map& patches_map);
@@ -212,7 +212,7 @@ public:
 	void append_global_patches();
 
 	// Load from title relevant files and append to member patches map
-	void append_title_patches(const std::string& title_id);
+	void append_title_patches(std::string_view title_id);
 
 	// Apply patch (returns the number of entries applied)
 	std::basic_string<u32> apply(const std::string& name, std::function<u8*(u32, u32)> mem_translate, u32 filesz = -1, u32 min_addr = 0);

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -211,11 +211,12 @@ void patch_manager_dialog::load_patches(bool show_error)
 
 	bool has_errors = false;
 
-	for (const auto& path : path_list)
+	for (const QString& path : path_list)
 	{
 		if (!patch_engine::load(m_map, patches_path + path.toStdString()))
 		{
 			has_errors = true;
+			patch_log.error("Errors in patch file '%s'", path);
 		}
 	}
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -402,7 +402,7 @@ void patch_manager_dialog::populate_tree()
 		const auto item = all_title_items[0];
 		ensure(item && all_title_items.size() == 1);
 
-		if (const int index = ui->patch_tree->indexOfTopLevelItem(item); index >= 0)
+		if (const int index = ui->patch_tree->indexOfTopLevelItem(item); item && index >= 0)
 		{
 			const bool all_titles_expanded = item->isExpanded();
 			const auto all_serials_item = item->child(0);
@@ -1065,9 +1065,9 @@ void patch_manager_dialog::dropEvent(QDropEvent* event)
 			else
 			{
 				QString message = tr("Errors were found in the patch file.");
-				QMessageBox mb(QMessageBox::Icon::Critical, tr("Validation failed"), message, QMessageBox::Ok, this);
-				mb.setInformativeText(tr("To see the error log, please click \"Show Details\"."));
-				mb.setDetailedText(tr("%0").arg(summary));
+				QMessageBox* mb = new QMessageBox(QMessageBox::Icon::Critical, tr("Validation failed"), message, QMessageBox::Ok, this);
+				mb->setInformativeText(tr("To see the error log, please click \"Show Details\"."));
+				mb->setDetailedText(tr("%0").arg(summary));
 
 				// Smartass hack to make the unresizeable message box wide enough for the changelog
 				const int log_width = QLabel(summary).sizeHint().width();
@@ -1076,8 +1076,8 @@ void patch_manager_dialog::dropEvent(QDropEvent* event)
 					message += "          ";
 				}
 
-				mb.setText(message);
-				mb.exec();
+				mb->setText(message);
+				mb->show();
 			}
 		}
 	}
@@ -1277,9 +1277,9 @@ bool patch_manager_dialog::handle_json(const QByteArray& data)
 		else
 		{
 			QString message = tr("Errors were found in the downloaded patch file.");
-			QMessageBox mb(QMessageBox::Icon::Critical, tr("Validation failed"), message, QMessageBox::Ok, this);
-			mb.setInformativeText(tr("To see the error log, please click \"Show Details\"."));
-			mb.setDetailedText(tr("%0").arg(summary));
+			QMessageBox* mb = new QMessageBox(QMessageBox::Icon::Critical, tr("Validation failed"), message, QMessageBox::Ok, this);
+			mb->setInformativeText(tr("To see the error log, please click \"Show Details\"."));
+			mb->setDetailedText(tr("%0").arg(summary));
 
 			// Smartass hack to make the unresizeable message box wide enough for the changelog
 			const int log_width = QLabel(message).sizeHint().width();
@@ -1288,8 +1288,8 @@ bool patch_manager_dialog::handle_json(const QByteArray& data)
 				message += "          ";
 			}
 
-			mb.setText(message);
-			mb.exec();
+			mb->setText(message);
+			mb->show();
 		}
 	}
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -1069,6 +1069,7 @@ void patch_manager_dialog::dropEvent(QDropEvent* event)
 				QMessageBox* mb = new QMessageBox(QMessageBox::Icon::Critical, tr("Validation failed"), message, QMessageBox::Ok, this);
 				mb->setInformativeText(tr("To see the error log, please click \"Show Details\"."));
 				mb->setDetailedText(tr("%0").arg(summary));
+				mb->setAttribute(Qt::WA_DeleteOnClose);
 
 				// Smartass hack to make the unresizeable message box wide enough for the changelog
 				const int log_width = QLabel(summary).sizeHint().width();
@@ -1281,6 +1282,7 @@ bool patch_manager_dialog::handle_json(const QByteArray& data)
 			QMessageBox* mb = new QMessageBox(QMessageBox::Icon::Critical, tr("Validation failed"), message, QMessageBox::Ok, this);
 			mb->setInformativeText(tr("To see the error log, please click \"Show Details\"."));
 			mb->setDetailedText(tr("%0").arg(summary));
+			mb->setAttribute(Qt::WA_DeleteOnClose);
 
 			// Smartass hack to make the unresizeable message box wide enough for the changelog
 			const int log_width = QLabel(message).sizeHint().width();

--- a/rpcs3/util/yaml.cpp
+++ b/rpcs3/util/yaml.cpp
@@ -45,7 +45,7 @@ std::pair<YAML::Node, std::string> yaml_load(const std::string& from)
 }
 
 template <typename T>
-T get_yaml_node_value(YAML::Node node, std::string& error_message)
+T get_yaml_node_value(const YAML::Node& node, std::string& error_message)
 {
 	try
 	{
@@ -59,7 +59,7 @@ T get_yaml_node_value(YAML::Node node, std::string& error_message)
 	return {};
 }
 
-std::string get_yaml_node_location(YAML::Node node)
+std::string get_yaml_node_location(const YAML::Node& node)
 {
 	try
 	{
@@ -81,9 +81,15 @@ std::string get_yaml_node_location(const YAML::detail::iterator_value& it)
 	return get_yaml_node_location(it.first);
 }
 
-template u32 get_yaml_node_value<u32>(YAML::Node, std::string&);
-template u64 get_yaml_node_value<u64>(YAML::Node, std::string&);
-template s64 get_yaml_node_value<s64>(YAML::Node, std::string&);
-template f64 get_yaml_node_value<f64>(YAML::Node, std::string&);
-template std::string get_yaml_node_value<std::string>(YAML::Node, std::string&);
-template cheat_info get_yaml_node_value<cheat_info>(YAML::Node, std::string&);
+template u8 get_yaml_node_value<u8>(const YAML::Node&, std::string&);
+template s8 get_yaml_node_value<s8>(const YAML::Node&, std::string&);
+template u16 get_yaml_node_value<u16>(const YAML::Node&, std::string&);
+template s16 get_yaml_node_value<s16>(const YAML::Node&, std::string&);
+template u32 get_yaml_node_value<u32>(const YAML::Node&, std::string&);
+template s32 get_yaml_node_value<s32>(const YAML::Node&, std::string&);
+template u64 get_yaml_node_value<u64>(const YAML::Node&, std::string&);
+template s64 get_yaml_node_value<s64>(const YAML::Node&, std::string&);
+template f32 get_yaml_node_value<f32>(const YAML::Node&, std::string&);
+template f64 get_yaml_node_value<f64>(const YAML::Node&, std::string&);
+template std::string get_yaml_node_value<std::string>(const YAML::Node&, std::string&);
+template cheat_info get_yaml_node_value<cheat_info>(const YAML::Node&, std::string&);

--- a/rpcs3/util/yaml.hpp
+++ b/rpcs3/util/yaml.hpp
@@ -24,8 +24,8 @@ std::pair<YAML::Node, std::string> yaml_load(const std::string& from);
 
 // Use try/catch in YAML::Node::as<T>() instead of YAML::Node::as<T>(fallback) in order to get an error message
 template <typename T>
-T get_yaml_node_value(YAML::Node node, std::string& error_message);
+T get_yaml_node_value(const YAML::Node& node, std::string& error_message);
 
 // Get the location of the node in the document
-std::string get_yaml_node_location(YAML::Node node);
+std::string get_yaml_node_location(const YAML::Node& node);
 std::string get_yaml_node_location(const YAML::detail::iterator_value& it);


### PR DESCRIPTION
- Improve patch.yml value validation.
Turns out that we were accepting values that were too large for data types <= 32bit.
This fix shouldn't break the official patch file. It seems to work fine.
- Use fs::write_file in patch code
- Use show instead of exec for some message boxes
- Fix some random msvc warnings