### PR TITLE
Fix arm64 RPCS3 being reported by macOS as an iOS app

### DIFF
--- a/rpcs3/rpcs3.plist.in
+++ b/rpcs3/rpcs3.plist.in
@@ -22,6 +22,10 @@
 	<string>${RPCS3_GIT_TAG}</string>
 	<key>CFBundleVersion</key>
 	<string>${RPCS3_GIT_TAG}</string>
+ 	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Licensed under GPLv2</string>
 	<key>NSHighResolutionCapable</key>


### PR DESCRIPTION
This is just a minor change involving how macOS/Mac OS X reports arm64-only app bundles (so not Intel only or Universal) as being iOS apps in various places like Settings and System Information unless the bundle's Info.plist explicitly specifies it is only supported on Mac OS X, in which case it will then be correctly reported as an Apple Silicon app. This PR just adds the necessary entry to rpcs3.plist.in to handle the above.