### PR TITLE
aarch64: Re-enable GHC return paths to support patches

### DIFF
--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.cpp
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.cpp
@@ -415,7 +415,8 @@ namespace aarch64
         ensure(llvm::isa<llvm::ReturnInst>(where));
         irb->SetInsertPoint(llvm::dyn_cast<llvm::Instruction>(where));
 
-        if (instruction_info.callee_is_GHC &&                      // Calls to C++ ABI will always return
+        if (m_config.trap_GHC_return &&                            // Only apply this trap if config allows
+            instruction_info.callee_is_GHC &&                      // Calls to C++ ABI will always return
             !instruction_info.is_indirect &&                       // We don't know enough when calling indirectly to know if we'll return or not
             instruction_info.callee_name.find("-pp-") == umax)     // Skip branch patch-points as those are just indirect calls. TODO: Move this to instruction decode.
         {

--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.h
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.h
@@ -44,6 +44,7 @@ namespace aarch64
             bool debug_info = false;         // Record debug information
             bool use_stack_frames = true;    // Allocate a stack frame for each function. The gateway can alternatively manage a global stack to use as scratch.
             bool optimize = true;            // Optimize instructions when possible. Set to false when debugging.
+            bool trap_GHC_return = false;    // Debugging option. Will inject traps to catch returning GHC functions. Disabled in production to accomodate patches.
             u32 hypervisor_context_offset = 0; // Offset within the "thread" object where we can find the hypervisor context (registers configured at gateway).
             std::function<bool(const std::string&)> exclusion_callback;    // [Optional] Callback run on each function before transform. Return "true" to exclude from frame processing.
             std::vector<std::pair<std::string, gpr>> base_register_lookup; // [Optional] Function lookup table to determine the location of the "thread" context.

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1486,6 +1486,7 @@ public:
 				{
 					.debug_info = false,         // Set to "true" to insert debug frames on x27
 					.use_stack_frames = false,   // We don't need this since the SPU GW allocates global scratch on the stack
+					.trap_GHC_return = true,     // SPU patches don't support code caves, we can safely trap return paths and benefit from the better codegen
 					.hypervisor_context_offset = ::offset32(&spu_thread::hv_ctx),
 					.exclusion_callback = should_exclude_function,
 					.base_register_lookup = {}   // Unused, always x19 on SPU


### PR DESCRIPTION
We lose JIT verification capabilities but patches with odd construction will run.
One common way of doing complex patches is using a calloc modifier to allocate a code cave. Unfortunately the patch does not end with a return, but a branch back to the start function. This breaks the code analysis since it looks like a normal function and not a leaf function which is what it actually is. Also, since the calling side goes through a thunk which leads to a branch patch-point, we cannot detect these branches accurately in LLVM IR. Just allow the return paths in production, I can re-enable them when debugging.

Closes https://github.com/RPCS3/rpcs3/issues/16014