### PR TITLE
Qt: Improve patch creator and patch manager dialogs

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -360,6 +360,13 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 								continue;
 							}
 
+							if (app_versions.contains(app_version))
+							{
+								append_log_message(log_messages, fmt::format("Error: Skipping duplicate app version '%s' (title: %s, serial: %s, patch: %s, key: %s, location: %s, file: %s)", app_version, title, serial, description, main_key, get_yaml_node_location(serial_node), path), &patch_log.error);
+								is_valid = false;
+								continue;
+							}
+
 							// Get this patch's config values
 							const patch_config_values& config_values = patch_config[main_key].patch_info_map[description].titles[title][serial][app_version];
 

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -11,6 +11,7 @@
 #include "util/asm.hpp"
 
 #include <charconv>
+#include <regex>
 
 LOG_CHANNEL(patch_log, "PAT");
 
@@ -349,6 +350,15 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 						for (const auto version : serial_node.second)
 						{
 							const std::string& app_version = version.Scalar();
+
+							static const std::regex app_ver_regexp("^([0-9]{2}\\.[0-9]{2})$");
+
+							if (app_version != patch_key::all && (app_version.size() != 5 || !std::regex_match(app_version, app_ver_regexp)))
+							{
+								append_log_message(log_messages, fmt::format("Error: Skipping invalid app version '%s' (title: %s, serial: %s, patch: %s, key: %s, location: %s, file: %s)", app_version, title, serial, description, main_key, get_yaml_node_location(serial_node), path), &patch_log.error);
+								is_valid = false;
+								continue;
+							}
 
 							// Get this patch's config values
 							const patch_config_values& config_values = patch_config[main_key].patch_info_map[description].titles[title][serial][app_version];

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -347,7 +347,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 							// Get this patch's config values
 							const patch_config_values& config_values = patch_config[main_key].patch_info_map[description].titles[title][serial][app_version];
 
-							app_versions[version.Scalar()] = config_values;
+							app_versions[app_version] = config_values;
 						}
 
 						if (app_versions.empty())
@@ -357,7 +357,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 						}
 						else
 						{
-							info.titles[title][serial] = app_versions;
+							info.titles[title][serial] = std::move(app_versions);
 						}
 					}
 				}
@@ -544,7 +544,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 													}
 													else
 													{
-														config_value.allowed_values.push_back(new_allowed_value);
+														config_value.allowed_values.push_back(std::move(new_allowed_value));
 													}
 												}
 												else
@@ -627,7 +627,7 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 			}
 
 			// Insert patch information
-			container.patch_info_map[description] = info;
+			container.patch_info_map[description] = std::move(info);
 		}
 	}
 
@@ -821,7 +821,7 @@ bool patch_engine::add_patch_data(YAML::Node node, patch_info& info, u32 modifie
 		return false;
 	}
 
-	info.data_list.emplace_back(p_data);
+	info.data_list.emplace_back(std::move(p_data));
 
 	return true;
 }

--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -330,6 +330,12 @@ bool patch_engine::load(patch_map& patches_map, const std::string& path, std::st
 							is_valid = false;
 							continue;
 						}
