### PR TITLE
Do not close savedata confirmation dialogs in cellMsgDialogAbort

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCrossController.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCrossController.cpp
@@ -72,7 +72,7 @@ struct cross_controller
 		msg_dialog_callback.set(g_fxo->get<ppu_function_manager>().func_addr(FIND_FUNC(finish_callback)));
 
 		// TODO: Show icons from comboplay_plugin.rco in dialog. Maybe use a new dialog or add an optional icon to this one.
-		error_code res = open_msg_dialog(false, CELL_MSGDIALOG_TYPE_DISABLE_CANCEL_OFF, vm::make_str(msg), msg_dialog_callback, userdata);
+		error_code res = open_msg_dialog(false, CELL_MSGDIALOG_TYPE_DISABLE_CANCEL_OFF, vm::make_str(msg), msg_dialog_source::_cellCrossController, msg_dialog_callback, userdata);
 
 		sysutil_register_cb([this, res](ppu_thread& ppu) -> s32
 		{

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -579,7 +579,7 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 		lv2_obj::sleep(ppu);
 
 		// Get user confirmation by opening a blocking dialog
-		error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_ERROR | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK | CELL_MSGDIALOG_TYPE_DISABLE_CANCEL_ON, vm::make_str(error_msg));
+		error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_ERROR | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK | CELL_MSGDIALOG_TYPE_DISABLE_CANCEL_ON, vm::make_str(error_msg), msg_dialog_source::_cellGame);
 
 		// Reschedule after a blocking dialog returns
 		if (ppu.check_state())
@@ -664,7 +664,7 @@ error_code cellHddGameSetSystemVer(vm::cptr<char> systemVersion)
 error_code cellHddGameExitBroken()
 {
 	cellGame.warning("cellHddGameExitBroken()");
-	return open_exit_dialog(get_localized_string(localized_string_id::CELL_HDD_GAME_EXIT_BROKEN), true);
+	return open_exit_dialog(get_localized_string(localized_string_id::CELL_HDD_GAME_EXIT_BROKEN), true, msg_dialog_source::_cellGame);
 }
 
 error_code cellGameDataGetSizeKB(ppu_thread& ppu, vm::ptr<u32> size)
@@ -723,7 +723,7 @@ error_code cellGameDataSetSystemVer(vm::cptr<char> systemVersion)
 error_code cellGameDataExitBroken()
 {
 	cellGame.warning("cellGameDataExitBroken()");
-	return open_exit_dialog(get_localized_string(localized_string_id::CELL_GAME_DATA_EXIT_BROKEN), true);
+	return open_exit_dialog(get_localized_string(localized_string_id::CELL_GAME_DATA_EXIT_BROKEN), true, msg_dialog_source::_cellGame);
 }
 
 error_code cellGameBootCheck(vm::ptr<u32> type, vm::ptr<u32> attributes, vm::ptr<CellGameContentSize> size, vm::ptr<char[CELL_GAME_DIRNAME_SIZE]> dirName)
@@ -1198,7 +1198,7 @@ error_code cellGameDataCheckCreate2(ppu_thread& ppu, u32 version, vm::cptr<char>
 		lv2_obj::sleep(ppu);
 
 		// Get user confirmation by opening a blocking dialog
-		error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_ERROR | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK | CELL_MSGDIALOG_TYPE_DISABLE_CANCEL_ON, vm::make_str(error_msg));
+		error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_ERROR | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK | CELL_MSGDIALOG_TYPE_DISABLE_CANCEL_ON, vm::make_str(error_msg), msg_dialog_source::_cellGame);
 
 		// Reschedule after a blocking dialog returns
 		if (ppu.check_state())
@@ -1714,7 +1714,7 @@ error_code cellGameContentErrorDialog(s32 type, s32 errNeedSizeKB, vm::cptr<char
 		error_msg += get_localized_string(localized_string_id::CELL_GAME_ERROR_DIR_NAME, fmt::format("%s", dirName).c_str());
 	}
 
