### PR TITLE
SPU: Remove condition from GETLLAR spin detection

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -819,7 +819,7 @@ public:
 	u32 current_bp_pc = umax;
 	bool stop_flag_removal_protection = false;
 
-	std::array<std::array<u8, 4>, SPU_LS_SIZE / 32> getllar_wait_time{};
+	std::array<std::array<u8, 4>, SPU_LS_SIZE / 128> getllar_wait_time{};
  
 	void push_snr(u32 number, u32 value);
 	static void do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8* ls);


### PR DESCRIPTION
Seems to reduce reservation CPU time in Dark Souls from 96% to 46%. (beware that resrvation CPU time is not an accurate measure and more testing needs to be done)