### PR TITLE
Qt: fix pad settings latency

### DIFF
--- a/rpcs3/rpcs3qt/pad_motion_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_motion_settings_dialog.cpp
@@ -166,7 +166,7 @@ pad_motion_settings_dialog::pad_motion_settings_dialog(QDialog* parent, std::sha
 			}
 		}
 	});
-	m_timer_input.start(1);
+	m_timer_input.start(10);
 
 	// Use thread to get button input
 	m_input_thread = std::make_unique<named_thread<std::function<void()>>>("UI Pad Motion Thread", [this]()

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -445,7 +445,7 @@ void pad_settings_dialog::InitButtons()
 		if (ui->chooseDevice->isEnabled() && ui->chooseDevice->currentIndex() >= 0)
 		{
 			start_input_thread();
-			m_timer_input.start(1);
+			m_timer_input.start(10);
 			m_timer_pad_refresh.start(1000);
 		}
 	});
@@ -530,7 +530,7 @@ void pad_settings_dialog::InitButtons()
 
 		while (thread_ctrl::state() != thread_state::aborting)
 		{
-			thread_ctrl::wait_for(10000);
+			thread_ctrl::wait_for(1000);
 
 			if (m_input_thread_state != input_thread_state::active)
 			{


### PR DESCRIPTION
Increase input timers back to 1000Hz. The DS4 lags if it's slower.
Decrease all pad UI update timers from 1000Hz to 100 Hz.

fixes #15951