### PR TITLE
Qt: Fix debugger state when emulation was stopped since the debugger was last shown

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -87,7 +87,6 @@ debugger_frame::debugger_frame(std::shared_ptr<gui_settings> gui_settings, QWidg
 
 	m_update = new QTimer(this);
 	connect(m_update, &QTimer::timeout, this, &debugger_frame::UpdateUI);
-	EnableUpdateTimer(true);
 
 	m_mono = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 	m_mono.setPointSize(9);

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -980,12 +980,14 @@ Q_DECLARE_METATYPE(data_type);
 
 void debugger_frame::UpdateUnitList()
 {
+	const u64 emulation_id = static_cast<std::underlying_type_t<Emulator::stop_counter_t>>(Emu.GetEmulationIdentifier());
 	const u64 threads_created = cpu_thread::g_threads_created;
 	const u64 threads_deleted = cpu_thread::g_threads_deleted;
 	const system_state emu_state = Emu.GetStatus();
 
-	if (threads_created != m_threads_created || threads_deleted != m_threads_deleted || emu_state != m_emu_state)
+	if (emulation_id != m_emulation_id || threads_created != m_threads_created || threads_deleted != m_threads_deleted || emu_state != m_emu_state)
 	{
+		m_emulation_id = emulation_id;
 		m_threads_created = threads_created;
 		m_threads_deleted = threads_deleted;
 		m_emu_state = emu_state;

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -61,6 +61,7 @@ class debugger_frame : public custom_dock_widget
 	u64 m_threads_created = -1;
 	u64 m_threads_deleted = -1;
 	system_state m_emu_state{};
+	u64 m_emulation_id{};
 	u32 m_last_pc = -1;
 	std::vector<char> m_last_query_state;
 	std::string m_last_reg_state;


### PR DESCRIPTION
- Force reset of debugger when a different instance was booted between hide and show.
- Don't start the debug update timer in the constructor.
This caused the timer to be active even when the debugger is initially hidden.

fixes #16042