### PR TITLE
CELL: Rewrite reservation notification postponing

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2297,6 +2297,27 @@ void ppu_thread::cpu_on_stop()
 	}
 }
 
+void ppu_thread::cpu_wait(bs_t<cpu_flag> old)
+{
+	// Meanwhile while waiting, notify SPU waiters
+	if (u32 addr = res_notify)
+	{
+		res_notify = 0;
+
+		if (res_notify_time == vm::reservation_notifier_count_index(addr).second)
+		{
+			vm::reservation_notifier_notify(addr);
+		}
+	}
+
+	if (old != state)
+	{
+		return;
+	}
+
+	state.wait(old);
+}
+
 void ppu_thread::exec_task()
 {
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::_static)

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -150,6 +150,7 @@ public:
 	virtual void cpu_task() override final;
 	virtual void cpu_sleep() override;
 	virtual void cpu_on_stop() override;
+	virtual void cpu_wait(bs_t<cpu_flag> old) override;
 	virtual ~ppu_thread() override;
 
 	SAVESTATE_INIT_POS(3);

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -446,7 +446,7 @@ waitpkg_func static void __tpause(u32 cycles, u32 cstate)
 
 namespace vm
 {
-	std::array<atomic_t<reservation_waiter_t>, 512> g_resrv_waiters_count{};
+	std::array<atomic_t<reservation_waiter_t>, 1024> g_resrv_waiters_count{};
 }
 
 void do_cell_atomic_128_store(u32 addr, const void* to_write);

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1335,7 +1335,7 @@ bool lv2_obj::sleep(cpu_thread& cpu, const u64 timeout)
 		{
 			static_cast<ppu_thread&>(cpu).res_notify = 0;
 
-			if (static_cast<ppu_thread&>(cpu).res_notify_time != (vm::reservation_acquire(addr) & -128))
+			if (static_cast<ppu_thread&>(cpu).res_notify_time != vm::reservation_notifier_count_index(addr).second)
 			{
 				// Ignore outdated notification request
 			}
@@ -1388,7 +1388,7 @@ bool lv2_obj::awake(cpu_thread* thread, s32 prio)
 		{
 			ppu->res_notify = 0;
 
-			if (ppu->res_notify_time != (vm::reservation_acquire(addr) & -128))
+			if (ppu->res_notify_time != vm::reservation_notifier_count_index(addr).second)
 			{
 				// Ignore outdated notification request
 			}

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -387,6 +387,9 @@ namespace vm
 			ok = false;
 		}
 
+		// Do some CPU work
+		cpu.cpu_wait(+cpu_flag::exit);
+
 		if (!ok || cpu.state & cpu_flag::memory)
 		{
 			for (u64 i = 0;; i++)

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -947,6 +947,7 @@
     <ClInclude Include="Emu\Memory\vm.h" />
     <ClInclude Include="Emu\Memory\vm_ptr.h" />
     <ClInclude Include="Emu\Memory\vm_ref.h" />
+    <ClInclude Include="Emu\Memory\vm_reservation.h" />
     <ClInclude Include="Emu\Memory\vm_var.h" />
     <ClInclude Include="Emu\RSX\rsx_methods.h" />
     <ClInclude Include="Emu\RSX\rsx_utils.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1461,6 +1461,9 @@
     <ClInclude Include="Emu\Memory\vm_ref.h">
       <Filter>Emu\Memory</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\Memory\vm_reservation.h">
+      <Filter>Emu\Memory</Filter>
+    </ClInclude>
     <ClInclude Include="Emu\Memory\vm_var.h">
       <Filter>Emu\Memory</Filter>
     </ClInclude>


### PR DESCRIPTION
1. Do not postpone reservation notification if there is more than one SPU waiter on this reservation, potentially resulting in a loss of CPU time.
2. Do not use local reservation time to check for notification redundancy, this was a bug as other thread may walk through the same path of updating reservation then postponing notification then no notification is made at all.
3. Notify SPU waiters while the PPU itself is idle.

May fix or aid with #16360