### PR TITLE
cellSysutilAvc: Fix cellSysutilAvcEnumPlayers error check

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutilAvc.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutilAvc.cpp
@@ -63,8 +63,18 @@ error_code cellSysutilAvcEnumPlayers(vm::ptr<SceNpId> players_id, vm::ptr<s32> p
 {
 	cellSysutil.todo("cellSysutilAvcEnumPlayers(players_id=*0x%x, players_num=*0x%x)", players_id, players_num);
 
-	if (!players_id || !players_num)
+	if (!players_num)
 		return CELL_AVC_ERROR_INVALID_ARGUMENT;
+
+	if (players_id)
+	{
+		// Fill players_id with players_num participants
+	}
+	else
+	{
+		// Return number of participants
+		*players_num = 0;
+	}
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/cellSysutilAvcExt.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutilAvcExt.cpp
@@ -252,7 +252,7 @@ error_code cellSysutilAvcExtStopMicDetection()
 
 error_code cellSysutilAvcExtInitOptionParam(s32 avcOptionParamVersion, vm::ptr<CellSysutilAvcOptionParam> option)
 {
-	cellSysutilAvcExt.todo("cellSysutilAvcExtInitOptionParam(avcOptionParamVersion=0x%x, option=*0x%x)", avcOptionParamVersion, option);
+	cellSysutilAvcExt.notice("cellSysutilAvcExtInitOptionParam(avcOptionParamVersion=0x%x, option=*0x%x)", avcOptionParamVersion, option);
 
 	if (!option)
 		return CELL_AVC_ERROR_INVALID_ARGUMENT;

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1058,7 +1058,7 @@ void debugger_frame::UpdateUnitList()
 
 		if (reselected_index != umax)
 		{
-			m_choice_units->setCurrentIndex(reselected_index);
+			m_choice_units->setCurrentIndex(::narrow<s32>(reselected_index));
 		}
 	}
 


### PR DESCRIPTION
- Fix cellSysutilAvcEnumPlayers error check
- Set log level of cellSysutilAvcExtInitOptionParam to notice
- Fix some new narrowing conversion warning