### PR TITLE
arm64: Fix remaining issues for WoA

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1841,9 +1841,9 @@ static LONG exception_filter(PEXCEPTION_POINTERS pExp) noexcept
 	}
 
 #if defined(ARCH_X64)
-	const exec_addr = pExp->ContextRecord->Rip;
+	const auto exec_addr = pExp->ContextRecord->Rip;
 #elif defined(ARCH_ARM64)
-	const exec_addr = pExp->ContextRecord->Pc;
+	const auto exec_addr = pExp->ContextRecord->Pc;
 #else
 #error "Unimplemented exception handling for this architecture"
 #endif

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1841,17 +1841,17 @@ static LONG exception_filter(PEXCEPTION_POINTERS pExp) noexcept
 	}
 
 #if defined(ARCH_X64)
-#define RIP(ctx) ctx->Rip
+	const exec_addr = pExp->ContextRecord->Rip;
 #elif defined(ARCH_ARM64)
-#define RIP(ctx) ctx->Pc
+	const exec_addr = pExp->ContextRecord->Pc;
 #else
 #error "Unimplemented exception handling for this architecture"
 #endif
 
-	fmt::append(msg, "Instruction address: %p.\n", RIP(pExp->ContextRecord));
+	fmt::append(msg, "Instruction address: %p.\n", exec_addr);
 
 	DWORD64 unwind_base;
-	if (const auto rtf = RtlLookupFunctionEntry(RIP(pExp->ContextRecord), &unwind_base, nullptr))
+	if (const auto rtf = RtlLookupFunctionEntry(exec_addr, &unwind_base, nullptr))
 	{
 		// Get function address
 		const DWORD64 func_addr = rtf->BeginAddress + unwind_base;
@@ -1868,7 +1868,7 @@ static LONG exception_filter(PEXCEPTION_POINTERS pExp) noexcept
 		{
 			const DWORD64 base = reinterpret_cast<DWORD64>(info.lpBaseOfDll);
 
-			if (RIP(pExp->ContextRecord) >= base && RIP(pExp->ContextRecord) < base + info.SizeOfImage)
+			if (exec_addr >= base && exec_addr < base + info.SizeOfImage)
 			{
 				std::string module_name;
 				for (DWORD size = 15; module_name.size() != size;)

--- a/buildfiles/cmake/ConfigureCompiler.cmake
+++ b/buildfiles/cmake/ConfigureCompiler.cmake
@@ -113,7 +113,10 @@ else()
 		# Increase stack limit to 8 MB
 		add_link_options(-Wl,--stack -Wl,8388608)
 
-		add_link_options(-Wl,--image-base,0x10000)
+		# For arm64 windows, the image base cannot be below 4GB or the OS rejects the binary without much explanation.
+		if(COMPILER_X86)
+			add_link_options(-Wl,--image-base,0x10000)
+		endif()
 	endif()
 
 	# Specify C++ library to use as standard C++ when using clang

--- a/buildfiles/cmake/ConfigureCompiler.cmake
+++ b/buildfiles/cmake/ConfigureCompiler.cmake
@@ -100,10 +100,6 @@ else()
 			add_link_options(-no-pie)
 		endif()
 	elseif(APPLE)
-		if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-			add_compile_options(-stdlib=libc++)
-		endif()
-
 		if (CMAKE_OSX_ARCHITECTURES MATCHES "x86_64")
 			add_link_options(-Wl,-image_base,0x10000 -Wl,-pagezero_size,0x10000)
 			add_link_options(-Wl,-no_pie)
@@ -118,5 +114,10 @@ else()
 		add_link_options(-Wl,--stack -Wl,8388608)
 
 		add_link_options(-Wl,--image-base,0x10000)
+	endif()
+
+	# Specify C++ library to use as standard C++ when using clang
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+		add_compile_options(-stdlib=libc++)
 	endif()
 endif()

--- a/buildfiles/cmake/ConfigureCompiler.cmake
+++ b/buildfiles/cmake/ConfigureCompiler.cmake
@@ -119,8 +119,8 @@ else()
 		endif()
 	endif()
 
-	# Specify C++ library to use as standard C++ when using clang
-	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+	# Specify C++ library to use as standard C++ when using clang (not required on linux due to GNU)
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND (APPLE OR WIN32))
 		add_compile_options(-stdlib=libc++)
 	endif()
 endif()

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -114,7 +114,7 @@ if(UNIX)
 endif()
 
 if(WIN32)
-    target_link_libraries(rpcs3 PRIVATE bcrypt ws2_32 Iphlpapi Winmm Psapi gdi32 setupapi pdh c++)
+    target_link_libraries(rpcs3 PRIVATE bcrypt ws2_32 Iphlpapi Winmm Psapi gdi32 setupapi pdh)
 else()
     target_link_libraries(rpcs3 PRIVATE ${CMAKE_DL_LIBS})
 endif()

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -68,14 +68,76 @@ namespace Darwin_ProcessInfo
 }
 #endif
 
-#if defined(ARCH_ARM64) && defined (_WIN32) && !defined(_MSC_VER)
-static inline u64 __readx18qword(int offset)
+namespace utils
 {
-	u64* peb = nullptr;
-	__asm__ volatile("mov %0, x18" : "=r"(peb));
-	return peb[offset];
-}
+#ifdef _WIN32
+	// Alternative way to read OS version using the registry.
+	static std::string get_fallback_windows_version()
+	{
+		// Some helpers for sanity
+		const auto read_reg_dword = [](HKEY hKey, std::string_view value_name) -> std::pair<bool, DWORD>
+		{
+			DWORD val;
+			DWORD len = sizeof(val);
+			if (ERROR_SUCCESS != RegQueryValueExA(hKey, value_name.data(), nullptr, nullptr, reinterpret_cast<LPBYTE>(&val), &len))
+			{
+				return { false, 0 };
+			}
+			return { true, val };
+		};
+
+		const auto read_reg_sz = [](HKEY hKey, std::string_view value_name) -> std::pair<bool, std::string>
+		{
+			char sz[256];
+			DWORD sz_len = sizeof(sz);
+			if (ERROR_SUCCESS != RegQueryValueExA(hKey, value_name.data(), nullptr, nullptr, reinterpret_cast<LPBYTE>(sz), &sz_len))
+			{
+				return { false, "" };
+			}
+
+			if (sz_len < sizeof(sz))
+			{
+				// Safety, force null terminator
+				sz[sz_len] = 0;
+			}
+			return { true, sz };
+		};
+
+		HKEY hKey;
+		if (ERROR_SUCCESS != RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_READ, &hKey))
+		{
+			return "Unknown Windows";
+		}
+
+		// Read ProductName (string), CurrentMajorVersionNumber (dword), CurrentMinorVersionNumber (dword) and CurrentBuildNumber (string) as well as CurrentVersion (string)
+		const auto [product_valid, product_name] = read_reg_sz(hKey, "ProductName");
+		if (!product_valid)
+		{
+			return "Unknown Windows";
+		}
+
+		const auto [check_major, version_major] = read_reg_dword(hKey, "CurrentMajorVersionNumber");
+		const auto [check_minor, version_minor] = read_reg_dword(hKey, "CurrentMinorVersionNumber");
+		const auto [check_build_no, build_no] = read_reg_sz(hKey, "CurrentBuildNumber");
+		const auto [check_nt_ver, nt_ver] = read_reg_sz(hKey, "CurrentVersion");
+
+		// Close the registry key
+		RegCloseKey(hKey);
+
+		std::string version_id = "Unknown";
+		if (check_major && check_minor && check_build_no)
+		{
+			version_id = fmt::format("%u.%u.%s", version_major, version_minor, build_no);
+			if (check_nt_ver)
+			{
+				version_id += " NT" + nt_ver;
+			}
+		}
+
+		return fmt::format("Operating system: %s, Version %s", product_name, version_id);
+	}
 #endif
