### PR TITLE
Qt: sync gui settings by default after setting or removing values

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -248,7 +248,6 @@ bool debugger_frame::eventFilter(QObject* object, QEvent* event)
 void debugger_frame::closeEvent(QCloseEvent* event)
 {
 	SaveSettings();
-	m_gui_settings->sync();
 
 	QDockWidget::closeEvent(event);
 	Q_EMIT DebugFrameClosed();

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -637,9 +637,8 @@ void gs_frame::hide_on_close()
 {
 	// Make sure not to save the hidden state, which is useless to us.
 	const Visibility current_visibility = visibility();
-	m_gui_settings->SetValue(gui::gs_visibility, current_visibility == Visibility::Hidden ? Visibility::AutomaticVisibility : current_visibility);
-	m_gui_settings->SetValue(gui::gs_geometry, geometry());
-	m_gui_settings->sync();
+	m_gui_settings->SetValue(gui::gs_visibility, current_visibility == Visibility::Hidden ? Visibility::AutomaticVisibility : current_visibility, false);
+	m_gui_settings->SetValue(gui::gs_geometry, geometry(), true);
 
 	if (!g_progr.load())
 	{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -166,8 +166,6 @@ bool gui_application::Init()
 		{
 			m_gui_settings->SetValue(gui::m_currentStylesheet, "Darker Style by TheMitoSan");
 		}
-
-		m_gui_settings->sync();
 	}
 
 	// Check maxfiles
@@ -819,7 +817,7 @@ void gui_application::StartPlaytime(bool start_playtime = true)
 		return;
 	}
 
-	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format));
+	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format), true);
 	m_timer_playtime.start();
 	m_timer.start(10000); // Update every 10 seconds in case the emulation crashes
 }
@@ -840,8 +838,8 @@ void gui_application::UpdatePlaytime()
 		return;
 	}
 
-	m_persistent_settings->AddPlaytime(serial, m_timer_playtime.restart());
-	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format));
+	m_persistent_settings->AddPlaytime(serial, m_timer_playtime.restart(), false);
+	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format), true);
 }
 
 void gui_application::StopPlaytime()
@@ -858,8 +856,8 @@ void gui_application::StopPlaytime()
 		return;
 	}
 
-	m_persistent_settings->AddPlaytime(serial, m_timer_playtime.restart());
-	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format));
+	m_persistent_settings->AddPlaytime(serial, m_timer_playtime.restart(), false);
+	m_persistent_settings->SetLastPlayed(serial, QDateTime::currentDateTime().toString(gui::persistent::last_played_date_format), true);
 	m_timer_playtime.invalidate();
 }
 

