### PR TITLE
SPU: More SPURS limiter fixes

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -769,7 +769,6 @@ public:
 	u32 spurs_addr = 0;
 	bool spurs_waited = false;
 	bool spurs_entered_wait = false;
-	bool spurs_read_events = false;
 	u64 spurs_wait_duration_last = 0;
 	u64 spurs_average_task_duration = 0;
 	u64 spurs_last_task_timestamp = 0;


### PR DESCRIPTION
* increase minimum wait duration.
* Use SPURS data 0x73 to tell if SPU has already been waiting or entering Idle state,