### PR TITLE
gl: Implement host GPU labels [AMD only for now]

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -478,6 +478,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/gcm_printing.cpp
     RSX/GL/GLCommonDecompiler.cpp
     RSX/GL/GLCompute.cpp
+    RSX/GL/GLDMA.cpp
     RSX/GL/GLDraw.cpp
     RSX/GL/GLFragmentProgram.cpp
     RSX/GL/GLGSRender.cpp
@@ -503,6 +504,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/GL/OpenGL.cpp
     RSX/GL/upscalers/fsr1/fsr_pass.cpp
     RSX/GSRender.cpp
+    RSX/Host/RSXDMAWriter.cpp
     RSX/Null/NullGSRender.cpp
     RSX/NV47/FW/draw_call.cpp
     RSX/NV47/FW/reg_context.cpp

--- a/rpcs3/Emu/RSX/GL/GLCompute.h
+++ b/rpcs3/Emu/RSX/GL/GLCompute.h
@@ -300,7 +300,7 @@ namespace gl
 
 			m_src = fmt::replace_all(m_src, syntax_replace);
 
-			param_buffer.create(gl::buffer::target::uniform, 32, nullptr, gl::buffer::memory_type::local, GL_DYNAMIC_COPY);
+			param_buffer.create(gl::buffer::target::uniform, 32, nullptr, gl::buffer::memory_type::local, gl::buffer::usage::dynamic_update);
 		}
 
 		~cs_deswizzle_3d()

