### PR TITLE
Vk/Gl/Overlays: Do not blend the alpha channel when rendering overlays

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLOverlays.cpp
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.cpp
@@ -164,7 +164,7 @@ namespace gl
 			if (enable_blending)
 			{
 				cmd->enablei(GL_BLEND, 0);
-				glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+				glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 				glBlendEquation(GL_FUNC_ADD);
 			}
 			else

--- a/rpcs3/Emu/RSX/Program/RSXOverlay.h
+++ b/rpcs3/Emu/RSX/Program/RSXOverlay.h
@@ -7,7 +7,7 @@ namespace rsx
 	namespace overlays
 	{
 		// This is overlay common code meant only for render backends
-		enum class texture_sampling_mode: s32
+		enum class texture_sampling_mode : s32
 		{
 			none = 0,
 			font2D = 1,

--- a/rpcs3/Emu/RSX/VK/VKOverlays.cpp
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.cpp
@@ -336,6 +336,7 @@ namespace vk
 	}
 
 	ui_overlay_renderer::ui_overlay_renderer()
+		: m_texture_type(rsx::overlays::texture_sampling_mode::none)
 	{
 		vs_src =
 		#include "../Program/GLSLSnippets/OverlayRenderVS.glsl"
@@ -365,8 +366,8 @@ namespace vk
 		renderpass_config.set_color_mask(0, true, true, true, true);
 		renderpass_config.set_depth_mask(false);
 		renderpass_config.enable_blend(0,
-			VK_BLEND_FACTOR_SRC_ALPHA, VK_BLEND_FACTOR_SRC_ALPHA,
-			VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+			VK_BLEND_FACTOR_SRC_ALPHA, VK_BLEND_FACTOR_ZERO,
+			VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_FACTOR_ONE,
 			VK_BLEND_OP_ADD, VK_BLEND_OP_ADD);
 	}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/graphics_pipeline_state.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/graphics_pipeline_state.hpp
@@ -132,7 +132,8 @@ namespace vk
 			ds.depthBoundsTestEnable = enable? VK_TRUE : VK_FALSE;
 		}
 
-		void enable_blend(int mrt_index, VkBlendFactor src_factor_rgb, VkBlendFactor src_factor_a,
+		void enable_blend(int mrt_index,
+			VkBlendFactor src_factor_rgb, VkBlendFactor src_factor_a,
 			VkBlendFactor dst_factor_rgb, VkBlendFactor dst_factor_a,
 			VkBlendOp equation_rgb, VkBlendOp equation_a)
 		{


### PR DESCRIPTION
When blending a source pixel with alpha less than 1 onto a texture, we will end up having even less alpha than before.
This can lead to ugly "holes" in the overlays, especially on the edges of glyphs with smooth fonts for example.
We can fix this by only blending the RGB values while keeping the destination's alpha value.
I haven't really seen this happen in RPCS3 (yet), but it's better to be safe than sorry.