### PR TITLE
Fix sys_spu_thread_group_disconnect_event

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1919,17 +1919,15 @@ error_code sys_spu_thread_group_disconnect_event(ppu_thread& ppu, u32 id, u32 et
 	if (!ep)
 	{
 		sys_spu.error("sys_spu_thread_group_disconnect_event(): unknown event type (%d)", et);
-		return CELL_EINVAL;
+		return CELL_OK;
 	}
+
+	// No error checking is performed
 
 	std::lock_guard lock(group->mutex);
 
-	if (!lv2_obj::check(*ep))
-	{
-		return CELL_EINVAL;
-	}
-
 	ep->reset();
+
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -1831,16 +1831,16 @@ error_code sys_spu_thread_write_snr(ppu_thread& ppu, u32 id, u32 number, u32 val
 
 	sys_spu.trace("sys_spu_thread_write_snr(id=0x%x, number=%d, value=0x%x)", id, number, value);
 
+	if (number > 1)
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto [thread, group] = lv2_spu_group::get_thread(id);
 
 	if (!thread) [[unlikely]]
 	{
 		return CELL_ESRCH;
-	}
-
-	if (number > 1)
-	{
-		return CELL_EINVAL;
 	}
 
 	thread->push_snr(number, value);
@@ -2090,17 +2090,17 @@ error_code sys_spu_thread_group_connect_event_all_threads(ppu_thread& ppu, u32 i
 
 	sys_spu.warning("sys_spu_thread_group_connect_event_all_threads(id=0x%x, eq=0x%x, req=0x%llx, spup=*0x%x)", id, eq, req, spup);
 
+	if (!req)
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto group = idm::get<lv2_spu_group>(id);
 	const auto queue = idm::get<lv2_obj, lv2_event_queue>(eq);
 
 	if (!group || !queue)
 	{
 		return CELL_ESRCH;
-	}
-
-	if (!req)
-	{
-		return CELL_EINVAL;
 	}
 
 	std::unique_lock lock(group->mutex);
@@ -2172,16 +2172,16 @@ error_code sys_spu_thread_group_disconnect_event_all_threads(ppu_thread& ppu, u3
 
 	sys_spu.warning("sys_spu_thread_group_disconnect_event_all_threads(id=0x%x, spup=%d)", id, spup);
 
+	if (spup > 63)
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto group = idm::get<lv2_spu_group>(id);
 
 	if (!group)
 	{
 		return CELL_ESRCH;
-	}
-
-	if (spup > 63)
-	{
-		return CELL_EINVAL;
 	}
 
 	std::lock_guard lock(group->mutex);


### PR DESCRIPTION
This syscall does not report errors for the disconnection of the event port, nor for the event port type.