### PR TITLE
GitHub Actions CI Port

### DIFF
--- a/.ci/build-linux-aarch64.sh
+++ b/.ci/build-linux-aarch64.sh
@@ -12,9 +12,16 @@ git submodule -q update --init $(awk '/path/ && !/llvm/ && !/opencv/ { print $3 
 
 mkdir build && cd build || exit 1
 
-export CC="${CLANG_BINARY}"
-export CXX="${CLANGXX_BINARY}"
-export LINKER="${LLD_BINARY}"
+if [ "$COMPILER" = "gcc" ]; then
+    # These are set in the dockerfile
+    export CC="${GCC_BINARY}"
+    export CXX="${GXX_BINARY}"
+    export LINKER=gold
+else
+    export CC="${CLANG_BINARY}"
+    export CXX="${CLANGXX_BINARY}"
+    export LINKER="${LLD_BINARY}"
+fi
 export CFLAGS="$CFLAGS -fuse-ld=${LINKER}"
 export CXXFLAGS="$CXXFLAGS -fuse-ld=${LINKER}"
 

--- a/.ci/setup-windows.sh
+++ b/.ci/setup-windows.sh
@@ -103,16 +103,24 @@ COMM_HASH=$(git rev-parse --short=8 HEAD)
 # Format the above into filenames
 if [ -n "$PR_NUMBER" ]; then
     AVVER="${COMM_TAG}-${COMM_HASH}"
-    BUILD="rpcs3-v${AVVER}_win64.7z"
+    BUILD_RAW="rpcs3-v${AVVER}_win64"
+    BUILD="${BUILD_RAW}.7z"
 else
     AVVER="${COMM_TAG}-${COMM_COUNT}"
-    BUILD="rpcs3-v${AVVER}-${COMM_HASH}_win64.7z"
+    BUILD_RAW="rpcs3-v${AVVER}-${COMM_HASH}_win64"
+    BUILD="${BUILD_RAW}.7z"
 fi
 
 # BRANCH is used for experimental build warnings for pr builds, used in main_window.cpp.
 # BUILD is the name of the release artifact
+# BUILD_RAW is just filename
 # AVVER is used for GitHub releases, it is the version number.
 BRANCH="${REPO_NAME}/${REPO_BRANCH}"
-echo "BRANCH=$BRANCH" > .ci/ci-vars.env
-echo "BUILD=$BUILD" >> .ci/ci-vars.env
-echo "AVVER=$AVVER" >> .ci/ci-vars.env
+
+# SC2129
+{
+    echo "BRANCH=$BRANCH"
+    echo "BUILD=$BUILD"
+    echo "BUILD_RAW=$BUILD_RAW"
+    echo "AVVER=$AVVER"
+} >> .ci/ci-vars.env

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -23,10 +23,18 @@ env:
 
 jobs:
   Linux_Build:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         compiler: [clang, gcc]
+        cfg:
+          - os: ubuntu-24.04-arm
+            docker_img: "rpcs3/rpcs3-ci-focal-aarch64:1.0"
+            build_sh: "/rpcs3/.ci/build-linux-aarch64.sh"
+          - os: ubuntu-24.04
+            docker_img: "rpcs3/rpcs3-ci-focal:1.9"
+            build_sh: "/rpcs3/.ci/build-linux.sh"
+    runs-on: ${{ matrix.cfg.os }}
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       CI_HAS_ARTIFACTS: true
@@ -56,19 +64,19 @@ jobs:
 
       - name: Docker setup and build
         run: |
-          docker pull --quiet rpcs3/rpcs3-ci-focal:1.7
+          docker pull --quiet ${{ matrix.cfg.docker_img }}
           docker run                      \
             -v $PWD:/rpcs3              \
             --env-file .ci/docker.env \
             -v ${{ env.CCACHE_DIR }}:/root/.ccache  \
             -v ${{ github.workspace }}/artifacts:/root/artifacts \
-            rpcs3/rpcs3-ci-focal:1.7 \
-            /rpcs3/.ci/build-linux.sh
+            ${{ matrix.cfg.docker_img }} \
+            ${{ matrix.cfg.build_sh }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@main
         with:
-          name: RPCS3 for Linux (${{ matrix.compiler }})
+          name: RPCS3 for Linux (${{ runner.arch }}, ${{ matrix.compiler }})
           path: ${{ github.workspace }}/build/*.AppImage
           compression-level: 0
 
@@ -77,9 +85,9 @@ jobs:
     env:
       COMPILER: msvc
       QT_VER_MAIN: '6'
-      QT_VER: '6.6.3'
-      QT_VER_MSVC: 'msvc2019'
-      QT_DATE: '202403191840'
+      QT_VER: '6.8.1'
+      QT_VER_MSVC: 'msvc2022'
+      QT_DATE: '202411221531'
       VULKAN_VER: '1.3.268.0'
       VULKAN_SDK_SHA: '8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5'
       CACHE_DIR: ./cache

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -1,0 +1,159 @@
+name: Build RPCS3
+
+on:
+  push:
+    paths-ignore:
+      - '.cirrus.yml'
+      - '.azure-pipelines.yml'
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - '.cirrus.yml'
+      - '.azure-pipelines.yml'
+      - 'README.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+env:
+  BUILD_REPOSITORY_NAME: ${{ github.repository }}
+  BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
+
+jobs:
+  Linux_Build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [clang, gcc]
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      CI_HAS_ARTIFACTS: true
+      DEPLOY_APPIMAGE: true
+      APPDIR: "/rpcs3/build/appdir"
+      ARTDIR: "/root/artifacts"
+      RELEASE_MESSAGE: "/rpcs3/GitHubReleaseMessage-${{ matrix.compiler }}.txt"
+      COMPILER: ${{ matrix.compiler }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@main
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Cache
+        uses: actions/cache@main
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-ccache-${{ matrix.compiler }}
+
+      - name: Append Compiler version to appimage
+        run: |
+          file=".ci/deploy-linux.sh"
+          sed -i 's/RPCS3_APPIMAGE="rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}_linux64.AppImage"/RPCS3_APPIMAGE="rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}-${COMPILER}_linux64.AppImage"/g' $file
+
+      - name: Docker setup and build
+        run: |
+          docker pull --quiet rpcs3/rpcs3-ci-focal:1.7
+          docker run                      \
+            -v $PWD:/rpcs3              \
+            --env-file .ci/docker.env \
+            -v ${{ env.CCACHE_DIR }}:/root/.ccache  \
+            -v ${{ github.workspace }}/artifacts:/root/artifacts \
+            rpcs3/rpcs3-ci-focal:1.7 \
+            /rpcs3/.ci/build-linux.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@main
+        with:
+          name: RPCS3 for Linux (${{ matrix.compiler }})
+          path: ${{ github.workspace }}/build/*.AppImage
+          compression-level: 0
+
+  Windows_Build:
+    runs-on: windows-latest
+    env:
+      COMPILER: msvc
+      QT_VER_MAIN: '6'
+      QT_VER: '6.6.3'
+      QT_VER_MSVC: 'msvc2019'
+      QT_DATE: '202403191840'
+      VULKAN_VER: '1.3.268.0'
+      VULKAN_SDK_SHA: '8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5'
+      CACHE_DIR: ./cache
+      BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ github.workspace }}\build
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@main
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup env
+        run: |
+          echo "QTDIR=C:\Qt\${{ env.QT_VER }}\${{ env.QT_VER_MSVC }}_64" >> ${{ github.env }}
+          echo "VULKAN_SDK=C:\VulkanSDK\${{ env.VULKAN_VER }}" >> ${{ github.env }}
+
+      - name: Get Cache Keys
+        shell: bash
+        run: .ci/get_keys-windows.sh
+
+      - name: Setup Cache
+        uses: actions/cache@main
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: ${{ runner.os }}-${{ env.COMPILER }}-${{ env.QT_VER }}-${{ env.VULKAN_SDK_SHA }}-llvm.lock-glslang.lock
+          restore-keys: ${{ runner.os }}-${{ env.COMPILER }}
+
+      - name: Download and unpack dependencies
+        shell: bash
+        run: .ci/setup-windows.sh
+
+      - name: Export Variables
+        run: |
+          Get-Content ".ci/ci-vars.env" | ForEach-Object {
+              # Skip over lines containing comments.
+              if ($_ -notmatch '^\s*#')
+              {
+                  $line = $_ -split '='
+                  $key = $line[0]
+                  $val = $line[1]
+                  echo "$key=$val" >> $env:GITHUB_ENV
+              }
+          }
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@main
+
+      - name: Compile RPCS3
+        run: msbuild rpcs3.sln /p:Configuration=Release /p:Platform=x64
+
+      - name: Pack up build artifacts
+        shell: bash
+        run: |
+          mkdir -p build
+          .ci/deploy-windows.sh
+          mkdir -p bin2/${{ env.BUILD_RAW }}
+          mv bin/* bin2/${{ env.BUILD_RAW }}
+
+      - name: Upload artifacts (zip)
+        uses: actions/upload-artifact@main
+        with:
+          name: RPCS3 for Windows (MSVC) (zip)
+          path: bin2
+          if-no-files-found: error
+
+      - name: Upload artifacts (7z)
+        uses: actions/upload-artifact@main
+        with:
+          name: RPCS3 for Windows (MSVC) (7z)
+          # 7z
+          # 7z.sha256
+          path: |
+            build/${{ env.BUILD }}
+            build/${{ env.BUILD }}.sha256
+          compression-level: 0
+          if-no-files-found: error

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -20,35 +20,40 @@ concurrency:
 env:
   BUILD_REPOSITORY_NAME: ${{ github.repository }}
   BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
+  BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ github.workspace }}/build
 
 jobs:
   Linux_Build:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [clang, gcc]
-        cfg:
-          - os: ubuntu-24.04-arm
-            docker_img: "rpcs3/rpcs3-ci-focal-aarch64:1.0"
-            build_sh: "/rpcs3/.ci/build-linux-aarch64.sh"
+        include:
           - os: ubuntu-24.04
-            docker_img: "rpcs3/rpcs3-ci-focal:1.9"
+            docker_img: "rpcs3/rpcs3-ci-jammy:1.0"
             build_sh: "/rpcs3/.ci/build-linux.sh"
-    runs-on: ${{ matrix.cfg.os }}
+            compiler: clang
+          - os: ubuntu-24.04
+            docker_img: "rpcs3/rpcs3-ci-jammy:1.0"
+            build_sh: "/rpcs3/.ci/build-linux.sh"
+            compiler: gcc
+          - os: ubuntu-24.04-arm
+            docker_img: "rpcs3/rpcs3-ci-jammy-aarch64:1.0"
+            build_sh: "/rpcs3/.ci/build-linux-aarch64.sh"
+            compiler: clang
+    runs-on: ${{ matrix.os }}
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       CI_HAS_ARTIFACTS: true
       DEPLOY_APPIMAGE: true
       APPDIR: "/rpcs3/build/appdir"
       ARTDIR: "/root/artifacts"
-      RELEASE_MESSAGE: "/rpcs3/GitHubReleaseMessage-${{ matrix.compiler }}.txt"
+      RELEASE_MESSAGE: "/rpcs3/GitHubReleaseMessage.txt"
       COMPILER: ${{ matrix.compiler }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@main
         with:
-          submodules: recursive
           fetch-depth: 0
 
       - name: Setup Cache
@@ -57,27 +62,29 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-ccache-${{ matrix.compiler }}
 
-      - name: Append Compiler version to appimage
-        run: |
-          file=".ci/deploy-linux.sh"
-          sed -i 's/RPCS3_APPIMAGE="rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}_linux64.AppImage"/RPCS3_APPIMAGE="rpcs3-v${COMM_TAG}-${COMM_COUNT}-${COMM_HASH}-${COMPILER}_linux64.AppImage"/g' $file
-
       - name: Docker setup and build
         run: |
-          docker pull --quiet ${{ matrix.cfg.docker_img }}
+          docker pull --quiet ${{ matrix.docker_img }}
           docker run                      \
             -v $PWD:/rpcs3              \
             --env-file .ci/docker.env \
             -v ${{ env.CCACHE_DIR }}:/root/.ccache  \
             -v ${{ github.workspace }}/artifacts:/root/artifacts \
-            ${{ matrix.cfg.docker_img }} \
-            ${{ matrix.cfg.build_sh }}
+            ${{ matrix.docker_img }} \
+            ${{ matrix.build_sh }}
 
       - name: Upload artifacts
+        #TODO: Upload artifact to release repository
+        #condition for release
+        #if: |
+        #  github.event_name != 'pull_request' &&
+        #  github.repository == 'RPCS3/rpcs3' &&
+        #  github.ref == 'refs/heads/master' &&
+        #  matrix.compiler == 'clang'
         uses: actions/upload-artifact@main
         with:
           name: RPCS3 for Linux (${{ runner.arch }}, ${{ matrix.compiler }})
-          path: ${{ github.workspace }}/build/*.AppImage
+          path: ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}/*.AppImage
           compression-level: 0
 
   Windows_Build:
@@ -91,13 +98,11 @@ jobs:
       VULKAN_VER: '1.3.268.0'
       VULKAN_SDK_SHA: '8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5'
       CACHE_DIR: ./cache
-      BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ github.workspace }}\build
     steps:
 
       - name: Checkout repository
         uses: actions/checkout@main
         with:
-          submodules: recursive
           fetch-depth: 0
 
       - name: Setup env
@@ -113,7 +118,7 @@ jobs:
         uses: actions/cache@main
         with:
           path: ${{ env.CACHE_DIR }}
-          key: ${{ runner.os }}-${{ env.COMPILER }}-${{ env.QT_VER }}-${{ env.VULKAN_SDK_SHA }}-llvm.lock-glslang.lock
+          key: "${{ runner.os }}-${{ env.COMPILER }}-${{ env.QT_VER }}-${{ env.VULKAN_SDK_SHA }}-${{ hashFiles('llvm.lock') }}-${{ hashFiles('glslang.lock') }}"
           restore-keys: ${{ runner.os }}-${{ env.COMPILER }}
 
       - name: Download and unpack dependencies
@@ -121,17 +126,13 @@ jobs:
         run: .ci/setup-windows.sh
 
       - name: Export Variables
+        shell: bash
         run: |
-          Get-Content ".ci/ci-vars.env" | ForEach-Object {
-              # Skip over lines containing comments.
-              if ($_ -notmatch '^\s*#')
-              {
-                  $line = $_ -split '='
-                  $key = $line[0]
-                  $val = $line[1]
-                  echo "$key=$val" >> $env:GITHUB_ENV
-              }
-          }
+          while IFS='=' read -r key val; do
+            # Skip lines that are empty or start with '#'
+            [[ -z "$key" || "$key" =~ ^# ]] && continue
+            echo "$key=$val" >> "${{ github.env }}"
+          done < .ci/ci-vars.env
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@main
@@ -142,26 +143,23 @@ jobs:
       - name: Pack up build artifacts
         shell: bash
         run: |
-          mkdir -p build
+          mkdir -p ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}
           .ci/deploy-windows.sh
-          mkdir -p bin2/${{ env.BUILD_RAW }}
-          mv bin/* bin2/${{ env.BUILD_RAW }}
-
-      - name: Upload artifacts (zip)
-        uses: actions/upload-artifact@main
-        with:
-          name: RPCS3 for Windows (MSVC) (zip)
-          path: bin2
-          if-no-files-found: error
 
       - name: Upload artifacts (7z)
+        #TODO: Upload artifact to release repository
+        #condition for release
+        #if: |
+        #  github.event_name != 'pull_request' &&
+        #  github.repository == 'RPCS3/rpcs3' &&
+        #  github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@main
         with:
-          name: RPCS3 for Windows (MSVC) (7z)
+          name: RPCS3 for Windows (MSVC)
           # 7z
           # 7z.sha256
           path: |
-            build/${{ env.BUILD }}
-            build/${{ env.BUILD }}.sha256
+            ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}/${{ env.BUILD }}
+            ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}/${{ env.BUILD }}.sha256
           compression-level: 0
           if-no-files-found: error


### PR DESCRIPTION
Cache is supported on the penguin
Cold: https://github.com/illusion0001/rpcs3/actions/runs/10871089443/attempts/1
Warm: https://github.com/illusion0001/rpcs3/actions/runs/10871089443

Plans for later, build in clang and gcc on Windows and OSX and releases to upload repo
