### PR TITLE
GUI: Fix recursion of booting inside GetBootConfirmation()

### DIFF
--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -475,7 +475,7 @@ namespace fs
 		dir() = default;
 
 		// Open dir handle
-		explicit dir(const std::string& path)
+		explicit dir(const std::string& path) noexcept
 		{
 			open(path);
 		}
@@ -484,7 +484,7 @@ namespace fs
 		bool open(const std::string& path);
 
 		// Check whether the handle is valid (opened directory)
-		explicit operator bool() const
+		explicit operator bool() const noexcept
 		{
 			return m_dir.operator bool();
 		}
@@ -531,7 +531,7 @@ namespace fs
 				from_current
 			};
 
-			iterator(const dir* parent, mode mode_ = mode::from_first)
+			iterator(const dir* parent, mode mode_ = mode::from_first) noexcept
 				: m_parent(parent)
 			{
 				if (!m_parent)
@@ -567,6 +567,13 @@ namespace fs
 			{
 				*this = {m_parent, mode::from_current};
 				return *this;
+			}
+
+			iterator operator++(int)
+			{
+				iterator old = *this;
+				*this = {m_parent, mode::from_current};
+				return old;
 			}
 
 			bool operator !=(const iterator& rhs) const

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -430,11 +430,11 @@ static void ppu_initialize_modules(ppu_linkage_info* link, utils::serial* ar = n
 
 	if (ar)
 	{
-		g_fxo->init<hle_vars_save>(*ar);
+		ensure(g_fxo->init<hle_vars_save>(*ar));
 	}
 	else
 	{
-		g_fxo->init<hle_vars_save>();
+		ensure(g_fxo->init<hle_vars_save>());
 	}
 
 	for (auto& pair : ppu_module_manager::get())
@@ -1090,7 +1090,7 @@ void init_ppu_functions(utils::serial* ar, bool full = false)
 
 	if (ar)
 	{
-		const u32 addr = g_fxo->init<ppu_function_manager>(*ar)->addr;
+		const u32 addr = ensure(g_fxo->init<ppu_function_manager>(*ar))->addr;
 
 		if (addr % 0x1000 || !vm::check_addr(addr))
 		{
@@ -1098,7 +1098,7 @@ void init_ppu_functions(utils::serial* ar, bool full = false)
 		}
 	}
 	else
-		g_fxo->init<ppu_function_manager>();
+		ensure(g_fxo->init<ppu_function_manager>());
 
 	if (full)
 	{
@@ -2279,7 +2279,7 @@ bool ppu_load_exec(const ppu_exec_object& elf, bool virtual_load, const std::str
 	// Static HLE patching
 	if (g_cfg.core.hook_functions && !virtual_load)
 	{
-		auto shle = g_fxo->init<statichle_handler>(0);
+		auto shle = ensure(g_fxo->init<statichle_handler>(0));
 
 		for (u32 i = _main.segs[0].addr; i < (_main.segs[0].addr + _main.segs[0].size); i += 4)
 		{
@@ -2531,11 +2531,14 @@ bool ppu_load_exec(const ppu_exec_object& elf, bool virtual_load, const std::str
 			// Make init_mem_containers empty before call
 			const auto callback = std::move(Emu.init_mem_containers);
 			callback(mem_size);
+
+			ensure(g_fxo->is_init<id_manager::id_map<lv2_memory_container>>());
+			ensure(g_fxo->is_init<lv2_memory_container>());
 		}
 		else if (!ar)
 		{
-			g_fxo->init<id_manager::id_map<lv2_memory_container>>();
-			g_fxo->init<lv2_memory_container>(mem_size);
+			ensure(g_fxo->init<id_manager::id_map<lv2_memory_container>>());
+			ensure(g_fxo->init<lv2_memory_container>(mem_size));
 		}
 
 		void init_fxo_for_exec(utils::serial* ar, bool full);

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -493,7 +493,7 @@ namespace rsx
 		default:
 			break;
 		}
-		fmt::throw_exception("RSXVertexData::GetTypeSize: Bad vertex data type (%d)!", static_cast<u8>(type));
+		fmt::throw_exception("Bad vertex data type (%d)!", static_cast<u8>(type));
 	}
 
 	void tiled_region::write(const void *src, u32 width, u32 height, u32 pitch)
@@ -552,7 +552,7 @@ namespace rsx
 			}
 			break;
 		default:
-			::narrow(tile->comp);
+			fmt::throw_exception("Bad tile compression type (%d)!", tile->comp);
 		}
 	}
 
@@ -603,7 +603,7 @@ namespace rsx
 			}
 			break;
 		default:
-			::narrow(tile->comp);
+			fmt::throw_exception("Bad tile compression type (%d)!", tile->comp);
 		}
 	}
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1646,7 +1646,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 		{
 			m_state = system_state::ready;
 			GetCallbacks().on_ready();
-			g_fxo->init<main_ppu_module>();
+			ensure(g_fxo->init<main_ppu_module>());
 			vm::init();
 			m_force_boot = false;
 
@@ -2345,7 +2345,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 				sys_log.error("Booting HG category outside of HDD0!");
 			}
 
-			const auto _main = g_fxo->init<main_ppu_module>();
+			const auto _main = ensure(g_fxo->init<main_ppu_module>());
 
 			if (ppu_load_exec(ppu_exec, false, m_path, DeserialManager()))
 			{

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -32,6 +32,7 @@ namespace cfg
 enum class system_state : u32
 {
 	stopped,
+	loading,
 	stopping,
 	running,
 	paused,

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -54,6 +54,8 @@ namespace rsx::overlays
 	extern void reset_debug_overlay();
 }
 
+extern void qt_events_aware_op(int repeat_duration_ms, std::function<bool()> wrapped_op);
+
 /** Emu.Init() wrapper for user management */
 void main_application::InitializeEmulator(const std::string& user, bool show_gui)
 {
@@ -182,8 +184,8 @@ EmuCallbacks main_application::CreateCallbacks()
 	callbacks.init_pad_handler = [this](std::string_view title_id)
 	{
 		ensure(g_fxo->init<named_thread<pad_thread>>(get_thread(), m_game_window, title_id));
-		extern void process_qt_events();
-		while (!pad::g_started) process_qt_events();
+
+		qt_events_aware_op(0, [](){ return !!pad::g_started; });
 	};
 
 	callbacks.get_audio = []() -> std::shared_ptr<AudioBackend>

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -125,7 +125,7 @@ EmuCallbacks main_application::CreateCallbacks()
 		{
 		case keyboard_handler::null:
 		{
-			g_fxo->init<KeyboardHandlerBase, NullKeyboardHandler>(Emu.DeserialManager());
+			ensure(g_fxo->init<KeyboardHandlerBase, NullKeyboardHandler>(Emu.DeserialManager()));
 			break;
 		}
 		case keyboard_handler::basic:
@@ -162,7 +162,7 @@ EmuCallbacks main_application::CreateCallbacks()
 		{
 		case mouse_handler::null:
 		{
-			g_fxo->init<MouseHandlerBase, NullMouseHandler>(Emu.DeserialManager());
+			ensure(g_fxo->init<MouseHandlerBase, NullMouseHandler>(Emu.DeserialManager()));
 			break;
 		}
 		case mouse_handler::basic:
@@ -175,7 +175,7 @@ EmuCallbacks main_application::CreateCallbacks()
 		}
 		case mouse_handler::raw:
 		{
-			g_fxo->init<MouseHandlerBase, raw_mouse_handler>(Emu.DeserialManager());
+			ensure(g_fxo->init<MouseHandlerBase, raw_mouse_handler>(Emu.DeserialManager()));
 			break;
 		}
 		}

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -577,12 +577,10 @@ void gui_application::InitializeCallbacks()
 
 	callbacks.on_missing_fw = [this]()
 	{
-		if (!m_main_window)
+		if (m_main_window)
 		{
-			return;
+			m_main_window->OnMissingFw();
 		}
-
-		m_main_window->OnMissingFw();
 	};
 
 	callbacks.handle_taskbar_progress = [this](s32 type, s32 value)

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -195,13 +195,17 @@ void gui_settings::ShowInfoBox(const QString& title, const QString& text, const 
 
 bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save_entry)
 {
-	auto info = Emu.GetEmulationIdentifier();
+	// Ensure no game has booted inbetween
+	const auto guard = Emu.MakeEmulationStateGuard();
+
+	const auto info = Emu.GetEmulationIdentifier();
+	const auto old_status = Emu.GetStatus(false);
 
 	qt_events_aware_op(16, [&]()
 	{
 		if (Emu.GetStatus(false) != system_state::stopping)
 		{
-			ensure(info == Emu.GetEmulationIdentifier());
+			ensure(info == Emu.GetEmulationIdentifier(old_status == system_state::stopping ? true : false));
 			return true;
 		}
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -562,6 +562,7 @@ void main_window::show_boot_error(game_boot_result status)
 		break;
 	case game_boot_result::firmware_missing: // Handled elsewhere
 	case game_boot_result::already_added: // Handled elsewhere
+	case game_boot_result::currently_restricted:
 	case game_boot_result::no_errors:
 		return;
 	case game_boot_result::generic_error:
@@ -576,12 +577,18 @@ void main_window::show_boot_error(game_boot_result status)
 	msg->setTextFormat(Qt::RichText);
 	msg->setStandardButtons(QMessageBox::Ok);
 	msg->setText(tr("Booting failed: %1 %2").arg(message).arg(link));
+	msg->setParent(this);
 	msg->setAttribute(Qt::WA_DeleteOnClose);
 	msg->open();
 }
 
 void main_window::Boot(const std::string& path, const std::string& title_id, bool direct, bool refresh_list, cfg_mode config_mode, const std::string& config_path)
 {
+	if (Emu.IsBootingRestricted())
+	{
+		return;
+	}
+
 	if (!m_gui_settings->GetBootConfirmation(this, gui::ib_confirm_boot))
 	{
 		return;
@@ -3776,6 +3783,11 @@ void main_window::RemoveFirmwareCache()
 
 void main_window::CreateFirmwareCache()
 {
+	if (Emu.IsBootingRestricted())
+	{
+		return;
+	}
+
 	if (!m_gui_settings->GetBootConfirmation(this))
 	{
 		return;
@@ -4092,6 +4104,11 @@ void main_window::dropEvent(QDropEvent* event)
 	}
 	case drop_type::drop_game: // import valid games to gamelist (games.yaml)
 	{
+		if (Emu.IsBootingRestricted())
+		{
+			return;
+		}
+
 		if (!m_gui_settings->GetBootConfirmation(this))
 		{
 			return;

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -24,6 +24,8 @@ static constexpr int radius_range = 1000;
 static const constexpr f64 min_radius_conversion = radius_range / g_cfg_move.min_radius.max;
 static const constexpr f64 max_radius_conversion = radius_range / g_cfg_move.max_radius.max;
 
+extern void qt_events_aware_op(int repeat_duration_ms, std::function<bool()> wrapped_op);
+
 ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 	: QDialog(parent)
 	, ui(new Ui::ps_move_tracker_dialog)
@@ -232,7 +234,7 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 	reset_camera();
 
 	m_input_thread = std::make_unique<named_thread<pad_thread>>(thread(), window(), "");
-	while (!pad::g_started) QApplication::processEvents();
+	qt_events_aware_op(0, [](){ return !!pad::g_started; });
 
 	adjustSize();
 


### PR DESCRIPTION
* Deprecate more QCoreApplication::processEvents() usages. Followup to #13876.
* Fix recursion of booting inside GetBootConfirmation(). Fixes #13800 
* Fix emulator args restoration on failed Emulator::BootGame(), queue the restoration to Emulator::Kill() if emulation sop is pending.