### PR TITLE
input: Some fixes

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -70,6 +70,13 @@ public:
 		disconnected
 	};
 
+	enum class trigger_recognition_mode
+	{
+		any,             // Add all trigger modes to the button map
+		one_directional, // Treat trigger axis as one-directional only
+		two_directional  // Treat trigger axis as two-directional only (similar to sticks)
+	};
+
 protected:
 	enum button
 	{
@@ -124,7 +131,7 @@ protected:
 	usz m_max_devices = 0;
 	u32 m_trigger_threshold = 0;
 	u32 m_thumb_threshold = 0;
-	bool m_triggers_as_sticks_only = false;
+	trigger_recognition_mode m_trigger_recognition_mode = trigger_recognition_mode::any;
 
 	bool b_has_led = false;
 	bool b_has_rgb = false;
@@ -285,7 +292,7 @@ public:
 
 	u16 NormalizeStickInput(u16 raw_value, s32 threshold, s32 multiplier, bool ignore_threshold = false) const;
 	void convert_stick_values(u16& x_out, u16& y_out, s32 x_in, s32 y_in, u32 deadzone, u32 anti_deadzone, u32 padsquircling) const;
-	void set_triggers_as_sticks_only(bool enabled) { m_triggers_as_sticks_only = enabled; }
+	void set_trigger_recognition_mode(trigger_recognition_mode mode) { m_trigger_recognition_mode = mode; }
 
 	virtual bool Init() { return true; }
 	PadHandlerBase(pad_handler type = pad_handler::null);

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -23,6 +23,8 @@ public:
 	u8 player_id{0};
 	u8 large_motor{0};
 	u8 small_motor{0};
+	bool new_output_data{true};
+	steady_clock::time_point last_output;
 	std::set<u64> trigger_code_left{};
 	std::set<u64> trigger_code_right{};
 	std::array<std::set<u64>, 4> axis_code_left{};
@@ -114,6 +116,7 @@ protected:
 	static constexpr u32 MAX_GAMEPADS = 7;
 	static constexpr u16 button_press_threshold = 50;
 	static constexpr u16 touch_threshold = static_cast<u16>(255 * 0.9f);
+	static constexpr auto min_output_interval = 300ms;
 
 	std::array<bool, MAX_GAMEPADS> last_connection_status{{ false, false, false, false, false, false, false }};
 

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -802,7 +802,10 @@ dualsense_pad_handler::~dualsense_pad_handler()
 			// Turns off the lights (disabled due to user complaints)
 			//controller.second->release_leds = true;
 
-			send_output_report(controller.second.get());
+			if (send_output_report(controller.second.get()) == -1)
+			{
+				dualsense_log.error("~dualsense_pad_handler: send_output_report failed! Reason: %s", hid_error(controller.second->hidDevice));
+			}
 		}
 	}
 }
@@ -1008,9 +1011,13 @@ void dualsense_pad_handler::apply_pad_data(const pad_ensemble& binding)
 
 	if (dualsense_dev->new_output_data)
 	{
-		if (send_output_report(dualsense_dev) >= 0)
+		if (const int res = send_output_report(dualsense_dev); res >= 0)
 		{
 			dualsense_dev->new_output_data = false;
+		}
+		else if (res == -1)
+		{
+			dualsense_log.error("apply_pad_data: send_output_report failed! error=%s", hid_error(dualsense_dev->hidDevice));
 		}
 	}
 }
@@ -1050,11 +1057,17 @@ void dualsense_pad_handler::SetPadData(const std::string& padId, u8 player_id, u
 	if (device->init_lightbar)
 	{
 		// Initialize first
-		send_output_report(device.get());
+		if (send_output_report(device.get()) == -1)
+		{
+			dualsense_log.error("SetPadData: send_output_report failed! Reason: %s", hid_error(device->hidDevice));
+		}
 	}
 
 	// Start/Stop the engines :)
-	send_output_report(device.get());
+	if (send_output_report(device.get()) == -1)
+	{
+		dualsense_log.error("SetPadData: send_output_report failed! Reason: %s", hid_error(device->hidDevice));
+	}
 }
 
 u32 dualsense_pad_handler::get_battery_level(const std::string& padId)

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -243,7 +243,7 @@ public:
 	void init_config(cfg_pad* cfg) override;
 
 private:
-	bool get_calibration_data(DualSenseDevice* dualsense_device) const;
+	bool get_calibration_data(DualSenseDevice* dev) const;
 
 	DataStatus get_data(DualSenseDevice* device) override;
 	void check_add_device(hid_device* hidDevice, std::string_view path, std::wstring_view wide_serial) override;

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -396,7 +396,6 @@ class evdev_joystick_handler final : public PadHandlerBase
 		int effect_id = -1;
 		bool has_rumble = false;
 		bool has_motion = false;
