### PR TITLE
fix dark theme switching on initial welcome dialog

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -161,20 +161,16 @@ bool gui_application::Init()
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, false);
 
-		bool use_dark_theme = false;
-
 		connect(welcome, &QDialog::finished, this, [&]()
 		{
-			use_dark_theme = welcome->use_dark_theme();
+			if (welcome->use_dark_theme())
+			{
+				m_gui_settings->SetValue(gui::m_currentStylesheet, gui::DarkStylesheet);
+			}
 		});
 
 		// welcome dialog is auto-flagged (in its constructor) as WA_DeleteOnClose, so its pointer is no more usable after welcome->exec()
 		welcome->exec();
-
-		if (use_dark_theme)
-		{
-			m_gui_settings->SetValue(gui::m_currentStylesheet, gui::DarkStylesheet);
-		}
 	}
 
 	// Check maxfiles

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -163,16 +163,17 @@ bool gui_application::Init()
 
 		bool use_dark_theme = false;
 
-		connect(welcome, &QDialog::accepted, this, [&]()
+		connect(welcome, &QDialog::finished, this, [&]()
 		{
-			use_dark_theme = welcome->does_user_want_dark_theme();
+			use_dark_theme = welcome->use_dark_theme();
 		});
 
+		// welcome dialog is auto-flagged (in its constructor) as WA_DeleteOnClose, so its pointer is no more usable after welcome->exec()
 		welcome->exec();
 
 		if (use_dark_theme)
 		{
-			m_gui_settings->SetValue(gui::m_currentStylesheet, "Darker Style by TheMitoSan");
+			m_gui_settings->SetValue(gui::m_currentStylesheet, gui::DarkStylesheet);
 		}
 	}
 

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -161,15 +161,6 @@ bool gui_application::Init()
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, false);
 
-		connect(welcome, &QDialog::finished, this, [&]()
-		{
-			if (welcome->use_dark_theme())
-			{
-				m_gui_settings->SetValue(gui::m_currentStylesheet, gui::DarkStylesheet);
-			}
-		});
-
-		// welcome dialog is auto-flagged (in its constructor) as WA_DeleteOnClose, so its pointer is no more usable after welcome->exec()
 		welcome->exec();
 	}
 

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -87,10 +87,11 @@ namespace gui
 		return q_string_pair(path, title.simplified()); // simplified() forces single line text
 	}
 
-	const QString Settings = "CurrentSettings";
+	const QString Settings          = "CurrentSettings";
 	const QString DefaultStylesheet = "default";
-	const QString NoStylesheet = "none";
-	const QString NativeStylesheet = "native";
+	const QString NoStylesheet      = "none";
+	const QString NativeStylesheet  = "native";
+	const QString DarkStylesheet    = "Darker Style by TheMitoSan";
 
 	const QString main_window  = "main_window";
 	const QString game_list    = "GameList";

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3275,6 +3275,8 @@ void main_window::CreateConnects()
 	connect(ui->welcomeAct, &QAction::triggered, this, [this]()
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);
+
+		// welcome dialog is auto-flagged (in its constructor) as WA_DeleteOnClose, so its pointer is no more usable after welcome->open()
 		welcome->open();
 	});
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3275,8 +3275,6 @@ void main_window::CreateConnects()
 	connect(ui->welcomeAct, &QAction::triggered, this, [this]()
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);
-
-		// welcome dialog is auto-flagged (in its constructor) as WA_DeleteOnClose, so its pointer is no more usable after welcome->open()
 		welcome->open();
 	});
 

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -150,12 +150,13 @@ namespace gui
 
 		static inline Qt::ColorScheme color_scheme()
 		{
+			// use the QGuiApplication's properties to report the default GUI color scheme
 			return QGuiApplication::styleHints()->colorScheme();
 		}
 
 		static inline bool dark_mode_active()
 		{
-			// use the QGuiApplication's properties to report the default color scheme
+			// "true" if the default GUI color scheme is dark. "false" otherwise
 			return color_scheme() == Qt::ColorScheme::Dark;
 		}
 

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -155,6 +155,7 @@ namespace gui
 
 		static inline bool dark_mode_active()
 		{
+			// use the QGuiApplication's properties to report the default color scheme
 			return color_scheme() == Qt::ColorScheme::Dark;
 		}
 

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -15,6 +15,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	: QDialog(parent)
 	, ui(new Ui::welcome_dialog)
 	, m_gui_settings(std::move(gui_settings))
