### PR TITLE
ffmpeg: Update submodule, supports linux arm64

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -4,6 +4,9 @@ include(CMakeDependentOption)
 
 set(CMAKE_CXX_STANDARD 20)
 
+# Defines the ARCHITECTURE variable
+include("DetectArchitecture.cmake")
+
 # Warnings are silenced for 3rdparty code
 if(NOT MSVC)
 	add_compile_options("$<$<COMPILE_LANGUAGE:CXX,C>:-w>")
@@ -267,37 +270,29 @@ if(USE_SYSTEM_FFMPEG)
 	target_include_directories(3rdparty_ffmpeg INTERFACE ${FFMPEG_INCLUDE_DIR})
 	target_link_libraries(3rdparty_ffmpeg INTERFACE ${FFMPEG_LIBRARIES})
 else()
-	if (NOT MSVC AND WIN32)
-		message(FATAL_ERROR "-- RPCS3: building ffmpeg submodule is currently not supported")
-	else()
-		message(STATUS "RPCS3: using builtin ffmpeg")
+	message(STATUS "RPCS3: using builtin ffmpeg")
+	add_subdirectory(ffmpeg EXCLUDE_FROM_ALL)
+	# ffmpeg-core libraries are extracted to CMAKE_BINARY_DIR
+	set(FFMPEG_LIB_DIR "${CMAKE_BINARY_DIR}/3rdparty/ffmpeg/lib")
 
-		if (WIN32)
-			set(FFMPEG_LIB_DIR "ffmpeg/lib/windows/x86_64")
-			target_link_libraries(3rdparty_ffmpeg INTERFACE "Bcrypt.lib")
-		elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-			set(FFMPEG_LIB_DIR "ffmpeg/lib/linux/ubuntu-20.04/x86_64")
-		elseif(APPLE)
-			set(FFMPEG_LIB_DIR "ffmpeg/lib/macos/x86_64")
-		else()
-			message(FATAL_ERROR "Prebuilt ffmpeg is not available on this platform! Try USE_SYSTEM_FFMPEG=ON.")
-		endif()
-
-		find_library(FFMPEG_LIB_AVFORMAT avformat PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
-		find_library(FFMPEG_LIB_AVCODEC avcodec PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
-		find_library(FFMPEG_LIB_AVUTIL avutil PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
-		find_library(FFMPEG_LIB_SWSCALE swscale PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
-		find_library(FFMPEG_LIB_SWRESAMPLE swresample PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
-
-		target_link_libraries(3rdparty_ffmpeg
-		INTERFACE
-			${FFMPEG_LIB_AVFORMAT}
-			${FFMPEG_LIB_AVCODEC}
-			${FFMPEG_LIB_AVUTIL}
-			${FFMPEG_LIB_SWSCALE}
-			${FFMPEG_LIB_SWRESAMPLE}
-		)
+	if (WIN32)
+		target_link_libraries(3rdparty_ffmpeg INTERFACE "Bcrypt.lib")
 	endif()
+
+	find_library(FFMPEG_LIB_AVFORMAT avformat PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
+	find_library(FFMPEG_LIB_AVCODEC avcodec PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
+	find_library(FFMPEG_LIB_AVUTIL avutil PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
+	find_library(FFMPEG_LIB_SWSCALE swscale PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
+	find_library(FFMPEG_LIB_SWRESAMPLE swresample PATHS ${FFMPEG_LIB_DIR} NO_DEFAULT_PATH)
+
+	target_link_libraries(3rdparty_ffmpeg
+	INTERFACE
+		${FFMPEG_LIB_AVFORMAT}
+		${FFMPEG_LIB_AVCODEC}
+		${FFMPEG_LIB_AVUTIL}
+		${FFMPEG_LIB_SWSCALE}
+		${FFMPEG_LIB_SWRESAMPLE}
+	)
 
 	target_include_directories(3rdparty_ffmpeg INTERFACE "ffmpeg/include")
 endif()

--- a/3rdparty/DetectArchitecture.cmake
+++ b/3rdparty/DetectArchitecture.cmake
@@ -1,0 +1,63 @@
+# From https://github.com/merryhime/dynarmic
+include(CheckSymbolExists)
+
+if (CMAKE_OSX_ARCHITECTURES)
+    set(DYNARMIC_MULTIARCH_BUILD 1)
+    set(ARCHITECTURE "${CMAKE_OSX_ARCHITECTURES}")
+    return()
+endif()
+
+function(detect_architecture symbol arch)
+    if (NOT DEFINED ARCHITECTURE)
+        set(CMAKE_REQUIRED_QUIET YES)
+        check_symbol_exists("${symbol}" "" DETECT_ARCHITECTURE_${arch})
+        unset(CMAKE_REQUIRED_QUIET)
+
+        if (DETECT_ARCHITECTURE_${arch})
+            set(ARCHITECTURE "${arch}" PARENT_SCOPE)
+        endif()
+
+        unset(DETECT_ARCHITECTURE_${arch} CACHE)
+    endif()
+endfunction()
+
+detect_architecture("__ARM64__" arm64)
+detect_architecture("__aarch64__" arm64)
+detect_architecture("_M_ARM64" arm64)
+
+detect_architecture("__arm__" arm)
+detect_architecture("__TARGET_ARCH_ARM" arm)
+detect_architecture("_M_ARM" arm)
+
+detect_architecture("__x86_64" x86_64)
+detect_architecture("__x86_64__" x86_64)
+detect_architecture("__amd64" x86_64)
+detect_architecture("_M_X64" x86_64)
+
+detect_architecture("__i386" x86)
+detect_architecture("__i386__" x86)
+detect_architecture("_M_IX86" x86)
+
+detect_architecture("__ia64" ia64)
+detect_architecture("__ia64__" ia64)
+detect_architecture("_M_IA64" ia64)
+
+detect_architecture("__mips" mips)
+detect_architecture("__mips__" mips)
+detect_architecture("_M_MRX000" mips)
+
+detect_architecture("__ppc64__" ppc64)
+detect_architecture("__powerpc64__" ppc64)
+
+detect_architecture("__ppc__" ppc)
+detect_architecture("__ppc" ppc)
+detect_architecture("__powerpc__" ppc)
+detect_architecture("_ARCH_COM" ppc)
+detect_architecture("_ARCH_PWR" ppc)
+detect_architecture("_ARCH_PPC" ppc)
+detect_architecture("_M_MPPC" ppc)
+detect_architecture("_M_PPC" ppc)
+
+detect_architecture("__riscv" riscv)
+
+detect_architecture("__EMSCRIPTEN__" wasm)


### PR DESCRIPTION
Enables `USE_SYSTEM_FFMPEG=OFF` default compatibility with linux arm64

Requires the submodule update to be merged first:
https://github.com/RPCS3/ffmpeg-core/pull/4