### PR TITLE
rsx: Fix crash when host labels option is disabled

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1165,7 +1165,11 @@ namespace rsx
 
 				// Update other sub-units
 				zcull_ctrl->update(this);
-				m_host_dma_ctrl->update();
+
+				if (m_host_dma_ctrl)
+				{
+					m_host_dma_ctrl->update();
+				}
 			}
 
 			// Execute FIFO queue


### PR DESCRIPTION
Closes https://github.com/RPCS3/rpcs3/issues/16237