+						else if (serial.size() != 9 || !std::all_of(serial.begin(), serial.end(), [](char c) { return std::isalnum(c); }))
+						{
+							append_log_message(log_messages, fmt::format("Error: Serial '%s' invalid (patch: %s, key: %s, location: %s, file: %s)", serial, description, main_key, get_yaml_node_location(serial_node), path), &patch_log.error);
+							is_valid = false;
+							continue;
+						}
 
 						if (const auto yml_type = serial_node.second.Type(); yml_type != YAML::NodeType::Sequence)
 						{

--- a/rpcs3/rpcs3qt/patch_creator_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.cpp
@@ -479,40 +479,71 @@ void patch_creator_dialog::export_patch()
 
 void patch_creator_dialog::generate_yml(const QString& /*text*/)
 {
-	QString patch;
-	patch.append(QString("%0: %1\n").arg(qstr(patch_key::version)).arg(qstr(patch_engine_version)));
-	patch.append("\n");
-	patch.append(QString("%0:\n").arg(ui->hashEdit->text()));
-	patch.append(QString("  \"%0\":\n").arg(ui->patchNameEdit->text()));
-	patch.append(QString("    %0:\n").arg(qstr(patch_key::games)));
-	patch.append(QString("      \"%0\":\n").arg(ui->gameEdit->text()));
-	patch.append(QString("        %0: [ %1 ]\n").arg(ui->serialEdit->text()).arg(ui->gameVersionEdit->text()));
-	patch.append(QString("    %0: \"%1\"\n").arg(qstr(patch_key::author)).arg(ui->authorEdit->text()));
-	patch.append(QString("    %0: %1.%2\n").arg(qstr(patch_key::patch_version)).arg(ui->versionMajorSpinBox->text()).arg(ui->versionMinorSpinBox->text()));
-	patch.append(QString("    %0: \"%1\"\n").arg(qstr(patch_key::group)).arg(ui->groupEdit->text()));
-	patch.append(QString("    %0: \"%1\"\n").arg(qstr(patch_key::notes)).arg(ui->notesEdit->text()));
-	patch.append(QString("    %0:\n").arg(qstr(patch_key::patch)));
-
-	for (int i = 0; i < ui->instructionTable->rowCount(); i++)
+	YAML::Emitter out;
+	out << YAML::BeginMap;
+	out << patch_key::version << patch_engine_version;
+	out << YAML::Newline;
+	out << ui->hashEdit->text().toStdString();
 	{
-		const QComboBox* type_item           = qobject_cast<QComboBox*>(ui->instructionTable->cellWidget(i, patch_column::type));
-		const QTableWidgetItem* offset_item  = ui->instructionTable->item(i, patch_column::offset);
-		const QTableWidgetItem* value_item   = ui->instructionTable->item(i, patch_column::value);
-		const QTableWidgetItem* comment_item = ui->instructionTable->item(i, patch_column::comment);
-
-		const QString type    = type_item ? type_item->currentText() : "";
-		const QString offset  = offset_item ? offset_item->text() : "";
-		const QString value   = value_item ? value_item->text() : "";
-		const QString comment = comment_item ? comment_item->text() : "";
-
-		if (patch_engine::get_patch_type(type.toStdString()) == patch_type::invalid)
+		out << YAML::BeginMap;
+		out << YAML::DoubleQuoted << ui->patchNameEdit->text().toStdString();
 		{
-			ui->patchEdit->setText(tr("Instruction %0: Type '%1' is invalid!").arg(i + 1).arg(type));
-			return;
-		}
+			out << YAML::BeginMap;
+			out << patch_key::games;
+			{
+				out << YAML::BeginMap;
+				out << YAML::DoubleQuoted << ui->gameEdit->text().toStdString();
+				{
+					out << YAML::BeginMap;
+					out << ui->serialEdit->text().simplified().toStdString();
+					{
+						out << YAML::Flow << YAML::BeginSeq << ui->gameVersionEdit->text().toStdString() << YAML::EndSeq;
+					}
+					out << YAML::EndMap;
+				}
+				out << YAML::EndMap;
+			}
+			out << patch_key::author << YAML::DoubleQuoted << ui->authorEdit->text().toStdString();
+			out << patch_key::patch_version << fmt::format("%s.%s", ui->versionMajorSpinBox->text(), ui->versionMinorSpinBox->text());
+			out << patch_key::group << YAML::DoubleQuoted << ui->groupEdit->text().toStdString();
+			out << patch_key::notes << YAML::DoubleQuoted << ui->notesEdit->text().toStdString();
+			out << patch_key::patch;
+			{
+				out << YAML::BeginSeq;
+				for (int i = 0; i < ui->instructionTable->rowCount(); i++)
+				{
+					const QComboBox* type_item           = qobject_cast<QComboBox*>(ui->instructionTable->cellWidget(i, patch_column::type));
+					const QTableWidgetItem* offset_item  = ui->instructionTable->item(i, patch_column::offset);
+					const QTableWidgetItem* value_item   = ui->instructionTable->item(i, patch_column::value);
+					const QTableWidgetItem* comment_item = ui->instructionTable->item(i, patch_column::comment);
 
-		patch.append(QString("      - [ %0, %1, %2 ]%3\n").arg(type).arg(offset).arg(value).arg(comment.isEmpty() ? QStringLiteral("") : QString(" # %0").arg(comment)));
+					const std::string type    = type_item ? type_item->currentText().toStdString() : "";
+					const std::string offset  = offset_item ? offset_item->text().toStdString() : "";
+					const std::string value   = value_item ? value_item->text().toStdString() : "";
+					const std::string comment = comment_item ? comment_item->text().toStdString() : "";
+
+					if (patch_engine::get_patch_type(type) == patch_type::invalid)
+					{
+						ui->patchEdit->setText(tr("Instruction %0: Type '%1' is invalid!").arg(i + 1).arg(type_item ? type_item->currentText() : ""));
+						return;
+					}
+
+					out << YAML::Flow << YAML::BeginSeq << type << offset << value << YAML::EndSeq;
+
+					if (!comment.empty())
+					{
+						out << YAML::Comment(comment);
+					}
+				}
+				out << YAML::EndSeq;
+			}
+			out << YAML::EndMap;
+		}
+		out << YAML::EndMap;
 	}
+	out << YAML::EndMap;
+
+	const QString patch = QString::fromUtf8(out.c_str(), out.size());
 
 	validate(patch);
 }