+}
 
 bool utils::has_ssse3()
 {
@@ -590,14 +652,9 @@ std::string utils::get_OS_version()
 #ifdef _WIN32
 	// GetVersionEx is deprecated, RtlGetVersion is kernel-mode only and AnalyticsInfo is UWP only.
 	// So we're forced to read PEB instead to get Windows version info. It's ugly but works.
-
-	const DWORD peb_offset = 0x60;
 #if defined(ARCH_X64)
+	const DWORD peb_offset = 0x60;
 	const INT_PTR peb = __readgsqword(peb_offset);
-#elif defined(_M_ARM64)
-	const INT_PTR peb = __readx18qword(peb_offset);
-#endif
-
 	const DWORD version_major = *reinterpret_cast<const DWORD*>(peb + 0x118);
 	const DWORD version_minor = *reinterpret_cast<const DWORD*>(peb + 0x11c);
 	const WORD build = *reinterpret_cast<const WORD*>(peb + 0x120);
@@ -615,6 +672,11 @@ std::string utils::get_OS_version()
 	fmt::append(output,
 		"Operating system: Windows, Major: %lu, Minor: %lu, Build: %u, Service Pack: %s, Compatibility mode: %llu",
 		version_major, version_minor, build, has_sp ? holder.data() : "none", compatibility_mode);
+#else
+	// PEB cannot be easily accessed on ARM64, fall back to registry
+	static const auto s_windows_version = utils::get_fallback_windows_version();
+	return s_windows_version;
+#endif
 #elif defined (__APPLE__)
 	const int major_version = Darwin_Version::getNSmajorVersion();
 	const int minor_version = Darwin_Version::getNSminorVersion();


### PR DESCRIPTION
Gets native arm64 binaries for windows, One caveat is that ASLR is mandatory for WoA, but for whatever reason, the emulator seems to work even with dynamic base enabled. LLVM also works.
Not much testing has been done on the platform due to lack of testing hardware, but cube and the other simple demos work fine.