-	return open_exit_dialog(error_msg, type > CELL_GAME_ERRDIALOG_NOSPACE);
+	return open_exit_dialog(error_msg, type > CELL_GAME_ERRDIALOG_NOSPACE, msg_dialog_source::_cellGame);
 }
 
 error_code cellGameThemeInstall(vm::cptr<char> usrdirPath, vm::cptr<char> fileName, u32 option)

--- a/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
+++ b/rpcs3/Emu/Cell/Modules/cellMsgDialog.h
@@ -89,9 +89,21 @@ enum class MsgDialogState
 	Close,
 };
 
+enum class msg_dialog_source
+{
+	_cellMsgDialog,
+	_cellSaveData,
+	_cellGame,
+	_cellCrossController,
+	_sceNp,
+	_sceNpTrophy,
+	sys_progress,
+	shader_loading,
+};
+
 void close_msg_dialog();
-error_code open_msg_dialog(bool is_blocking, u32 type, vm::cptr<char> msgString, vm::ptr<CellMsgDialogCallback> callback = vm::null, vm::ptr<void> userData = vm::null, vm::ptr<void> extParam = vm::null, s32* return_code = nullptr);
-error_code open_exit_dialog(const std::string& message, bool is_exit_requested);
+error_code open_msg_dialog(bool is_blocking, u32 type, vm::cptr<char> msgString, msg_dialog_source source, vm::ptr<CellMsgDialogCallback> callback = vm::null, vm::ptr<void> userData = vm::null, vm::ptr<void> extParam = vm::null, s32* return_code = nullptr);
+error_code open_exit_dialog(const std::string& message, bool is_exit_requested, msg_dialog_source source);
 
 class MsgDialogBase
 {
@@ -103,6 +115,7 @@ public:
 	atomic_t<MsgDialogState> state{ MsgDialogState::Close };
 
 	MsgDialogType type{};
+	msg_dialog_source source = msg_dialog_source::_cellMsgDialog;
 
 	std::function<void(s32 status)> on_close = nullptr;
 

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -333,7 +333,7 @@ static error_code select_and_delete(ppu_thread& ppu)
 
 		// Get user confirmation by opening a blocking dialog
 		s32 return_code = CELL_MSGDIALOG_BUTTON_NONE;
-		error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO, vm::make_str(msg), vm::null, vm::null, vm::null, &return_code);
+		error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO, vm::make_str(msg), msg_dialog_source::_cellSaveData, vm::null, vm::null, vm::null, &return_code);
 
 		// Reschedule after a blocking dialog returns
 		if (ppu.check_state())
@@ -370,7 +370,7 @@ static error_code select_and_delete(ppu_thread& ppu)
 			lv2_obj::sleep(ppu);
 
 			// Display success message by opening a blocking dialog (return value should be irrelevant here)
-			res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK, vm::make_str(msg));
+			res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK, vm::make_str(msg), msg_dialog_source::_cellSaveData);
 
 			// Reschedule after blocking dialog returns
 			if (ppu.check_state())
@@ -423,7 +423,7 @@ static error_code display_callback_result_error_message(ppu_thread& ppu, const C
 	lv2_obj::sleep(ppu);
 
 	// Get user confirmation by opening a blocking dialog (return value should be irrelevant here)
-	[[maybe_unused]] error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK, use_invalid_message ? result.invalidMsg : vm::make_str(msg));
+	[[maybe_unused]] error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_OK, use_invalid_message ? result.invalidMsg : vm::make_str(msg), msg_dialog_source::_cellSaveData);
 
 	// Reschedule after a blocking dialog returns
 	if (ppu.check_state())
@@ -1219,7 +1219,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 			// Get user confirmation by opening a blocking dialog
 			s32 return_code = CELL_MSGDIALOG_BUTTON_NONE;
-			error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO, vm::make_str(message), vm::null, vm::null, vm::null, &return_code);
+			error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO, vm::make_str(message), msg_dialog_source::_cellSaveData, vm::null, vm::null, vm::null, &return_code);
 
 			// Reschedule after a blocking dialog returns
 			if (ppu.check_state())
@@ -1350,7 +1350,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 				// Get user confirmation by opening a blocking dialog
 				s32 return_code = CELL_MSGDIALOG_BUTTON_NONE;
