### PR TITLE
config: Set minimum allowed resolution scale to 25%

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -3824,8 +3824,8 @@ public:
 				m_ir->CreateStore(stat_val, stat_ptr);
 				m_ir->CreateBr(next);
 				m_ir->SetInsertPoint(next);
-				return;
 			}
+			return;
 		}
 		case MFC_LSA:
 		{

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -166,7 +166,7 @@ struct cfg_root : cfg::node
 		cfg::_bool precise_zpass_count{ this, "Accurate ZCULL stats", true };
 		cfg::_int<1, 8> consecutive_frames_to_draw{ this, "Consecutive Frames To Draw", 1, true};
 		cfg::_int<1, 8> consecutive_frames_to_skip{ this, "Consecutive Frames To Skip", 1, true};
-		cfg::_int<50, 800> resolution_scale_percent{ this, "Resolution Scale", 100 };
+		cfg::_int<25, 800> resolution_scale_percent{ this, "Resolution Scale", 100 };
 		cfg::uint<0, 16> anisotropic_level_override{ this, "Anisotropic Filter Override", 0, true };
 		cfg::_float<-32, 32> texture_lod_bias{ this, "Texture LOD Bias Addend", 0, true };
 		cfg::_int<1, 1024> min_scalable_dimension{ this, "Minimum Scalable Dimension", 16 };

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -624,7 +624,7 @@
                     <item>
                      <widget class="QLabel" name="resolutionScaleMin">
                       <property name="text">
-                       <string>50</string>
+                       <string>25</string>
                       </property>
                       <property name="alignment">
                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>


### PR DESCRIPTION
- config: Set minimum allowed resolution scale to 25%
  - Allows rendering at PSP resolution with 38%, required for aarch64 devices with extremely weak GPUs
- spu: Workaround GCC 14.1 compiler bug
  - Stumbled upon this issue with gcc 14.1.1+r1+g43b730b9134-1 on aarch64, failing compilation due to implicit fallthrough warnings being treated as errors