### PR TITLE
linux/amd64: Fix steam deck compositor issues

### DIFF
--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -15,7 +15,13 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     chmod +x ./linuxdeploy-plugin-checkrt.sh
 
     export EXTRA_PLATFORM_PLUGINS="libqwayland-egl.so;libqwayland-generic.so"
-    export EXTRA_QT_PLUGINS="svg;wayland-decoration-client;wayland-graphics-integration-client;wayland-shell-integration;waylandcompositor"
+    export EXTRA_QT_PLUGINS="svg;wayland-decoration-client;wayland-graphics-integration-client;wayland-shell-integration"
+
+    if [ "$CPU_ARCH" = "aarch64" ]; then
+        # Ideally we should always ship the wayland integration libraries. Unfortunately glibc ABI issues on steam deck make this undesirable right now, so we only ship for arm64
+        export EXTRA_QT_PLUGINS="$EXTRA_QTPLUGINS;waylandcompositor"
+    fi
+
     APPIMAGE_EXTRACT_AND_RUN=1 linuxdeploy --appdir AppDir --plugin qt
 
     # Remove libwayland-client because it has platform-dependent exports and breaks other OSes

--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -19,7 +19,7 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
 
     if [ "$CPU_ARCH" = "aarch64" ]; then
         # Ideally we should always ship the wayland integration libraries. Unfortunately glibc ABI issues on steam deck make this undesirable right now, so we only ship for arm64
-        export EXTRA_QT_PLUGINS="$EXTRA_QTPLUGINS;waylandcompositor"
+        export EXTRA_QT_PLUGINS="$EXTRA_QT_PLUGINS;waylandcompositor"
     fi
 
     APPIMAGE_EXTRACT_AND_RUN=1 linuxdeploy --appdir AppDir --plugin qt


### PR DESCRIPTION
Drops wayland shell integration from x64 linux appimages. Wayland is still shipping for arm64 binaries however as it is the primary compositor in use for most arm64 distros.