### PR TITLE
Sulfuric Fixes

### DIFF
--- a/rpcs3/Emu/Memory/vm.h
+++ b/rpcs3/Emu/Memory/vm.h
@@ -133,8 +133,8 @@ namespace vm
 		bool try_alloc(u32 addr, u64 bflags, u32 size, std::shared_ptr<utils::shm>&&) const;
 
 		// Unmap block
-		bool unmap();
-		friend bool _unmap_block(const std::shared_ptr<block_t>&);
+		bool unmap(std::vector<std::pair<u32, u32>>* unmapped = nullptr);
+		friend bool _unmap_block(const std::shared_ptr<block_t>&, std::vector<std::pair<u32, u32>>* unmapped);
 
 	public:
 		block_t(u32 addr, u32 size, u64 flags);

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -1214,7 +1214,7 @@ void GLGSRender::notify_tile_unbound(u32 tile)
 	if (false)
 	{
 		u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
-		on_notify_memory_unmapped(addr, tiles[tile].size);
+		on_notify_pre_memory_unmapped(addr, tiles[tile].size);
 		m_rtts.invalidate_surface_address(addr, false);
 	}
 

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -500,10 +500,16 @@ namespace rsx
 		void on_notify_memory_mapped(u32 address_base, u32 size);
 
 		/**
+		 * Notify that a section of memory is to be unmapped
+		 * Any data held in the defined range is discarded
+		 */
+		void on_notify_pre_memory_unmapped(u32 address_base, u32 size);
+
+		/**
 		 * Notify that a section of memory has been unmapped
 		 * Any data held in the defined range is discarded
 		 */
-		void on_notify_memory_unmapped(u32 address_base, u32 size);
+		void on_notify_post_memory_unmapped(u32 address_base, u32 size);
 
 		/**
 		 * Notify to check internal state during semaphore wait

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1257,7 +1257,7 @@ void VKGSRender::notify_tile_unbound(u32 tile)
 	if (false)
 	{
 		u32 addr = rsx::get_address(tiles[tile].offset, tiles[tile].location);
-		on_notify_memory_unmapped(addr, tiles[tile].size);
+		on_notify_pre_memory_unmapped(addr, tiles[tile].size);
 		m_rtts.invalidate_surface_address(addr, false);
 	}
 


### PR DESCRIPTION
* Filesystem fix: According to documentation, `ReplaceFile` seems to not actually replace a file, but rather its data so hard-links are preserved. Use it instead of `MoveFileEx` to preserve hardlinks 
* Exclude RSX events from VM mutex, should fix some deadlocks.

Test #16255 please.
Fixes  #16270 