-		clock_t last_vibration = 0;
 	};
 
 public:

--- a/rpcs3/Input/hid_pad_handler.h
+++ b/rpcs3/Input/hid_pad_handler.h
@@ -34,7 +34,6 @@ public:
 
 	hid_device* hidDevice{nullptr};
 	std::string path;
-	bool new_output_data{true};
 	bool enable_player_leds{false};
 	u8 led_delay_on{0};
 	u8 led_delay_off{0};

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -169,20 +169,20 @@ std::array<std::set<u32>, PadHandlerBase::button::button_count> mm_joystick_hand
 {
 	std::array<std::set<u32>, button::button_count> mapping{};
 
-	MMJOYDevice* joy_device = static_cast<MMJOYDevice*>(device.get());
-	if (!joy_device || !cfg)
+	MMJOYDevice* dev = static_cast<MMJOYDevice*>(device.get());
+	if (!dev || !cfg)
 		return mapping;
 
-	joy_device->trigger_code_left  = find_keys<u64>(cfg->l2);
-	joy_device->trigger_code_right = find_keys<u64>(cfg->r2);
-	joy_device->axis_code_left[0]  = find_keys<u64>(cfg->ls_left);
-	joy_device->axis_code_left[1]  = find_keys<u64>(cfg->ls_right);
-	joy_device->axis_code_left[2]  = find_keys<u64>(cfg->ls_down);
-	joy_device->axis_code_left[3]  = find_keys<u64>(cfg->ls_up);
-	joy_device->axis_code_right[0] = find_keys<u64>(cfg->rs_left);
-	joy_device->axis_code_right[1] = find_keys<u64>(cfg->rs_right);
-	joy_device->axis_code_right[2] = find_keys<u64>(cfg->rs_down);
-	joy_device->axis_code_right[3] = find_keys<u64>(cfg->rs_up);
+	dev->trigger_code_left  = find_keys<u64>(cfg->l2);
+	dev->trigger_code_right = find_keys<u64>(cfg->r2);
+	dev->axis_code_left[0]  = find_keys<u64>(cfg->ls_left);
+	dev->axis_code_left[1]  = find_keys<u64>(cfg->ls_right);
+	dev->axis_code_left[2]  = find_keys<u64>(cfg->ls_down);
+	dev->axis_code_left[3]  = find_keys<u64>(cfg->ls_up);
+	dev->axis_code_right[0] = find_keys<u64>(cfg->rs_left);
+	dev->axis_code_right[1] = find_keys<u64>(cfg->rs_right);
+	dev->axis_code_right[2] = find_keys<u64>(cfg->rs_down);
+	dev->axis_code_right[3] = find_keys<u64>(cfg->rs_up);
 
 	mapping[button::up]       = find_keys<u32>(cfg->up);
 	mapping[button::down]     = find_keys<u32>(cfg->down);
@@ -193,22 +193,22 @@ std::array<std::set<u32>, PadHandlerBase::button::button_count> mm_joystick_hand
 	mapping[button::circle]   = find_keys<u32>(cfg->circle);
 	mapping[button::triangle] = find_keys<u32>(cfg->triangle);
 	mapping[button::l1]       = find_keys<u32>(cfg->l1);
-	mapping[button::l2]       = narrow_set(joy_device->trigger_code_left);
+	mapping[button::l2]       = narrow_set(dev->trigger_code_left);
 	mapping[button::l3]       = find_keys<u32>(cfg->l3);
 	mapping[button::r1]       = find_keys<u32>(cfg->r1);
-	mapping[button::r2]       = narrow_set(joy_device->trigger_code_right);
+	mapping[button::r2]       = narrow_set(dev->trigger_code_right);
 	mapping[button::r3]       = find_keys<u32>(cfg->r3);
 	mapping[button::start]    = find_keys<u32>(cfg->start);
 	mapping[button::select]   = find_keys<u32>(cfg->select);
 	mapping[button::ps]       = find_keys<u32>(cfg->ps);
-	mapping[button::ls_left]  = narrow_set(joy_device->axis_code_left[0]);
-	mapping[button::ls_right] = narrow_set(joy_device->axis_code_left[1]);
-	mapping[button::ls_down]  = narrow_set(joy_device->axis_code_left[2]);
-	mapping[button::ls_up]    = narrow_set(joy_device->axis_code_left[3]);
-	mapping[button::rs_left]  = narrow_set(joy_device->axis_code_right[0]);
-	mapping[button::rs_right] = narrow_set(joy_device->axis_code_right[1]);
-	mapping[button::rs_down]  = narrow_set(joy_device->axis_code_right[2]);
-	mapping[button::rs_up]    = narrow_set(joy_device->axis_code_right[3]);
+	mapping[button::ls_left]  = narrow_set(dev->axis_code_left[0]);
+	mapping[button::ls_right] = narrow_set(dev->axis_code_left[1]);
+	mapping[button::ls_down]  = narrow_set(dev->axis_code_left[2]);
+	mapping[button::ls_up]    = narrow_set(dev->axis_code_left[3]);
+	mapping[button::rs_left]  = narrow_set(dev->axis_code_right[0]);
+	mapping[button::rs_right] = narrow_set(dev->axis_code_right[1]);
+	mapping[button::rs_down]  = narrow_set(dev->axis_code_right[2]);
+	mapping[button::rs_up]    = narrow_set(dev->axis_code_right[3]);
 
 	mapping[button::skateboard_ir_nose]    = find_keys<u32>(cfg->ir_nose);
 	mapping[button::skateboard_ir_tail]    = find_keys<u32>(cfg->ir_tail);

--- a/rpcs3/Input/sdl_pad_handler.h
+++ b/rpcs3/Input/sdl_pad_handler.h
@@ -64,9 +64,6 @@ public:
 	bool led_is_on = true;
 	bool led_is_blinking = false;
 	steady_clock::time_point led_timestamp{};
-
-	bool has_new_rumble_data = true;
-	steady_clock::time_point last_vibration{};
 };
 
 class sdl_pad_handler : public PadHandlerBase

