### PR TITLE
[macOS] Force native style as macOS default

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -213,7 +213,11 @@ namespace gui
 	const gui_save rsx_geometry = gui_save(rsx, "geometry", QByteArray());
 	const gui_save rsx_states   = gui_save(rsx, "states",   QVariantMap());
 
+#ifdef __APPLE__
+	const gui_save m_currentStylesheet = gui_save(meta, "currentStylesheet", "native (macOS)");
+#else
 	const gui_save m_currentStylesheet = gui_save(meta, "currentStylesheet", DefaultStylesheet);
+#endif
 	const gui_save m_showDebugTab      = gui_save(meta, "showDebugTab",      false);
 	const gui_save m_attachCommandLine = gui_save(meta, "attachCommandLine", false);
 	const gui_save m_enableUIColors    = gui_save(meta, "enableUIColors",    false);

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -69,6 +69,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->create_applications_menu_shortcut->setText(tr("&Create Start Menu shortcut"));
 #elif defined(__APPLE__)
 	ui->create_applications_menu_shortcut->setText(tr("&Create Launchpad shortcut"));
+	ui->use_dark_theme->setVisible(false);
 #else
 	ui->create_applications_menu_shortcut->setText(tr("&Create Application Menu shortcut"));
 #endif


### PR DESCRIPTION
The merging of Qt 6.7.3 makes the native macOS style look good enough across Light and Dark mode that for the time being, until the RPCS3 default stylesheet can be fixed to support dark mode properly, it should be the default for this platform. Otherwise you end up with hilariously broken UI as seen currently by default: 
![image](https://github.com/user-attachments/assets/05393e0c-f9be-4b93-88f9-645c78a87b4c)
Versus with this PR (or manually switching to the native style currently):
![image](https://github.com/user-attachments/assets/5b6c8e52-1564-4159-9606-475f9d60e9e7)

The PR handles this by (on macOS only):
-Setting the default selected stylesheet choice to Native on macOS
~~-Removing broken style choices (e.g. Native styles for Windows which look awful on macOS, and the Default (Bright) style due to unreadability) so that only the Native style and other custom stylesheets are shown~~
~~-Overriding the default style if still selected with Native (affects users updating from older builds who may still have unreadable UI due to having Default (Bright) selected previously)~~
-Hiding the "Use Dark Mode" toggle on macOS as a) it didn't work before, and b) it isn't necessary with the native styling which syncs with the system theme.

Fixes #16107 for the time being, but may be superseded by a proper fix for the default stylesheet.