--- a/rpcs3/rpcs3qt/log_frame.cpp
+++ b/rpcs3/rpcs3qt/log_frame.cpp
@@ -273,10 +273,10 @@ void log_frame::CreateAndConnectActions()
 	m_ansi_act_tty = new QAction(tr("ANSI Code (TTY)"), this);
 	m_ansi_act_tty->setCheckable(true);
 	connect(m_ansi_act_tty, &QAction::toggled, [this](bool checked)
-		{
-			m_gui_settings->SetValue(gui::l_ansi_code, checked);
-			m_ansi_tty = checked;
-		});
+	{
+		m_gui_settings->SetValue(gui::l_ansi_code, checked);
+		m_ansi_tty = checked;
+	});
 
 	m_tty_channel_acts = new QActionGroup(this);
 	// Special Channel: All

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1731,16 +1731,14 @@ void main_window::DecryptSPRXLibraries()
 void main_window::SaveWindowState() const
 {
 	// Save gui settings
-	m_gui_settings->SetValue(gui::mw_geometry, saveGeometry());
-	m_gui_settings->SetValue(gui::mw_windowState, saveState());
-	m_gui_settings->SetValue(gui::mw_mwState, m_mw->saveState());
+	m_gui_settings->SetValue(gui::mw_geometry, saveGeometry(), false);
+	m_gui_settings->SetValue(gui::mw_windowState, saveState(), false);
+	m_gui_settings->SetValue(gui::mw_mwState, m_mw->saveState(), true);
 
 	// Save column settings
 	m_game_list_frame->SaveSettings();
 	// Save splitter state
 	m_debugger_frame->SaveSettings();
-
-	m_gui_settings->sync();
 }
 
 void main_window::RepaintThumbnailIcons()

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -233,7 +233,6 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 void pad_settings_dialog::closeEvent(QCloseEvent* event)
 {
 	m_gui_settings->SetValue(gui::pads_geometry, saveGeometry());
-	m_gui_settings->sync();
 
 	QDialog::closeEvent(event);
 }

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -154,9 +154,8 @@ patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_set
 void patch_manager_dialog::closeEvent(QCloseEvent* event)
 {
 	// Save gui settings
-	m_gui_settings->SetValue(gui::pm_geometry, saveGeometry());
-	m_gui_settings->SetValue(gui::pm_splitter_state, ui->splitter->saveState());
-	m_gui_settings->sync();
+	m_gui_settings->SetValue(gui::pm_geometry, saveGeometry(), false);
+	m_gui_settings->SetValue(gui::pm_splitter_state, ui->splitter->saveState(), true);
 
 	QDialog::closeEvent(event);
 }

--- a/rpcs3/rpcs3qt/persistent_settings.cpp
+++ b/rpcs3/rpcs3qt/persistent_settings.cpp
@@ -11,16 +11,16 @@ persistent_settings::persistent_settings(QObject* parent) : settings(parent)
 	m_settings.reset(new QSettings(ComputeSettingsDir() + gui::persistent::persistent_file_name + ".dat", QSettings::Format::IniFormat, parent));
 }
 
-void persistent_settings::SetPlaytime(const QString& serial, quint64 playtime)
+void persistent_settings::SetPlaytime(const QString& serial, quint64 playtime, bool sync)
 {
 	m_playtime[serial] = playtime;
-	SetValue(gui::persistent::playtime, serial, playtime);
+	SetValue(gui::persistent::playtime, serial, playtime, sync);
 }
 
-void persistent_settings::AddPlaytime(const QString& serial, quint64 elapsed)
+void persistent_settings::AddPlaytime(const QString& serial, quint64 elapsed, bool sync)
 {
 	const quint64 playtime = GetValue(gui::persistent::playtime, serial, 0).toULongLong();
-	SetPlaytime(serial, playtime + elapsed);
+	SetPlaytime(serial, playtime + elapsed, sync);
 }
 
 quint64 persistent_settings::GetPlaytime(const QString& serial)
@@ -28,10 +28,10 @@ quint64 persistent_settings::GetPlaytime(const QString& serial)
 	return m_playtime[serial];
 }
 
-void persistent_settings::SetLastPlayed(const QString& serial, const QString& date)
+void persistent_settings::SetLastPlayed(const QString& serial, const QString& date, bool sync)
 {
 	m_last_played[serial] = date;
-	SetValue(gui::persistent::last_played, serial, date);
+	SetValue(gui::persistent::last_played, serial, date, sync);
 }
 
 QString persistent_settings::GetLastPlayed(const QString& serial)

--- a/rpcs3/rpcs3qt/persistent_settings.h
+++ b/rpcs3/rpcs3qt/persistent_settings.h
@@ -38,11 +38,11 @@ public:
 	QString GetCurrentUser(const QString& fallback) const;
 
 public Q_SLOTS:
-	void SetPlaytime(const QString& serial, quint64 playtime);
-	void AddPlaytime(const QString& serial, quint64 elapsed);
+	void SetPlaytime(const QString& serial, quint64 playtime, bool sync);
+	void AddPlaytime(const QString& serial, quint64 elapsed, bool sync);
 	quint64 GetPlaytime(const QString& serial);
 
