### PR TITLE
SPU: Make SPURS limit a dynamic setting

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4894,6 +4894,52 @@ bool spu_thread::process_mfc_cmd()
 		// Avoid logging useless commands if there is no reservation
 		const bool dump = g_cfg.core.mfc_debug && raddr;
 
+		const bool is_spurs_task_wait = pc == 0x11e4 && group->max_run != group->max_num && spurs_addr != 0u - 0x80 && !spurs_waited;
+
+		if (is_spurs_task_wait)
+		{
+			const u32 prev_running = group->spurs_running;
+
+			// Wait for other threads to complete their tasks (temporarily)
+			if (!is_stopped())
+			{
+				const u32 max_run = group->max_run;
+
+				u32 prev_running = group->spurs_running;
+
+				if (prev_running > max_run)
+				{
+					const u64 before = get_system_time();
+
+					spurs_waited = true;
+
+					while (true)
+					{
+						thread_ctrl::wait_on(group->spurs_running, prev_running, 10000);
+
+						if (is_stopped())
+						{
+							break;
+						}
+
+						prev_running = group->spurs_running;
+
+						if (prev_running <= max_run)
+						{
+							break;
+						}
+
+						if (get_system_time() - before >= 4000)
+						{
+							// Timed-out
+							break;
+						}
+					}
+				}
+			}
+		}
+
+
 		if (do_putllc(ch_mfc_cmd))
 		{
 			ch_atomic_stat.set_value(MFC_PUTLLC_SUCCESS);
@@ -5497,8 +5543,6 @@ s64 spu_thread::get_ch_value(u32 ch)
 
 		if (is_spurs_task_wait)
 		{
-			spurs_waited = true;
-
 			const u32 prev_running = group->spurs_running.fetch_op([](u32& x)
 			{
 				if (x)
@@ -5527,7 +5571,9 @@ s64 spu_thread::get_ch_value(u32 ch)
 				// Wait for other threads to complete their tasks (temporarily)
 				if (!is_stopped())
 				{
-					const u32 prev_running = group->spurs_running.fetch_op([max = group->max_run](u32& x)
+					const u32 max_run = group->max_run;
+
+					u32 prev_running = group->spurs_running.fetch_op([max = max_run](u32& x)
 					{
 						if (x < max)
 						{
@@ -5538,20 +5584,44 @@ s64 spu_thread::get_ch_value(u32 ch)
 						return false;
 					}).first;
 
-					if (prev_running >= group->max_run)
+					if (prev_running >= max_run)
 					{
 						const u64 before = get_system_time();
-						thread_ctrl::wait_on(group->spurs_running, prev_running, 10000);
 
-						// Check for missed waiting (due to thread-state notification or value change)
-						const u32 new_running = group->spurs_running;
+						spurs_waited = true;
 
-						if (!is_stopped() && new_running >= group->max_run && get_system_time() - before < 1500)
+						while (true)
 						{
-							thread_ctrl::wait_on(group->spurs_running, new_running, 10000);
-						}
+							thread_ctrl::wait_on(group->spurs_running, prev_running, 10000);
 
-						group->spurs_running++;
+							if (is_stopped())
+							{
+								break;
+							}
+
+							prev_running = group->spurs_running.fetch_op([max_run](u32& x)
+							{
+								if (x < max_run)
+								{
+									x++;
+									return true;
+								}
+
+								return false;
+							}).first;
+
+							if (prev_running < max_run)
+							{
+								break;
+							}
+
+							if (get_system_time() - before >= 4000)
+							{
+								// Timed-out
+								group->spurs_running++;
+								break;
+							}
+						}
 					}
 				}
 			}

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_settings.cpp
@@ -63,6 +63,7 @@ namespace rsx
 			add_unsigned_slider(&g_cfg.core.max_cpu_preempt_count_per_frame, "Max Power Saving CPU-Preemptions", "", 1);
 			add_checkbox(&g_cfg.core.rsx_accurate_res_access, "Accurate RSX reservation access");
 			add_dropdown(&g_cfg.core.sleep_timers_accuracy, "Sleep Timers Accuracy");
+			add_signed_slider(&g_cfg.core.max_spurs_threads, "Max SPURS Threads", "", 1);
 
 			add_unsigned_slider(&g_cfg.video.driver_wakeup_delay, "Driver Wake-Up Delay", " µs", 20, {}, g_cfg.video.driver_wakeup_delay.min, 800);
 			add_signed_slider(&g_cfg.video.vblank_rate, "VBlank Frequency", " Hz", 30);

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -39,7 +39,7 @@ struct cfg_root : cfg::node
 		cfg::_int<0, 6> preferred_spu_threads{ this, "Preferred SPU Threads", 0, true }; // Number of hardware threads dedicated to heavy simultaneous spu tasks
 		cfg::_int<0, 16> spu_delay_penalty{ this, "SPU delay penalty", 3 }; // Number of milliseconds to block a thread if a virtual 'core' isn't free
 		cfg::_bool spu_loop_detection{ this, "SPU loop detection", false }; // Try to detect wait loops and trigger thread yield
-		cfg::_int<0, 6> max_spurs_threads{ this, "Max SPURS Threads", 6 }; // HACK. If less then 6, max number of running SPURS threads in each thread group.
+		cfg::_int<0, 6> max_spurs_threads{ this, "Max SPURS Threads", 6, true }; // HACK. If less then 6, max number of running SPURS threads in each thread group.
 		cfg::_enum<spu_block_size_type> spu_block_size{ this, "SPU Block Size", spu_block_size_type::safe };
 		cfg::_bool spu_accurate_dma{ this, "Accurate SPU DMA", false };
 		cfg::_bool spu_accurate_reservations{ this, "Accurate SPU Reservations", true };


### PR DESCRIPTION
#16109 made the "Max SPURS threads" setting be based on limiting dynamic execution of SPURS tasks instead of selectively deactivating thread altogether.
This approach with few adjustments allows us to update the limit dynamically each time SPURS task wait is encountered.