--- a/rpcs3/Emu/RSX/GL/GLDMA.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDMA.cpp
@@ -36,7 +36,7 @@ namespace gl
 
 	void dma_block::resize(u32 new_length)
 	{
-		if (new_length < length())
+		if (new_length <= length())
 		{
 			return;
 		}

--- a/rpcs3/Emu/RSX/GL/GLDMA.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDMA.cpp
@@ -1,0 +1,120 @@
+#include "stdafx.h"
+#include "GLDMA.h"
+
+#include "Emu/Memory/vm.h"
+
+namespace gl
+{
+	static constexpr u32 s_dma_block_size = 0x10000;
+	std::unordered_map<u32, std::unique_ptr<dma_block>> g_dma_pool;
+
+	void dma_block::allocate(u32 base_address, u32 block_size)
+	{
+		// Since this is a userptr block, we don't need to move data around on resize. Just "claim" a different chunk and move on.
+		if (m_data)
+		{
+			m_data->remove();
+		}
+
+		void* userptr = vm::get_super_ptr(base_address);
+
+		m_data = std::make_unique<gl::buffer>();
+		m_data->create(buffer::target::userptr, block_size, userptr);
+		m_base_address = base_address;
+	}
+
+	void* dma_block::map(const utils::address_range& range) const
+	{
+		ensure(range.inside(this->range()));
+		return vm::get_super_ptr(range.start);
+	}
+
+	void dma_block::resize(u32 new_length)
+	{
+		if (new_length < length())
+		{
+			return;
+		}
+
+		allocate(m_base_address, new_length);
+	}
+
+	void dma_block::set_parent(const dma_block* other)
+	{
+		ensure(this->range().inside(other->range()));
+		ensure(other != this);
+
+		m_parent = other;
+		if (m_data)
+		{
+			m_data->remove();
+			m_data.reset();
+		}
+	}
+
+	bool dma_block::can_map(const utils::address_range& range) const
+	{
+		if (m_parent)
+		{
+			return m_parent->can_map(range);
+		}
+
+		return range.inside(this->range());
+	}
+
+	void clear_dma_resources()
+	{
+		g_dma_pool.clear();
+	}
+
+	utils::address_range to_dma_block_range(u32 start, u32 length)
+	{
+		const auto start_block_address = start & ~s_dma_block_size;
+		const auto end_block_address = (start + length - 1) & ~s_dma_block_size;
+		return utils::address_range::start_end(start_block_address, end_block_address);
+	}
+
+	const dma_block& get_block(u32 start, u32 length)
+	{
+		const auto block_range = to_dma_block_range(start, length);
+		auto& block = g_dma_pool[block_range.start];
+		if (!block)
+		{
+			block = std::make_unique<dma_block>();
+			block->allocate(block_range.start, length);
+			return *block;
+		}
+
+		const auto range = utils::address_range::start_length(start, length);
+		if (block->can_map(range)) [[ likely ]]
+		{
+			return *block;
+		}
+
+		const auto owner = block->head();
+		const auto new_length = (block_range.end + 1) - owner->base_addr();
+		const auto search_end = (block_range.end + 1);
+
+		// 1. Resize to new length
+		auto new_owner = std::make_unique<dma_block>();
+		new_owner->allocate(owner->base_addr(), new_length);
+
+		// 2. Acquire all the extras
+		for (u32 id = owner->base_addr() + s_dma_block_size;
+			 id < search_end;
+			 id += s_dma_block_size)
+		{
+			ensure((id % s_dma_block_size) == 0);
+			g_dma_pool[id]->set_parent(new_owner.get());
+		}
+
+		block = std::move(new_owner);
+		return *block;
+	}
+
+	dma_mapping_handle map_dma(u32 guest_address, u32 length)
+	{
+		auto& block = get_block(guest_address, length);
+		return { guest_address - block.base_addr(), block.get() };
+	}
+}

--- a/rpcs3/Emu/RSX/GL/GLDMA.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDMA.cpp
@@ -6,6 +6,8 @@
 namespace gl
 {
 	static constexpr u32 s_dma_block_size = 0x10000;
+	static constexpr u32 s_dma_block_mask = ~(s_dma_block_size - 1);
+
 	std::unordered_map<u32, std::unique_ptr<dma_block>> g_dma_pool;
 
 	void dma_block::allocate(u32 base_address, u32 block_size)
@@ -72,8 +74,8 @@ namespace gl
 
 	utils::address_range to_dma_block_range(u32 start, u32 length)
 	{
-		const auto start_block_address = start & -s_dma_block_size;
-		const auto end_block_address = (start + length + s_dma_block_size - 1) & -s_dma_block_size;
+		const auto start_block_address = start & s_dma_block_mask;
+		const auto end_block_address = (start + length + s_dma_block_size - 1) & s_dma_block_mask;
 		return utils::address_range::start_end(start_block_address, end_block_address);
 	}
 
@@ -99,7 +101,7 @@ namespace gl
 		const auto search_end = (block_range.end + 1);
 
 		// 1. Resize to new length
-		ensure((new_length & -s_dma_block_size) == new_length);
+		ensure((new_length & ~s_dma_block_mask) == 0);
 		auto new_owner = std::make_unique<dma_block>();
 		new_owner->allocate(owner->base_addr(), new_length);
 

--- a/rpcs3/Emu/RSX/GL/GLDMA.h
+++ b/rpcs3/Emu/RSX/GL/GLDMA.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <util/types.hpp>
+#include "Utilities/address_range.h"
+
+#include "glutils/buffer_object.h"
+
+// TODO: Unify the DMA implementation across backends as part of RSX restructuring.
+namespace gl
+{
+	using dma_mapping_handle = std::pair<u32, gl::buffer*>;
+
+	dma_mapping_handle map_dma(u32 guest_addr, u32 length);
+	void clear_dma_resources();
+
+	// GL does not currently support mixed block types...
+	class dma_block
+	{
+	public:
+		dma_block() = default;
+
+		void allocate(u32 base_address, u32 block_size);
+		void resize(u32 new_length);
+		void* map(const utils::address_range& range) const;
+
+		void set_parent(const dma_block* other);
+		const dma_block* head() const { return m_parent; }
+		bool can_map(const utils::address_range& range) const;
+
+		u32 base_addr() const { return m_base_address; }
+		u32 length() const { return m_data ? static_cast<u32>(m_data->size()) : 0; }
+		bool empty() const { return length() == 0; }
+		buffer* get() const { return m_data.get(); }
+		utils::address_range range() const { return utils::address_range::start_length(m_base_address, length()); }
+
+	protected:
+		u32 m_base_address = 0;
+		const dma_block* m_parent = nullptr;
+		std::unique_ptr<gl::buffer> m_data;
+	};
+}

--- a/rpcs3/Emu/RSX/GL/GLDMA.h
+++ b/rpcs3/Emu/RSX/GL/GLDMA.h
@@ -24,7 +24,7 @@ namespace gl
 		void* map(const utils::address_range& range) const;
 
 		void set_parent(const dma_block* other);
-		const dma_block* head() const { return m_parent; }
+		const dma_block* head() const { return m_parent ? m_parent : this; }
 		bool can_map(const utils::address_range& range) const;
 
 		u32 base_addr() const { return m_base_address; }

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -7,6 +7,7 @@
 
 #include "Emu/Memory/vm_locking.h"
 #include "Emu/RSX/rsx_methods.h"
+#include "Emu/RSX/Host/RSXDMAWriter.h"
 #include "Emu/RSX/NV47/HW/context_accessors.define.h"
 
 [[noreturn]] extern void report_fatal_error(std::string_view _text, bool is_html = false, bool include_help_text = true);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -128,7 +128,7 @@ class GLGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 
 	GLProgramBuffer m_prog_buffer;
 
-	//buffer
+	// Draw Buffers
 	gl::fbo* m_draw_fbo = nullptr;
 	std::list<gl::framebuffer_holder> m_framebuffer_cache;
 	std::unique_ptr<gl::texture> m_flip_tex_color[2];
@@ -137,7 +137,7 @@ class GLGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 	std::unique_ptr<gl::upscaler> m_upscaler;
 	output_scaling_mode m_output_scaling = output_scaling_mode::bilinear;
 
-	//vaos are mandatory for core profile
+	// VAOs are mandatory for core profile
 	gl::vao m_vao;
 
 	shared_mutex m_sampler_mutex;
@@ -149,6 +149,9 @@ class GLGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 
 	// Occlusion query type, can be SAMPLES_PASSED or ANY_SAMPLES_PASSED
 	GLenum m_occlusion_type = GL_ANY_SAMPLES_PASSED;
+
+	// Host context for GPU-driven work
+	std::unique_ptr<gl::buffer> m_host_gpu_context_data;
 
 public:
 	u64 get_cycles() final;

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -152,6 +152,7 @@ class GLGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 
 	// Host context for GPU-driven work
 	std::unique_ptr<gl::buffer> m_host_gpu_context_data;
+	std::unique_ptr<gl::scratch_ring_buffer> m_enqueued_host_write_buffer;
 
 public:
 	u64 get_cycles() final;
@@ -195,6 +196,11 @@ public:
 	bool check_occlusion_query_status(rsx::reports::occlusion_query_info* query) override;
 	void get_occlusion_query_result(rsx::reports::occlusion_query_info* query) override;
 	void discard_occlusion_query(rsx::reports::occlusion_query_info* query) override;
+
+	// DMA
+	bool release_GCM_label(u32 address, u32 data) override;
+	void enqueue_host_context_write(u32 offset, u32 size, const void* data);
+	void on_guest_texture_read();
 
 	// GRAPH backend
 	void patch_transform_constants(rsx::context* ctx, u32 index, u32 count) override;

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -59,7 +59,7 @@ namespace gl
 				pbo.remove();
 			}
 
-			pbo.create(buffer::target::pixel_pack, buffer_size, nullptr, buffer::memory_type::host_visible, GL_STREAM_READ);
+			pbo.create(buffer::target::pixel_pack, buffer_size, nullptr, buffer::memory_type::host_visible, buffer::usage::host_read);
 			glBindBuffer(GL_PIXEL_PACK_BUFFER, GL_NONE);
 		}
 

