### PR TITLE
Debugger/Qt: Non-blocking thread list refreshing

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -54,6 +54,7 @@ class debugger_frame : public custom_dock_widget
 	QPushButton* m_btn_step;
 	QPushButton* m_btn_step_over;
 	QPushButton* m_btn_run;
+
 	QComboBox* m_choice_units;
 	QTimer* m_update;
 	QSplitter* m_splitter;
@@ -69,6 +70,7 @@ class debugger_frame : public custom_dock_widget
 	u32 m_last_step_over_breakpoint = -1;
 	u64 m_ui_update_ctr = 0;
 	u64 m_ui_fast_update_permission_deadline = 0;
+	bool m_thread_list_pending_update = false;
 
 	std::shared_ptr<CPUDisAsm> m_disasm; // Only shared to allow base/derived functionality
 	std::shared_ptr<cpu_thread> m_cpu;

--- a/rpcs3/rpcs3qt/debugger_list.cpp
+++ b/rpcs3/rpcs3qt/debugger_list.cpp
@@ -46,7 +46,7 @@ debugger_list::debugger_list(QWidget* parent, std::shared_ptr<gui_settings> gui_
 
 		u32 pc = m_start_addr;
 
-		const auto cpu = m_disasm ? m_disasm->get_cpu() : nullptr;
+		const auto cpu = m_disasm && !Emu.IsStopped() ? m_disasm->get_cpu() : nullptr;
 
 		for (; cpu && cpu->get_class() == thread_class::rsx && row; row--)
 		{
@@ -71,7 +71,7 @@ void debugger_list::UpdateCPUData(std::shared_ptr<CPUDisAsm> disasm)
 
 u32 debugger_list::GetStartAddress(u32 address)
 {
-	const auto cpu = m_disasm ? m_disasm->get_cpu() : nullptr;
+	const auto cpu = m_disasm && !Emu.IsStopped() ? m_disasm->get_cpu() : nullptr;
 
 	const u32 steps = m_item_count / 3;
 	const u32 inst_count_jump_on_step = std::min<u32>(steps, 4);
@@ -134,14 +134,14 @@ u32 debugger_list::GetStartAddress(u32 address)
 
 bool debugger_list::IsSpu() const
 {
-	const auto cpu = m_disasm ? m_disasm->get_cpu() : nullptr;
+	const auto cpu = m_disasm && !Emu.IsStopped() ? m_disasm->get_cpu() : nullptr;
 
 	return (cpu && cpu->get_class() == thread_class::spu) || (m_disasm && !cpu);
 }
 
 void debugger_list::ShowAddress(u32 addr, bool select_addr, bool direct)
 {
-	const auto cpu = m_disasm ? m_disasm->get_cpu() : nullptr;
+	const auto cpu = m_disasm && !Emu.IsStopped() ? m_disasm->get_cpu() : nullptr;
 
 	const decltype(spu_thread::local_breakpoints)* spu_bps_list{};
 
@@ -299,7 +299,7 @@ void debugger_list::EnableThreadFollowing(bool enable)
 
 void debugger_list::scroll(s32 steps)
 {
-	const auto cpu = m_disasm ? m_disasm->get_cpu() : nullptr;
+	const auto cpu = m_disasm && !Emu.IsStopped() ? m_disasm->get_cpu() : nullptr;
 
 	for (; cpu && cpu->get_class() == thread_class::rsx && steps > 0; steps--)
 	{
@@ -324,7 +324,7 @@ void debugger_list::scroll(s32 steps)
 
 void debugger_list::keyPressEvent(QKeyEvent* event)
 {
-	const auto cpu = m_disasm ? m_disasm->get_cpu() : nullptr;
+	const auto cpu = m_disasm && !Emu.IsStopped() ? m_disasm->get_cpu() : nullptr;
 
 	// Always accept event (so it would not bubble upwards, debugger_frame already sees it)
 	struct accept_event_t
@@ -436,7 +436,7 @@ void debugger_list::mouseDoubleClickEvent(QMouseEvent* event)
 
 		u32 pc = m_start_addr;
 
-		const auto cpu = m_disasm ? m_disasm->get_cpu() : nullptr;
+		const auto cpu = m_disasm && !Emu.IsStopped() ? m_disasm->get_cpu() : nullptr;
 
 		for (; cpu && cpu->get_class() == thread_class::rsx && i; i--)
 		{


### PR DESCRIPTION
Do not use blocking-wait on IDM's mutex for the debugger as, in the case of emulation crash or simply long hold of IDM's mutex ownership, can cause the UI to deadlock.
Instead, if locking fails queue the thread-list refresh to next QT events workload. 
This is also an optimization, moving thread refresh away from the constant update timer onto the moment you click on the thread-selector combo box.