### PR TITLE
Improved welcome dialog

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -163,7 +163,7 @@ bool gui_application::Init()
 
 		if (welcome->exec() == QDialog::Rejected)
 		{
-			// If the agreement on RPCS3's usage conditions was not accecpted by the user, ask the main window to gracefully terminate
+			// If the agreement on RPCS3's usage conditions was not accepted by the user, ask the main window to gracefully terminate
 			return false;
 		}
 	}

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -163,7 +163,7 @@ bool gui_application::Init()
 
 		if (welcome->exec() == QDialog::Rejected)
 		{
-			// if the agreement on RPCS3's usage conditions was not accecped by the user, ask the main window to softly terminate
+			// If the agreement on RPCS3's usage conditions was not accecpted by the user, ask the main window to gracefully terminate
 			return false;
 		}
 	}

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -161,7 +161,11 @@ bool gui_application::Init()
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, false);
 
-		welcome->exec();
+		if (welcome->exec() == QDialog::Rejected)
+		{
+			// if the agreement on RPCS3's usage conditions was not accecped by the user, ask the main window to softly terminate
+			return false;
+		}
 	}
 
 	// Check maxfiles

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1848,12 +1848,29 @@ void main_window::SaveWindowState() const
 	// Save gui settings
 	m_gui_settings->SetValue(gui::mw_geometry, saveGeometry(), false);
 	m_gui_settings->SetValue(gui::mw_windowState, saveState(), false);
-	m_gui_settings->SetValue(gui::mw_mwState, m_mw->saveState(), true);
 
-	// Save column settings
-	m_game_list_frame->SaveSettings();
-	// Save splitter state
-	m_debugger_frame->SaveSettings();
+	// NOTE:
+	//
+	// This method is also invoked in case the gui_application::Init() method failed ("false" was returned)
+	// to initialize some modules leaving other modules uninitialized (NULL pointed).
+	// So, the following checks on NULL pointer are provided before accessing the related module's object
+
+	if (m_mw != nullptr)
+	{
+		m_gui_settings->SetValue(gui::mw_mwState, m_mw->saveState(), true);
+	}
+
+	if (m_game_list_frame != nullptr)
+	{
+		// Save column settings
+		m_game_list_frame->SaveSettings();
+	}
+
+	if (m_debugger_frame != nullptr)
+	{
+		// Save splitter state
+		m_debugger_frame->SaveSettings();
+	}
 }
 
 void main_window::RepaintThumbnailIcons()

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1855,18 +1855,18 @@ void main_window::SaveWindowState() const
 	// to initialize some modules leaving other modules uninitialized (NULL pointed).
 	// So, the following checks on NULL pointer are provided before accessing the related module's object
 
-	if (m_mw != nullptr)
+	if (m_mw)
 	{
 		m_gui_settings->SetValue(gui::mw_mwState, m_mw->saveState(), true);
 	}
 
-	if (m_game_list_frame != nullptr)
+	if (m_game_list_frame)
 	{
 		// Save column settings
 		m_game_list_frame->SaveSettings();
 	}
 
-	if (m_debugger_frame != nullptr)
+	if (m_debugger_frame)
 	{
 		// Save splitter state
 		m_debugger_frame->SaveSettings();

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -64,8 +64,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->reject->setVisible(!is_manual_show);
 	ui->i_have_read->setVisible(!is_manual_show);
 	ui->i_have_read->setChecked(is_manual_show);
-	ui->do_not_show->setVisible(!is_manual_show);
-	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
+	ui->show_at_startup->setChecked(m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
 
 	if (!is_manual_show)
 	{
@@ -74,12 +73,12 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 			ui->accept->setEnabled(checked);
 			ui->reject->setEnabled(!checked);
 		});
-
-		connect(ui->do_not_show, &QCheckBox::clicked, this, [this](bool checked)
-		{
-			m_gui_settings->SetValue(gui::ib_show_welcome, QVariant(!checked));
-		});
 	}