--- a/rpcs3/Emu/RSX/GL/glutils/buffer_object.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/buffer_object.cpp
@@ -3,38 +3,35 @@
 
 namespace gl
 {
-	void buffer::allocate(GLsizeiptr size, const void* data_, memory_type type, GLenum usage)
+	void buffer::allocate(GLsizeiptr size, const void* data_, memory_type type, GLuint usage_flags)
 	{
+		m_memory_type = type;
+
 		if (const auto& caps = get_driver_caps();
-			m_target != target::userptr && caps.ARB_buffer_storage_supported)
+			type != memory_type::userptr && caps.ARB_buffer_storage_supported)
 		{
 			GLenum flags = 0;
-			if (type == memory_type::host_visible)
+			if (usage_flags & usage::host_write)
 			{
-				switch (usage)
-				{
-				case GL_STREAM_DRAW:
-				case GL_STATIC_DRAW:
-				case GL_DYNAMIC_DRAW:
-					flags |= GL_MAP_WRITE_BIT;
-					break;
-				case GL_STREAM_READ:
-				case GL_STATIC_READ:
-				case GL_DYNAMIC_READ:
-					flags |= GL_MAP_READ_BIT;
-					break;
-				default:
-					fmt::throw_exception("Unsupported buffer usage 0x%x", usage);
-				}
+				flags |= GL_MAP_WRITE_BIT;
 			}
-			else
+			if (usage_flags & usage::host_read)
 			{
-				// Local memory hints
-				if (usage == GL_DYNAMIC_COPY)
-				{
-					flags |= GL_DYNAMIC_STORAGE_BIT;
-				}
+				flags |= GL_MAP_READ_BIT;
 			}
+			if (usage_flags & usage::persistent_map)
+			{
+				flags |= GL_MAP_PERSISTENT_BIT;
+			}
+			if (usage_flags & usage::dynamic_update)
+			{
+				flags |= GL_DYNAMIC_STORAGE_BIT;
+			}
+
+			ensure((flags & (GL_MAP_PERSISTENT_BIT | GL_DYNAMIC_STORAGE_BIT)) != (GL_MAP_PERSISTENT_BIT | GL_DYNAMIC_STORAGE_BIT),
+				"Mutually exclusive usage flags set!");
+
+			ensure(type == memory_type::local || flags != 0, "Host-visible memory must have usage flags set!");
 
 			if ((flags & GL_MAP_READ_BIT) && !caps.vendor_AMD)
 			{
@@ -51,10 +48,8 @@ namespace gl
 		}
 		else
 		{
-			data(size, data_, usage);
+			data(size, data_, GL_STREAM_COPY);
 		}
-
-		m_memory_type = type;
 	}
 
 	buffer::~buffer()
@@ -89,18 +84,18 @@ namespace gl
 		save_binding_state save(current_target(), *this);
 	}
 
-	void buffer::create(GLsizeiptr size, const void* data_, memory_type type, GLenum usage)
+	void buffer::create(GLsizeiptr size, const void* data_, memory_type type, GLuint usage_bits)
 	{
 		create();
-		allocate(size, data_, type, usage);
+		allocate(size, data_, type, usage_bits);
 	}
 
-	void buffer::create(target target_, GLsizeiptr size, const void* data_, memory_type type, GLenum usage)
+	void buffer::create(target target_, GLsizeiptr size, const void* data_, memory_type type, GLuint usage_bits)
 	{
 		m_target = target_;
 
 		create();
-		allocate(size, data_, type, usage);
+		allocate(size, data_, type, usage_bits);
 	}
 
 	void buffer::remove()
@@ -117,11 +112,19 @@ namespace gl
 	{
 		ensure(m_memory_type != memory_type::local);
 
-		DSA_CALL2(NamedBufferData, m_id, size, data_, usage);
 		m_size = size;
+
+		if (m_memory_type == memory_type::userptr)
+		{
+			glBindBuffer(GL_EXTERNAL_VIRTUAL_MEMORY_BUFFER_AMD, m_id);
+			glBufferData(GL_EXTERNAL_VIRTUAL_MEMORY_BUFFER_AMD, size, data_, usage);
+			return;
+		}
+
+		DSA_CALL2(NamedBufferData, m_id, size, data_, usage);
 	}
 
