### PR TITLE
MacOS - Implement remaining portions for native ARM64

### DIFF
--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -517,7 +517,7 @@ std::string jit_compiler::triple1()
 #elif defined(__APPLE__) && defined(ARCH_X64)
 	return llvm::Triple::normalize("x86_64-unknown-linux-gnu");
 #elif defined(__APPLE__) && defined(ARCH_ARM64)
-	return llvm::Triple::normalize("aarch64-unknown-linux-gnu");
+	return llvm::Triple::normalize("aarch64-unknown-linux-android"); // Set environment to android to reserve x18
 #else
 	return llvm::Triple::normalize(llvm::sys::getProcessTriple());
 #endif
@@ -532,7 +532,7 @@ std::string jit_compiler::triple2()
 #elif defined(__APPLE__) && defined(ARCH_X64)
 	return llvm::Triple::normalize("x86_64-unknown-linux-gnu");
 #elif defined(__APPLE__) && defined(ARCH_ARM64)
-	return llvm::Triple::normalize("aarch64-unknown-linux-gnu");
+	return llvm::Triple::normalize("aarch64-unknown-linux-android"); // Set environment to android to reserve x18
 #else
 	return llvm::Triple::normalize(llvm::sys::getProcessTriple());
 #endif


### PR DESCRIPTION
1. CPU topology, brand names, etc are available from sysctl. I couldn't find much info if these variables have codes we can use with sysconf command so I just used a shell to get it. Works well enough on my system where the CPU brand and number of P and E cores is correctly detected.
2. Change JIT environment to linux-android instead of linux-gnu. MacOS and android reserve use of the x18 register and it should not be used in emitted JIT.
3. Fix a rare crash when compiling a large number of SPU blocks without overcommit being available.

With these changes, LLVM is now usable on the M-series apple chips natively without going through rosetta. Same caveats as linux apply - not all games will work right now, but most of them should be fine, including AAA titles.