### PR TITLE
cellMic: add 16-bit PCM to 32-bit float conversion for DSP stream

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -263,8 +263,8 @@ inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std:
 	ensure(num_bytes % 2 == 0);
 	ensure(num_bytes < buffer.size());
 
-	std::vector<u8> floatBuffer;
-	floatBuffer.reserve(num_bytes * 2);
+	std::vector<u8> float_buffer;
+	float_buffer.reserve(num_bytes * 2);
 
 	for (size_t i = 0; i < num_bytes; i += 2)
 	{
@@ -281,10 +281,10 @@ inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std:
 		       ((temp & 0xFF000000) >> 24);
 
 		uint8_t* bytes = reinterpret_cast<uint8_t*>(&temp);
-		floatBuffer.insert(floatBuffer.end(), bytes, bytes + sizeof(uint32_t));
+		float_buffer.insert(float_buffer.end(), bytes, bytes + sizeof(uint32_t));
 	}
 
-	return floatBuffer;
+	return float_buffer;
 }
 
 // Public functions

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -258,15 +258,15 @@ inline void microphone_device::variable_byteswap(const void* src, void* dst)
 	}
 }
 
-inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, size_t numBytes)
+inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, size_t num_bytes)
 {
-	ensure(numBytes % 2 == 0);
-	ensure(numBytes < buffer.size());
+	ensure(num_bytes % 2 == 0);
+	ensure(num_bytes < buffer.size());
 
 	std::vector<u8> floatBuffer;
-	floatBuffer.reserve(numBytes * 2);
+	floatBuffer.reserve(num_bytes * 2);
 
-	for (size_t i = 0; i < numBytes; i += 2)
+	for (size_t i = 0; i < num_bytes; i += 2)
 	{
 		s16 sample = static_cast<s16>((buffer[i] << 8) | buffer[i + 1]);
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -266,7 +266,7 @@ inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>&
 	float_buf.resize(float_buf_size, 0);
 	ensure(num_bytes * 2 <= float_buf.size());
 
-	const be_t<s16>* src = reinterpret_cast<const be_t<s16>*>(buffer.data());
+	const be_t<s16>* src = reinterpret_cast<const be_t<s16>*>(static_cast<const void*>(buffer.data()));
 	be_t<f32>* dst = reinterpret_cast<be_t<f32>*>(float_buf.data());
 
 	for (usz i = 0; i < num_bytes / 2; i++)
@@ -278,7 +278,7 @@ inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>&
 		*dst++ = normalized_sample_be;
 	}
 
-	return num_bytes * 2;
+	return static_cast<u32>(num_bytes * 2);
 }
 
 // Public functions

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -270,10 +270,10 @@ inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std:
 	{
 		const s16 sample = static_cast<s16>((buffer[i] << 8) | buffer[i + 1]);
 
-		f32 normalizedSample = static_cast<f32>(sample) / 32768.0f;
-		normalizedSample = std::clamp(normalizedSample, -1.0f, 1.0f);
+		f32 normalized_sample = static_cast<f32>(sample) / std::numeric_limits<s16>::max();
+		normalized_sample = std::clamp(normalized_sample, -1.0f, 1.0f);
 
-		uint32_t temp = *reinterpret_cast<uint32_t*>(&normalizedSample);
+		uint32_t temp = *reinterpret_cast<uint32_t*>(&normalized_sample);
 
 		temp = ((temp & 0x000000FF) << 24) |
 		       ((temp & 0x0000FF00) << 8) |

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -260,16 +260,16 @@ inline void microphone_device::variable_byteswap(const void* src, void* dst)
 
 inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, usz num_bytes)
 {
-	constexpr usz float_buf_size = 2 * inbuf_size;
-	static_assert((float_buf_size % sizeof(u32)) == 0);
+	static_assert((float_buf_size % sizeof(f32)) == 0);
 
 	float_buf.resize(float_buf_size, 0);
-	ensure(num_bytes * 2 <= float_buf.size());
+	const u32 bytes_to_write = static_cast<u32>(num_bytes * (sizeof(f32) / sizeof(s16)));
+	ensure(bytes_to_write <= float_buf.size());
 
 	const be_t<s16>* src = reinterpret_cast<const be_t<s16>*>(static_cast<const void*>(buffer.data()));
 	be_t<f32>* dst = reinterpret_cast<be_t<f32>*>(float_buf.data());
 
-	for (usz i = 0; i < num_bytes / 2; i++)
+	for (usz i = 0; i < num_bytes / sizeof(s16); i++)
 	{
 		const be_t<s16> sample = *src++;
 
@@ -278,7 +278,7 @@ inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>&
 		*dst++ = normalized_sample_be;
 	}
 
-	return static_cast<u32>(num_bytes * 2);
+	return bytes_to_write;
 }
 
 // Public functions

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -268,7 +268,7 @@ inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std:
 
 	for (size_t i = 0; i < num_bytes; i += 2)
 	{
-		s16 sample = static_cast<s16>((buffer[i] << 8) | buffer[i + 1]);
+		const s16 sample = static_cast<s16>((buffer[i] << 8) | buffer[i + 1]);
 
 		f32 normalizedSample = static_cast<f32>(sample) / 32768.0f;
 		normalizedSample = std::clamp(normalizedSample, -1.0f, 1.0f);

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -727,7 +727,7 @@ void microphone_device::get_dsp(const u32 num_samples)
 	}
 	else
 	{
-		// The same as device RAW stream format, except that the data type is always big-endian
+		// The same as device RAW stream format, except that the data byte is always big-endian
 		rbuf_dsp.write_bytes(buf.data(), bufsize);
 	}
 }

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -273,15 +273,15 @@ inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std:
 		f32 normalized_sample = static_cast<f32>(sample) / std::numeric_limits<s16>::max();
 		normalized_sample = std::clamp(normalized_sample, -1.0f, 1.0f);
 