-	void buffer::sub_data(GLsizeiptr offset, GLsizeiptr length, GLvoid* data)
+	void buffer::sub_data(GLsizeiptr offset, GLsizeiptr length, const GLvoid* data)
 	{
 		ensure(m_memory_type == memory_type::local);
 		DSA_CALL2(NamedBufferSubData, m_id, offset, length, data);

--- a/rpcs3/Emu/RSX/GL/glutils/buffer_object.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/buffer_object.cpp
@@ -6,7 +6,7 @@ namespace gl
 	void buffer::allocate(GLsizeiptr size, const void* data_, memory_type type, GLenum usage)
 	{
 		if (const auto& caps = get_driver_caps();
-			caps.ARB_buffer_storage_supported)
+			m_target != target::userptr && caps.ARB_buffer_storage_supported)
 		{
 			GLenum flags = 0;
 			if (type == memory_type::host_visible)

--- a/rpcs3/Emu/RSX/GL/glutils/buffer_object.h
+++ b/rpcs3/Emu/RSX/GL/glutils/buffer_object.h
@@ -15,28 +15,37 @@ namespace gl
 			element_array = GL_ELEMENT_ARRAY_BUFFER,
 			uniform = GL_UNIFORM_BUFFER,
 			texture = GL_TEXTURE_BUFFER,
-			ssbo = GL_SHADER_STORAGE_BUFFER,
-			userptr = GL_EXTERNAL_VIRTUAL_MEMORY_BUFFER_AMD
+			ssbo = GL_SHADER_STORAGE_BUFFER
 		};
 
 		enum class access
 		{
 			read = GL_MAP_READ_BIT,
 			write = GL_MAP_WRITE_BIT,
-			read_write = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT
+			rw = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT,
+			persistent_rw = GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT
 		};
 
 		enum class memory_type
 		{
 			undefined = 0,
 			local = 1,
-			host_visible = 2
+			host_visible = 2,
+			userptr = 4
+		};
+
+		enum usage
+		{
+			host_write     = (1 << 0),
+			host_read      = (1 << 1),
+			persistent_map = (1 << 2),
+			dynamic_update = (1 << 3),
 		};
 
 		class save_binding_state
 		{
-			GLint m_last_binding;
-			GLenum m_target;
+			GLint m_last_binding = GL_ZERO;
+			GLenum m_target = GL_NONE;
 
 		public:
 			save_binding_state(target target_, const buffer& new_state) : save_binding_state(target_)
@@ -65,6 +74,11 @@ namespace gl
 
 			~save_binding_state()
 			{
+				if (!m_target)
+				{
+					return;
+				}
+
 				glBindBuffer(m_target, m_last_binding);
 			}
 		};
@@ -78,7 +92,7 @@ namespace gl
 		// Metadata
 		mutable std::pair<u32, u32> m_bound_range{};
 
-		void allocate(GLsizeiptr size, const void* data_, memory_type type, GLenum usage);
+		void allocate(GLsizeiptr size, const void* data_, memory_type type, GLuint usage_bits);
 
 	public:
 		buffer() = default;
@@ -89,8 +103,8 @@ namespace gl
 		void recreate(GLsizeiptr size, const void* data = nullptr);
 
 		void create();
-		void create(GLsizeiptr size, const void* data_ = nullptr, memory_type type = memory_type::local, GLenum usage = GL_STREAM_DRAW);
-		void create(target target_, GLsizeiptr size, const void* data_ = nullptr, memory_type type = memory_type::local, GLenum usage = GL_STREAM_DRAW);
+		void create(GLsizeiptr size, const void* data_ = nullptr, memory_type type = memory_type::local, GLuint usage_bits = 0);
+		void create(target target_, GLsizeiptr size, const void* data_ = nullptr, memory_type type = memory_type::local, GLuint usage_bits = 0);
 
 		void remove();
 
@@ -98,7 +112,7 @@ namespace gl
 		void bind() const { bind(current_target()); }
 
 		void data(GLsizeiptr size, const void* data_ = nullptr, GLenum usage = GL_STREAM_DRAW);
-		void sub_data(GLsizeiptr offset, GLsizeiptr length, GLvoid* data);
+		void sub_data(GLsizeiptr offset, GLsizeiptr length, const GLvoid* data);
 
 		GLubyte* map(GLsizeiptr offset, GLsizeiptr length, access access_);
 		void unmap();

--- a/rpcs3/Emu/RSX/GL/glutils/buffer_object.h
+++ b/rpcs3/Emu/RSX/GL/glutils/buffer_object.h
@@ -15,7 +15,8 @@ namespace gl
 			element_array = GL_ELEMENT_ARRAY_BUFFER,
 			uniform = GL_UNIFORM_BUFFER,
 			texture = GL_TEXTURE_BUFFER,
-			ssbo = GL_SHADER_STORAGE_BUFFER
+			ssbo = GL_SHADER_STORAGE_BUFFER,
+			userptr = GL_EXTERNAL_VIRTUAL_MEMORY_BUFFER_AMD
 		};
 
 		enum class access

--- a/rpcs3/Emu/RSX/GL/glutils/capabilities.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/capabilities.cpp
@@ -33,7 +33,7 @@ namespace gl
 
 	void capabilities::initialize()
 	{
-		int find_count = 16;
+		int find_count = 17;
 		int ext_count = 0;
 		glGetIntegerv(GL_NUM_EXTENSIONS, &ext_count);
 
@@ -161,6 +161,13 @@ namespace gl
 			if (check(ext_name, "GL_NV_fragment_shader_barycentric"))
 			{
 				NV_fragment_shader_barycentric_supported = true;
+				find_count--;
+				continue;
+			}
+
+			if (check(ext_name, "GL_AMD_pinned_memory"))
+			{
+				AMD_pinned_memory = true;
 				find_count--;
 				continue;
 			}

--- a/rpcs3/Emu/RSX/GL/glutils/capabilities.h
+++ b/rpcs3/Emu/RSX/GL/glutils/capabilities.h
@@ -25,6 +25,7 @@ namespace gl
 
 		bool EXT_dsa_supported = false;
 		bool EXT_depth_bounds_test = false;
+		bool AMD_pinned_memory = false;
 		bool ARB_dsa_supported = false;
 		bool ARB_bindless_texture_supported = false;
 		bool ARB_buffer_storage_supported = false;

--- a/rpcs3/Emu/RSX/GL/glutils/common.h
+++ b/rpcs3/Emu/RSX/GL/glutils/common.h
@@ -81,7 +81,7 @@ namespace gl
 	}
 
 	// Checks if GL state is still valid
