### PR TITLE
Debugger: Pointer comparison bugfix

### DIFF
--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -21,7 +21,8 @@ protected:
 	cpu_disasm_mode m_mode{};
 	const u8* m_offset{};
 	const u32 m_start_pc;
-	const std::add_pointer_t<const cpu_thread> m_cpu{};
+	std::add_pointer_t<const cpu_thread> m_cpu{};
+	std::shared_ptr<cpu_thread> m_cpu_handle;
 	u32 m_op = 0;
 
 	void format_by_mode()
@@ -73,6 +74,25 @@ public:
 	const u8* change_ptr(const u8* ptr)
 	{
 		return std::exchange(m_offset, ptr);
+	}
+
+	cpu_thread* get_cpu() const
+	{
+		return const_cast<cpu_thread*>(m_cpu);
+	}
+
+	void set_cpu_handle(std::shared_ptr<cpu_thread> cpu)
+	{
+		m_cpu_handle = std::move(cpu);
+
+		if (!m_cpu)
+		{
+			m_cpu = m_cpu_handle.get();
+		}
+		else
+		{
+			AUDIT(m_cpu == m_cpu_handle.get());
+		}
 	}
 
 protected:

--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -1219,7 +1219,7 @@ cpu_thread* cpu_thread::get_next_cpu()
 	return nullptr;
 }
 
-std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu);
+std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu, std::shared_ptr<cpu_thread> handle);
 
 void cpu_thread::dump_all(std::string& ret) const
 {
@@ -1235,7 +1235,7 @@ void cpu_thread::dump_all(std::string& ret) const
 	if (u32 cur_pc = get_pc(); cur_pc != umax)
 	{
 		// Dump a snippet of currently executed code (may be unreliable with non-static-interpreter decoders)
-		auto disasm = make_disasm(this);
+		auto disasm = make_disasm(this, nullptr);
 
 		const auto rsx = try_get<rsx::thread>();
 

--- a/rpcs3/rpcs3qt/breakpoint_list.h
+++ b/rpcs3/rpcs3qt/breakpoint_list.h
@@ -14,7 +14,7 @@ class breakpoint_list : public QListWidget
 
 public:
 	breakpoint_list(QWidget* parent, breakpoint_handler* handler);
-	void UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm);
+	void UpdateCPUData(std::shared_ptr<CPUDisAsm> disasm);
 	void ClearBreakpoints();
 	bool AddBreakpoint(u32 pc);
 	void RemoveBreakpoint(u32 addr);
@@ -33,6 +33,5 @@ private:
 	breakpoint_handler* m_ppu_breakpoint_handler;
 	QMenu* m_context_menu = nullptr;
 	QAction* m_delete_action;
-	cpu_thread* m_cpu = nullptr;
-	CPUDisAsm* m_disasm = nullptr;
+	std::shared_ptr<CPUDisAsm> m_disasm = nullptr;
 };

--- a/rpcs3/rpcs3qt/debugger_list.h
+++ b/rpcs3/rpcs3qt/debugger_list.h
@@ -33,7 +33,7 @@ Q_SIGNALS:
 	void BreakpointRequested(u32 loc, bool only_add = false);
 public:
 	debugger_list(QWidget* parent, std::shared_ptr<gui_settings> settings, breakpoint_handler* handler);
-	void UpdateCPUData(cpu_thread* cpu, CPUDisAsm* disasm);
+	void UpdateCPUData(std::shared_ptr<CPUDisAsm> disasm);
 	void EnableThreadFollowing(bool enable = true);
 public Q_SLOTS:
 	void ShowAddress(u32 addr, bool select_addr = true, bool direct = false);
@@ -58,7 +58,7 @@ private:
 
 	breakpoint_handler* m_ppu_breakpoint_handler;
 	cpu_thread* m_cpu = nullptr;
-	CPUDisAsm* m_disasm = nullptr;
+	std::shared_ptr<CPUDisAsm> m_disasm;
 	QDialog* m_cmd_detail = nullptr;
 	QLabel* m_detail_label = nullptr;
 };


### PR DESCRIPTION
Avoid using free-after-use pointers, even for simple stuff as comparison.