### PR TITLE
vk: Support v3dv, allow creating device without textureCompressionBC

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKCompute.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCompute.cpp
@@ -77,6 +77,7 @@ namespace vk
 				optimal_group_size = 128;
 				break;
 			case vk::driver_vendor::LAVAPIPE:
+			case vk::driver_vendor::V3DV:
 				// TODO: Actually bench this. Using 32 for now to match other common configurations.
 			case vk::driver_vendor::DOZEN:
 				// Actual optimal size depends on the D3D device. Use 32 since it should work well on both AMD and NVIDIA

--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -124,6 +124,9 @@ namespace vk
 		case driver_vendor::LAVAPIPE:
 			// This software device works well, with poor performance as the only downside
 			break;
+		case driver_vendor::V3DV:
+			// Broadcom GPUs need more testing, driver currently largely unstable
+			break;
 		case driver_vendor::DOZEN:
 			// This driver is often picked by mistake when the user meant to select something else. Complain loudly.
 #ifdef _WIN32

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -188,6 +188,7 @@ namespace vk
 			case driver_vendor::MVK:
 			case driver_vendor::DOZEN:
 			case driver_vendor::LAVAPIPE:
+			case driver_vendor::V3DV:
 				break;
 			}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/chip_class.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/chip_class.h
@@ -50,7 +50,8 @@ namespace vk
 		MVK,
 		DOZEN,
 		LAVAPIPE,
-		NVK
+		NVK,
+		V3DV
 	};
 
 	driver_vendor get_driver_vendor();

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -606,6 +606,13 @@ namespace vk
 			enabled_features.logicOp = VK_FALSE;
 		}
 
+		if (!pgpu->features.textureCompressionBC)
+		{
+			// v3dv supports BC1-BC3 which is all we require, support is reported as false since not all formats are supported
+			rsx_log.error("Your GPU does not support full texture block compression. Graphics may not render correctly.");
+			enabled_features.textureCompressionBC = VK_FALSE;
+		}
+
 		VkDeviceCreateInfo device = {};
 		device.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 		device.pNext = nullptr;

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -613,10 +613,10 @@ namespace vk
 			enabled_features.logicOp = VK_FALSE;
 		}
 
-		if (!pgpu->features.textureCompressionBC)
+		if (!pgpu->features.textureCompressionBC && get_driver_vendor() == driver_vendor::V3DV)
 		{
 			// v3dv supports BC1-BC3 which is all we require, support is reported as false since not all formats are supported
-			rsx_log.error("Your GPU does not support full texture block compression. Graphics may not render correctly.");
+			rsx_log.error("Your GPU running on the V3DV driver does not support full texture block compression. Graphics may not render correctly.");
 			enabled_features.textureCompressionBC = VK_FALSE;
 		}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -265,6 +265,11 @@ namespace vk
 				return driver_vendor::LAVAPIPE;
 			}
 
+			if (gpu_name.find("V3D") != umax)
+			{
+				return driver_vendor::V3DV;
+			}
+
 			return driver_vendor::unknown;
 		}
 		else
@@ -288,6 +293,8 @@ namespace vk
 				return driver_vendor::LAVAPIPE;
 			case VK_DRIVER_ID_MESA_NVK:
 				return driver_vendor::NVK;
+			case VK_DRIVER_ID_MESA_V3DV:
+				return driver_vendor::V3DV;
 			default:
 				// Mobile?
 				return driver_vendor::unknown;


### PR DESCRIPTION
v3dv supports BC1-BC3 which is all we require, support is reported as  false since not all formats are supported

Fixes #15969