-	void check_state()
+	static inline void check_state()
 	{
 		// GL_OUT_OF_MEMORY invalidates the OpenGL context and is actually the GL version of DEVICE_LOST.
 		// This spec workaround allows it to be abused by ISVs to indicate a broken GL context.

--- a/rpcs3/Emu/RSX/GL/glutils/common.h
+++ b/rpcs3/Emu/RSX/GL/glutils/common.h
@@ -79,4 +79,12 @@ namespace gl
 	{
 		glInsertEventMarkerEXT(static_cast<GLsizei>(strlen(label)), label);
 	}
+
+	// Checks if GL state is still valid
+	void check_state()
+	{
+		// GL_OUT_OF_MEMORY invalidates the OpenGL context and is actually the GL version of DEVICE_LOST.
+		// This spec workaround allows it to be abused by ISVs to indicate a broken GL context.
+		ensure(glGetError() != GL_OUT_OF_MEMORY);
+	}
 }

--- a/rpcs3/Emu/RSX/GL/glutils/ring_buffer.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/ring_buffer.cpp
@@ -242,14 +242,14 @@ namespace gl
 		}
 	}
 
-	void scratch_ring_buffer::create(buffer::target target_, u64 size)
+	void scratch_ring_buffer::create(buffer::target target_, u64 size, u32 usage_flags)
 	{
 		if (m_storage)
 		{
 			remove();
 		}
 
-		m_storage.create(target_, size, nullptr, gl::buffer::memory_type::local, GL_STATIC_COPY);
+		m_storage.create(target_, size, nullptr, gl::buffer::memory_type::local, usage_flags);
 	}
 
 	void scratch_ring_buffer::remove()

--- a/rpcs3/Emu/RSX/GL/glutils/ring_buffer.h
+++ b/rpcs3/Emu/RSX/GL/glutils/ring_buffer.h
@@ -103,7 +103,7 @@ namespace gl
 		scratch_ring_buffer(const scratch_ring_buffer&) = delete;
 		~scratch_ring_buffer();
 
-		void create(buffer::target _target, u64 size);
+		void create(buffer::target _target, u64 size, u32 usage_flags = 0);
 		void remove();
 
 		u32 alloc(u32 size, u32 alignment);

