### PR TITLE
Qt: Make sure that table columns and their actions have the same state after restoring the layout

### DIFF
--- a/rpcs3/rpcs3qt/game_list.cpp
+++ b/rpcs3/rpcs3qt/game_list.cpp
@@ -14,6 +14,30 @@ game_list::game_list() : QTableWidget(), game_list_base()
 	};
 }
 
+void game_list::sync_header_actions(QList<QAction*>& actions, std::function<bool(int)> get_visibility)
+{
+	ensure(get_visibility);
+
+	bool is_dirty = false;
+
+	for (int col = 0; col < actions.count(); ++col)
+	{
+		const bool is_hidden = !get_visibility(col);
+		actions[col]->setChecked(!is_hidden);
+
+		if (isColumnHidden(col) != is_hidden)
+		{
+			setColumnHidden(col, is_hidden);
+			is_dirty = true;
+		}
+	}
+
+	if (is_dirty)
+	{
+		fix_narrow_columns();
+	}
+}
+
 void game_list::create_header_actions(QList<QAction*>& actions, std::function<bool(int)> get_visibility, std::function<void(int, bool)> set_visibility)
 {
 	ensure(get_visibility);
@@ -48,6 +72,7 @@ void game_list::create_header_actions(QList<QAction*>& actions, std::function<bo
 					return;
 				}
 			}
+
 			setColumnHidden(col, !checked); // Negate because it's a set col hidden and we have menu say show.
 			set_visibility(col, checked);
 
@@ -56,11 +81,9 @@ void game_list::create_header_actions(QList<QAction*>& actions, std::function<bo
 				fix_narrow_columns();
 			}
 		});
-
-		const bool vis = get_visibility(col);
-		actions[col]->setChecked(vis);
-		setColumnHidden(col, !vis);
 	}
+
+	sync_header_actions(actions, get_visibility);
 }
 
 void game_list::clear_list()

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -24,6 +24,7 @@ class game_list : public QTableWidget, public game_list_base
 public:
 	game_list();
 
+	void sync_header_actions(QList<QAction*>& actions, std::function<bool(int)> get_visibility);
 	void create_header_actions(QList<QAction*>& actions, std::function<bool(int)> get_visibility, std::function<void(int, bool)> set_visibility);
 
 	void clear_list() override; // Use this instead of clearContents

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -230,12 +230,7 @@ void game_list_frame::LoadSettings()
 	m_show_custom_icons = m_gui_settings->GetValue(gui::gl_custom_icon).toBool();
 	m_play_hover_movies = m_gui_settings->GetValue(gui::gl_hover_gifs).toBool();
 
-	for (int col = 0; col < m_columnActs.count(); ++col)
-	{
-		const bool vis = m_gui_settings->GetGamelistColVisibility(static_cast<gui::game_list_columns>(col));
-		m_columnActs[col]->setChecked(vis);
-		m_game_list->setColumnHidden(col, !vis);
-	}
+	m_game_list->sync_header_actions(m_columnActs, [this](int col) { return m_gui_settings->GetGamelistColVisibility(static_cast<gui::game_list_columns>(col)); });
 }
 
 game_list_frame::~game_list_frame()
@@ -915,6 +910,7 @@ void game_list_frame::OnRefreshFinished()
 	if (!std::exchange(m_initial_refresh_done, true))
 	{
 		m_game_list->restore_layout(m_gui_settings->GetValue(gui::gl_state).toByteArray());
+		m_game_list->sync_header_actions(m_columnActs, [this](int col) { return m_gui_settings->GetGamelistColVisibility(static_cast<gui::game_list_columns>(col)); });
 	}
 
 	// Emit signal and remove slots

--- a/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/trophy_manager_dialog.cpp
@@ -522,6 +522,13 @@ void trophy_manager_dialog::RepaintUI(bool restore_layout)
 		//m_trophy_table->horizontalHeader()->resizeSections(QHeaderView::ResizeMode::ResizeToContents);
 	}
 
+	if (restore_layout)
+	{
+		// Make sure the actions and the headers are synced
+		m_game_table->sync_header_actions(m_game_column_acts, [this](int col) { return m_gui_settings->GetTrophyGamelistColVisibility(static_cast<gui::trophy_game_list_columns>(col)); });
+		m_trophy_table->sync_header_actions(m_trophy_column_acts, [this](int col) { return m_gui_settings->GetTrophylistColVisibility(static_cast<gui::trophy_list_columns>(col)); });
+	}
+
 	ApplyFilter();
 
 	// Show dialog and then paint gui in order to adjust headers correctly
@@ -542,6 +549,10 @@ void trophy_manager_dialog::HandleRepaintUiRequest()
 	m_splitter->restoreState(splitter_state);
 	m_game_table->horizontalHeader()->restoreState(game_table_state);
 	m_trophy_table->horizontalHeader()->restoreState(trophy_table_state);
+
+	// Make sure the actions and the headers are synced
+	m_game_table->sync_header_actions(m_game_column_acts, [this](int col) { return m_gui_settings->GetTrophyGamelistColVisibility(static_cast<gui::trophy_game_list_columns>(col)); });
+	m_trophy_table->sync_header_actions(m_trophy_column_acts, [this](int col) { return m_gui_settings->GetTrophylistColVisibility(static_cast<gui::trophy_list_columns>(col)); });
 
 	resize(window_size);
 }


### PR DESCRIPTION
- Make sure that table columns and their actions have the same state after restoring the layout.
In theory this shouldn't be necessary, but sometimes the GuiSettings may contain different states for both.

Related to #16198