### PR TITLE
aarch64 fixes

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2310,6 +2310,10 @@ thread_base::native_entry thread_base::make_trampoline(u64(*entry)(thread_base* 
 		c.bind(_ret);
 		c.add(x86::rsp, 0x28);
 		c.ret();
+#else
+	UNUSED(c);
+	UNUSED(args);
+	UNUSED(entry);
 #endif
 	});
 }

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1929,16 +1929,20 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 #elif defined(ARCH_ARM64)
 	const bool is_executing = uptr(info->si_addr) == uptr(RIP(context));
 	const u32 insn = is_executing ? 0 : *reinterpret_cast<u32*>(RIP(context));
-	const bool is_writing = (insn & 0xbfff0000) == 0x0c000000
-		|| (insn & 0xbfe00000) == 0x0c800000
-		|| (insn & 0xbfdf0000) == 0x0d000000
-		|| (insn & 0xbfc00000) == 0x0d800000
-		|| (insn & 0x3f400000) == 0x08000000
-		|| (insn & 0x3bc00000) == 0x39000000
-		|| (insn & 0x3fc00000) == 0x3d800000
-		|| (insn & 0x3bc00000) == 0x38000000
-		|| (insn & 0x3fe00000) == 0x3c800000
-		|| (insn & 0x3a400000) == 0x28000000;
+	const bool is_writing = 
+		(insn & 0xbfff0000) == 0x0c000000 ||  // STR <Wt>, [<Xn>, #<imm>] (store word with immediate offset)
+		(insn & 0xbfe00000) == 0x0c800000 ||  // STP <Wt1>, <Wt2>, [<Xn>, #<imm>] (store pair of registers with immediate offset)
+		(insn & 0xbfdf0000) == 0x0d000000 ||  // STR <Wt>, [<Xn>, <Xm>] (store word with register offset)
+		(insn & 0xbfc00000) == 0x0d800000 ||  // STP <Wt1>, <Wt2>, [<Xn>, <Xm>] (store pair of registers with register offset)
+		(insn & 0x3f400000) == 0x08000000 ||  // STR <Vd>, [<Xn>, #<imm>] (store SIMD/FP register with immediate offset)
+		(insn & 0x3bc00000) == 0x39000000 ||  // STR <Wt>, [<Xn>, #<imm>] (store word with immediate offset)
+		(insn & 0x3fc00000) == 0x3d800000 ||  // STR <Vd>, [<Xn>, <Xm>] (store SIMD/FP register with register offset)
+		(insn & 0x3bc00000) == 0x38000000 ||  // STR <Wt>, [<Xn>, <Xm>] (store word with register offset)
+		(insn & 0x3fe00000) == 0x3c800000 ||  // STUR <Vd>, [<Xn>, #<imm>] (store unprivileged register with immediate offset)
+		(insn & 0x3fe00000) == 0x3ca00000 ||  // STR <Vd>, [<Xn>, #<imm>] (store SIMD/FP register with immediate offset)
+		(insn & 0x3a400000) == 0x28000000 ||  // STP <Wt1>, <Wt2>, [<Xn>, #<imm>] (store pair of registers with immediate offset)
+		(insn & 0xad000000) == 0xad000000 ||  // STP <Vd1>, <Vd2>, [<Xn>, #<imm>] (store SIMD/FP 128-bit register pair with immediate offset)
+		(insn & 0xad000000) == 0xad000000;    // STP <Dd1>, <Dd2>, [<Xn>, #<imm>] (store SIMD/FP 64-bit register pair with immediate offset)
 
 #else
 #error "signal_handler not implemented"

--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.cpp
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.cpp
@@ -496,6 +496,7 @@ namespace aarch64
                 auto i = llvm::dyn_cast<llvm::Instruction>(bit);
                 if (!is_ret_instruction(i))
                 {
+                    ++bit;
                     continue;
                 }
 

--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -129,7 +129,9 @@ struct ppu_exec_select
 		}; \
 	}
 
+#ifdef ARCH_X64
 static constexpr ppu_opcode_t s_op{};
+#endif
 
 namespace asmjit
 {
@@ -293,7 +295,7 @@ struct ppu_abstract_t
 			}
 
 			template <typename T>
-			void operator=(T&& _val) const
+			void operator=([[maybe_unused]] T&& _val) const
 			{
 				FOR_X64(store_op, kIdMovaps, kIdVmovaps, static_cast<asmjit::ppu_builder*>(g_vc)->ppu_vr(bf_t<u32, I, N>{}, true), std::forward<T>(_val));
 			}
@@ -316,11 +318,9 @@ struct ppu_abstract_t
 		}
 
 		template <typename T>
-		void operator=(T&& _val) const
+		void operator=([[maybe_unused]] T&& _val) const
 		{
-		#if defined(ARCH_X64)
 			FOR_X64(store_op, kIdMovaps, kIdVmovaps, *this, std::forward<T>(_val));
-		#endif
 		}
 	} sat{};
 };

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3292,6 +3292,8 @@ const auto ppu_stcx_accurate_tx = build_function_asm<u64(*)(u32 raddr, u64 rtime
 	maybe_flush_lbr(c);
 	c.ret();
 #else
+	UNUSED(args);
+
 	// Unimplemented should fail.
 	c.brk(Imm(0x42));
 	c.ret(a64::x30);

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -216,6 +216,9 @@ DECLARE(spu_runtime::tr_all) = []
 		{
 			using namespace asmjit;
 
+			// Args implicitly defined via registers
+			UNUSED(args);
+
 			// Inputs:
 			// x19 = m_thread a.k.a arg[0]
 			// x20 = ls_base

--- a/rpcs3/Emu/Cell/SPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/SPUInterpreter.cpp
@@ -69,7 +69,9 @@ struct spu_exec_select
 	}
 };
 
+#ifdef ARCH_X64
 static constexpr spu_opcode_t s_op{};
+#endif
 
 namespace asmjit
 {

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -848,6 +848,8 @@ const auto spu_putllc_tx = build_function_asm<u64(*)(u32 raddr, u64 rtime, void*
 	maybe_flush_lbr(c);
 	c.ret();
 #else
+	UNUSED(args);
+
 	c.brk(Imm(0x42));
 	c.ret(a64::x30);
 #endif
@@ -972,6 +974,8 @@ const auto spu_putlluc_tx = build_function_asm<u64(*)(u32 raddr, const void* rda
 	maybe_flush_lbr(c);
 	c.ret();
 #else
+	UNUSED(args);
+
 	c.brk(Imm(0x42));
 	c.ret(a64::x30);
 #endif
@@ -1105,6 +1109,8 @@ const auto spu_getllar_tx = build_function_asm<u64(*)(u32 raddr, void* rdata, cp
 	maybe_flush_lbr(c);
 	c.ret();
 #else
+	UNUSED(args);
+
 	c.brk(Imm(0x42));
 	c.ret(a64::x30);
 #endif

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -1377,3 +1377,5 @@ extern bool serialize(utils::serial& ar, T& obj);
 
 #define ENABLE_BITWISE_SERIALIZATION using enable_bitcopy = std::true_type;
 #define SAVESTATE_INIT_POS(...) static constexpr double savestate_init_pos = (__VA_ARGS__)
+
+#define UNUSED(expr) do { (void)(expr); } while (0)


### PR DESCRIPTION
- Fix "unused variable" warnings caused by arm64 path not consuming some variables.
- Fix hang when compiling leaf blocks
- Add more instruction families to the write detection code. Fixes hangs in some games.

Fixes https://github.com/RPCS3/rpcs3/issues/15970