-				error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO, vm::make_str(message), vm::null, vm::null, vm::null, &return_code);
+				error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_SE_TYPE_NORMAL | CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO, vm::make_str(message), msg_dialog_source::_cellSaveData, vm::null, vm::null, vm::null, &return_code);
 
 				// Reschedule after a blocking dialog returns
 				if (ppu.check_state())

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -572,7 +572,7 @@ error_code sceNpTrophyRegisterContext(ppu_thread& ppu, u32 context, u32 handle, 
 	{
 		if (!!(options & SCE_NP_TROPHY_OPTIONS_REGISTER_CONTEXT_SHOW_ERROR_EXIT))
 		{
-			static_cast<void>(open_exit_dialog("Error during trophy registration! The game will now be terminated.", true));
+			static_cast<void>(open_exit_dialog("Error during trophy registration! The game will now be terminated.", true, msg_dialog_source::_sceNpTrophy));
 		}
 	};
 

--- a/rpcs3/Emu/RSX/Overlays/Network/overlay_sendmessage_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Network/overlay_sendmessage_dialog.cpp
@@ -247,7 +247,7 @@ namespace rsx
 					// Hide list
 					visible = false;
 
-					error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO, vm::make_str(confirmation_msg), vm::null, vm::null, vm::null, &confirmation_code);
+					error_code res = open_msg_dialog(true, CELL_MSGDIALOG_TYPE_BUTTON_TYPE_YESNO, vm::make_str(confirmation_msg), msg_dialog_source::_sceNp, vm::null, vm::null, vm::null, &confirmation_code);
 					if (res != CELL_OK)
 					{
 						rsx_log.fatal("sendmessage dialog failed to open confirmation dialog (error=%d)", +res);

--- a/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Shaders/shader_loading_dialog_native.cpp
@@ -21,7 +21,7 @@ namespace rsx
 
 		dlg = g_fxo->get<rsx::overlays::display_manager>().create<rsx::overlays::message_dialog>(true);
 		dlg->progress_bar_set_taskbar_index(-1);
-		dlg->show(false, msg, type, [](s32 status)
+		dlg->show(false, msg, type, msg_dialog_source::shader_loading, [](s32 status)
 		{
 			if (status != CELL_OK)
 			{

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.cpp
@@ -201,9 +201,10 @@ namespace rsx
 				fade_animation.update(timestamp_us);
 		}
 
-		error_code message_dialog::show(bool is_blocking, const std::string& text, const MsgDialogType& type, std::function<void(s32 status)> on_close)
+		error_code message_dialog::show(bool is_blocking, const std::string& text, const MsgDialogType& type, msg_dialog_source source, std::function<void(s32 status)> on_close)
 		{
 			visible = false;
+			m_source = source;
 
 			num_progress_bars = type.progress_bar_count;
 			if (num_progress_bars)

--- a/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_message_dialog.h
@@ -10,6 +10,8 @@ namespace rsx
 	{
 		class message_dialog : public user_interface
 		{
+			msg_dialog_source m_source = msg_dialog_source::_cellMsgDialog;
+
 			label text_display;
 			image_button btn_ok;
 			image_button btn_cancel;
@@ -44,7 +46,7 @@ namespace rsx
 			void on_button_pressed(pad_button button_press, bool is_auto_repeat) override;
 			void close(bool use_callback, bool stop_pad_interception) override;
 
-			error_code show(bool is_blocking, const std::string& text, const MsgDialogType& type, std::function<void(s32 status)> on_close);
+			error_code show(bool is_blocking, const std::string& text, const MsgDialogType& type, msg_dialog_source source, std::function<void(s32 status)> on_close);
 
 			void set_text(std::string text);
 			void update_custom_background();
@@ -56,6 +58,8 @@ namespace rsx
 			error_code progress_bar_set_value(u32 index, f32 value);
 			error_code progress_bar_reset(u32 index);
 			error_code progress_bar_set_limit(u32 index, u32 limit);
+
+			msg_dialog_source source() const { return m_source; }
 		};
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -199,6 +199,8 @@ namespace rsx
 
 		s32 save_dialog::show(std::vector<SaveDataEntry>& save_entries, u32 focused, u32 op, vm::ptr<CellSaveDataListSet> listSet, bool enable_overlay)
 		{
+			rsx_log.notice("Showing native UI save_dialog (save_entries=%d, focused=%d, op=0x%x, listSet=*0x%x, enable_overlay=%d)", save_entries.size(), focused, op, listSet, enable_overlay);
+
 			visible = false;
 
 			if (enable_overlay)

--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -130,7 +130,7 @@ void progress_dialog_server::operator()()
 				type.progress_bar_count = 1;
 
 				native_dlg = manager->create<rsx::overlays::progress_dialog>(true);
-				native_dlg->show(false, text0, type, nullptr);
+				native_dlg->show(false, text0, type, msg_dialog_source::sys_progress, nullptr);
 				native_dlg->progress_bar_set_message(0, "Please wait");
 			}
 		}

--- a/rpcs3/rpcs3qt/save_data_list_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_data_list_dialog.cpp
@@ -10,7 +10,7 @@
 #include <QScreen>
 #include <QMouseEvent>
 
-constexpr auto qstr = QString::fromStdString;
+LOG_CHANNEL(cellSaveData);
 
 //Show up the savedata list, either to choose one to save/load or to manage saves.
 //I suggest to use function callbacks to give save data list or get save data entry. (Not implemented or stubbed)
@@ -18,6 +18,8 @@ save_data_list_dialog::save_data_list_dialog(const std::vector<SaveDataEntry>& e
 	: QDialog(parent)
 	, m_save_entries(entries)
 {
+	cellSaveData.notice("Creating Qt save_data_list_dialog (entries=%d, focusedEntry=%d, op=0x%x, listSet=*0x%x)", entries.size(), focusedEntry, op, listSet);
+
 	if (op >= 8)
 	{
 		setWindowTitle(tr("Save Data Interface (Delete)"));
@@ -107,7 +109,7 @@ save_data_list_dialog::save_data_list_dialog(const std::vector<SaveDataEntry>& e
 	{
 		const int original_index = m_list->item(row, 0)->data(Qt::UserRole).toInt();
 		const SaveDataEntry original_entry = m_save_entries[original_index];
-		const QString original_dir_name = qstr(original_entry.dirName);
+		const QString original_dir_name = QString::fromStdString(original_entry.dirName);
 		QVariantMap notes = m_persistent_settings->GetValue(gui::persistent::save_notes).toMap();
 		notes[original_dir_name] = m_list->item(row, col)->text();
 		m_persistent_settings->SetValue(gui::persistent::save_notes, notes);
@@ -127,7 +129,7 @@ void save_data_list_dialog::UpdateSelectionLabel()
 		else
 		{
 			const int entry = m_list->item(m_list->currentRow(), 0)->data(Qt::UserRole).toInt();
-			m_entry_label->setText(tr("Currently Selected: ") + qstr(m_save_entries[entry].dirName));
+			m_entry_label->setText(tr("Currently Selected: ") + QString::fromStdString(m_save_entries[entry].dirName));
 		}
 	}
 }
@@ -186,9 +188,9 @@ void save_data_list_dialog::UpdateList()
 	int row = 0;
 	for (const SaveDataEntry& entry: m_save_entries)
 	{
-		QString title = qstr(entry.title);
-		QString subtitle = qstr(entry.subtitle);
-		QString dirName = qstr(entry.dirName);
+		const QString title = QString::fromStdString(entry.title);
+		const QString subtitle = QString::fromStdString(entry.subtitle);
+		const QString dirName = QString::fromStdString(entry.dirName);
 
 		QTableWidgetItem* titleItem = new QTableWidgetItem(title);
 		titleItem->setData(Qt::UserRole, row); // For sorting to work properly


### PR DESCRIPTION
- Only abort dialogs that were actually spawned by cellMsgDialog when calling cellMsgDialogAbort
- Only close dialogs that were actually spawned by cellMsgDialog when calling cellMsgDialogClose
- Improve logging of cellSaveData overlays

This fixes the save data dialog of Oddworld: Munch's Oddysee HD.
The game keeps spamming cellMsgDialogAbort each frame.
This causes the confirmation dialog during the savedata op to close and return an error.

Fixes #16073