-		uint32_t temp = *reinterpret_cast<uint32_t*>(&normalized_sample);
+		u32 temp = *reinterpret_cast<u32*>(&normalized_sample);
 
 		temp = ((temp & 0x000000FF) << 24) |
 		       ((temp & 0x0000FF00) << 8) |
 		       ((temp & 0x00FF0000) >> 8) |
 		       ((temp & 0xFF000000) >> 24);
 
-		const uint8_t* bytes = reinterpret_cast<uint8_t*>(&temp);
-		float_buffer.insert(float_buffer.end(), bytes, bytes + sizeof(uint32_t));
+		const u8* bytes = reinterpret_cast<u8*>(&temp);
+		float_buffer.insert(float_buffer.end(), bytes, bytes + sizeof(u32));
 	}
 
 	return float_buffer;

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -729,7 +729,7 @@ void microphone_device::get_dsp(const u32 num_samples)
 	{
 		// Convert 16-bit PCM audio data to 32-bit float (DSP format)
 		const std::vector<u8> float_buf = convert_16_bit_pcm_to_float(buf, bufsize);
-		rbuf_dsp.write_bytes(float_buf.data(), bufsize * 2);
+		rbuf_dsp.write_bytes(float_buf.data(), float_buf.size());
 	}
 	else
 	{

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -258,7 +258,7 @@ inline void microphone_device::variable_byteswap(const void* src, void* dst)
 	}
 }
 
-inline std::vector<u8> microphone_device::convert16BitPCMtoFloat(const std::vector<u8>& buffer, size_t numBytes)
+inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, size_t numBytes)
 {
 	ensure(numBytes % 2 == 0);
 	ensure(numBytes < buffer.size());
@@ -728,7 +728,7 @@ void microphone_device::get_dsp(const u32 num_samples)
 	if (attr_dsptype != 0x01)
 	{
 		// Convert 16-bit PCM audio data to 32-bit float (DSP format)
-		std::vector<u8> float_buf = convert16BitPCMtoFloat(buf, bufsize);
+		std::vector<u8> float_buf = convert_16_bit_pcm_to_float(buf, bufsize);
 		rbuf_dsp.write_bytes(float_buf.data(), bufsize * 2);
 	}
 	else

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -266,11 +266,12 @@ inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>&
 	float_buf.resize(float_buf_size, 0);
 	ensure(num_bytes * 2 <= float_buf.size());
 
+	const be_t<s16>* src = reinterpret_cast<const be_t<s16>*>(buffer.data());
 	be_t<f32>* dst = reinterpret_cast<be_t<f32>*>(float_buf.data());
 
-	for (usz i = 0; i < num_bytes; i += 2)
+	for (usz i = 0; i < num_bytes / 2; i++)
 	{
-		const s16 sample = static_cast<s16>((buffer[i] << 8) | buffer[i + 1]);
+		const be_t<s16> sample = *src++;
 
 		const be_t<f32> normalized_sample_be = std::clamp(static_cast<f32>(sample) / std::numeric_limits<s16>::max(), -1.0f, 1.0f);
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -258,7 +258,7 @@ inline void microphone_device::variable_byteswap(const void* src, void* dst)
 	}
 }
 
-inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, size_t num_bytes)
+inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, usz num_bytes)
 {
 	ensure(num_bytes % 2 == 0);
 	ensure(num_bytes < buffer.size());
@@ -266,7 +266,7 @@ inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std:
 	std::vector<u8> float_buffer;
 	float_buffer.reserve(num_bytes * 2);
 
-	for (size_t i = 0; i < num_bytes; i += 2)
+	for (usz i = 0; i < num_bytes; i += 2)
 	{
 		const s16 sample = static_cast<s16>((buffer[i] << 8) | buffer[i + 1]);
 
@@ -280,7 +280,7 @@ inline std::vector<u8> microphone_device::convert_16_bit_pcm_to_float(const std:
 		       ((temp & 0x00FF0000) >> 8) |
 		       ((temp & 0xFF000000) >> 24);
 
-		uint8_t* bytes = reinterpret_cast<uint8_t*>(&temp);
+		const uint8_t* bytes = reinterpret_cast<uint8_t*>(&temp);
 		float_buffer.insert(float_buffer.end(), bytes, bytes + sizeof(uint32_t));
 	}
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -266,7 +266,7 @@ inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>&
 	float_buf.resize(float_buf_size, 0);
 	ensure(num_bytes * 2 <= float_buf.size());
 
-	u32* dst = reinterpret_cast<u32*>(float_buf.data());
+	be_t<f32>* dst = reinterpret_cast<be_t<f32>*>(float_buf.data());
 
 	for (usz i = 0; i < num_bytes; i += 2)
 	{
@@ -274,7 +274,7 @@ inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>&
 
 		const be_t<f32> normalized_sample_be = std::clamp(static_cast<f32>(sample) / std::numeric_limits<s16>::max(), -1.0f, 1.0f);
 
-		write_to_ptr<be_t<f32>>(dst++, normalized_sample_be);
+		*dst++ = normalized_sample_be;
 	}
 
 	return num_bytes * 2;

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -728,7 +728,7 @@ void microphone_device::get_dsp(const u32 num_samples)
 	if (attr_dsptype != 0x01)
 	{
 		// Convert 16-bit PCM audio data to 32-bit float (DSP format)
-		std::vector<u8> float_buf = convert_16_bit_pcm_to_float(buf, bufsize);
+		const std::vector<u8> float_buf = convert_16_bit_pcm_to_float(buf, bufsize);
 		rbuf_dsp.write_bytes(float_buf.data(), bufsize * 2);
 	}
 	else

--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -258,7 +258,7 @@ inline void microphone_device::variable_byteswap(const void* src, void* dst)
 	}
 }
 
-inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, usz num_bytes)
+inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, u32 num_bytes)
 {
 	static_assert((float_buf_size % sizeof(f32)) == 0);
 
@@ -266,7 +266,7 @@ inline u32 microphone_device::convert_16_bit_pcm_to_float(const std::vector<u8>&
 	const u32 bytes_to_write = static_cast<u32>(num_bytes * (sizeof(f32) / sizeof(s16)));
 	ensure(bytes_to_write <= float_buf.size());
 
-	const be_t<s16>* src = reinterpret_cast<const be_t<s16>*>(static_cast<const void*>(buffer.data()));
+	const be_t<s16>* src = utils::bless<const be_t<s16>>(buffer.data());
 	be_t<f32>* dst = reinterpret_cast<be_t<f32>*>(float_buf.data());
 
 	for (usz i = 0; i < num_bytes / sizeof(s16); i++)

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -323,7 +323,7 @@ public:
 private:
 	template <u32 bytesize>
 	static inline void variable_byteswap(const void* src, void* dst);
-	inline u32 convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, usz num_bytes);
+	inline u32 convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, u32 num_bytes);
 
 	u32 capture_audio();
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -360,9 +360,10 @@ private:
 
 	static constexpr u8 bit_resolution = 16;
 	static constexpr usz inbuf_size = 400000; // Default value unknown