--- a/rpcs3/Emu/RSX/GL/upscalers/fsr1/fsr_pass.cpp
+++ b/rpcs3/Emu/RSX/GL/upscalers/fsr1/fsr_pass.cpp
@@ -80,7 +80,7 @@ namespace gl
 			if (!m_ubo)
 			{
 				ensure(compiled);
-				m_ubo.create(gl::buffer::target::uniform, push_buffer_size, nullptr, gl::buffer::memory_type::local, GL_DYNAMIC_COPY);
+				m_ubo.create(gl::buffer::target::uniform, push_buffer_size, nullptr, gl::buffer::memory_type::local, gl::buffer::usage::dynamic_update);
 
 				// Statically bind the image sources
 				m_program.uniforms["InputTexture"] = GL_TEMP_IMAGE_SLOT(0);

--- a/rpcs3/Emu/RSX/Host/RSXDMAWriter.cpp
+++ b/rpcs3/Emu/RSX/Host/RSXDMAWriter.cpp
@@ -1,0 +1,67 @@
+#include "stdafx.h"
+#include "RSXDMAWriter.h"
+
+#include "Utilities//Thread.h"
+#include <util/asm.hpp>
+
+namespace rsx
+{
+	void RSXDMAWriter::update()
+	{
+		if (m_dispatch_handlers.empty())
+		{
+			m_job_queue.clear();
+			return;
+		}
+
+		while (!m_job_queue.empty())
+		{
+			const auto job = m_job_queue.front();
+
+			if (const auto dispatch = m_dispatch_handlers.find(job.dispatch_class);
+				dispatch == m_dispatch_handlers.end() || dispatch->second.handler(m_host_context_ptr, &job))
+			{
+				// No handler registered, or callback consumed the job
+				m_job_queue.pop_front();
+				continue;
+			}
+
+			// Dispatcher found and rejected the job. Stop, we'll try again later.
+			break;
+		}
+	}
+
+	void RSXDMAWriter::register_handler(host_dispatch_handler_t handler)
+	{
+		m_dispatch_handlers[handler.dispatch_class] = handler;
+	}
+
+	void RSXDMAWriter::deregister_handler(int dispatch_class)
+	{
+		m_dispatch_handlers.erase(dispatch_class);
+	}
+
+	void RSXDMAWriter::enqueue(const host_gpu_write_op_t& request)
+	{
+		m_job_queue.push_back(request);
+	}
+
+	void RSXDMAWriter::drain_label_queue()
+	{
+		if (!m_host_context_ptr)
+		{
+			return;
+		}
+
+		// FIXME: This is a busy wait, consider yield to improve responsiveness on weak devices.
+		while (!m_host_context_ptr->in_flight_commands_completed())
+		{
+			utils::pause();
+
+			if (thread_ctrl::state() == thread_state::aborting)
+			{
+				break;
+			}
+		}
+	}
+}

--- a/rpcs3/Emu/RSX/Host/RSXDMAWriter.h
+++ b/rpcs3/Emu/RSX/Host/RSXDMAWriter.h
@@ -27,7 +27,7 @@ namespace rsx
 
 		inline bool in_flight_commands_completed() const volatile
 		{
-			return last_label_release2_event == commands_complete_event;
+			return last_label_release2_event <= commands_complete_event;
 		}
 
 		inline bool texture_loads_completed() const volatile

--- a/rpcs3/Emu/RSX/Host/RSXDMAWriter.h
+++ b/rpcs3/Emu/RSX/Host/RSXDMAWriter.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <util/types.hpp>
+
+#include <unordered_map>
+#include <functional>
+#include <deque>
+
+namespace rsx
+{
+	struct host_gpu_context_t
+	{
+		u64 magic = 0xCAFEBABE;
+		u64 event_counter = 0;
+		u64 texture_load_request_event = 0;
+		u64 texture_load_complete_event = 0;
+		u64 last_label_acquire_event = 0;
+		u64 last_label_release2_event = 0;
+		u64 commands_complete_event = 0;
+
+		inline u64 inc_counter() volatile
+		{
+			// Workaround for volatile increment warning. GPU can see this value directly, but currently we do not modify it on the device.
+			event_counter = event_counter + 1;
+			return event_counter;
+		}
+
+		inline bool in_flight_commands_completed() const volatile
+		{
+			return last_label_release2_event == commands_complete_event;
+		}
+
+		inline bool texture_loads_completed() const volatile
+		{
+			// Return true if all texture load requests are done.
+			return texture_load_complete_event == texture_load_request_event;
+		}
+
+		inline bool has_unflushed_texture_loads() const volatile
+		{
+			return texture_load_request_event > last_label_release2_event;
+		}
+
+		inline u64 on_texture_load_acquire() volatile
+		{
+			texture_load_request_event = inc_counter();
+			return texture_load_request_event;
+		}
+
+		inline void on_texture_load_release() volatile
+		{
+			// Normally released by the host device, but implemented nonetheless for software fallback
+			texture_load_complete_event = texture_load_request_event;
+		}
+
+		inline u64 on_label_acquire() volatile
+		{
+			last_label_acquire_event = inc_counter();
+			return last_label_acquire_event;
+		}
+
+		inline void on_label_release() volatile
+		{
+			last_label_release2_event = last_label_acquire_event;
+		}
+
+		inline bool needs_label_release() const volatile
+		{
+			return last_label_acquire_event > last_label_release2_event;
+		}
+	};
+
+	struct host_gpu_write_op_t
+	{
+		int dispatch_class = 0;
+		void* userdata = nullptr;
+	};
+
+	struct host_dispatch_handler_t
+	{
+		int dispatch_class = 0;
+		std::function<bool(const volatile host_gpu_context_t*, const host_gpu_write_op_t*)> handler;
+	};
+
+	class RSXDMAWriter
+	{
+	public:
+		RSXDMAWriter(void* mem)
+			: m_host_context_ptr(new (mem)host_gpu_context_t)
+		{}
+
+		RSXDMAWriter(host_gpu_context_t* pctx)
+			: m_host_context_ptr(pctx)
+		{}
+
+		void update();
+
+		void register_handler(host_dispatch_handler_t handler);
+		void deregister_handler(int dispatch_class);
+
+		void enqueue(const host_gpu_write_op_t& request);
+		void drain_label_queue();
+
+		volatile host_gpu_context_t* host_ctx() const
+		{
+			return m_host_context_ptr;
+		}
+
+	private:
+		std::unordered_map<int, host_dispatch_handler_t> m_dispatch_handlers;
+		volatile host_gpu_context_t* m_host_context_ptr = nullptr;
+
+		std::deque<host_gpu_write_op_t> m_job_queue;
+	};
+}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1162,6 +1162,7 @@ namespace rsx
 
 				// Update other sub-units
 				zcull_ctrl->update(this);
+				m_host_dma_ctrl->update();
 			}
 
 			// Execute FIFO queue

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1,10 +1,6 @@
 #include "stdafx.h"
 #include "RSXThread.h"
 
-#include "Emu/Cell/PPUCallback.h"
-#include "Emu/Cell/SPUThread.h"
-#include "Emu/Cell/timers.hpp"
-
 #include "Capture/rsx_capture.h"
 #include "Common/BufferUtils.h"
 #include "Common/buffer_stream.hpp"
@@ -13,9 +9,17 @@
 #include "Common/time.hpp"
 #include "Core/RSXReservationLock.hpp"
 #include "Core/RSXEngLock.hpp"
+#include "Host/RSXDMAWriter.h"
+#include "NV47/HW/context.h"
+#include "Program/GLSLCommon.h"
 #include "rsx_methods.h"
+
 #include "gcm_printing.h"
 #include "RSXDisAsm.h"
+
+#include "Emu/Cell/PPUCallback.h"
+#include "Emu/Cell/SPUThread.h"
+#include "Emu/Cell/timers.hpp"
 #include "Emu/Cell/lv2/sys_event.h"
 #include "Emu/Cell/lv2/sys_time.h"
 #include "Emu/Cell/Modules/cellGcmSys.h"
@@ -23,11 +27,10 @@
 #include "Overlays/overlay_perf_metrics.h"
 #include "Overlays/overlay_debug_overlay.h"
 #include "Overlays/overlay_message.h"
-#include "Program/GLSLCommon.h"
+
 #include "Utilities/date_time.h"
 #include "Utilities/StrUtil.h"
 #include "Crypto/unzip.h"
-#include "NV47/HW/context.h"
 
 #include "util/asm.hpp"
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -35,6 +35,8 @@
 
 #include "NV47/FW/GRAPH_backend.h"
 
