### PR TITLE
[Misc] Fix some Qt-related issues on macOS

### DIFF
--- a/.ci/build-mac-arm64.sh
+++ b/.ci/build-mac-arm64.sh
@@ -64,7 +64,7 @@ if [ ! -d "/tmp/Qt/$QT_VER" ]; then
   cd "/tmp/Qt"
   "$BREW_X64_PATH/bin/pipenv" run pip3 install py7zr requests semantic_version lxml
   mkdir -p "$QT_VER/macos" ; ln -s "macos" "$QT_VER/clang_64"
-  "$BREW_X64_PATH/bin/pipenv" run "$WORKDIR/qt-downloader/qt-downloader" macos desktop "$QT_VER" clang_64 --opensource --addons qtmultimedia
+  "$BREW_X64_PATH/bin/pipenv" run "$WORKDIR/qt-downloader/qt-downloader" macos desktop "$QT_VER" clang_64 --opensource --addons qtmultimedia qtimageformats
 fi
 
 cd "$WORKDIR"

--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -42,7 +42,7 @@ if [ ! -d "/tmp/Qt/$QT_VER" ]; then
   cd "/tmp/Qt"
   "$BREW_X64_PATH/bin/pipenv" run pip3 install py7zr requests semantic_version lxml
   mkdir -p "$QT_VER/macos" ; ln -s "macos" "$QT_VER/clang_64"
-  "$BREW_X64_PATH/bin/pipenv" run "$WORKDIR/qt-downloader/qt-downloader" macos desktop "$QT_VER" clang_64 --opensource --addons qtmultimedia
+  "$BREW_X64_PATH/bin/pipenv" run "$WORKDIR/qt-downloader/qt-downloader" macos desktop "$QT_VER" clang_64 --opensource --addons qtmultimedia qtimageformats
 fi
 
 cd "$WORKDIR"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,10 +150,10 @@ jobs:
     
     - task: Cache@2
       inputs:
-        key: qt | "$(Agent.OS)" | "$(QT_VER)"
+        key: qt | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(QT_VER)" 
         path: /tmp/Qt
         restoreKeys: |
-          qt | "$(Agent.OS)" | "$(QT_VER)"
+          qt | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(QT_VER)" 
       displayName: Qt cache
     
     # - task: Cache@2
@@ -211,10 +211,10 @@ jobs:
     
     - task: Cache@2
       inputs:
-        key: qt | "$(Agent.OS)" | "$(QT_VER)"
+        key: qt | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(QT_VER)"
         path: /tmp/Qt
         restoreKeys: |
-          qt | "$(Agent.OS)" | "$(QT_VER)"
+          qt | "$(Agent.OS)" | "$(Agent.OSArchitecture)" | "$(QT_VER)"
       displayName: Qt cache
     
     # - task: Cache@2

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -130,6 +130,7 @@ if(APPLE)
     else()
         set(QT_DEPLOY_FLAGS "")
     endif()
+    qt_finalize_target(rpcs3)
     add_custom_command(TARGET rpcs3 POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_CURRENT_SOURCE_DIR}/rpcs3.icns $<TARGET_FILE_DIR:rpcs3>/../Resources/rpcs3.icns


### PR DESCRIPTION
Small changes that are bundled into one PR, which fix a few Qt-related problems on macOS RPCS3 builds from my testing.

-Added a line to CMakeLists that apparently is needed to ensure Qt permission prompt handling works, fixing camera support on macOS.
-Made CI scripts for macOS also download the qtimageformats plugin, which is needed for successful icon creation when making Desktop/Launchpad shortcuts.

Should fix #14795 properly, partially deals with #16017 when it comes to shortcut icon creation failure only.