### PR TITLE
Include udev/devd rules in Linux/FreeBSD packages using `make install`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ option(USE_LTO "Use LTO for building" ON)
 option(BUILD_RPCS3_TESTS "Build RPCS3 unit tests." OFF)
 option(RUN_RPCS3_TESTS "Run RPCS3 unit tests. Requires BUILD_RPCS3_TESTS" OFF)
 option(USE_GAMEMODE "Choose whether to enable GameMode features or not." ON)
+option(BUNDLE_UDEV_RULES "Include udev rules on Linux/FreeBSD" OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/buildfiles/cmake")
 

--- a/config/udev/devd.conf
+++ b/config/udev/devd.conf
@@ -1,0 +1,49 @@
+# DualShock 3
+notify 100 {
+        match "system"          "USB";
+        match "subsystem"       "INTERFACE";
+        match "type"            "ATTACH";
+        match "vendor" "0x054c";
+        match "product" "0x0268";
+        action "chmod 0666 /dev/$cdev";
+};
+
+# DualShock 4
+notify 100 {
+        match "system"          "USB";
+        match "subsystem"       "INTERFACE";
+        match "type"            "ATTACH";
+        match "vendor" "0x054c";
+        match "product" "0x05c4";
+        action "chmod 0666 /dev/$cdev";
+};
+
+# DualShock 4 Wireless Adapter
+notify 100 {
+        match "system"          "USB";
+        match "subsystem"       "INTERFACE";
+        match "type"            "ATTACH";
+        match "vendor" "0x054c";
+        match "product" "0x0ba0";
+        action "chmod 0666 /dev/$cdev";
+};
+
+# DualShock 4 Slim
+notify 100 {
+        match "system"          "USB";
+        match "subsystem"       "INTERFACE";
+        match "type"            "ATTACH";
+        match "vendor" "0x054c";
+        match "product" "0x09cc";
+        action "chmod 0666 /dev/$cdev";
+};
+
+# DualSense
+notify 100 {
+        match "system"          "USB";
+        match "subsystem"       "INTERFACE";
+        match "type"            "ATTACH";
+        match "vendor" "0x054c";
+        match "product" "0x0ce6";
+        action "chmod 0666 /dev/$cdev";
+};

--- a/config/udev/udev.rules
+++ b/config/udev/udev.rules
@@ -1,0 +1,26 @@
+# DualShock 3 over USB
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0268", MODE="0666"
+
+# DualShock 3 over Bluetooth
+KERNEL=="hidraw*", KERNELS=="*054C:0268*", MODE="0666"
+
+# DualShock 4 over USB
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="05c4", MODE="0666"
+
+# DualShock 4 Wireless Adapter over USB
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0ba0", MODE="0666"
+
+# DualShock 4 Slim over USB
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="09cc", MODE="0666"
+
+# DualShock 4 over Bluetooth
+KERNEL=="hidraw*", KERNELS=="*054C:05C4*", MODE="0666"
+
+# DualShock 4 Slim over Bluetooth
+KERNEL=="hidraw*", KERNELS=="*054C:09CC*", MODE="0666"
+
+# PS5 DualSense controller over USB hidraw
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0ce6", MODE="0666", TAG+="uaccess"
+
+# PS5 DualSense controller over bluetooth hidraw
+KERNEL=="hidraw*", KERNELS=="*054C:0CE6*", MODE="0666", TAG+="uaccess"

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -226,3 +226,14 @@ if(BUILD_RPCS3_TESTS)
      )
     endif()
 endif()
+
+# Udev rules, per platform
+if (BUNDLE_UDEV_RULES)
+    if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+        install(FILES ../config/udev/udev.rules
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d/ RENAME 99-rpcs3.rules)
+    elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+        install(FILES ../config/udev/devd.conf
+            DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/devd/ RENAME rpcs3.conf)
+    endif()
+endif()


### PR DESCRIPTION
This bundle the udev / devd config files described in the [rpcs3 wiki](https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration) as part of the rpcs3 install on Linux and FreeBSD.
Packagers using `make install` will end up with the udev rules in '<prefix>/lib/udev/rules.d', which will cause (on most Linux distributions, which include install hooks for reloading new rules in `/usr/lib/udev/rules.d`) a reload of the udev rules on rpcs3 install.

The idea is to have out of the box support rather than needing manual action.

[How to test this PR](.github/PR-BUILD.md)
