### PR TITLE
AArch64: fix warning, add files to VS

### DIFF
--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64Signal.cpp
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64Signal.cpp
@@ -3,8 +3,6 @@
 
 namespace aarch64
 {
-    constexpr u32 ESR_CTX_MAGIC = 0x45535201;
-
     // Some of the EC codes we care about
     enum class EL1_exception_class
     {
@@ -23,6 +21,8 @@ namespace aarch64
     };
 
 #ifdef __linux__
+    constexpr u32 ESR_CTX_MAGIC = 0x45535201;
+
     const aarch64_esr_ctx* find_EL1_esr_context(const ucontext_t* ctx)
     {
         u32 offset = 0;

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -1001,6 +1001,14 @@
     <None Include="Emu\RSX\Program\Upscalers\FSR1\fsr_ffx_a_flattened.inc" />
     <None Include="Emu\RSX\Program\Upscalers\FSR1\fsr_ffx_fsr1_flattened.inc" />
     <None Include="Emu\RSX\Program\Upscalers\FSR1\fsr_ubershader.glsl" />
+    <None Include="Emu\CPU\Backends\AArch64\AArch64ASM.h" />
+    <None Include="Emu\CPU\Backends\AArch64\AArch64Common.h" />
+    <None Include="Emu\CPU\Backends\AArch64\AArch64JIT.h" />
+    <None Include="Emu\CPU\Backends\AArch64\AArch64Signal.h" />
+    <None Include="Emu\CPU\Backends\AArch64\AArch64ASM.cpp" />
+    <None Include="Emu\CPU\Backends\AArch64\AArch64Common.cpp" />
+    <None Include="Emu\CPU\Backends\AArch64\AArch64JIT.cpp" />
+    <None Include="Emu\CPU\Backends\AArch64\AArch64Signal.cpp" />
   </ItemGroup>
   <PropertyGroup Label="UserMacros" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -106,6 +106,12 @@
     <Filter Include="Emu\GPU\RSX\NV47\FW">
       <UniqueIdentifier>{fdb8ff8f-5a03-45a2-8c0a-16a89b7a574b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Emu\CPU\Backends">
+      <UniqueIdentifier>{636c461d-99c0-4f98-89dc-1d4ec7157bfc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Emu\CPU\Backends\AArch64">
+      <UniqueIdentifier>{73650043-acf8-4890-9f84-5bfa7a8c946b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Crypto\aes.cpp">
@@ -2675,6 +2681,30 @@
     </None>
     <None Include="Emu\RSX\Program\Upscalers\FSR1\fsr_ubershader.glsl">
       <Filter>Emu\GPU\RSX\Program\Upscalers\FSR1</Filter>
+    </None>
+    <None Include="Emu\CPU\Backends\AArch64\AArch64ASM.h">
+      <Filter>Emu\CPU\Backends\AArch64</Filter>
+    </None>
+    <None Include="Emu\CPU\Backends\AArch64\AArch64Common.h">
+      <Filter>Emu\CPU\Backends\AArch64</Filter>
+    </None>
+    <None Include="Emu\CPU\Backends\AArch64\AArch64JIT.h">
+      <Filter>Emu\CPU\Backends\AArch64</Filter>
+    </None>
+    <None Include="Emu\CPU\Backends\AArch64\AArch64Signal.h">
+      <Filter>Emu\CPU\Backends\AArch64</Filter>
+    </None>
+    <None Include="Emu\CPU\Backends\AArch64\AArch64ASM.cpp">
+      <Filter>Emu\CPU\Backends\AArch64</Filter>
+    </None>
+    <None Include="Emu\CPU\Backends\AArch64\AArch64Common.cpp">
+      <Filter>Emu\CPU\Backends\AArch64</Filter>
+    </None>
+    <None Include="Emu\CPU\Backends\AArch64\AArch64JIT.cpp">
+      <Filter>Emu\CPU\Backends\AArch64</Filter>
+    </None>
+    <None Include="Emu\CPU\Backends\AArch64\AArch64Signal.cpp">
+      <Filter>Emu\CPU\Backends\AArch64</Filter>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Fix unused variable warning in MacOs Arm64 build
- Add AArch64 files to VS Project