### PR TITLE
aarch64: Support calloc patch blocks

### DIFF
--- a/Utilities/ppu_patch.h
+++ b/Utilities/ppu_patch.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <util/types.hpp>
+#include <unordered_set>
+#include <vector>
+#include <string>
+
+// Patch utilities specific to PPU code
+struct ppu_patch_block_registry_t
+{
+    ppu_patch_block_registry_t() = default;
+    ppu_patch_block_registry_t(const ppu_patch_block_registry_t&) = delete;
+    ppu_patch_block_registry_t& operator=(const ppu_patch_block_registry_t&) = delete;
+
+    std::unordered_set<u32> block_addresses{};
+};
+
+void ppu_register_range(u32 addr, u32 size);
+bool ppu_form_branch_to_code(u32 entry, u32 target, bool link = false, bool with_toc = false, std::string module_name = {});
+u32 ppu_generate_id(std::string_view name);

--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.h
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.h
@@ -41,12 +41,13 @@ namespace aarch64
 
         struct config_t
         {
-            bool debug_info = false;         // Record debug information
-            bool use_stack_frames = true;    // Allocate a stack frame for each function. The gateway can alternatively manage a global stack to use as scratch.
-            bool optimize = true;            // Optimize instructions when possible. Set to false when debugging.
+            bool debug_info = false;           // Record debug information
+            bool use_stack_frames = true;      // Allocate a stack frame for each function. The gateway can alternatively manage a global stack to use as scratch.
+            bool optimize = true;              // Optimize instructions when possible. Set to false when debugging.
             u32 hypervisor_context_offset = 0; // Offset within the "thread" object where we can find the hypervisor context (registers configured at gateway).
             std::function<bool(const std::string&)> exclusion_callback;    // [Optional] Callback run on each function before transform. Return "true" to exclude from frame processing.
             std::vector<std::pair<std::string, gpr>> base_register_lookup; // [Optional] Function lookup table to determine the location of the "thread" context.
+            std::vector<std::string> faux_function_list;                   // [Optional] List of faux block names to treat as untrusted - typically fake functions representing codecaves.
         };
 
     protected:
@@ -63,6 +64,8 @@ namespace aarch64
         bool is_ret_instruction(const llvm::Instruction* i);
 
         bool is_inlined_call(const llvm::CallInst* ci);
+
+        bool is_faux_function(const std::string& function_name);
 
         gpr get_base_register_for_call(const std::string& callee_name, gpr default_reg = gpr::x19);
 


### PR DESCRIPTION
Closes https://github.com/RPCS3/rpcs3/issues/16014

The calloc setup inserts a call to a function at the address that has the same signature as the source address from the IR POV. The calloced block isn't injected as a regular function though, we go through a thunk so it is equivalent to an indirect branch from a flow pov. Assume we don't actually know enough about the target in that situation and do not trap on return. The callee is responsible for making sure they do not spill anything to our stack, same as indirect branches.