-	void SetLastPlayed(const QString& serial, const QString& date);
+	void SetLastPlayed(const QString& serial, const QString& date, bool sync);
 	QString GetLastPlayed(const QString& serial);
 private:
 	QMap<QString, quint64> m_playtime;

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -265,9 +265,8 @@ void rsx_debugger::closeEvent(QCloseEvent* event)
 	for (int i = 0; i < m_tw_rsx->count(); i++)
 		states[QString::number(i)] = (static_cast<QTableWidget*>(m_tw_rsx->widget(i)))->horizontalHeader()->saveState();
 
-	m_gui_settings->SetValue(gui::rsx_states, states);
-	m_gui_settings->SetValue(gui::rsx_geometry, saveGeometry());
-	m_gui_settings->sync();
+	m_gui_settings->SetValue(gui::rsx_states, states, false);
+	m_gui_settings->SetValue(gui::rsx_geometry, saveGeometry(), true);
 
 	QDialog::closeEvent(event);
 }

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -585,13 +585,12 @@ void save_manager_dialog::SetIconSize(int size)
 {
 	m_icon_size = QSize(size, size * 176 / 320);
 	UpdateIcons();
-	m_gui_settings->SetValue(gui::sd_icon_size, size);
+	m_gui_settings->SetValue(gui::sd_icon_size, size, false); // Don't sync while sliding
 }
 
 void save_manager_dialog::closeEvent(QCloseEvent *event)
 {
 	m_gui_settings->SetValue(gui::sd_geometry, saveGeometry());
-	m_gui_settings->sync();
 
 	QDialog::closeEvent(event);
 }

--- a/rpcs3/rpcs3qt/settings.cpp
+++ b/rpcs3/rpcs3qt/settings.cpp
@@ -32,19 +32,24 @@ QString settings::ComputeSettingsDir()
 	return QString::fromStdString(fs::get_config_dir()) + "/GuiConfigs/";
 }
 
-void settings::RemoveValue(const QString& key, const QString& name) const
+void settings::RemoveValue(const QString& key, const QString& name, bool sync) const
 {
 	if (m_settings)
 	{
 		m_settings->beginGroup(key);
 		m_settings->remove(name);
 		m_settings->endGroup();
+
+		if (sync)
+		{
+			m_settings->sync();
+		}
 	}
 }
 
-void settings::RemoveValue(const gui_save& entry) const
+void settings::RemoveValue(const gui_save& entry, bool sync) const
 {
-	RemoveValue(entry.key, entry.name);
+	RemoveValue(entry.key, entry.name, sync);
 }
 
 QVariant settings::GetValue(const QString& key, const QString& name, const QVariant& def) const
@@ -74,30 +79,35 @@ q_pair_list settings::Var2List(const QVariant& var)
 	return list;
 }
 
-void settings::SetValue(const gui_save& entry, const QVariant& value) const
+void settings::SetValue(const gui_save& entry, const QVariant& value, bool sync) const
 {
-	if (m_settings)
-	{
-		m_settings->beginGroup(entry.key);
-		m_settings->setValue(entry.name, value);
-		m_settings->endGroup();
-	}
+	SetValue(entry.key, entry.name, value, sync);
 }
 
-void settings::SetValue(const QString& key, const QVariant& value) const
+void settings::SetValue(const QString& key, const QVariant& value, bool sync) const
 {
 	if (m_settings)
 	{
 		m_settings->setValue(key, value);
+
+		if (sync)
+		{
+			m_settings->sync();
+		}
 	}
 }
 
-void settings::SetValue(const QString& key, const QString& name, const QVariant& value) const
+void settings::SetValue(const QString& key, const QString& name, const QVariant& value, bool sync) const
 {
 	if (m_settings)
 	{
 		m_settings->beginGroup(key);
 		m_settings->setValue(name, value);
 		m_settings->endGroup();
+
+		if (sync)
+		{
+			m_settings->sync();
+		}
 	}
 }