+
+	connect(ui->show_at_startup, &QCheckBox::clicked, this, [this](bool checked)
+	{
+		m_gui_settings->SetValue(gui::ib_show_welcome, QVariant(checked));
+	});
 
 	connect(ui->accept, &QPushButton::clicked, this, &QDialog::accept); // trigger "accept" signal (setting also dialog's result code to QDialog::Accepted)
 	connect(ui->reject, &QPushButton::clicked, this, &QDialog::reject); // trigger "reject" signal (setting also dialog's result code to QDialog::Rejected)

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -103,7 +103,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 
 	connect(this, &QDialog::rejected, this, [this]() // "reject" signal's event handler
 	{
-		// if the agreement on RPCS3's usage conditions was not accecpted by the user, always display the initial welcome dialog at next startup
+		// if the agreement on RPCS3's usage conditions was not accepted by the user, always display the initial welcome dialog at next startup
 		m_gui_settings->SetValue(gui::ib_show_welcome, QVariant(true));
 	});
 }

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -19,17 +19,12 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->setupUi(this);
 
 	setAttribute(Qt::WA_DeleteOnClose);
-	setWindowFlag(Qt::WindowCloseButtonHint, is_manual_show);
+	setWindowFlag(Qt::WindowCloseButtonHint, false); // disable the close button shown on the dialog's top right corner
+	layout()->setSizeConstraint(QLayout::SetFixedSize);
 
-	ui->okay->setEnabled(is_manual_show);
-	ui->i_have_read->setEnabled(!is_manual_show);
-	ui->i_have_read->setChecked(is_manual_show);
-	ui->do_not_show->setEnabled(!is_manual_show);
-	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
-	ui->use_dark_theme->setEnabled(!is_manual_show);
-	ui->use_dark_theme->setChecked(gui::utils::dark_mode_active());
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));
-	ui->label_3->setText(tr(
+
+	ui->label_desc->setText(tr(
 		R"(
 			<p style="white-space: nowrap;">
 				RPCS3 is an open-source Sony PlayStation 3 emulator and debugger.<br>
@@ -51,11 +46,33 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 		)"
 	).arg(gui::utils::get_link_style()));
 
+#ifdef __APPLE__
+	ui->create_applications_menu_shortcut->setText(tr("&Create Launchpad shortcut"));
+	ui->use_dark_theme->setVisible(false);
+	ui->use_dark_theme->setEnabled(false);
+#else
+	#ifndef _WIN32
+		ui->create_applications_menu_shortcut->setText(tr("&Create Application Menu shortcut"));
+	#endif
+
+	ui->use_dark_theme->setVisible(!is_manual_show);
+	ui->use_dark_theme->setEnabled(!is_manual_show);
+	ui->use_dark_theme->setChecked(gui::utils::dark_mode_active());
+#endif
+
+	ui->accept->setEnabled(is_manual_show);
+	ui->reject->setVisible(!is_manual_show);
+	ui->i_have_read->setVisible(!is_manual_show);
+	ui->i_have_read->setChecked(is_manual_show);
+	ui->do_not_show->setVisible(!is_manual_show);
+	ui->do_not_show->setChecked(!m_gui_settings->GetValue(gui::ib_show_welcome).toBool());
+
 	if (!is_manual_show)
 	{
 		connect(ui->i_have_read, &QCheckBox::clicked, this, [this](bool checked)
 		{
-			ui->okay->setEnabled(checked);
+			ui->accept->setEnabled(checked);
+			ui->reject->setEnabled(!checked);
 		});
 
 		connect(ui->do_not_show, &QCheckBox::clicked, this, [this](bool checked)
@@ -64,20 +81,10 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 		});
 	}
 
-	connect(ui->okay, &QPushButton::clicked, this, &QDialog::accept);
+	connect(ui->accept, &QPushButton::clicked, this, &QDialog::accept); // trigger "accept" signal (setting also dialog's result code to QDialog::Accepted)
+	connect(ui->reject, &QPushButton::clicked, this, &QDialog::reject); // trigger "reject" signal (setting also dialog's result code to QDialog::Rejected)
 