+	static constexpr usz float_buf_size = inbuf_size * (sizeof(f32) / sizeof(s16));
 
 	simple_ringbuf<inbuf_size> rbuf_raw;
-	simple_ringbuf<inbuf_size * 2> rbuf_dsp;
+	simple_ringbuf<float_buf_size> rbuf_dsp;
 	simple_ringbuf<inbuf_size> rbuf_aux;
 };
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -323,7 +323,7 @@ public:
 private:
 	template <u32 bytesize>
 	static inline void variable_byteswap(const void* src, void* dst);
-	static inline std::vector<u8> convert16BitPCMtoFloat(const std::vector<u8>& buffer, size_t numBytes);
+	static inline std::vector<u8> convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, size_t numBytes);
 
 	u32 capture_audio();
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -323,6 +323,7 @@ public:
 private:
 	template <u32 bytesize>
 	static inline void variable_byteswap(const void* src, void* dst);
+	static inline std::vector<u8> convert16BitPCMtoFloat(const std::vector<u8>& buffer, size_t numBytes);
 
 	u32 capture_audio();
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -323,7 +323,7 @@ public:
 private:
 	template <u32 bytesize>
 	static inline void variable_byteswap(const void* src, void* dst);
-	static inline std::vector<u8> convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, usz num_bytes);
+	inline u32 convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, usz num_bytes);
 
 	u32 capture_audio();
 
@@ -346,6 +346,7 @@ private:
 
 	std::vector<mic_device> devices;
 	std::vector<u8> temp_buf;
+	std::vector<u8> float_buf;
 
 	// Sampling information provided at opening of mic
 	u32 raw_samplingrate = 48000;

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -362,7 +362,7 @@ private:
 	static constexpr usz inbuf_size = 400000; // Default value unknown
 
 	simple_ringbuf<inbuf_size> rbuf_raw;
-	simple_ringbuf<inbuf_size> rbuf_dsp;
+	simple_ringbuf<inbuf_size * 2> rbuf_dsp;
 	simple_ringbuf<inbuf_size> rbuf_aux;
 };
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -323,7 +323,7 @@ public:
 private:
 	template <u32 bytesize>
 	static inline void variable_byteswap(const void* src, void* dst);
-	static inline std::vector<u8> convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, size_t num_bytes);
+	static inline std::vector<u8> convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, usz num_bytes);
 
 	u32 capture_audio();
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -323,7 +323,7 @@ public:
 private:
 	template <u32 bytesize>
 	static inline void variable_byteswap(const void* src, void* dst);
-	static inline std::vector<u8> convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, size_t numBytes);
+	static inline std::vector<u8> convert_16_bit_pcm_to_float(const std::vector<u8>& buffer, size_t num_bytes);
 
 	u32 capture_audio();
 


### PR DESCRIPTION
libmic provides three types of audio streams from the microphone input:
- DSP stream: Echo-cancelled and noise-reduced data stream (format : 32-bit float)
- RAW stream: Raw data stream directly from the device (format : 16-bit PCM)
- AUX stream: Reference data stream for echo cancellation (format : 16-bit PCM)

The PS3 captures raw data and then converts it to 32-bit float (higher precision) for digital signal processing.

The `get_dsp` function in `cellMic.cpp` has been updated to use the new `convert16BitPCMtoFloat` function when `attr_dsptype` is not `0x01`, converting the 16-bit PCM audio data to 32-bit float format before writing it to `rbuf_dsp`. If `attr_dsptype` is 
`0x01`, the original behavior of writing the raw buffer data is retained.

If there’s anything that needs to be addressed, please let me know. I have tried to keep modifications to the current cellMic code to a minimum while aligning as closely as possible with the PS3's approach.

Resolves #15085 