### PR TITLE
Rework aarch64 signal handling

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -11,6 +11,10 @@
 #include <thread>
 #include <cfenv>
 
+#ifdef ARCH_ARM64
+#include "Emu/CPU/Backends/AArch64/AArch64Signal.h"
+#endif
+
 #ifdef _WIN32
 #include <Windows.h>
 #include <Psapi.h>
@@ -1929,6 +1933,20 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 #elif defined(ARCH_ARM64)
 	const bool is_executing = uptr(info->si_addr) == uptr(RIP(context));
 	const u32 insn = is_executing ? 0 : *reinterpret_cast<u32*>(RIP(context));
+
+#ifdef __linux__
+	// Current CPU state decoder is reverse-engineered from the linux kernel and may not work on other platforms.
+	const auto decoded_reason = aarch64::decode_fault_reason(context);
+	const bool is_writing = (decoded_reason == aarch64::fault_reason::data_write);
+
+	if (decoded_reason != aarch64::fault_reason::data_write &&
+		decoded_reason != aarch64::fault_reason::data_read)
+	{
+		// We don't expect other classes of exceptions during normal executions
+		sig_log.warning("Unexpected fault. Reason: %d", static_cast<int>(decoded_reason));
+	}
+
+#else
 	const bool is_writing = 
 		(insn & 0xbfff0000) == 0x0c000000 ||  // STR <Wt>, [<Xn>, #<imm>] (store word with immediate offset)
 		(insn & 0xbfe00000) == 0x0c800000 ||  // STP <Wt1>, <Wt2>, [<Xn>, #<imm>] (store pair of registers with immediate offset)
@@ -1941,8 +1959,9 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 		(insn & 0x3fe00000) == 0x3c800000 ||  // STUR <Vd>, [<Xn>, #<imm>] (store unprivileged register with immediate offset)
 		(insn & 0x3fe00000) == 0x3ca00000 ||  // STR <Vd>, [<Xn>, #<imm>] (store SIMD/FP register with immediate offset)
 		(insn & 0x3a400000) == 0x28000000 ||  // STP <Wt1>, <Wt2>, [<Xn>, #<imm>] (store pair of registers with immediate offset)
-		(insn & 0xad000000) == 0xad000000 ||  // STP <Vd1>, <Vd2>, [<Xn>, #<imm>] (store SIMD/FP 128-bit register pair with immediate offset)
-		(insn & 0xad000000) == 0xad000000;    // STP <Dd1>, <Dd2>, [<Xn>, #<imm>] (store SIMD/FP 64-bit register pair with immediate offset)
+		(insn & 0xbf000000) == 0xad000000 ||  // STP <Vd1>, <Vd2>, [<Xn>, #<imm>] (store SIMD/FP 128-bit register pair with immediate offset)
+		(insn & 0xbf000000) == 0x6d000000;    // STP <Dd1>, <Dd2>, [<Xn>, #<imm>] (store SIMD/FP 64-bit register pair with immediate offset)
+#endif
 
 #else
 #error "signal_handler not implemented"

--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -393,6 +393,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
     target_sources(rpcs3_emu PRIVATE
         CPU/Backends/AArch64/AArch64ASM.cpp
         CPU/Backends/AArch64/AArch64JIT.cpp
+        CPU/Backends/AArch64/AArch64Signal.cpp
     )
 endif()
 