+#include "Host/RSXDMAWriter.h"
+
 extern atomic_t<bool> g_user_asked_for_frame_capture;
 extern atomic_t<bool> g_disable_frame_limit;
 extern rsx::frame_trace_data frame_debug;
@@ -211,6 +213,9 @@ namespace rsx
 
 		// Context
 		context* m_ctx = nullptr;
+
+		// Host DMA
+		std::unique_ptr<RSXDMAWriter> m_host_dma_ctrl;
 
 	public:
 		atomic_t<u64> new_get_put = u64{umax};

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -35,8 +35,6 @@
 
 #include "NV47/FW/GRAPH_backend.h"
 
-#include "Host/RSXDMAWriter.h"
-
 extern atomic_t<bool> g_user_asked_for_frame_capture;
 extern atomic_t<bool> g_disable_frame_limit;
 extern rsx::frame_trace_data frame_debug;
@@ -44,6 +42,8 @@ extern rsx::frame_capture_data frame_capture;
 
 namespace rsx
 {
+	class RSXDMAWriter;
+
 	struct context;
 
 	namespace overlays

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1785,7 +1785,7 @@ void VKGSRender::flush_command_queue(bool hard_sync, bool do_not_switch)
 
 std::pair<volatile vk::host_data_t*, VkBuffer> VKGSRender::map_host_object_data() const
 {
-	return { m_host_dma_ctrl->host_ctx(), m_host_object_data->value};
+	return { m_host_dma_ctrl->host_ctx(), m_host_object_data->value };
 }
 
 bool VKGSRender::release_GCM_label(u32 address, u32 args)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -280,6 +280,7 @@ public:
 
 	// Host sync object
 	std::pair<volatile vk::host_data_t*, VkBuffer> map_host_object_data() const;
+	void on_guest_texture_read(const vk::command_buffer& cmd);
 
 	// GRAPH backend
 	void patch_transform_constants(rsx::context* ctx, u32 index, u32 count) override;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -1,6 +1,4 @@
 #pragma once
-#include "Emu/RSX/GSRender.h"
-#include "Emu/Cell/timers.hpp"
 
 #include "upscalers/upscaling.h"
 
@@ -19,14 +17,22 @@
 #include "VKFramebuffer.h"
 #include "VKShaderInterpreter.h"
 #include "VKQueryPool.h"
-#include "../GCM.h"
 #include "util/asm.hpp"
+
+#include "Emu/RSX/GCM.h"
+#include "Emu/RSX/GSRender.h"
+#include "Emu/RSX/Host/RSXDMAWriter.h"
 
 #include <thread>
 #include <optional>
 
 using namespace vk::vmm_allocation_pool_; // clang workaround.
 using namespace vk::upscaling_flags_;     // ditto
+
+namespace vk
+{
+	using host_data_t = rsx::host_gpu_context_t;
+}
 
 class VKGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 {
@@ -118,7 +124,6 @@ private:
 	vk::command_buffer_chain<VK_MAX_ASYNC_CB_COUNT> m_primary_cb_list;
 	vk::command_buffer_chunk* m_current_command_buffer = nullptr;
 
-	volatile vk::host_data_t* m_host_data_ptr = nullptr;
 	std::unique_ptr<vk::buffer> m_host_object_data;
 
 	vk::descriptor_pool m_descriptor_pool;
@@ -274,7 +279,7 @@ public:
 	void end_conditional_rendering() override;
 
 	// Host sync object
-	inline std::pair<volatile vk::host_data_t*, VkBuffer> map_host_object_data() { return { m_host_data_ptr, m_host_object_data->value }; }
+	std::pair<volatile vk::host_data_t*, VkBuffer> map_host_object_data() const;
 
 	// GRAPH backend
 	void patch_transform_constants(rsx::context* ctx, u32 index, u32 count) override;

--- a/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
@@ -6,6 +6,7 @@
 
 #include "Emu/RSX/Common/simple_array.hpp"
 #include "Emu/RSX/rsx_utils.h"
+#include "Emu/RSX/rsx_cache.h"
 #include "Utilities/mutex.h"
 #include "util/asm.hpp"
 

--- a/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
@@ -11,6 +11,7 @@
 #include "util/asm.hpp"
 
 #include <optional>
+#include <thread>
 
 // Initial heap allocation values. The heaps are growable and will automatically increase in size to accomodate demands
 #define VK_ATTRIB_RING_BUFFER_SIZE_M 64

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -1240,15 +1240,9 @@ namespace vk
 			dst_image->queue_release(cmd2, cmd.get_queue_family(), dst_image->current_layout);
 		}
 
-		if (auto rsxthr = rsx::get_current_renderer();
-			rsxthr->get_backend_config().supports_host_gpu_labels)
+		if (auto rsxthr = static_cast<VKGSRender*>(rsx::get_current_renderer()))
 		{
-			// Queue a sync update on the CB doing the load
-			auto [host_data, host_buffer] = static_cast<VKGSRender*>(rsxthr)->map_host_object_data();
-			ensure(host_data);
-
-			const auto event_id = host_data->on_texture_load_acquire();
-			vkCmdUpdateBuffer(cmd2, host_buffer, ::offset32(&vk::host_data_t::texture_load_complete_event), sizeof(u64), &event_id);
+			rsxthr->on_guest_texture_read(cmd2);
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKTexture.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTexture.cpp
@@ -1246,8 +1246,8 @@ namespace vk
 			// Queue a sync update on the CB doing the load
 			auto [host_data, host_buffer] = static_cast<VKGSRender*>(rsxthr)->map_host_object_data();
 			ensure(host_data);
-			const auto event_id = host_data->inc_counter();
-			host_data->texture_load_request_event = event_id;
+
+			const auto event_id = host_data->on_texture_load_acquire();
 			vkCmdUpdateBuffer(cmd2, host_buffer, ::offset32(&vk::host_data_t::texture_load_complete_event), sizeof(u64), &event_id);
 		}
 	}

