### PR TITLE
Implement thread_ctrl::wait_until()

### DIFF
--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -276,6 +276,9 @@ public:
 	// Wait once with timeout. Infinite value is -1.
 	static void wait_for(u64 usec, bool alert = true);
 
+	// Wait once with time point, add_time is added to the time point.
+	static void wait_until(u64* wait_time, u64 add_time = 0, u64 min_wait = 0, bool update_to_current_time = true);
+
 	// Waiting with accurate timeout
 	static void wait_for_accurate(u64 usec);
 

--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -392,14 +392,35 @@ void spu_load_exec(const spu_exec_object& elf)
 
 	const auto funcs = spu->discover_functions(0, { spu->ls , SPU_LS_SIZE }, true, umax);
 
-	for (u32 addr : funcs)
+	if (spu_log.notice && !funcs.empty())
 	{
-		spu_log.success("Found SPU function at: 0x%08x", addr);
+		std::string to_log;
+
+		for (usz i = 0; i < funcs.size(); i++)
+		{
+			if (i == 0 && funcs.size() < 4)
+			{
+				// Skip newline in this case
+				to_log += ' ';
+			}
+			else if (i % 4 == 0)
+			{
+				to_log += '\n';
+			}
+			else
+			{
+				to_log += ", ";
+			}
+
+			fmt::append(to_log, "0x%05x", funcs[i]);
+		}
+
+		spu_log.notice("Found SPU function(s) at:%s", to_log);
 	}
 
 	if (!funcs.empty())
 	{
-		spu_log.success("Found %u SPU functions", funcs.size());
+		spu_log.success("Found %u SPU function(s)", funcs.size());
 	}
 }
 

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -543,12 +543,33 @@ extern void utilize_spu_data_segment(u32 vaddr, const void* ls_data_vaddr, u32 s
 		return;
 	}
 
-	for (u32 addr : obj.funcs)
+	if (spu_log.notice)
 	{
-		spu_log.notice("Found SPU function at: 0x%05x", addr);
+		std::string to_log;
+
+		for (usz i = 0; i < obj.funcs.size(); i++)
+		{
+			if (i == 0 && obj.funcs.size() < 4)
+			{
+				// Skip newline in this case
+				to_log += ' ';
+			}
+			else if (i % 4 == 0)
+			{
+				to_log += '\n';
+			}
+			else
+			{
+				to_log += ", ";
+			}
+
+			fmt::append(to_log, "0x%05x", obj.funcs[i]);
+		}
+
+		spu_log.notice("Found SPU function(s) at:%s", to_log);
 	}
 
-	spu_log.notice("Found %u SPU functions", obj.funcs.size());
+	spu_log.success("Found %u SPU function(s)", obj.funcs.size());
 
 	g_fxo->get<spu_cache>().precompile_funcs.push(std::move(obj));
 }

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1206,10 +1206,11 @@ public:
 	void operator()()
 	{
 		bool was_paused = false;
+		u64 sleep_until = get_system_time();
 
 		for (u32 i = 1; thread_ctrl::state() != thread_state::aborting; i++)
 		{
-			thread_ctrl::wait_for(1'000'000);
+			thread_ctrl::wait_until(&sleep_until, 1'000'000);
 
 			const bool is_paused = Emu.IsPaused();
 

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -894,7 +894,7 @@ void gdb_thread::operator()()
 {
 	start_server();
 
-	while (server_socket != -1 && thread_ctrl::state() != thread_state::aborting)
+	for (u64 sleep_until = get_system_time(); server_socket != -1 && thread_ctrl::state() != thread_state::aborting;)
 	{
 		sockaddr_in client;
 		socklen_t client_len = sizeof(client);
@@ -904,7 +904,7 @@ void gdb_thread::operator()()
 		{
 			if (check_errno_again())
 			{
-				thread_ctrl::wait_for(5000);
+				thread_ctrl::wait_until(&sleep_until, 5000);
 				continue;
 			}
 

--- a/rpcs3/Emu/perf_monitor.cpp
+++ b/rpcs3/Emu/perf_monitor.cpp
@@ -20,10 +20,11 @@ void perf_monitor::operator()()
 	u64 last_pause_time = umax;
 
 	std::vector<double> per_core_usage;
+	std::string msg;
 
-	while (thread_ctrl::state() != thread_state::aborting)
+	for (u64 sleep_until = get_system_time(); thread_ctrl::state() != thread_state::aborting;)
 	{
-		thread_ctrl::wait_for(update_interval_us);
+		thread_ctrl::wait_until(&sleep_until, update_interval_us);
 		elapsed_us += update_interval_us;
 
 		if (thread_ctrl::state() == thread_state::aborting)
@@ -61,14 +62,15 @@ void perf_monitor::operator()()
 				logged_pause++;
 			}
 
-			std::string msg = fmt::format("CPU Usage: Total: %.1f%%", total_usage);
+			msg.clear();
+			fmt::append(msg, "CPU Usage: Total: %.1f%%", total_usage);
 
 			if (!per_core_usage.empty())
 			{
 				fmt::append(msg, ", Cores:");
 			}
 
-			for (size_t i = 0; i < per_core_usage.size(); i++)
+			for (usz i = 0; i < per_core_usage.size(); i++)
 			{
 				fmt::append(msg, "%s %.1f%%", i > 0 ? "," : "", per_core_usage[i]);
 			}

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -175,7 +175,9 @@ void progress_dialog_server::operator()()
 		usz time_left_queue_idx = 0;
 
 		// Update progress
-		while (!g_system_progress_stopping && thread_ctrl::state() != thread_state::aborting)
+		for (u64 sleep_until = get_system_time(), sleep_for = 500;
+			!g_system_progress_stopping && thread_ctrl::state() != thread_state::aborting;
+			thread_ctrl::wait_until(&sleep_until, std::exchange(sleep_for, 500)))
 		{
 			const auto& [text_new, ftotal_new, fdone_new, ftotal_bits_new, fknown_bits_new, ptotal_new, pdone_new] = get_state();
 
@@ -236,7 +238,7 @@ void progress_dialog_server::operator()()
 						}
 					}
 
-					thread_ctrl::wait_for(10000);
+					sleep_for = 10000;
 					continue;
 				}
 
@@ -365,7 +367,7 @@ void progress_dialog_server::operator()()
 				break;
 			}
 
-			thread_ctrl::wait_for(10'000);
+			sleep_for = 10'000;
 			wait_no_update_count++;
 		}
 


### PR DESCRIPTION
Make loops with constant duration intervals more accurate by accounting time spent in code, by implementing and using a function parallel to `std::this_thread::sleep_until()`.