+	, m_use_dark_theme(gui::utils::dark_mode_active())
 {
 	ui->setupUi(this);
 
@@ -27,7 +28,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->do_not_show->setEnabled(!is_manual_show);
 	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
 	ui->use_dark_theme->setEnabled(!is_manual_show);
-	ui->use_dark_theme->setChecked(gui::utils::dark_mode_active());
+	ui->use_dark_theme->setChecked(m_use_dark_theme);
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));
 	ui->label_3->setText(tr(
 		R"(

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -22,10 +22,11 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	setWindowFlag(Qt::WindowCloseButtonHint, is_manual_show);
 
 	ui->okay->setEnabled(is_manual_show);
-	ui->i_have_read->setChecked(is_manual_show);
 	ui->i_have_read->setEnabled(!is_manual_show);
+	ui->i_have_read->setChecked(is_manual_show);
 	ui->do_not_show->setEnabled(!is_manual_show);
 	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
+	ui->use_dark_theme->setEnabled(!is_manual_show);
 	ui->use_dark_theme->setChecked(gui::utils::dark_mode_active());
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));
 	ui->label_3->setText(tr(
@@ -76,7 +77,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 
 	layout()->setSizeConstraint(QLayout::SetFixedSize);
 
-	connect(this, &QDialog::finished, this, [this]()
+	connect(this, &QDialog::accepted, this, [this]()
 	{
 		if (ui->create_desktop_shortcut->isChecked())
 		{
@@ -88,7 +89,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 			gui::utils::create_shortcut("RPCS3", "", "", "RPCS3", ":/rpcs3.svg", fs::get_temp_dir(), gui::utils::shortcut_location::applications);
 		}
 
-		m_user_wants_dark_theme = ui->use_dark_theme->isChecked();
+		m_use_dark_theme = ui->use_dark_theme->isChecked();
 	});
 }
 

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -15,7 +15,6 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	: QDialog(parent)
 	, ui(new Ui::welcome_dialog)
 	, m_gui_settings(std::move(gui_settings))
-	, m_use_dark_theme(gui::utils::dark_mode_active())
 {
 	ui->setupUi(this);
 
@@ -28,7 +27,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->do_not_show->setEnabled(!is_manual_show);
 	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
 	ui->use_dark_theme->setEnabled(!is_manual_show);
-	ui->use_dark_theme->setChecked(m_use_dark_theme);
+	ui->use_dark_theme->setChecked(gui::utils::dark_mode_active());
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));
 	ui->label_3->setText(tr(
 		R"(
@@ -90,7 +89,10 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 			gui::utils::create_shortcut("RPCS3", "", "", "RPCS3", ":/rpcs3.svg", fs::get_temp_dir(), gui::utils::shortcut_location::applications);
 		}
 
-		m_use_dark_theme = ui->use_dark_theme->isChecked();
+		if (ui->use_dark_theme->isChecked() && ui->use_dark_theme->isEnabled()) // if checked and also on initial welcome dialog
+		{
+			m_gui_settings->SetValue(gui::m_currentStylesheet, gui::DarkStylesheet);
+		}
 	});
 }
 

--- a/rpcs3/rpcs3qt/welcome_dialog.h
+++ b/rpcs3/rpcs3qt/welcome_dialog.h
@@ -17,12 +17,7 @@ public:
 	explicit welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool is_manual_show, QWidget* parent = nullptr);
 	~welcome_dialog();
 
-	bool use_dark_theme() const
-	{
-		return m_use_dark_theme;
-	}
 private:
 	std::unique_ptr<Ui::welcome_dialog> ui;
 	std::shared_ptr<gui_settings> m_gui_settings;
-	bool m_use_dark_theme;
 };

--- a/rpcs3/rpcs3qt/welcome_dialog.h
+++ b/rpcs3/rpcs3qt/welcome_dialog.h
@@ -24,5 +24,5 @@ public:
 private:
 	std::unique_ptr<Ui::welcome_dialog> ui;
 	std::shared_ptr<gui_settings> m_gui_settings;
-	bool m_use_dark_theme = false;
+	bool m_use_dark_theme;
 };

--- a/rpcs3/rpcs3qt/welcome_dialog.h
+++ b/rpcs3/rpcs3qt/welcome_dialog.h
@@ -17,12 +17,12 @@ public:
 	explicit welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool is_manual_show, QWidget* parent = nullptr);
 	~welcome_dialog();
 
-	bool does_user_want_dark_theme() const
+	bool use_dark_theme() const
 	{
-		return m_user_wants_dark_theme;
+		return m_use_dark_theme;
 	}
 private:
 	std::unique_ptr<Ui::welcome_dialog> ui;
 	std::shared_ptr<gui_settings> m_gui_settings;
-	bool m_user_wants_dark_theme = false;
+	bool m_use_dark_theme = false;
 };


### PR DESCRIPTION
**BUGFIXES:**
* Fixed broken switching to dark theme in case it is selected on the initial welcome dialog. Currently, dark theme is never engaged when selected on initial welcome dialog.
* Disabled `Use Dark Theme (Can Be Configured Later)` checkbox on welcome dialog opened from `Help->View The Welcome Dialog` menu (from that menu, the checkbox has no effect on switching theme; it can be changed only from `Config->GUI` tab)