--- a/rpcs3/Emu/RSX/VK/vkutils/sync.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/sync.h
@@ -18,25 +18,6 @@ namespace vk
 		gpu = 1
 	};
 
-	struct host_data_t // Pick a better name
-	{
-		u64 magic = 0xCAFEBABE;
-		u64 event_counter = 0;
-		u64 texture_load_request_event = 0;
-		u64 texture_load_complete_event = 0;
-		u64 last_label_release_event = 0;
-		u64 last_label_submit_event = 0;
-		u64 commands_complete_event = 0;
-		u64 last_label_request_timestamp = 0;
-
-		inline u64 inc_counter() volatile
-		{
-			// Workaround for volatile increment warning. GPU can see this value directly, but currently we do not modify it on the device.
-			event_counter = event_counter + 1;
-			return event_counter;
-		}
-	};
-
 	struct fence
 	{
 		atomic_t<bool> flushed = false;

--- a/rpcs3/GLGSRender.vcxproj
+++ b/rpcs3/GLGSRender.vcxproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Emu\RSX\GL\GLCompute.h" />
+    <ClInclude Include="Emu\RSX\GL\GLDMA.h" />
     <ClInclude Include="Emu\RSX\GL\GLOverlays.h" />
     <ClInclude Include="Emu\RSX\GL\GLPipelineCompiler.h" />
     <ClInclude Include="Emu\RSX\GL\GLCommonDecompiler.h" />
@@ -88,6 +89,7 @@
   <ItemGroup>
     <ClCompile Include="Emu\RSX\GL\GLCommonDecompiler.cpp" />
     <ClCompile Include="Emu\RSX\GL\GLCompute.cpp" />
+    <ClCompile Include="Emu\RSX\GL\GLDMA.cpp" />
     <ClCompile Include="Emu\RSX\GL\GLDraw.cpp" />
     <ClCompile Include="Emu\RSX\GL\GLFragmentProgram.cpp" />
     <ClCompile Include="Emu\RSX\GL\GLGSRender.cpp" />

--- a/rpcs3/GLGSRender.vcxproj.filters
+++ b/rpcs3/GLGSRender.vcxproj.filters
@@ -47,6 +47,7 @@
     <ClCompile Include="Emu\RSX\GL\upscalers\fsr1\fsr_pass.cpp">
       <Filter>upscalers\fsr1</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\GL\GLDMA.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Emu\RSX\GL\GLTexture.h" />
@@ -118,6 +119,7 @@
     <ClInclude Include="Emu\RSX\GL\upscalers\fsr_pass.h">
       <Filter>upscalers</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\GL\GLDMA.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="glutils">

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -104,6 +104,7 @@
     <ClCompile Include="Emu\perf_monitor.cpp" />
     <ClCompile Include="Emu\RSX\Common\texture_cache.cpp" />
     <ClCompile Include="Emu\RSX\Core\RSXContext.cpp" />
+    <ClCompile Include="Emu\RSX\Host\RSXDMAWriter.cpp" />
     <ClCompile Include="Emu\RSX\NV47\FW\draw_call.cpp" />
     <ClCompile Include="Emu\RSX\NV47\FW\reg_context.cpp" />
     <ClCompile Include="Emu\RSX\NV47\HW\common.cpp" />
@@ -617,6 +618,7 @@
     <ClInclude Include="Emu\RSX\Core\RSXDisplay.h" />
     <ClInclude Include="Emu\RSX\Core\RSXReservationLock.hpp" />
     <ClInclude Include="Emu\RSX\Core\RSXVertexTypes.h" />
+    <ClInclude Include="Emu\RSX\Host\RSXDMAWriter.h" />
     <ClInclude Include="Emu\RSX\NV47\FW\draw_call.hpp" />
     <ClInclude Include="Emu\RSX\NV47\FW\draw_call.inc.h" />
     <ClInclude Include="Emu\RSX\NV47\FW\GRAPH_backend.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1300,6 +1300,9 @@
     <ClCompile Include="Emu\RSX\gcm_enums.cpp">
       <Filter>Emu\GPU\RSX\NV47\FW</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Host\RSXDMAWriter.cpp">
+      <Filter>Emu\GPU\RSX\Host Mini-Driver</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -2619,6 +2622,9 @@
     </ClInclude>
     <ClInclude Include="Emu\RSX\color_utils.h">
       <Filter>Emu\GPU\RSX\Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Host\RSXDMAWriter.h">
+      <Filter>Emu\GPU\RSX\Host Mini-Driver</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Implements the host labels feature for OpenGL including dependencies such as a passthrough DMA layer simulating RSX memory views into CELL XDR memory. Only AMD supports GPU commands working on user-provided memory through the GL_AMD_pinned_memory extension so this implementation focuses on that. I have also refactored the core implementation to support other vendors in a separate update using callback hooks, but that work is still WIP.

Eventually the host labels will be decoupled from passthrough DMA support which should allow more devices to run correctly. The option will then be auto-enabled with the "Strict Rendering Mode" toggle as it offers a correct RSX label synchronization implementation.

Closes https://github.com/RPCS3/rpcs3/issues/16197