### PR TITLE
patch_manager: fix multiple configurable value dropdowns per patch

### DIFF
--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -622,7 +622,7 @@ void patch_manager_dialog::update_patch_info(const patch_manager_dialog::gui_pat
 	}
 }
 
-void patch_manager_dialog::handle_item_selected(QTreeWidgetItem *current, QTreeWidgetItem *previous)
+void patch_manager_dialog::handle_item_selected(QTreeWidgetItem* current, QTreeWidgetItem* previous)
 {
 	if (!current)
 	{
@@ -670,7 +670,7 @@ void patch_manager_dialog::handle_item_selected(QTreeWidgetItem *current, QTreeW
 					// Update the config value combo box with the new config keys
 					ui->configurable_selector->blockSignals(true);
 					ui->configurable_selector->clear();
-					for (const auto& key : info.config_values.keys())
+					for (const QString& key : info.config_values.keys())
 					{
 						const QVariant& variant = info.config_values.value(key);
 						ensure(variant.canConvert<patch_engine::patch_config_value>());
@@ -708,9 +708,12 @@ void patch_manager_dialog::handle_item_selected(QTreeWidgetItem *current, QTreeW
 	}
 
 	update_patch_info(info);
+
+	const QString key = ui->configurable_selector->currentIndex() < 0 ? "" : ui->configurable_selector->currentData().toString();
+	current->setData(0, config_key_role, key);
 }
 
-void patch_manager_dialog::handle_item_changed(QTreeWidgetItem *item, int /*column*/)
+void patch_manager_dialog::handle_item_changed(QTreeWidgetItem* item, int /*column*/)
 {
 	if (!item)
 	{

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -46,8 +46,8 @@ public:
 
 private Q_SLOTS:
 	void filter_patches(const QString& term);
-	void handle_item_selected(QTreeWidgetItem *current, QTreeWidgetItem *previous);
-	void handle_item_changed(QTreeWidgetItem *item, int column);
+	void handle_item_selected(QTreeWidgetItem* current, QTreeWidgetItem* previous);
+	void handle_item_changed(QTreeWidgetItem* item, int column);
 	void handle_config_value_changed(double value);
 	void handle_custom_context_menu_requested(const QPoint& pos);
 	void handle_show_owned_games_only(int state);


### PR DESCRIPTION
- Set config_key_role to current key after handle_item_selected
- The key was never changed if you selected different configurables in the same item. This means that all configurables used the same value list.

fixes #16037