--- a/rpcs3/rpcs3qt/settings.h
+++ b/rpcs3/rpcs3qt/settings.h
@@ -40,13 +40,13 @@ public:
 
 public Q_SLOTS:
 	/** Remove entry */
-	void RemoveValue(const QString& key, const QString& name) const;
-	void RemoveValue(const gui_save& entry) const;
+	void RemoveValue(const QString& key, const QString& name, bool sync = true) const;
+	void RemoveValue(const gui_save& entry, bool sync = true) const;
 
 	/** Write value to entry */
-	void SetValue(const gui_save& entry, const QVariant& value) const;
-	void SetValue(const QString& key, const QVariant& value) const;
-	void SetValue(const QString& key, const QString& name, const QVariant& value) const;
+	void SetValue(const gui_save& entry, const QVariant& value, bool sync = true) const;
+	void SetValue(const QString& key, const QVariant& value, bool sync = true) const;
+	void SetValue(const QString& key, const QString& name, const QVariant& value, bool sync = true) const;
 
 protected:
 	static QString ComputeSettingsDir();

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -200,8 +200,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		Q_EMIT EmuSettingsApplied();
 
 		// Discord Settings can be saved regardless of WITH_DISCORD_RPC
-		m_gui_settings->SetValue(gui::m_richPresence, m_use_discord);
-		m_gui_settings->SetValue(gui::m_discordState, m_discord_state);
+		m_gui_settings->SetValue(gui::m_richPresence, m_use_discord, false);
+		m_gui_settings->SetValue(gui::m_discordState, m_discord_state, true);
 
 #ifdef WITH_DISCORD_RPC
 		if (m_use_discord != use_discord_old)
@@ -2471,7 +2471,6 @@ void settings_dialog::refresh_countrybox()
 void settings_dialog::closeEvent([[maybe_unused]] QCloseEvent* event)
 {
 	m_gui_settings->SetValue(gui::cfg_geometry, saveGeometry());
-	m_gui_settings->sync();
 }
 
 settings_dialog::~settings_dialog()

--- a/rpcs3/rpcs3qt/shortcut_dialog.cpp
+++ b/rpcs3/rpcs3qt/shortcut_dialog.cpp
@@ -91,8 +91,9 @@ void shortcut_dialog::save()
 
 	for (const auto& entry : m_values)
 	{
-		m_gui_settings->SetValue(sc_settings.get_shortcut_gui_save(entry.first), entry.second);
+		m_gui_settings->SetValue(sc_settings.get_shortcut_gui_save(entry.first), entry.second, false);
 	}
+	m_gui_settings->sync();
 
 	Q_EMIT saved();
 }

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -1300,11 +1300,10 @@ bool trophy_manager_dialog::eventFilter(QObject *object, QEvent *event)
 void trophy_manager_dialog::closeEvent(QCloseEvent *event)
 {
 	// Save gui settings
-	m_gui_settings->SetValue(gui::tr_geometry, saveGeometry());
-	m_gui_settings->SetValue(gui::tr_splitterState, m_splitter->saveState());
-	m_gui_settings->SetValue(gui::tr_games_state,  m_game_table->horizontalHeader()->saveState());
-	m_gui_settings->SetValue(gui::tr_trophy_state, m_trophy_table->horizontalHeader()->saveState());
-	m_gui_settings->sync();
+	m_gui_settings->SetValue(gui::tr_geometry, saveGeometry(), false);
+	m_gui_settings->SetValue(gui::tr_splitterState, m_splitter->saveState(), false);
+	m_gui_settings->SetValue(gui::tr_games_state,  m_game_table->horizontalHeader()->saveState(), false);
+	m_gui_settings->SetValue(gui::tr_trophy_state, m_trophy_table->horizontalHeader()->saveState(), true);
 
 	QWidget::closeEvent(event);
 }


### PR DESCRIPTION
Maybe reduces some strange UI errors that may happen when a game crashes.