--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64Signal.cpp
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64Signal.cpp
@@ -29,7 +29,7 @@ namespace aarch64
 
         while ((offset + 4) < sizeof(mctx.__reserved))
         {
-            auto head = reinterpret_cast<const aarch64_cpu_ctx_block*>(&mctx.__reserved[offset]);
+            const auto head = reinterpret_cast<const aarch64_cpu_ctx_block*>(&mctx.__reserved[offset]);
             if (!head->magic)
             {
                 // End of linked list
@@ -50,7 +50,8 @@ namespace aarch64
     fault_reason decode_fault_reason(const ucontext_t* uctx)
     {
         auto esr_ctx = find_EL1_esr_context(uctx);
-        if (!esr_ctx) {
+        if (!esr_ctx)
+        {
             return fault_reason::undefined;
         }
 

--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64Signal.cpp
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64Signal.cpp
@@ -1,0 +1,83 @@
+#include <stdafx.h>
+#include "AArch64Signal.h"
+
+namespace aarch64
+{
+    constexpr u32 ESR_CTX_MAGIC = 0x45535201;
+
+    // Some of the EC codes we care about
+    enum class EL1_exception_class
+    {
+        undefined = 0,
+
+        instr_abort_0 = 32,     // PAGE_FAULT - Execute, change in EL
+        instr_abort_1 = 33,     // PAGE_FAULT - Execute, same EL
+        data_abort_0 = 36,      // PAGE_FAULT - Generic, causing change in EL (e.g kernel sig handler back to EL0)
+        data_abort_1 = 37,      // PAGE_FAULT - Generic, no change in EL, e.g EL1 driver fault
+
+        illegal_execution = 14, // BUS_ERROR
+        unaligned_pc = 34,      // BUS_ERROR
+        unaligned_sp = 38,      // BUS_ERROR
+
+        breakpoint = 60,        // BRK
+    };
+
+    const aarch64_esr_ctx* find_EL1_esr_context(const ucontext_t* ctx)
+    {
+        u32 offset = 0;
+        const auto& mctx = ctx->uc_mcontext;
+
+        while ((offset + 4) < sizeof(mctx.__reserved))
+        {
+            auto head = reinterpret_cast<const aarch64_cpu_ctx_block*>(&mctx.__reserved[offset]);
+            if (!head->magic)
+            {
+                // End of linked list
+                return nullptr;
+            }
+
+            if (head->magic == ESR_CTX_MAGIC)
+            {
+                return reinterpret_cast<const aarch64_esr_ctx*>(head);
+            }
+
+            offset += head->size;
+        }
+
+        return nullptr;
+    }
+
+    fault_reason decode_fault_reason(const ucontext_t* uctx)
+    {
+        auto esr_ctx = find_EL1_esr_context(uctx);
+        if (!esr_ctx) {
+            return fault_reason::undefined;
+        }
+
+        // We don't really care about most of the register fields, but we can check for a few things.
+        const auto exception_class = (esr_ctx->esr >> 26) & 0b111111;
+        switch (static_cast<EL1_exception_class>(exception_class))
+        {
+        case EL1_exception_class::breakpoint:
+            // Debug break
+            return fault_reason::breakpoint;
+        case EL1_exception_class::illegal_execution:
+        case EL1_exception_class::unaligned_pc:
+        case EL1_exception_class::unaligned_sp:
+            return fault_reason::illegal_instruction;
+        case EL1_exception_class::instr_abort_0:
+        case EL1_exception_class::instr_abort_1:
+            return fault_reason::instruction_execute;
+        case EL1_exception_class::data_abort_0:
+        case EL1_exception_class::data_abort_1:
+            // Page fault
+            break;
+        default:
+            return fault_reason::undefined;
+        }
+
+        // Check direction bit
+        const auto direction = (esr_ctx->esr >> 6u) & 1u;
+        return direction ? fault_reason::data_write : fault_reason::data_read;
+    }
+}

--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64Signal.h
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64Signal.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <util/types.hpp>
+#include <sys/ucontext.h>
+
+namespace aarch64
+{
+    // Some renamed kernel definitions, we don't need to include kernel headers directly
+#pragma pack(push, 1)
+
+    struct aarch64_cpu_ctx_block
+    {
+        u32 magic;
+        u32 size;
+    };
+
+    struct aarch64_esr_ctx
+    {
+        aarch64_cpu_ctx_block head;
+        u64 esr;      // Exception syndrome register
+    };
+
+#pragma pack(pop)
+
+    // Fault reason
+    enum class fault_reason
+    {
+        undefined = 0,
+        data_read,
+        data_write,
+        instruction_execute,
+        illegal_instruction,
+        breakpoint
+    };
+
+    fault_reason decode_fault_reason(const ucontext_t* uctx);
+}


### PR DESCRIPTION
Decode fault details from parsing the machine context instead of trying to maintain a list of known instructions. Unlike x86, arm instructions are a jumbled mess without simple byte patterns.
The decoder is reversed from linux kernel sources, so I have only enabled it for linux.