-#ifdef _WIN32
-	ui->create_applications_menu_shortcut->setText(tr("&Create Start Menu shortcut"));
-#elif defined(__APPLE__)
-	ui->create_applications_menu_shortcut->setText(tr("&Create Launchpad shortcut"));
-	ui->use_dark_theme->setVisible(false);
-#else
-	ui->create_applications_menu_shortcut->setText(tr("&Create Application Menu shortcut"));
-#endif
-
-	layout()->setSizeConstraint(QLayout::SetFixedSize);
-
-	connect(this, &QDialog::accepted, this, [this]()
+	connect(this, &QDialog::accepted, this, [this]() // "accept" signal's event handler
 	{
 		if (ui->create_desktop_shortcut->isChecked())
 		{
@@ -93,6 +100,12 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 		{
 			m_gui_settings->SetValue(gui::m_currentStylesheet, gui::DarkStylesheet);
 		}
+	});
+
+	connect(this, &QDialog::rejected, this, [this]() // "reject" signal's event handler
+	{
+		// if the agreement on RPCS3's usage conditions was not accecped by the user, always display the initial welcome dialog at next startup
+		m_gui_settings->SetValue(gui::ib_show_welcome, QVariant(true));
 	});
 }
 

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -51,9 +51,9 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 	ui->use_dark_theme->setVisible(false);
 	ui->use_dark_theme->setEnabled(false);
 #else
-	#ifndef _WIN32
-		ui->create_applications_menu_shortcut->setText(tr("&Create Application Menu shortcut"));
-	#endif
+#ifndef _WIN32
+	ui->create_applications_menu_shortcut->setText(tr("&Create Application Menu shortcut"));
+#endif
 
 	ui->use_dark_theme->setVisible(!is_manual_show);
 	ui->use_dark_theme->setEnabled(!is_manual_show);
@@ -103,7 +103,7 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 
 	connect(this, &QDialog::rejected, this, [this]() // "reject" signal's event handler
 	{
-		// if the agreement on RPCS3's usage conditions was not accecped by the user, always display the initial welcome dialog at next startup
+		// if the agreement on RPCS3's usage conditions was not accecpted by the user, always display the initial welcome dialog at next startup
 		m_gui_settings->SetValue(gui::ib_show_welcome, QVariant(true));
 	});
 }

--- a/rpcs3/rpcs3qt/welcome_dialog.ui
+++ b/rpcs3/rpcs3qt/welcome_dialog.ui
@@ -103,7 +103,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label_3">
+           <widget class="QLabel" name="label_desc">
             <property name="font">
              <font>
               <family>Arial</family>
@@ -201,7 +201,7 @@
      <item>
       <widget class="QCheckBox" name="use_dark_theme">
        <property name="text">
-        <string>Use Dark Theme (Can Be Configured Later)</string>
+        <string>Use Dark Theme (can be configured later)</string>
        </property>
       </widget>
      </item>
@@ -233,9 +233,19 @@
         <number>0</number>
        </property>
        <item alignment="Qt::AlignLeft">
-        <widget class="QPushButton" name="okay">
+        <widget class="QPushButton" name="accept">
          <property name="text">
           <string>Continue</string>
+         </property>
+         <property name="autoDefault">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item alignment="Qt::AlignLeft">
+        <widget class="QPushButton" name="reject">
+         <property name="text">
+          <string>Exit</string>
          </property>
          <property name="autoDefault">
           <bool>true</bool>

--- a/rpcs3/rpcs3qt/welcome_dialog.ui
+++ b/rpcs3/rpcs3qt/welcome_dialog.ui
@@ -286,9 +286,9 @@
         </spacer>
        </item>
        <item alignment="Qt::AlignLeft">
-        <widget class="QCheckBox" name="do_not_show">
+        <widget class="QCheckBox" name="show_at_startup">
          <property name="text">
-          <string>Do not show again</string>
+          <string>Show at startup</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Followup of #16373 according to some received feedbacks

**IMPROVEMENTS:**
* Contextual Welcome dialog:
  *  `initial welcome`: at application startup, a dialog asking to accept or reject RPCS3's usage conditions is provided. In case the reject button (`Exit`) is pressed, the application is gracefully terminated. Accept button (`Continue`) is enabled only if the agreement checkbox (`I have read the Quickstart guide`) is checked
  * `standard welcome`:  welcome dialog opened from `Help` menu will show only main info and applicable settings. Dark theme, reject button and agreement checkbox are not provided

**BUGFIXES:**
* Fixed crash due to access violation on` main_window::SaveWindowState()` method in case the `gui_application::Init()` method failed (`false` was returned) to initialize some modules leaving other modules uninitialized (NULL pointed).


### Initial Welcome dialog:
![initial_welcome](https://github.com/user-attachments/assets/036d0340-13cd-4af3-a95b-4472a4fa3658)


### Standard Welcome dialog:
![standard_welcome](https://github.com/user-attachments/assets/8cfdc0b8-ab84-4d36-a5eb-9935afef4eb5)
