### PR TITLE
[Testers Needed][Performance] SPU: Task-based SPURS limiter

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -5701,7 +5701,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 					static thread_local bool s_tls_try_notify = false;
 					s_tls_try_notify = false;
 
-					atomic_wait_engine::set_one_time_use_wait_callback(mask1 != SPU_EVENT_LR ? nullptr : +[](u64 attempts) -> bool
+					const auto wait_cb = mask1 != SPU_EVENT_LR ? nullptr : +[](u64 attempts) -> bool
 					{
 						const auto _this = static_cast<spu_thread*>(cpu_thread::get_current());
 						AUDIT(_this->get_class() == thread_class::spu);
@@ -5750,10 +5750,11 @@ s64 spu_thread::get_ch_value(u32 ch)
 						}
 
 						return true;
-					});
+					};
 
 					if (auto wait_var = vm::reservation_notifier_begin_wait(_raddr, rtime))
 					{
+						atomic_wait_engine::set_one_time_use_wait_callback(wait_cb);
 						utils::bless<atomic_t<u32>>(&wait_var->raw().wait_flag)->wait(1, atomic_wait_timeout{80'000});
 						vm::reservation_notifier_end_wait(*wait_var);
 					}

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -767,6 +767,7 @@ public:
 	const u32 option; // sys_spu_thread_initialize option
 	const u32 lv2_id; // The actual id that is used by syscalls
 	u32 spurs_addr = 0;
+	bool spurs_waited = false;
 
 	spu_thread* next_cpu{}; // LV2 thread queues' node link
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1057,7 +1057,7 @@ error_code sys_spu_thread_group_start(ppu_thread& ppu, u32 id)
 	default: return CELL_ESTAT;
 	}
 
-	const u32 max_threads = group->max_run;
+	const u32 max_threads = group->max_num;
 
 	group->join_state = 0;
 	group->exit_status = 0;

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -289,6 +289,7 @@ struct lv2_spu_group
 	atomic_t<s32> exit_status; // SPU Thread Group Exit Status
 	atomic_t<u32> join_state; // flags used to detect exit cause and signal
 	atomic_t<u32> running = 0; // Number of running threads
+	atomic_t<u32> spurs_running = 0;
 	atomic_t<u32> stop_count = 0;
 	atomic_t<u32> wait_term_count = 0; 
 	u32 waiter_spu_index = -1; // Index of SPU executing a waiting syscall


### PR DESCRIPTION
Instead of limiting how many SPURS threads are initialized, limit how many concurrent SPURS tasks are active at the same time.
Makes it compatible with The Last Of Us (because it uses the last thread in its group for special tasks, this should make it be able operate at times too).
May perform differently than the how it the SPURS limiter was before, needs testing.

Edit: this has effect on the SPURS limiter setting in advanced tab, when setting to other values than unlimited.