--- a/rpcs3/rpcs3qt/patch_creator_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_creator_dialog.cpp
@@ -497,7 +497,7 @@ void patch_creator_dialog::generate_yml(const QString& /*text*/)
 					out << YAML::BeginMap;
 					out << ui->serialEdit->text().simplified().toStdString();
 					{
-						out << YAML::Flow << YAML::BeginSeq << ui->gameVersionEdit->text().toStdString() << YAML::EndSeq;
+						out << YAML::Flow << fmt::split(ui->gameVersionEdit->text().toStdString(), { ",", " " });
 					}
 					out << YAML::EndMap;
 				}

--- a/rpcs3/rpcs3qt/patch_manager_dialog.ui
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.ui
@@ -120,6 +120,9 @@
                 <property name="wordWrap">
                  <bool>true</bool>
                 </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                </property>
                </widget>
               </item>
              </layout>
@@ -139,6 +142,9 @@
                 <property name="wordWrap">
                  <bool>true</bool>
                 </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                </property>
                </widget>
               </item>
              </layout>
@@ -154,6 +160,9 @@
                <widget class="QLabel" name="label_app_version">
                 <property name="text">
                  <string/>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
                 </property>
                </widget>
               </item>
@@ -174,6 +183,9 @@
                 <property name="wordWrap">
                  <bool>true</bool>
                 </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                </property>
                </widget>
               </item>
              </layout>
@@ -192,6 +204,9 @@
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
                 </property>
                </widget>
               </item>
@@ -212,6 +227,9 @@
                 <property name="wordWrap">
                  <bool>true</bool>
                 </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                </property>
                </widget>
               </item>
              </layout>
@@ -230,6 +248,9 @@
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
                 </property>
                </widget>
               </item>
@@ -252,6 +273,9 @@
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
- Patch creator: use YAML emitter to produce valid YAML blocks
- Patch manager: allow to select text (notes etc.) with the mouse, so you can copy them
- Patch validation: check if serial is 9 characters long and alphanumeric
- Patch validation: check if app version is 5 characters long and like 01.00
- Patch validation: don't allow duplicate app versions

One "downside" is that it doesn't look exactly as before, since yaml-cpp adds or omits some spaces in places.
In theory we could omit the "" in keys if they are not needed, but I kept it in for consistency.

fixes #14168