--- a/rpcs3/Input/skateboard_pad_handler.cpp
+++ b/rpcs3/Input/skateboard_pad_handler.cpp
@@ -358,9 +358,13 @@ void skateboard_pad_handler::apply_pad_data(const pad_ensemble& binding)
 
 	if (dev->new_output_data)
 	{
-		if (send_output_report(dev) >= 0)
+		if (const int res = send_output_report(dev); res >= 0)
 		{
 			dev->new_output_data = false;
+		}
+		else if (res == -1)
+		{
+			skateboard_log.error("apply_pad_data: send_output_report failed! error=%s", hid_error(dev->hidDevice));
 		}
 	}
 }
@@ -377,5 +381,8 @@ void skateboard_pad_handler::SetPadData(const std::string& padId, u8 player_id, 
 	ensure(device->config);
 
 	// Disabled until needed
-	//send_output_report(device.get());
+	//if (send_output_report(device.get()) == -1)
+	//{
+	//	skateboard_log.error("SetPadData: send_output_report failed! Reason: %s", hid_error(device->hidDevice));
+	//}
 }

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -123,8 +123,8 @@ private:
 	typedef DWORD (WINAPI * PFN_XINPUTGETBATTERYINFORMATION)(DWORD, BYTE, XINPUT_BATTERY_INFORMATION *);
 
 	int GetDeviceNumber(const std::string& padId);
-	static PadButtonValues get_button_values_base(const XINPUT_STATE& state, bool triggers_as_sticks_only);
-	static PadButtonValues get_button_values_scp(const SCP_EXTN& state, bool triggers_as_sticks_only);
+	static PadButtonValues get_button_values_base(const XINPUT_STATE& state, trigger_recognition_mode trigger_mode);
+	static PadButtonValues get_button_values_scp(const SCP_EXTN& state, trigger_recognition_mode trigger_mode);
 
 	HMODULE library{ nullptr };
 	PFN_XINPUTGETEXTENDED xinputGetExtended{ nullptr };

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -98,8 +98,6 @@ class xinput_pad_handler final : public PadHandlerBase
 	struct XInputDevice : public PadDevice
 	{
 		u32 deviceNumber{ 0 };
-		bool newVibrateData{ true };
-		steady_clock::time_point last_vibration;
 		bool is_scp_device{ false };
 		DWORD state{ ERROR_NOT_CONNECTED }; // holds internal controller state change
 		SCP_EXTN state_scp{};

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1312,7 +1312,7 @@ void pad_settings_dialog::OnPadButtonClicked(int id)
 	}
 
 	// On alt+click or alt+space allow to handle triggers as the entire stick axis
-	m_handler->set_triggers_as_sticks_only(QApplication::keyboardModifiers() & Qt::KeyboardModifier::AltModifier);
+	m_handler->set_trigger_recognition_mode((QApplication::keyboardModifiers() & Qt::KeyboardModifier::AltModifier) ? PadHandlerBase::trigger_recognition_mode::two_directional : PadHandlerBase::trigger_recognition_mode::one_directional);
 
 	for (auto but : m_pad_buttons->buttons())
 	{


### PR DESCRIPTION
- Always send output report after at least 300ms to prevent lost updates (for example rumble won't stop)
- Qt/XInput: Don't report two direction trigger values unless actually requested
Fixes a bug in the pad settings dialog where you could map LT- in XInput even if you weren't pressing ALT when clicking on the button before.

Fixes #15955