### PR TITLE
IDM: Implement lock-free smart pointers

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1360,7 +1360,7 @@ bool handle_access_violation(u32 addr, bool is_writing, ucontext_t* context) noe
 	// check if address is RawSPU MMIO register
 	do if (addr - RAW_SPU_BASE_ADDR < (6 * RAW_SPU_OFFSET) && (addr % RAW_SPU_OFFSET) >= RAW_SPU_PROB_OFFSET)
 	{
-		auto thread = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu((addr - RAW_SPU_BASE_ADDR) / RAW_SPU_OFFSET));
+		auto thread = idm::get_unlocked<named_thread<spu_thread>>(spu_thread::find_raw_spu((addr - RAW_SPU_BASE_ADDR) / RAW_SPU_OFFSET));
 
 		if (!thread)
 		{
@@ -1548,7 +1548,7 @@ bool handle_access_violation(u32 addr, bool is_writing, ucontext_t* context) noe
 			}
 		}
 
-		if (auto pf_port = idm::get<lv2_obj, lv2_event_port>(pf_port_id); pf_port && pf_port->queue)
+		if (auto pf_port = idm::get_unlocked<lv2_obj, lv2_event_port>(pf_port_id); pf_port && pf_port->queue)
 		{
 			// We notify the game that a page fault occurred so it can rectify it.
 			// Note, for data3, were the memory readable AND we got a page fault, it must be due to a write violation since reads are allowed.
@@ -2602,7 +2602,7 @@ bool thread_base::join(bool dtor) const
 
 		if (i >= 16 && !(i & (i - 1)) && timeout != atomic_wait_timeout::inf)
 		{
-			sig_log.error(u8"Thread [%s] is too sleepy. Waiting for it %.3fµs already!", *m_tname.load(), (utils::get_tsc() - stamp0) / (utils::get_tsc_freq() / 1000000.));
+			sig_log.error(u8"Thread [%s] is too sleepy. Waiting for it %.3fus already!", *m_tname.load(), (utils::get_tsc() - stamp0) / (utils::get_tsc_freq() / 1000000.));
 		}
 	}
 

--- a/Utilities/mutex.h
+++ b/Utilities/mutex.h
@@ -121,7 +121,7 @@ public:
 
 	void unlock_hle()
 	{
-		const u32 value = atomic_storage<u32>::fetch_add_hle_rel(m_value.raw(), 0u - c_one);
+		const u32 value = atomic_storage<u32>::fetch_add_hle_rel(m_value.raw(), ~c_one + 1);
 
 		if (value != c_one) [[unlikely]]
 		{

--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include "Emu/CPU/CPUThread.h"
 #include "Utilities/StrFmt.h"
 
 enum class cpu_disasm_mode
@@ -22,7 +23,7 @@ protected:
 	const u8* m_offset{};
 	const u32 m_start_pc;
 	std::add_pointer_t<const cpu_thread> m_cpu{};
-	std::shared_ptr<cpu_thread> m_cpu_handle;
+	shared_ptr<cpu_thread> m_cpu_handle;
 	u32 m_op = 0;
 
 	void format_by_mode()
@@ -81,7 +82,7 @@ public:
 		return const_cast<cpu_thread*>(m_cpu);
 	}
 
-	void set_cpu_handle(std::shared_ptr<cpu_thread> cpu)
+	void set_cpu_handle(shared_ptr<cpu_thread> cpu)
 	{
 		m_cpu_handle = std::move(cpu);
 

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -556,7 +556,7 @@ void cell_audio_thread::advance(u64 timestamp)
 	m_dynamic_period = 0;
 
 	// send aftermix event (normal audio event)
-	std::array<std::shared_ptr<lv2_event_queue>, MAX_AUDIO_EVENT_QUEUES> queues;
+	std::array<shared_ptr<lv2_event_queue>, MAX_AUDIO_EVENT_QUEUES> queues;
 	u32 queue_count = 0;
 
 	event_period++;

--- a/rpcs3/Emu/Cell/Modules/cellAudio.h
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.h
@@ -400,7 +400,7 @@ public:
 		u32 flags = 0; // iFlags
 		u64 source = 0; // Event source
 		u64 ack_timestamp = 0; // timestamp of last call of cellAudioSendAck
-		std::shared_ptr<lv2_event_queue> port{}; // Underlying event port
+		shared_ptr<lv2_event_queue> port{}; // Underlying event port
 	};
 
 	std::vector<key_info> keys{};

--- a/rpcs3/Emu/Cell/Modules/cellDmux.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellDmux.cpp
@@ -1031,7 +1031,7 @@ error_code cellDmuxClose(u32 handle)
 {
 	cellDmux.warning("cellDmuxClose(handle=0x%x)", handle);
 
-	const auto dmux = idm::get<Demuxer>(handle);
+	const auto dmux = idm::get_unlocked<Demuxer>(handle);
 
 	if (!dmux)
 	{
@@ -1060,7 +1060,7 @@ error_code cellDmuxSetStream(u32 handle, u32 streamAddress, u32 streamSize, b8 d
 {
 	cellDmux.trace("cellDmuxSetStream(handle=0x%x, streamAddress=0x%x, streamSize=%d, discontinuity=%d, userData=0x%llx)", handle, streamAddress, streamSize, discontinuity, userData);
 
-	const auto dmux = idm::get<Demuxer>(handle);
+	const auto dmux = idm::get_unlocked<Demuxer>(handle);
 
 	if (!dmux)
 	{
@@ -1088,7 +1088,7 @@ error_code cellDmuxResetStream(u32 handle)
 {
 	cellDmux.warning("cellDmuxResetStream(handle=0x%x)", handle);
 
-	const auto dmux = idm::get<Demuxer>(handle);
+	const auto dmux = idm::get_unlocked<Demuxer>(handle);
 
 	if (!dmux)
 	{
@@ -1103,7 +1103,7 @@ error_code cellDmuxResetStreamAndWaitDone(u32 handle)
 {
 	cellDmux.warning("cellDmuxResetStreamAndWaitDone(handle=0x%x)", handle);
 
-	const auto dmux = idm::get<Demuxer>(handle);
+	const auto dmux = idm::get_unlocked<Demuxer>(handle);
 
 	if (!dmux)
 	{
@@ -1164,7 +1164,7 @@ error_code cellDmuxEnableEs(u32 handle, vm::cptr<CellCodecEsFilterId> esFilterId
 {
 	cellDmux.warning("cellDmuxEnableEs(handle=0x%x, esFilterId=*0x%x, esResourceInfo=*0x%x, esCb=*0x%x, esSpecificInfo=*0x%x, esHandle=*0x%x)", handle, esFilterId, esResourceInfo, esCb, esSpecificInfo, esHandle);
 
-	const auto dmux = idm::get<Demuxer>(handle);
+	const auto dmux = idm::get_unlocked<Demuxer>(handle);
 
 	if (!dmux)
 	{
@@ -1194,7 +1194,7 @@ error_code cellDmuxDisableEs(u32 esHandle)
 {
 	cellDmux.warning("cellDmuxDisableEs(esHandle=0x%x)", esHandle);
 
-	const auto es = idm::get<ElementaryStream>(esHandle);
+	const auto es = idm::get_unlocked<ElementaryStream>(esHandle);
 
 	if (!es)
 	{
@@ -1213,7 +1213,7 @@ error_code cellDmuxResetEs(u32 esHandle)
 {
 	cellDmux.trace("cellDmuxResetEs(esHandle=0x%x)", esHandle);
 
-	const auto es = idm::get<ElementaryStream>(esHandle);
+	const auto es = idm::get_unlocked<ElementaryStream>(esHandle);
 
 	if (!es)
 	{
@@ -1232,7 +1232,7 @@ error_code cellDmuxGetAu(u32 esHandle, vm::ptr<u32> auInfo, vm::ptr<u32> auSpeci
 {
 	cellDmux.trace("cellDmuxGetAu(esHandle=0x%x, auInfo=**0x%x, auSpecificInfo=**0x%x)", esHandle, auInfo, auSpecificInfo);
 
-	const auto es = idm::get<ElementaryStream>(esHandle);
+	const auto es = idm::get_unlocked<ElementaryStream>(esHandle);
 
 	if (!es)
 	{
@@ -1255,7 +1255,7 @@ error_code cellDmuxPeekAu(u32 esHandle, vm::ptr<u32> auInfo, vm::ptr<u32> auSpec
 {
 	cellDmux.trace("cellDmuxPeekAu(esHandle=0x%x, auInfo=**0x%x, auSpecificInfo=**0x%x)", esHandle, auInfo, auSpecificInfo);
 
-	const auto es = idm::get<ElementaryStream>(esHandle);
+	const auto es = idm::get_unlocked<ElementaryStream>(esHandle);
 
 	if (!es)
 	{
@@ -1278,7 +1278,7 @@ error_code cellDmuxGetAuEx(u32 esHandle, vm::ptr<u32> auInfoEx, vm::ptr<u32> auS
 {
 	cellDmux.trace("cellDmuxGetAuEx(esHandle=0x%x, auInfoEx=**0x%x, auSpecificInfo=**0x%x)", esHandle, auInfoEx, auSpecificInfo);
 
-	const auto es = idm::get<ElementaryStream>(esHandle);
+	const auto es = idm::get_unlocked<ElementaryStream>(esHandle);
 
 	if (!es)
 	{
@@ -1301,7 +1301,7 @@ error_code cellDmuxPeekAuEx(u32 esHandle, vm::ptr<u32> auInfoEx, vm::ptr<u32> au
 {
 	cellDmux.trace("cellDmuxPeekAuEx(esHandle=0x%x, auInfoEx=**0x%x, auSpecificInfo=**0x%x)", esHandle, auInfoEx, auSpecificInfo);
 
-	const auto es = idm::get<ElementaryStream>(esHandle);
+	const auto es = idm::get_unlocked<ElementaryStream>(esHandle);
 
 	if (!es)
 	{
@@ -1324,7 +1324,7 @@ error_code cellDmuxReleaseAu(u32 esHandle)
 {
 	cellDmux.trace("cellDmuxReleaseAu(esHandle=0x%x)", esHandle);
 
-	const auto es = idm::get<ElementaryStream>(esHandle);
+	const auto es = idm::get_unlocked<ElementaryStream>(esHandle);
 
 	if (!es)
 	{
@@ -1342,7 +1342,7 @@ error_code cellDmuxFlushEs(u32 esHandle)
 {
 	cellDmux.warning("cellDmuxFlushEs(esHandle=0x%x)", esHandle);
 
-	const auto es = idm::get<ElementaryStream>(esHandle);
+	const auto es = idm::get_unlocked<ElementaryStream>(esHandle);
 
 	if (!es)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellFs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellFs.cpp
@@ -598,7 +598,7 @@ error_code cellFsSetIoBufferFromDefaultContainer(u32 fd, u32 buffer_size, u32 pa
 {
 	cellFs.todo("cellFsSetIoBufferFromDefaultContainer(fd=%d, buffer_size=%d, page_type=%d)", fd, buffer_size, page_type);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -695,7 +695,7 @@ s32 cellFsStReadInit(u32 fd, vm::cptr<CellFsRingBuffer> ringbuf)
 		return CELL_EINVAL;
 	}
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -716,7 +716,7 @@ s32 cellFsStReadFinish(u32 fd)
 {
 	cellFs.todo("cellFsStReadFinish(fd=%d)", fd);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -732,7 +732,7 @@ s32 cellFsStReadGetRingBuf(u32 fd, vm::ptr<CellFsRingBuffer> ringbuf)
 {
 	cellFs.todo("cellFsStReadGetRingBuf(fd=%d, ringbuf=*0x%x)", fd, ringbuf);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -748,7 +748,7 @@ s32 cellFsStReadGetStatus(u32 fd, vm::ptr<u64> status)
 {
 	cellFs.todo("cellFsStReadGetRingBuf(fd=%d, status=*0x%x)", fd, status);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -764,7 +764,7 @@ s32 cellFsStReadGetRegid(u32 fd, vm::ptr<u64> regid)
 {
 	cellFs.todo("cellFsStReadGetRingBuf(fd=%d, regid=*0x%x)", fd, regid);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -780,7 +780,7 @@ s32 cellFsStReadStart(u32 fd, u64 offset, u64 size)
 {
 	cellFs.todo("cellFsStReadStart(fd=%d, offset=0x%llx, size=0x%llx)", fd, offset, size);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -796,7 +796,7 @@ s32 cellFsStReadStop(u32 fd)
 {
 	cellFs.todo("cellFsStReadStop(fd=%d)", fd);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -812,7 +812,7 @@ s32 cellFsStRead(u32 fd, vm::ptr<u8> buf, u64 size, vm::ptr<u64> rsize)
 {
 	cellFs.todo("cellFsStRead(fd=%d, buf=*0x%x, size=0x%llx, rsize=*0x%x)", fd, buf, size, rsize);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -828,7 +828,7 @@ s32 cellFsStReadGetCurrentAddr(u32 fd, vm::ptr<u32> addr, vm::ptr<u64> size)
 {
 	cellFs.todo("cellFsStReadGetCurrentAddr(fd=%d, addr=*0x%x, size=*0x%x)", fd, addr, size);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -844,7 +844,7 @@ s32 cellFsStReadPutCurrentAddr(u32 fd, vm::ptr<u8> addr, u64 size)
 {
 	cellFs.todo("cellFsStReadPutCurrentAddr(fd=%d, addr=*0x%x, size=0x%llx)", fd, addr, size);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -860,7 +860,7 @@ s32 cellFsStReadWait(u32 fd, u64 size)
 {
 	cellFs.todo("cellFsStReadWait(fd=%d, size=0x%llx)", fd, size);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -876,7 +876,7 @@ s32 cellFsStReadWaitCallback(u32 fd, u64 size, vm::ptr<void(s32 xfd, u64 xsize)>
 {
 	cellFs.todo("cellFsStReadWaitCallback(fd=%d, size=0x%llx, func=*0x%x)", fd, size, func);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -908,7 +908,7 @@ struct fs_aio_thread : ppu_thread
 			s32 error = CELL_EBADF;
 			u64 result = 0;
 
-			const auto file = idm::get<lv2_fs_object, lv2_file>(aio->fd);
+			const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(aio->fd);
 
 			if (!file || (type == 1 && file->flags & CELL_FS_O_WRONLY) || (type == 2 && !(file->flags & CELL_FS_O_ACCMODE)))
 			{

--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -961,7 +961,7 @@ error_code cellGameContentPermit(ppu_thread& ppu, vm::ptr<char[CELL_GAME_PATH_MA
 
 	if (!perm.temp.empty())
 	{
-		std::vector<std::shared_ptr<lv2_file>> lv2_files;
+		std::vector<shared_ptr<lv2_file>> lv2_files;
 
 		const std::string real_dir = vfs::get(dir) + "/";
 

--- a/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGcmSys.cpp
@@ -455,7 +455,7 @@ error_code _cellGcmInitBody(ppu_thread& ppu, vm::pptr<CellGcmContextData> contex
 	vm::var<u64> _tid;
 	vm::var<char[]> _name = vm::make_str("_gcm_intr_thread");
 	ppu_execute<&sys_ppu_thread_create>(ppu, +_tid, 0x10000, 0, 1, 0x4000, SYS_PPU_THREAD_CREATE_INTERRUPT, +_name);
-	render->intr_thread = idm::get<named_thread<ppu_thread>>(static_cast<u32>(*_tid));
+	render->intr_thread = idm::get_unlocked<named_thread<ppu_thread>>(static_cast<u32>(*_tid));
 	render->intr_thread->state -= cpu_flag::stop;
 	thread_ctrl::notify(*render->intr_thread);
 

--- a/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
@@ -288,7 +288,7 @@ error_code cellGifDecReadHeader(vm::ptr<GifDecoder> mainHandle, vm::ptr<GifStrea
 	}
 	case CELL_GIFDEC_FILE:
 	{
-		auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+		auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 		file->file.seek(0);
 		file->file.read(buffer, sizeof(buffer));
 		break;
@@ -500,7 +500,7 @@ error_code cellGifDecDecodeData(vm::ptr<GifDecoder> mainHandle, vm::cptr<GifStre
 
 	case CELL_GIFDEC_FILE:
 	{
-		auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+		auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 		file->file.seek(0);
 		file->file.read(gif.get(), fileSize);
 		break;

--- a/rpcs3/Emu/Cell/Modules/cellJpgDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellJpgDec.cpp
@@ -103,7 +103,7 @@ error_code cellJpgDecClose(u32 mainHandle, u32 subHandle)
 {
 	cellJpgDec.warning("cellJpgDecOpen(mainHandle=0x%x, subHandle=0x%x)", mainHandle, subHandle);
 
-	const auto subHandle_data = idm::get<CellJpgDecSubHandle>(subHandle);
+	const auto subHandle_data = idm::get_unlocked<CellJpgDecSubHandle>(subHandle);
 
 	if (!subHandle_data)
 	{
@@ -120,7 +120,7 @@ error_code cellJpgDecReadHeader(u32 mainHandle, u32 subHandle, vm::ptr<CellJpgDe
 {
 	cellJpgDec.trace("cellJpgDecReadHeader(mainHandle=0x%x, subHandle=0x%x, info=*0x%x)", mainHandle, subHandle, info);
 
-	const auto subHandle_data = idm::get<CellJpgDecSubHandle>(subHandle);
+	const auto subHandle_data = idm::get_unlocked<CellJpgDecSubHandle>(subHandle);
 
 	if (!subHandle_data)
 	{
@@ -142,7 +142,7 @@ error_code cellJpgDecReadHeader(u32 mainHandle, u32 subHandle, vm::ptr<CellJpgDe
 
 	case CELL_JPGDEC_FILE:
 	{
-		auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+		auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 		file->file.seek(0);
 		file->file.read(buffer.get(), fileSize);
 		break;
@@ -201,7 +201,7 @@ error_code cellJpgDecDecodeData(u32 mainHandle, u32 subHandle, vm::ptr<u8> data,
 
 	dataOutInfo->status = CELL_JPGDEC_DEC_STATUS_STOP;
 
-	const auto subHandle_data = idm::get<CellJpgDecSubHandle>(subHandle);
+	const auto subHandle_data = idm::get_unlocked<CellJpgDecSubHandle>(subHandle);
 
 	if (!subHandle_data)
 	{
@@ -223,7 +223,7 @@ error_code cellJpgDecDecodeData(u32 mainHandle, u32 subHandle, vm::ptr<u8> data,
 
 	case CELL_JPGDEC_FILE:
 	{
-		auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+		auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 		file->file.seek(0);
 		file->file.read(jpg.get(), fileSize);
 		break;
@@ -340,7 +340,7 @@ error_code cellJpgDecSetParameter(u32 mainHandle, u32 subHandle, vm::cptr<CellJp
 {
 	cellJpgDec.trace("cellJpgDecSetParameter(mainHandle=0x%x, subHandle=0x%x, inParam=*0x%x, outParam=*0x%x)", mainHandle, subHandle, inParam, outParam);
 
-	const auto subHandle_data = idm::get<CellJpgDecSubHandle>(subHandle);
+	const auto subHandle_data = idm::get_unlocked<CellJpgDecSubHandle>(subHandle);
 
 	if (!subHandle_data)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellPngDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPngDec.cpp
@@ -93,7 +93,7 @@ void pngDecReadBuffer(png_structp png_ptr, png_bytep out, png_size_t length)
 	if (buffer.file)
 	{
 		// Get the file
-		auto file = idm::get<lv2_fs_object, lv2_file>(buffer.fd);
+		auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(buffer.fd);
 
 		// Read the data
 		file->file.read(out, length);

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -1265,7 +1265,7 @@ s32 _spurs::initialize(ppu_thread& ppu, vm::ptr<CellSpurs> spurs, u32 revision, 
 		}
 
 		// entry point cannot be initialized immediately because SPU LS will be rewritten by sys_spu_thread_group_start()
-		//idm::get<named_thread<spu_thread>>(spurs->spus[num])->custom_task = [entry = spurs->spuImg.entry_point](spu_thread& spu)
+		//idm::get_unlocked<named_thread<spu_thread>>(spurs->spus[num])->custom_task = [entry = spurs->spuImg.entry_point](spu_thread& spu)
 		{
 			// Disabled
 			//spu.RegisterHleFunction(entry, spursKernelEntry);

--- a/rpcs3/Emu/Cell/Modules/cellVdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVdec.cpp
@@ -659,7 +659,7 @@ extern bool check_if_vdec_contexts_exist()
 
 extern void vdecEntry(ppu_thread& ppu, u32 vid)
 {
-	idm::get<vdec_context>(vid)->exec(ppu, vid);
+	idm::get_unlocked<vdec_context>(vid)->exec(ppu, vid);
 
 	ppu.state += cpu_flag::exit;
 }
@@ -886,7 +886,7 @@ static error_code vdecOpen(ppu_thread& ppu, T type, U res, vm::cptr<CellVdecCb> 
 	}
 
 	// Create decoder context
-	std::shared_ptr<vdec_context> vdec;
+	shared_ptr<vdec_context> vdec;
 
 	if (std::unique_lock lock{g_fxo->get<hle_locks_t>(), std::try_to_lock})
 	{
@@ -909,7 +909,7 @@ static error_code vdecOpen(ppu_thread& ppu, T type, U res, vm::cptr<CellVdecCb> 
 	ppu_execute<&sys_ppu_thread_create>(ppu, +_tid, 0x10000, vid, +res->ppuThreadPriority, +res->ppuThreadStackSize, SYS_PPU_THREAD_CREATE_INTERRUPT, +_name);
 	*handle = vid;
 
-	const auto thrd = idm::get<named_thread<ppu_thread>>(static_cast<u32>(*_tid));
+	const auto thrd = idm::get_unlocked<named_thread<ppu_thread>>(static_cast<u32>(*_tid));
 
 	thrd->cmd_list
 	({
@@ -949,7 +949,7 @@ error_code cellVdecClose(ppu_thread& ppu, u32 handle)
 		return {};
 	}
 
-	auto vdec = idm::get<vdec_context>(handle);
+	auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	if (!vdec)
 	{
@@ -1003,7 +1003,7 @@ error_code cellVdecStartSeq(ppu_thread& ppu, u32 handle)
 
 	cellVdec.warning("cellVdecStartSeq(handle=0x%x)", handle);
 
-	const auto vdec = idm::get<vdec_context>(handle);
+	const auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	if (!vdec)
 	{
@@ -1055,7 +1055,7 @@ error_code cellVdecEndSeq(ppu_thread& ppu, u32 handle)
 
 	cellVdec.warning("cellVdecEndSeq(handle=0x%x)", handle);
 
-	const auto vdec = idm::get<vdec_context>(handle);
+	const auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	if (!vdec)
 	{
@@ -1088,7 +1088,7 @@ error_code cellVdecDecodeAu(ppu_thread& ppu, u32 handle, CellVdecDecodeMode mode
 
 	cellVdec.trace("cellVdecDecodeAu(handle=0x%x, mode=%d, auInfo=*0x%x)", handle, +mode, auInfo);
 
-	const auto vdec = idm::get<vdec_context>(handle);
+	const auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	if (!vdec || !auInfo || !auInfo->size || !auInfo->startAddr)
 	{
@@ -1136,7 +1136,7 @@ error_code cellVdecDecodeAuEx2(ppu_thread& ppu, u32 handle, CellVdecDecodeMode m
 
 	cellVdec.todo("cellVdecDecodeAuEx2(handle=0x%x, mode=%d, auInfo=*0x%x)", handle, +mode, auInfo);
 
-	const auto vdec = idm::get<vdec_context>(handle);
+	const auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	if (!vdec || !auInfo || !auInfo->size || !auInfo->startAddr)
 	{
@@ -1192,7 +1192,7 @@ error_code cellVdecGetPictureExt(ppu_thread& ppu, u32 handle, vm::cptr<CellVdecP
 
 	cellVdec.trace("cellVdecGetPictureExt(handle=0x%x, format=*0x%x, outBuff=*0x%x, arg4=*0x%x)", handle, format, outBuff, arg4);
 
-	const auto vdec = idm::get<vdec_context>(handle);
+	const auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	if (!vdec || !format)
 	{
@@ -1245,7 +1245,7 @@ error_code cellVdecGetPictureExt(ppu_thread& ppu, u32 handle, vm::cptr<CellVdecP
 
 	if (notify)
 	{
-		auto vdec_ppu = idm::get<named_thread<ppu_thread>>(vdec->ppu_tid);
+		auto vdec_ppu = idm::get_unlocked<named_thread<ppu_thread>>(vdec->ppu_tid);
 		if (vdec_ppu) thread_ctrl::notify(*vdec_ppu);
 	}
 
@@ -1354,7 +1354,7 @@ error_code cellVdecGetPicItem(ppu_thread& ppu, u32 handle, vm::pptr<CellVdecPicI
 
 	cellVdec.trace("cellVdecGetPicItem(handle=0x%x, picItem=**0x%x)", handle, picItem);
 
-	const auto vdec = idm::get<vdec_context>(handle);
+	const auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	if (!vdec || !picItem)
 	{
@@ -1596,7 +1596,7 @@ error_code cellVdecSetFrameRate(u32 handle, CellVdecFrameRate frameRateCode)
 {
 	cellVdec.trace("cellVdecSetFrameRate(handle=0x%x, frameRateCode=0x%x)", handle, +frameRateCode);
 
-	const auto vdec = idm::get<vdec_context>(handle);
+	const auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	// 0x80 seems like a common prefix
 	if (!vdec || (frameRateCode & 0xf8) != 0x80)
@@ -1659,7 +1659,7 @@ error_code cellVdecSetPts(u32 handle, vm::ptr<void> unk)
 {
 	cellVdec.error("cellVdecSetPts(handle=0x%x, unk=*0x%x)", handle, unk);
 
-	const auto vdec = idm::get<vdec_context>(handle);
+	const auto vdec = idm::get_unlocked<vdec_context>(handle);
 
 	if (!vdec || !unk)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellVpost.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVpost.cpp
@@ -205,7 +205,7 @@ error_code cellVpostClose(u32 handle)
 {
 	cellVpost.warning("cellVpostClose(handle=0x%x)", handle);
 
-	const auto vpost = idm::get<VpostInstance>(handle);
+	const auto vpost = idm::get_unlocked<VpostInstance>(handle);
 
 	if (!vpost)
 	{
@@ -220,7 +220,7 @@ error_code cellVpostExec(u32 handle, vm::cptr<u8> inPicBuff, vm::cptr<CellVpostC
 {
 	cellVpost.trace("cellVpostExec(handle=0x%x, inPicBuff=*0x%x, ctrlParam=*0x%x, outPicBuff=*0x%x, picInfo=*0x%x)", handle, inPicBuff, ctrlParam, outPicBuff, picInfo);
 
-	const auto vpost = idm::get<VpostInstance>(handle);
+	const auto vpost = idm::get_unlocked<VpostInstance>(handle);
 
 	if (!vpost)
 	{

--- a/rpcs3/Emu/Cell/Modules/libmixer.cpp
+++ b/rpcs3/Emu/Cell/Modules/libmixer.cpp
@@ -510,7 +510,7 @@ s32 cellSurMixerCreate(vm::cptr<CellSurMixerConfig> config)
 
 	libmixer.warning("*** surMixer created (ch1=%d, ch2=%d, ch6=%d, ch8=%d)", config->chStrips1, config->chStrips2, config->chStrips6, config->chStrips8);
 
-	//auto thread = idm::make_ptr<ppu_thread>("Surmixer Thread");
+	//auto thread = idm::make_ptr<named_thread<ppu_thread>>("Surmixer Thread");
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/Modules/sceNp.h
+++ b/rpcs3/Emu/Cell/Modules/sceNp.h
@@ -1837,7 +1837,7 @@ public:
 	virtual ~RecvMessageDialogBase() = default;
 
 	virtual error_code Exec(SceNpBasicMessageMainType type, SceNpBasicMessageRecvOptions options, SceNpBasicMessageRecvAction& recv_result, u64& chosen_msg_id) = 0;
-	virtual void callback_handler(const std::shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id) = 0;
+	virtual void callback_handler(const shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id) = 0;
 
 protected:
 	std::shared_ptr<rpcn::rpcn_client> m_rpcn;

--- a/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpSns.cpp
@@ -139,7 +139,7 @@ error_code sceNpSnsFbAbortHandle(u32 handle)
 		return SCE_NP_SNS_ERROR_INVALID_ARGUMENT;
 	}
 
-	const auto sfh = idm::get<sns_fb_handle_t>(handle);
+	const auto sfh = idm::get_unlocked<sns_fb_handle_t>(handle);
 
 	if (!sfh)
 	{
@@ -172,7 +172,7 @@ error_code sceNpSnsFbGetAccessToken(u32 handle, vm::cptr<SceNpSnsFbAccessTokenPa
 		return SCE_NP_SNS_ERROR_INVALID_ARGUMENT;
 	}
 
-	const auto sfh = idm::get<sns_fb_handle_t>(handle);
+	const auto sfh = idm::get_unlocked<sns_fb_handle_t>(handle);
 
 	if (!sfh)
 	{
@@ -200,7 +200,7 @@ s32 sceNpSnsFbStreamPublish(u32 handle) // add more arguments
 		return SCE_NP_SNS_ERROR_INVALID_ARGUMENT;
 	}
 
-	const auto sfh = idm::get<sns_fb_handle_t>(handle);
+	const auto sfh = idm::get_unlocked<sns_fb_handle_t>(handle);
 
 	if (!sfh)
 	{
@@ -258,7 +258,7 @@ s32 sceNpSnsFbLoadThrottle(u32 handle)
 		return SCE_NP_SNS_ERROR_INVALID_ARGUMENT;
 	}
 
-	const auto sfh = idm::get<sns_fb_handle_t>(handle);
+	const auto sfh = idm::get_unlocked<sns_fb_handle_t>(handle);
 
 	if (!sfh)
 	{
@@ -299,7 +299,7 @@ error_code sceNpSnsFbGetLongAccessToken(u32 handle, vm::cptr<SceNpSnsFbAccessTok
 		return SCE_NP_SNS_ERROR_INVALID_ARGUMENT;
 	}
 
-	const auto sfh = idm::get<sns_fb_handle_t>(handle);
+	const auto sfh = idm::get_unlocked<sns_fb_handle_t>(handle);
 
 	if (!sfh)
 	{

--- a/rpcs3/Emu/Cell/Modules/sceNpTus.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTus.cpp
@@ -133,7 +133,7 @@ error_code sceNpTusCreateTransactionCtx(s32 titleCtxId)
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto tus = idm::get<tus_ctx>(titleCtxId);
+	auto tus = idm::get_unlocked<tus_ctx>(titleCtxId);
 
 	if (!tus)
 	{
@@ -185,24 +185,12 @@ error_code sceNpTusSetTimeout(s32 ctxId, u32 timeout)
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ARGUMENT;
 	}
 
-	const u32 idm_id = static_cast<u32>(ctxId);
-
-	if (idm_id >= tus_transaction_ctx::id_base && idm_id < (tus_transaction_ctx::id_base + tus_transaction_ctx::id_count))
+	if (auto trans = idm::get_unlocked<tus_transaction_ctx>(ctxId))
 	{
-		auto trans = idm::get<tus_transaction_ctx>(ctxId);
-		if (!trans)
-		{
-			return SCE_NP_COMMUNITY_ERROR_INVALID_ID;
-		}
 		trans->timeout = timeout;
 	}
-	else if (idm_id >= tus_ctx::id_base && idm_id < (tus_ctx::id_base + tus_ctx::id_count))
+	else if (auto tus = idm::get_unlocked<tus_ctx>(ctxId))
 	{
-		auto tus = idm::get<tus_ctx>(ctxId);
-		if (!ctxId)
-		{
-			return SCE_NP_COMMUNITY_ERROR_INVALID_ID;
-		}
 		tus->timeout = timeout;
 	}
 	else
@@ -224,7 +212,7 @@ error_code sceNpTusAbortTransaction(s32 transId)
 		return SCE_NP_COMMUNITY_ERROR_NOT_INITIALIZED;
 	}
 
-	auto trans = idm::get<tus_transaction_ctx>(transId);
+	auto trans = idm::get_unlocked<tus_transaction_ctx>(transId);
 	if (!trans)
 	{
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ID;
@@ -246,7 +234,7 @@ error_code sceNpTusWaitAsync(s32 transId, vm::ptr<s32> result)
 		return SCE_NP_COMMUNITY_ERROR_NOT_INITIALIZED;
 	}
 
-	auto trans = idm::get<tus_transaction_ctx>(transId);
+	auto trans = idm::get_unlocked<tus_transaction_ctx>(transId);
 	if (!trans)
 	{
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ID;
@@ -268,7 +256,7 @@ error_code sceNpTusPollAsync(s32 transId, vm::ptr<s32> result)
 		return SCE_NP_COMMUNITY_ERROR_NOT_INITIALIZED;
 	}
 
-	auto trans = idm::get<tus_transaction_ctx>(transId);
+	auto trans = idm::get_unlocked<tus_transaction_ctx>(transId);
 	if (!trans)
 	{
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ID;
@@ -326,7 +314,7 @@ error_code scenp_tus_set_multislot_variable(s32 transId, T targetNpId, vm::cptr<
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -413,7 +401,7 @@ error_code scenp_tus_get_multislot_variable(s32 transId, T targetNpId, vm::cptr<
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -500,7 +488,7 @@ error_code scenp_tus_get_multiuser_variable(s32 transId, T targetNpIdArray, SceN
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -599,7 +587,7 @@ error_code scenp_tus_get_friends_variable(s32 transId, SceNpTusSlotId slotId, s3
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -659,7 +647,7 @@ error_code scenp_tus_add_and_get_variable(s32 transId, T targetNpId, SceNpTusSlo
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -736,7 +724,7 @@ error_code scenp_tus_try_and_set_variable(s32 transId, T targetNpId, SceNpTusSlo
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -813,7 +801,7 @@ error_code scenp_tus_delete_multislot_variable(s32 transId, T targetNpId, vm::cp
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -885,7 +873,7 @@ error_code scenp_tus_set_data(s32 transId, T targetNpId, SceNpTusSlotId slotId, 
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -957,7 +945,7 @@ error_code scenp_tus_get_data(s32 transId, T targetNpId, SceNpTusSlotId slotId, 
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -1044,7 +1032,7 @@ error_code scenp_tus_get_multislot_data_status(s32 transId, T targetNpId, vm::cp
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -1131,7 +1119,7 @@ error_code scenp_tus_get_multiuser_data_status(s32 transId, T targetNpIdArray, S
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -1230,7 +1218,7 @@ error_code scenp_tus_get_friends_data_status(s32 transId, SceNpTusSlotId slotId,
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -1295,7 +1283,7 @@ error_code scenp_tus_delete_multislot_data(s32 transId, T targetNpId, vm::cptr<S
 		return SCE_NP_COMMUNITY_ERROR_INVALID_ONLINE_ID;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -1337,7 +1325,7 @@ error_code sceNpTusDeleteMultiSlotDataVUserAsync(s32 transId, vm::cptr<SceNpTusV
 	return scenp_tus_delete_multislot_data(transId, targetVirtualUserId, slotIdArray, arrayNum, option, true, true);
 }
 
-void scenp_tss_no_file(const std::shared_ptr<tus_transaction_ctx>& trans, vm::ptr<SceNpTssDataStatus> dataStatus)
+void scenp_tss_no_file(const shared_ptr<tus_transaction_ctx>& trans, vm::ptr<SceNpTssDataStatus> dataStatus)
 {
 	// TSS are files stored on PSN by developers, no dumps available atm
 	std::memset(dataStatus.get_ptr(), 0, sizeof(SceNpTssDataStatus));
@@ -1365,7 +1353,7 @@ error_code sceNpTssGetData(s32 transId, SceNpTssSlotId slotId, vm::ptr<SceNpTssD
 		return SCE_NP_COMMUNITY_ERROR_INSUFFICIENT_ARGUMENT;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{
@@ -1398,7 +1386,7 @@ error_code sceNpTssGetDataAsync(s32 transId, SceNpTssSlotId slotId, vm::ptr<SceN
 		return SCE_NP_COMMUNITY_ERROR_INSUFFICIENT_ARGUMENT;
 	}
 
-	auto trans_ctx = idm::get<tus_transaction_ctx>(transId);
+	auto trans_ctx = idm::get_unlocked<tus_transaction_ctx>(transId);
 
 	if (!trans_ctx)
 	{

--- a/rpcs3/Emu/Cell/Modules/sys_io_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_io_.cpp
@@ -51,7 +51,7 @@ void config_event_entry(ppu_thread& ppu)
 	}
 
 	const u32 queue_id = cfg.queue_id;
-	auto queue = idm::get<lv2_obj, lv2_event_queue>(queue_id);
+	auto queue = idm::get_unlocked<lv2_obj, lv2_event_queue>(queue_id);
 
 	while (queue && sys_event_queue_receive(ppu, queue_id, vm::null, 0) == CELL_OK)
 	{
@@ -81,7 +81,7 @@ void config_event_entry(ppu_thread& ppu)
 				if (!queue->exists)
 				{
 					// Exit condition
-					queue = nullptr;
+					queue = null_ptr;
 					break;
 				}
 
@@ -134,7 +134,7 @@ extern void send_sys_io_connect_event(usz index, u32 state)
 
 	if (cfg.init_ctr)
 	{
-		if (auto port = idm::get<lv2_obj, lv2_event_queue>(cfg.queue_id))
+		if (auto port = idm::get_unlocked<lv2_obj, lv2_event_queue>(cfg.queue_id))
 		{
 			port->send(0, 1, index, state);
 		}

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "PPUAnalyser.h"
 
+#include "lv2/sys_sync.h"
+
 #include "PPUOpcodes.h"
 #include "PPUThread.h"
 
@@ -37,7 +39,8 @@ void fmt_class_string<bs_t<ppu_attr>>::format(std::string& out, u64 arg)
 	format_bitset(out, arg, "[", ",", "]", &fmt_class_string<ppu_attr>::format);
 }
 
-void ppu_module::validate(u32 reloc)
+template <>
+void ppu_module<lv2_obj>::validate(u32 reloc)
 {
 	// Load custom PRX configuration if available
 	if (fs::file yml{path + ".yml"})
@@ -529,7 +532,8 @@ namespace ppu_patterns
 	};
 }
 
-bool ppu_module::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::vector<u32>& applied, const std::vector<u32>& exported_funcs, std::function<bool()> check_aborted)
+template <>
+bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::vector<u32>& applied, const std::vector<u32>& exported_funcs, std::function<bool()> check_aborted)
 {
 	if (segs.empty())
 	{

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -72,8 +72,11 @@ struct ppu_segment
 };
 
 // PPU Module Information
-struct ppu_module
+template <typename Type>
+struct ppu_module : public Type
 {
+	using Type::Type;
+
 	ppu_module() noexcept = default;
 
 	ppu_module(const ppu_module&) = delete;
@@ -177,7 +180,8 @@ struct ppu_module
 	}
 };
 
-struct main_ppu_module : public ppu_module
+template <typename T>
+struct main_ppu_module : public ppu_module<T>
 {
 	u32 elf_entry{};
 	u32 seg0_code_end{};

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -3,6 +3,7 @@
 
 #include "Emu/system_config.h"
 #include "Emu/Cell/Common.h"
+#include "Emu/Cell/lv2/sys_sync.h"
 #include "PPUTranslator.h"
 #include "PPUThread.h"
 #include "SPUThread.h"
@@ -28,7 +29,7 @@ const ppu_decoder<PPUTranslator> s_ppu_decoder;
 extern const ppu_decoder<ppu_itype> g_ppu_itype;
 extern const ppu_decoder<ppu_iname> g_ppu_iname;
 
-PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_module& info, ExecutionEngine& engine)
+PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_module<lv2_obj>& info, ExecutionEngine& engine)
 	: cpu_translator(_module, false)
 	, m_info(info)
 	, m_pure_attr()
@@ -322,7 +323,7 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 	return m_function;
 }
 
-Function* PPUTranslator::GetSymbolResolver(const ppu_module& info)
+Function* PPUTranslator::GetSymbolResolver(const ppu_module<lv2_obj>& info)
 {
 	m_function = cast<Function>(m_module->getOrInsertFunction("__resolve_symbols", FunctionType::get(get_type<void>(), { get_type<u8*>(), get_type<u64>() }, false)).getCallee());
 

--- a/rpcs3/Emu/Cell/PPUTranslator.h
+++ b/rpcs3/Emu/Cell/PPUTranslator.h
@@ -8,10 +8,15 @@
 
 #include "util/types.hpp"
 
+template <typename T>
+struct ppu_module;
+
+struct lv2_obj;
+
 class PPUTranslator final : public cpu_translator
 {
 	// PPU Module
-	const ppu_module& m_info;
+	const ppu_module<lv2_obj>& m_info;
 
 	// Relevant relocations
 	std::map<u64, const ppu_reloc*> m_relocs;
@@ -331,7 +336,7 @@ public:
 	// Handle compilation errors
 	void CompilationError(const std::string& error);
 
-	PPUTranslator(llvm::LLVMContext& context, llvm::Module* _module, const ppu_module& info, llvm::ExecutionEngine& engine);
+	PPUTranslator(llvm::LLVMContext& context, llvm::Module* _module, const ppu_module<lv2_obj>& info, llvm::ExecutionEngine& engine);
 	~PPUTranslator();
 
 	// Get thread context struct type
@@ -339,7 +344,7 @@ public:
 
 	// Parses PPU opcodes and translate them into LLVM IR
 	llvm::Function* Translate(const ppu_function& info);
-	llvm::Function* GetSymbolResolver(const ppu_module& info);
+	llvm::Function* GetSymbolResolver(const ppu_module<lv2_obj>& info);
 
 	void MFVSCR(ppu_opcode_t op);
 	void MTVSCR(ppu_opcode_t op);

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -2415,7 +2415,7 @@ void spu_thread::do_dma_transfer(spu_thread* _this, const spu_mfc_cmd& args, u8*
 		if (eal < SYS_SPU_THREAD_BASE_LOW)
 		{
 			// RawSPU MMIO
-			auto thread = idm::get<named_thread<spu_thread>>(find_raw_spu((eal - RAW_SPU_BASE_ADDR) / RAW_SPU_OFFSET));
+			auto thread = idm::get_unlocked<named_thread<spu_thread>>(find_raw_spu((eal - RAW_SPU_BASE_ADDR) / RAW_SPU_OFFSET));
 
 			if (!thread)
 			{
@@ -3837,7 +3837,7 @@ bool spu_thread::do_putllc(const spu_mfc_cmd& args)
 
 				if (count2 > 20000 && g_cfg.core.perf_report) [[unlikely]]
 				{
-					perf_log.warning(u8"PUTLLC: took too long: %.3fµs (%u c) (addr=0x%x) (S)", count2 / (utils::get_tsc_freq() / 1000'000.), count2, addr);
+					perf_log.warning("PUTLLC: took too long: %.3fus (%u c) (addr=0x%x) (S)", count2 / (utils::get_tsc_freq() / 1000'000.), count2, addr);
 				}
 
 				if (ok)
@@ -3872,7 +3872,7 @@ bool spu_thread::do_putllc(const spu_mfc_cmd& args)
 			{
 				if (count > 20000 && g_cfg.core.perf_report) [[unlikely]]
 				{
-					perf_log.warning(u8"PUTLLC: took too long: %.3fµs (%u c) (addr = 0x%x)", count / (utils::get_tsc_freq() / 1000'000.), count, addr);
+					perf_log.warning("PUTLLC: took too long: %.3fus (%u c) (addr = 0x%x)", count / (utils::get_tsc_freq() / 1000'000.), count, addr);
 				}
 
 				break;
@@ -4087,7 +4087,7 @@ void do_cell_atomic_128_store(u32 addr, const void* to_write)
 
 		if (result > 20000 && g_cfg.core.perf_report) [[unlikely]]
 		{
-			perf_log.warning(u8"STORE128: took too long: %.3fµs (%u c) (addr=0x%x)", result / (utils::get_tsc_freq() / 1000'000.), result, addr);
+			perf_log.warning("STORE128: took too long: %.3fus (%u c) (addr=0x%x)", result / (utils::get_tsc_freq() / 1000'000.), result, addr);
 		}
 
 		static_cast<void>(cpu->test_stopped());
@@ -6007,7 +6007,7 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 
 				spu_function_logger logger(*this, "sys_spu_thread_send_event");
 
-				std::shared_ptr<lv2_event_queue> queue;
+				shared_ptr<lv2_event_queue> queue;
 				{
 					std::lock_guard lock(group->mutex);
 
@@ -6059,7 +6059,7 @@ bool spu_thread::set_ch_value(u32 ch, u32 value)
 
 				spu_function_logger logger(*this, "sys_spu_thread_throw_event");
 
-				std::shared_ptr<lv2_event_queue> queue;
+				shared_ptr<lv2_event_queue> queue;
 				{
 					std::lock_guard lock{group->mutex};
 					queue = this->spup[spup];
@@ -6447,7 +6447,7 @@ bool spu_thread::stop_and_signal(u32 code)
 		return true;
 	}
 
-	auto get_queue = [this](u32 spuq) -> const std::shared_ptr<lv2_event_queue>&
+	auto get_queue = [this](u32 spuq) -> const shared_ptr<lv2_event_queue>&
 	{
 		for (auto& v : this->spuq)
 		{
@@ -6460,7 +6460,7 @@ bool spu_thread::stop_and_signal(u32 code)
 			}
 		}
 
-		static const std::shared_ptr<lv2_event_queue> empty;
+		static const shared_ptr<lv2_event_queue> empty;
 		return empty;
 	};
 
@@ -6523,7 +6523,7 @@ bool spu_thread::stop_and_signal(u32 code)
 
 		spu_function_logger logger(*this, "sys_spu_thread_receive_event");
 
-		std::shared_ptr<lv2_event_queue> queue;
+		shared_ptr<lv2_event_queue> queue;
 
 		while (true)
 		{
@@ -6665,7 +6665,7 @@ bool spu_thread::stop_and_signal(u32 code)
 
 		spu_log.trace("sys_spu_thread_tryreceive_event(spuq=0x%x)", spuq);
 
-		std::shared_ptr<lv2_event_queue> queue;
+		shared_ptr<lv2_event_queue> queue;
 
 		reader_lock{group->mutex}, queue = get_queue(spuq);
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -453,7 +453,7 @@ struct spu_int_ctrl_t
 	atomic_t<u64> mask;
 	atomic_t<u64> stat;
 
-	std::shared_ptr<struct lv2_int_tag> tag;
+	shared_ptr<struct lv2_int_tag> tag;
 
 	void set(u64 ints);
 
@@ -755,8 +755,8 @@ public:
 	atomic_t<status_npc_sync_var> status_npc{};
 	std::array<spu_int_ctrl_t, 3> int_ctrl{}; // SPU Class 0, 1, 2 Interrupt Management
 
-	std::array<std::pair<u32, std::shared_ptr<lv2_event_queue>>, 32> spuq{}; // Event Queue Keys for SPU Thread
-	std::shared_ptr<lv2_event_queue> spup[64]; // SPU Ports
+	std::array<std::pair<u32, shared_ptr<lv2_event_queue>>, 32> spuq{}; // Event Queue Keys for SPU Thread
+	shared_ptr<lv2_event_queue> spup[64]; // SPU Ports
 	spu_channel exit_status{}; // Threaded SPU exit status (not a channel, but the interface fits)
 	atomic_t<u32> last_exit_status; // Value to be written in exit_status after checking group termination
 	lv2_spu_group* const group; // SPU Thread Group (access by the spu threads in the group only! From other threads obtain a shared pointer to group using group ID)

--- a/rpcs3/Emu/Cell/lv2/sys_cond.h
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.h
@@ -26,19 +26,14 @@ struct lv2_cond final : lv2_obj
 	const u64 name;
 	const u32 mtx_id;
 
-	std::shared_ptr<lv2_mutex> mutex; // Associated Mutex
+	lv2_mutex* mutex; // Associated Mutex
+	shared_ptr<lv2_obj> _mutex;
 	ppu_thread* sq{};
 
-	lv2_cond(u64 key, u64 name, u32 mtx_id, std::shared_ptr<lv2_mutex> mutex)
-		: key(key)
-		, name(name)
-		, mtx_id(mtx_id)
-		, mutex(std::move(mutex))
-	{
-	}
+	lv2_cond(u64 key, u64 name, u32 mtx_id, shared_ptr<lv2_obj> mutex0) noexcept;
 
-	lv2_cond(utils::serial& ar);
-	static std::shared_ptr<void> load(utils::serial& ar);
+	lv2_cond(utils::serial& ar) noexcept;
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 
 	CellError on_id_create();

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -100,10 +100,10 @@ struct lv2_event_queue final : public lv2_obj
 	lv2_event_queue(u32 protocol, s32 type, s32 size, u64 name, u64 ipc_key) noexcept;
 
 	lv2_event_queue(utils::serial& ar) noexcept;
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 	static void save_ptr(utils::serial&, lv2_event_queue*);
-	static std::shared_ptr<lv2_event_queue> load_ptr(utils::serial& ar, std::shared_ptr<lv2_event_queue>& queue, std::string_view msg = {});
+	static shared_ptr<lv2_event_queue> load_ptr(utils::serial& ar, shared_ptr<lv2_event_queue>& queue, std::string_view msg = {});
 
 	CellError send(lv2_event event, bool* notified_thread = nullptr, lv2_event_port* port = nullptr);
 
@@ -113,7 +113,7 @@ struct lv2_event_queue final : public lv2_obj
 	}
 
 	// Get event queue by its global key
-	static std::shared_ptr<lv2_event_queue> find(u64 ipc_key);
+	static shared_ptr<lv2_event_queue> find(u64 ipc_key);
 };
 
 struct lv2_event_port final : lv2_obj
@@ -124,7 +124,7 @@ struct lv2_event_port final : lv2_obj
 	const u64 name; // Event source (generated from id and process id if not set)
 
 	atomic_t<usz> is_busy = 0; // Counts threads waiting on event sending
-	std::shared_ptr<lv2_event_queue> queue; // Event queue this port is connected to
+	shared_ptr<lv2_event_queue> queue; // Event queue this port is connected to
 
 	lv2_event_port(s32 type, u64 name)
 		: type(type)

--- a/rpcs3/Emu/Cell/lv2/sys_event_flag.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event_flag.h
@@ -54,7 +54,7 @@ struct lv2_event_flag final : lv2_obj
 	}
 
 	lv2_event_flag(utils::serial& ar);
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 
 	// Check mode arg

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -360,7 +360,7 @@ struct lv2_file final : lv2_fs_object
 	struct file_view;
 
 	// Make file view from lv2_file object (for MSELF support)
-	static fs::file make_view(const std::shared_ptr<lv2_file>& _file, u64 offset);
+	static fs::file make_view(const shared_ptr<lv2_file>& _file, u64 offset);
 };
 
 struct lv2_dir final : lv2_fs_object

--- a/rpcs3/Emu/Cell/lv2/sys_interrupt.h
+++ b/rpcs3/Emu/Cell/lv2/sys_interrupt.h
@@ -11,7 +11,7 @@ struct lv2_int_tag final : public lv2_obj
 	static const u32 id_base = 0x0a000000;
 
 	const u32 id;
-	std::shared_ptr<struct lv2_int_serv> handler;
+	shared_ptr<struct lv2_int_serv> handler;
 
 	lv2_int_tag() noexcept;
 	lv2_int_tag(utils::serial& ar) noexcept;
@@ -23,11 +23,11 @@ struct lv2_int_serv final : public lv2_obj
 	static const u32 id_base = 0x0b000000;
 
 	const u32 id;
-	const std::shared_ptr<named_thread<ppu_thread>> thread;
+	const shared_ptr<named_thread<ppu_thread>> thread;
 	const u64 arg1;
 	const u64 arg2;
 
-	lv2_int_serv(const std::shared_ptr<named_thread<ppu_thread>>& thread, u64 arg1, u64 arg2) noexcept;
+	lv2_int_serv(shared_ptr<named_thread<ppu_thread>> thread, u64 arg1, u64 arg2) noexcept;
 	lv2_int_serv(utils::serial& ar) noexcept;
 	void save(utils::serial& ar);
 

--- a/rpcs3/Emu/Cell/lv2/sys_io.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_io.cpp
@@ -43,7 +43,7 @@ error_code sys_io_buffer_allocate(u32 handle, vm::ptr<u32> block)
 		return CELL_EFAULT;
 	}
 
-	if (auto io = idm::get<lv2_io_buf>(handle))
+	if (auto io = idm::get_unlocked<lv2_io_buf>(handle))
 	{
 		// no idea what we actually need to allocate
 		if (u32 addr = vm::alloc(io->block_count * io->block_size, vm::main))
@@ -62,7 +62,7 @@ error_code sys_io_buffer_free(u32 handle, u32 block)
 {
 	sys_io.todo("sys_io_buffer_free(handle=0x%x, block=0x%x)", handle, block);
 
-	const auto io = idm::get<lv2_io_buf>(handle);
+	const auto io = idm::get_unlocked<lv2_io_buf>(handle);
 
 	if (!io)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -64,7 +64,7 @@ error_code _sys_lwcond_destroy(ppu_thread& ppu, u32 lwcond_id)
 
 	sys_lwcond.trace("_sys_lwcond_destroy(lwcond_id=0x%x)", lwcond_id);
 
-	std::shared_ptr<lv2_lwcond> _cond;
+	shared_ptr<lv2_lwcond> _cond;
 
 	while (true)
 	{
@@ -440,7 +440,7 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 
 	ppu.gpr[3] = CELL_OK;
 
-	std::shared_ptr<lv2_lwmutex> mutex;
+	shared_ptr<lv2_lwmutex> mutex;
 
 	auto& sstate = *ppu.optional_savestate_state;
 

--- a/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwmutex.cpp
@@ -56,7 +56,7 @@ error_code _sys_lwmutex_destroy(ppu_thread& ppu, u32 lwmutex_id)
 
 	sys_lwmutex.trace("_sys_lwmutex_destroy(lwmutex_id=0x%x)", lwmutex_id);
 
-	std::shared_ptr<lv2_lwmutex> _mutex;
+	shared_ptr<lv2_lwmutex> _mutex;
 
 	while (true)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_memory.h
+++ b/rpcs3/Emu/Cell/lv2/sys_memory.h
@@ -74,7 +74,7 @@ struct lv2_memory_container
 
 	lv2_memory_container(u32 size, bool from_idm = false) noexcept;
 	lv2_memory_container(utils::serial& ar, bool from_idm = false) noexcept;
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 	static lv2_memory_container* search(u32 id);
 

--- a/rpcs3/Emu/Cell/lv2/sys_mmapper.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mmapper.h
@@ -31,7 +31,7 @@ struct lv2_memory : lv2_obj
 	lv2_memory(u32 size, u32 align, u64 flags, u64 key, bool pshared, lv2_memory_container* ct);
 
 	lv2_memory(utils::serial& ar);
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 
 	CellError on_id_create();

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -25,10 +25,9 @@ lv2_mutex::lv2_mutex(utils::serial& ar)
 	control.raw().owner >>= 1;
 }
 
-std::shared_ptr<void> lv2_mutex::load(utils::serial& ar)
+std::function<void(void*)> lv2_mutex::load(utils::serial& ar)
 {
-	auto mtx = std::make_shared<lv2_mutex>(ar);
-	return lv2_obj::load(mtx->key, mtx);
+	return load_func(make_shared<lv2_mutex>(ar));
 }
 
 void lv2_mutex::save(utils::serial& ar)
@@ -88,7 +87,7 @@ error_code sys_mutex_create(ppu_thread& ppu, vm::ptr<u32> mutex_id, vm::ptr<sys_
 
 	if (auto error = lv2_obj::create<lv2_mutex>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]()
 	{
-		return std::make_shared<lv2_mutex>(
+		return make_shared<lv2_mutex>(
 			_attr.protocol,
 			_attr.recursive,
 			_attr.adaptive,

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -58,7 +58,7 @@ struct lv2_mutex final : lv2_obj
 	}
 
 	lv2_mutex(utils::serial& ar);
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 
 	template <typename T>

--- a/rpcs3/Emu/Cell/lv2/sys_net.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net.cpp
@@ -266,25 +266,25 @@ lv2_socket::lv2_socket(utils::serial& ar, lv2_socket_type _type)
 	ar(last_bound_addr);
 }
 
-std::shared_ptr<void> lv2_socket::load(utils::serial& ar)
+std::function<void(void*)> lv2_socket::load(utils::serial& ar)
 {
 	const lv2_socket_type type{ar};
 
-	std::shared_ptr<lv2_socket> sock_lv2;
+	shared_ptr<lv2_socket> sock_lv2;
 
 	switch (type)
 	{
 	case SYS_NET_SOCK_STREAM:
 	case SYS_NET_SOCK_DGRAM:
 	{
-		auto lv2_native = std::make_shared<lv2_socket_native>(ar, type);
+		auto lv2_native = make_shared<lv2_socket_native>(ar, type);
 		ensure(lv2_native->create_socket() >= 0);
 		sock_lv2 = std::move(lv2_native);
 		break;
 	}
-	case SYS_NET_SOCK_RAW: sock_lv2 = std::make_shared<lv2_socket_raw>(ar, type); break;
-	case SYS_NET_SOCK_DGRAM_P2P: sock_lv2 = std::make_shared<lv2_socket_p2p>(ar, type); break;
-	case SYS_NET_SOCK_STREAM_P2P: sock_lv2 = std::make_shared<lv2_socket_p2ps>(ar, type); break;
+	case SYS_NET_SOCK_RAW: sock_lv2 = make_shared<lv2_socket_raw>(ar, type); break;
+	case SYS_NET_SOCK_DGRAM_P2P: sock_lv2 = make_shared<lv2_socket_p2p>(ar, type); break;
+	case SYS_NET_SOCK_STREAM_P2P: sock_lv2 = make_shared<lv2_socket_p2ps>(ar, type); break;
 	}
 
 	if (std::memcmp(&sock_lv2->last_bound_addr, std::array<u8, 16>{}.data(), 16))
@@ -293,7 +293,7 @@ std::shared_ptr<void> lv2_socket::load(utils::serial& ar)
 		sock_lv2->bind(sock_lv2->last_bound_addr);
 	}
 
-	return sock_lv2;
+	return [ptr = sock_lv2](void* storage) { *static_cast<shared_ptr<lv2_socket>*>(storage) = ptr; };;
 }
 
 void lv2_socket::save(utils::serial& ar, bool save_only_this_class)
@@ -352,7 +352,7 @@ error_code sys_net_bnet_accept(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr>
 
 	s32 result = 0;
 	sys_net_sockaddr sn_addr{};
-	std::shared_ptr<lv2_socket> new_socket{};
+	shared_ptr<lv2_socket> new_socket{};
 
 	const auto sock = idm::check<lv2_socket>(s, [&, notify = lv2_obj::notify_all_t()](lv2_socket& sock)
 		{
@@ -465,7 +465,7 @@ error_code sys_net_bnet_bind(ppu_thread& ppu, s32 s, vm::cptr<sys_net_sockaddr> 
 		return -SYS_NET_EINVAL;
 	}
 
-	if (!idm::check<lv2_socket>(s))
+	if (!idm::check_unlocked<lv2_socket>(s))
 	{
 		return -SYS_NET_EBADF;
 	}
@@ -514,7 +514,7 @@ error_code sys_net_bnet_connect(ppu_thread& ppu, s32 s, vm::ptr<sys_net_sockaddr
 		return -SYS_NET_EAFNOSUPPORT;
 	}
 
-	if (!idm::check<lv2_socket>(s))
+	if (!idm::check_unlocked<lv2_socket>(s))
 	{
 		return -SYS_NET_EBADF;
 	}
@@ -1194,14 +1194,14 @@ error_code sys_net_bnet_socket(ppu_thread& ppu, lv2_socket_family family, lv2_so
 		return -SYS_NET_EPROTONOSUPPORT;
 	}
 
-	std::shared_ptr<lv2_socket> sock_lv2;
+	shared_ptr<lv2_socket> sock_lv2;
 
 	switch (type)
 	{
 	case SYS_NET_SOCK_STREAM:
 	case SYS_NET_SOCK_DGRAM:
 	{
-		auto lv2_native = std::make_shared<lv2_socket_native>(family, type, protocol);
+		auto lv2_native = make_shared<lv2_socket_native>(family, type, protocol);
 		if (s32 result = lv2_native->create_socket(); result < 0)
 		{
 			return sys_net_error{result};
@@ -1210,9 +1210,9 @@ error_code sys_net_bnet_socket(ppu_thread& ppu, lv2_socket_family family, lv2_so
 		sock_lv2 = std::move(lv2_native);
 		break;
 	}
-	case SYS_NET_SOCK_RAW: sock_lv2 = std::make_shared<lv2_socket_raw>(family, type, protocol); break;
-	case SYS_NET_SOCK_DGRAM_P2P: sock_lv2 = std::make_shared<lv2_socket_p2p>(family, type, protocol); break;
-	case SYS_NET_SOCK_STREAM_P2P: sock_lv2 = std::make_shared<lv2_socket_p2ps>(family, type, protocol); break;
+	case SYS_NET_SOCK_RAW: sock_lv2 = make_shared<lv2_socket_raw>(family, type, protocol); break;
+	case SYS_NET_SOCK_DGRAM_P2P: sock_lv2 = make_shared<lv2_socket_p2p>(family, type, protocol); break;
+	case SYS_NET_SOCK_STREAM_P2P: sock_lv2 = make_shared<lv2_socket_p2ps>(family, type, protocol); break;
 	}
 
 	const s32 s = idm::import_existing<lv2_socket>(sock_lv2);
@@ -1775,7 +1775,7 @@ error_code sys_net_abort(ppu_thread& ppu, s32 type, u64 arg, s32 flags)
 	{
 		std::lock_guard nw_lock(g_fxo->get<network_context>().mutex_thread_loop);
 
-		const auto sock = idm::get<lv2_socket>(static_cast<u32>(arg));
+		const auto sock = idm::get_unlocked<lv2_socket>(static_cast<u32>(arg));
 
 		if (!sock)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.cpp
@@ -64,7 +64,7 @@ void lv2_socket::set_poll_event(bs_t<lv2_socket::poll_t> event)
 	events += event;
 }
 
-void lv2_socket::poll_queue(std::shared_ptr<ppu_thread> ppu, bs_t<lv2_socket::poll_t> event, std::function<bool(bs_t<lv2_socket::poll_t>)> poll_cb)
+void lv2_socket::poll_queue(shared_ptr<ppu_thread> ppu, bs_t<lv2_socket::poll_t> event, std::function<bool(bs_t<lv2_socket::poll_t>)> poll_cb)
 {
 	set_poll_event(event);
 	queue.emplace_back(std::move(ppu), poll_cb);

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
@@ -60,7 +60,7 @@ public:
 	lv2_socket(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
 	lv2_socket(utils::serial&) {}
 	lv2_socket(utils::serial&, lv2_socket_type type);
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial&, bool save_only_this_class = false);
 	virtual ~lv2_socket() = default;
 
@@ -69,7 +69,7 @@ public:
 	void set_lv2_id(u32 id);
 	bs_t<poll_t> get_events() const;
 	void set_poll_event(bs_t<poll_t> event);
-	void poll_queue(std::shared_ptr<ppu_thread> ppu, bs_t<poll_t> event, std::function<bool(bs_t<poll_t>)> poll_cb);
+	void poll_queue(shared_ptr<ppu_thread> ppu, bs_t<poll_t> event, std::function<bool(bs_t<poll_t>)> poll_cb);
 	u32 clear_queue(ppu_thread*);
 	void handle_events(const pollfd& native_fd, bool unset_connecting = false);
 	void queue_wake(ppu_thread* ppu);
@@ -85,7 +85,7 @@ public:
 #endif
 
 public:
-	virtual std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) = 0;
+	virtual std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) = 0;
 	virtual s32 bind(const sys_net_sockaddr& addr) = 0;
 
 	virtual std::optional<s32> connect(const sys_net_sockaddr& addr) = 0;
@@ -133,7 +133,7 @@ protected:
 	atomic_bs_t<poll_t> events{};
 
 	// Event processing workload (pair of thread id and the processing function)
-	std::vector<std::pair<std::shared_ptr<ppu_thread>, std::function<bool(bs_t<poll_t>)>>> queue;
+	std::vector<std::pair<shared_ptr<ppu_thread>, std::function<bool(bs_t<poll_t>)>>> queue;
 
 	// Socket options value keepers
 	// Non-blocking IO option

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
@@ -106,7 +106,7 @@ void lv2_socket_native::set_socket(socket_type socket, lv2_socket_family family,
 	set_non_blocking();
 }
 
-std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_native::accept(bool is_lock)
+std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_native::accept(bool is_lock)
 {
 	std::unique_lock<shared_mutex> lock(mutex, std::defer_lock);
 
@@ -127,7 +127,7 @@ std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_
 
 	if (native_socket != invalid_socket)
 	{
-		auto newsock = std::make_shared<lv2_socket_native>(family, type, protocol);
+		auto newsock = make_single<lv2_socket_native>(family, type, protocol);
 		newsock->set_socket(native_socket, family, type, protocol);
 
 		// Sockets inherit non blocking behaviour from their parent
@@ -274,7 +274,7 @@ std::optional<s32> lv2_socket_native::connect(const sys_net_sockaddr& addr)
 #ifdef _WIN32
 			connecting = true;
 #endif
-			this->poll_queue(nullptr, lv2_socket::poll_t::write, [this](bs_t<lv2_socket::poll_t> events) -> bool
+			this->poll_queue(null_ptr, lv2_socket::poll_t::write, [this](bs_t<lv2_socket::poll_t> events) -> bool
 				{
 					if (events & lv2_socket::poll_t::write)
 					{

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
@@ -30,13 +30,15 @@
 class lv2_socket_native final : public lv2_socket
 {
 public:
+	static constexpr u32 id_type = 1;
+
 	lv2_socket_native(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
 	lv2_socket_native(utils::serial& ar, lv2_socket_type type);
 	void save(utils::serial& ar);
 	~lv2_socket_native();
 	s32 create_socket();
 
-	std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
+	std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
 	s32 bind(const sys_net_sockaddr& addr) override;
 
 	std::optional<s32> connect(const sys_net_sockaddr& addr) override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
@@ -72,7 +72,7 @@ void lv2_socket_p2p::handle_new_data(sys_net_sockaddr_in_p2p p2p_addr, std::vect
 	}
 }
 
-std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_p2p::accept([[maybe_unused]] bool is_lock)
+std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_p2p::accept([[maybe_unused]] bool is_lock)
 {
 	sys_net.fatal("[P2P] accept() called on a P2P socket");
 	return {};

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.h
@@ -9,7 +9,7 @@ public:
 	lv2_socket_p2p(utils::serial& ar, lv2_socket_type type);
 	void save(utils::serial& ar);
 
-	std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
+	std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
 	s32 bind(const sys_net_sockaddr& addr) override;
 
 	std::optional<s32> connect(const sys_net_sockaddr& addr) override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
@@ -467,7 +467,7 @@ bool lv2_socket_p2ps::handle_listening(p2ps_encapsulated_tcp* tcp_header, [[mayb
 		const u16 new_op_vport     = tcp_header->src_port;
 		const u64 new_cur_seq      = send_hdr.seq + 1;
 		const u64 new_data_beg_seq = send_hdr.ack;
-		auto sock_lv2              = std::make_shared<lv2_socket_p2ps>(socket, port, vport, new_op_addr, new_op_port, new_op_vport, new_cur_seq, new_data_beg_seq, so_nbio);
+		auto sock_lv2              = make_shared<lv2_socket_p2ps>(socket, port, vport, new_op_addr, new_op_port, new_op_vport, new_cur_seq, new_data_beg_seq, so_nbio);
 		const s32 new_sock_id      = idm::import_existing<lv2_socket>(sock_lv2);
 		sock_lv2->set_lv2_id(new_sock_id);
 		const u64 key_connected = (reinterpret_cast<struct sockaddr_in*>(op_addr)->sin_addr.s_addr) | (static_cast<u64>(tcp_header->src_port) << 48) | (static_cast<u64>(tcp_header->dst_port) << 32);
@@ -600,7 +600,7 @@ std::pair<s32, sys_net_sockaddr> lv2_socket_p2ps::getpeername()
 	return {CELL_OK, res};
 }
 
-std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_p2ps::accept(bool is_lock)
+std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_p2ps::accept(bool is_lock)
 {
 	std::unique_lock<shared_mutex> lock(mutex, std::defer_lock);
 

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
@@ -58,6 +58,8 @@ std::vector<u8> generate_u2s_packet(const p2ps_encapsulated_tcp& header, const u
 class lv2_socket_p2ps final : public lv2_socket_p2p
 {
 public:
+	static constexpr u32 id_type = 2;
+
 	lv2_socket_p2ps(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
 	lv2_socket_p2ps(socket_type socket, u16 port, u16 vport, u32 op_addr, u16 op_port, u16 op_vport, u64 cur_seq, u64 data_beg_seq, s32 so_nbio);
 	lv2_socket_p2ps(utils::serial& ar, lv2_socket_type type);
@@ -70,7 +72,7 @@ public:
 	void send_u2s_packet(std::vector<u8> data, const ::sockaddr_in* dst, u64 seq, bool require_ack);
 	void close_stream();
 
-	std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
+	std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
 	s32 bind(const sys_net_sockaddr& addr) override;
 
 	std::optional<s32> connect(const sys_net_sockaddr& addr) override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
@@ -36,7 +36,7 @@ void lv2_socket_raw::save(utils::serial& ar)
 	lv2_socket::save(ar, true);
 }
 
-std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_raw::accept([[maybe_unused]] bool is_lock)
+std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> lv2_socket_raw::accept([[maybe_unused]] bool is_lock)
 {
 	sys_net.fatal("[RAW] accept() called on a RAW socket");
 	return {};

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.h
@@ -5,11 +5,13 @@
 class lv2_socket_raw final : public lv2_socket
 {
 public:
+	static constexpr u32 id_type = 1;
+
 	lv2_socket_raw(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
 	lv2_socket_raw(utils::serial& ar, lv2_socket_type type);
 	void save(utils::serial& ar);
 
-	std::tuple<bool, s32, std::shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
+	std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;
 	s32 bind(const sys_net_sockaddr& addr) override;
 
 	std::optional<s32> connect(const sys_net_sockaddr& addr) override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
@@ -138,7 +138,7 @@ void p2p_thread::bind_sce_np_port()
 
 void network_thread::operator()()
 {
-	std::vector<std::shared_ptr<lv2_socket>> socklist;
+	std::vector<shared_ptr<lv2_socket>> socklist;
 	socklist.reserve(lv2_socket::id_count);
 
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
@@ -135,11 +135,11 @@ bool nt_p2p_port::handle_connected(s32 sock_id, p2ps_encapsulated_tcp* tcp_heade
 
 bool nt_p2p_port::handle_listening(s32 sock_id, p2ps_encapsulated_tcp* tcp_header, u8* data, ::sockaddr_storage* op_addr)
 {
-	auto sock = idm::get<lv2_socket>(sock_id);
+	auto sock = idm::get_unlocked<lv2_socket>(sock_id);
 	if (!sock)
 		return false;
 
-	auto& sock_p2ps = reinterpret_cast<lv2_socket_p2ps&>(*sock.get());
+	auto& sock_p2ps = reinterpret_cast<lv2_socket_p2ps&>(*sock);
 	return sock_p2ps.handle_listening(tcp_header, data, op_addr);
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.h
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.h
@@ -5,7 +5,7 @@
 #include "sys_sync.h"
 #include <vector>
 
-struct lv2_overlay final : lv2_obj, ppu_module
+struct lv2_overlay final : ppu_module<lv2_obj>
 {
 	static const u32 id_base = 0x25000000;
 
@@ -15,7 +15,7 @@ struct lv2_overlay final : lv2_obj, ppu_module
 
 	lv2_overlay() = default;
 	lv2_overlay(utils::serial&){}
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 };
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -17,12 +17,12 @@
 #include "sys_memory.h"
 #include <span>
 
-extern void dump_executable(std::span<const u8> data, const ppu_module* _module, std::string_view title_id);
+extern void dump_executable(std::span<const u8> data, const ppu_module<lv2_obj>* _module, std::string_view title_id);
 
-extern std::shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, bool virtual_load, const std::string&, s64, utils::serial* = nullptr);
+extern shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object&, bool virtual_load, const std::string&, s64, utils::serial* = nullptr);
 extern void ppu_unload_prx(const lv2_prx& prx);
-extern bool ppu_initialize(const ppu_module&, bool check_only = false, u64 file_size = 0);
-extern void ppu_finalize(const ppu_module& info, bool force_mem_release = false);
+extern bool ppu_initialize(const ppu_module<lv2_obj>&, bool check_only = false, u64 file_size = 0);
+extern void ppu_finalize(const ppu_module<lv2_obj>& info, bool force_mem_release = false);
 extern void ppu_manual_load_imports_exports(u32 imports_start, u32 imports_size, u32 exports_start, u32 exports_size, std::basic_string<char>& loaded_flags);
 
 LOG_CHANNEL(sys_prx);
@@ -235,7 +235,7 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 		prx->name = std::move(name);
 		prx->path = std::move(path);
 
-		sys_prx.warning(u8"Ignored module: “%s” (id=0x%x)", vpath, idm::last_id());
+		sys_prx.warning("Ignored module: \"%s\" (id=0x%x)", vpath, idm::last_id());
 
 		return not_an_error(idm::last_id());
 	};
@@ -253,7 +253,7 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 		{
 			if (fs_error + 0u == CELL_ENOENT && is_firmware_sprx)
 			{
-				sys_prx.error(u8"firmware SPRX not found: “%s” (forcing HLE implementation)", vpath, idm::last_id());
+				sys_prx.error("firmware SPRX not found: \"%s\" (forcing HLE implementation)", vpath, idm::last_id());
 				return hle_load();
 			}
 
@@ -298,14 +298,14 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	ppu_initialize(*prx);
 
-	sys_prx.success(u8"Loaded module: “%s” (id=0x%x)", vpath, idm::last_id());
+	sys_prx.success("Loaded module: \"%s\" (id=0x%x)", vpath, idm::last_id());
 
 	return not_an_error(idm::last_id());
 }
 
 fs::file make_file_view(fs::file&& file, u64 offset, u64 size);
 
-std::shared_ptr<void> lv2_prx::load(utils::serial& ar)
+std::function<void(void*)> lv2_prx::load(utils::serial& ar)
 {
 	[[maybe_unused]] const s32 version = GET_SERIALIZATION_VERSION(lv2_prx_overlay);
 
@@ -316,11 +316,11 @@ std::shared_ptr<void> lv2_prx::load(utils::serial& ar)
 	usz seg_count = 0;
 	ar.deserialize_vle(seg_count);
 
-	std::shared_ptr<lv2_prx> prx;
+	shared_ptr<lv2_prx> prx;
 
 	auto hle_load = [&]()
 	{
-		prx = std::make_shared<lv2_prx>();
+		prx = make_shared<lv2_prx>();
 		prx->path = path;
 		prx->name = path.substr(path.find_last_of(fs::delim) + 1);
 	};
@@ -337,7 +337,7 @@ std::shared_ptr<void> lv2_prx::load(utils::serial& ar)
 		{
 			u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 			file = make_file_view(std::move(file), offset, umax);
-			prx = ppu_load_prx(ppu_prx_object{ decrypt_self(std::move(file), reinterpret_cast<u8*>(&klic)) }, false, path, 0, &ar);
+			prx = ppu_load_prx(ppu_prx_object{decrypt_self(std::move(file), reinterpret_cast<u8*>(&klic))}, false, path, 0, &ar);
 			prx->m_loaded_flags = std::move(loaded_flags);
 			prx->m_external_loaded_flags = std::move(external_flags);
 
@@ -369,7 +369,11 @@ std::shared_ptr<void> lv2_prx::load(utils::serial& ar)
 	}
 
 	prx->state = state;
-	return prx;
+
+	return [prx](void* storage)
+	{
+		*static_cast<shared_ptr<lv2_obj>*>(storage) = prx;
+	};
 }
 
 void lv2_prx::save(utils::serial& ar)
@@ -407,7 +411,7 @@ error_code _sys_prx_load_module_by_fd(ppu_thread& ppu, s32 fd, u64 offset, u64 f
 
 	sys_prx.warning("_sys_prx_load_module_by_fd(fd=%d, offset=0x%x, flags=0x%x, pOpt=*0x%x)", fd, offset, flags, pOpt);
 
-	const auto file = idm::get<lv2_fs_object, lv2_file>(fd);
+	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
 	if (!file)
 	{
@@ -519,7 +523,7 @@ error_code _sys_prx_start_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sys
 		return CELL_EINVAL;
 	}
 
-	const auto prx = idm::get<lv2_obj, lv2_prx>(id);
+	const auto prx = idm::get_unlocked<lv2_obj, lv2_prx>(id);
 
 	if (!prx)
 	{
@@ -600,7 +604,7 @@ error_code _sys_prx_stop_module(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<sys_
 
 	sys_prx.warning("_sys_prx_stop_module(id=0x%x, flags=0x%x, pOpt=*0x%x)", id, flags, pOpt);
 
-	const auto prx = idm::get<lv2_obj, lv2_prx>(id);
+	const auto prx = idm::get_unlocked<lv2_obj, lv2_prx>(id);
 
 	if (!prx)
 	{
@@ -1013,7 +1017,7 @@ error_code _sys_prx_get_module_info(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<
 
 	sys_prx.warning("_sys_prx_get_module_info(id=0x%x, flags=%d, pOpt=*0x%x)", id, flags, pOpt);
 
-	const auto prx = idm::get<lv2_obj, lv2_prx>(id);
+	const auto prx = idm::get_unlocked<lv2_obj, lv2_prx>(id);
 
 	if (!pOpt)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -172,7 +172,7 @@ enum : u32
 	PRX_STATE_DESTROYED, // Last state, the module cannot be restarted
 };
 
-struct lv2_prx final : lv2_obj, ppu_module
+struct lv2_prx final : ppu_module<lv2_obj>
 {
 	static const u32 id_base = 0x23000000;
 
@@ -204,7 +204,7 @@ struct lv2_prx final : lv2_obj, ppu_module
 
 	lv2_prx() noexcept = default;
 	lv2_prx(utils::serial&) {}
-	static std::shared_ptr<void> load(utils::serial&);
+	static std::function<void(void*)> load(utils::serial&);
 	void save(utils::serial& ar);
 };
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsx.cpp
@@ -425,7 +425,7 @@ error_code sys_rsx_context_iomap(cpu_thread& cpu, u32 context_id, u32 io, u32 ea
 			return CELL_EINVAL;
 		}
 
-		if ((addr == ea || !(addr % 0x1000'0000)) && idm::check<sys_vm_t>(sys_vm_t::find_id(addr)))
+		if ((addr == ea || !(addr % 0x1000'0000)) && idm::check_unlocked<sys_vm_t>(sys_vm_t::find_id(addr)))
 		{
 			// Virtual memory is disallowed
 			return CELL_EINVAL;

--- a/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
@@ -164,7 +164,7 @@ error_code sys_rsxaudio_initialize(vm::ptr<u32> handle)
 		return CELL_ENOMEM;
 	}
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(id);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(id);
 	std::lock_guard lock(rsxaudio_obj->mutex);
 
 	rsxaudio_obj->shmem = vm::addr_t{vm::alloc(sizeof(rsxaudio_shmem), vm::main)};
@@ -201,7 +201,7 @@ error_code sys_rsxaudio_finalize(u32 handle)
 {
 	sys_rsxaudio.trace("sys_rsxaudio_finalize(handle=0x%x)", handle);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{
@@ -219,7 +219,7 @@ error_code sys_rsxaudio_finalize(u32 handle)
 
 	{
 		std::lock_guard ra_obj_lock{rsxaudio_thread.rsxaudio_obj_upd_m};
-		rsxaudio_thread.rsxaudio_obj_ptr = {};
+		rsxaudio_thread.rsxaudio_obj_ptr = null_ptr;
 	}
 
 	rsxaudio_obj->init = false;
@@ -235,7 +235,7 @@ error_code sys_rsxaudio_import_shared_memory(u32 handle, vm::ptr<u64> addr)
 {
 	sys_rsxaudio.trace("sys_rsxaudio_import_shared_memory(handle=0x%x, addr=*0x%x)", handle, addr);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{
@@ -264,7 +264,7 @@ error_code sys_rsxaudio_unimport_shared_memory(u32 handle, vm::ptr<u64> addr /* 
 {
 	sys_rsxaudio.trace("sys_rsxaudio_unimport_shared_memory(handle=0x%x, addr=*0x%x)", handle, addr);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{
@@ -287,7 +287,7 @@ error_code sys_rsxaudio_create_connection(u32 handle)
 {
 	sys_rsxaudio.trace("sys_rsxaudio_create_connection(handle=0x%x)", handle);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{
@@ -305,15 +305,15 @@ error_code sys_rsxaudio_create_connection(u32 handle)
 
 	const error_code port_create_status = [&]() -> error_code
 	{
-		if (auto queue1 = idm::get<lv2_obj, lv2_event_queue>(sh_page->ctrl.event_queue_1_id))
+		if (auto queue1 = idm::get_unlocked<lv2_obj, lv2_event_queue>(sh_page->ctrl.event_queue_1_id))
 		{
 			rsxaudio_obj->event_queue[0] = queue1;
 
-			if (auto queue2 = idm::get<lv2_obj, lv2_event_queue>(sh_page->ctrl.event_queue_2_id))
+			if (auto queue2 = idm::get_unlocked<lv2_obj, lv2_event_queue>(sh_page->ctrl.event_queue_2_id))
 			{
 				rsxaudio_obj->event_queue[1] = queue2;
 
-				if (auto queue3 = idm::get<lv2_obj, lv2_event_queue>(sh_page->ctrl.event_queue_3_id))
+				if (auto queue3 = idm::get_unlocked<lv2_obj, lv2_event_queue>(sh_page->ctrl.event_queue_3_id))
 				{
 					rsxaudio_obj->event_queue[2] = queue3;
 
@@ -350,7 +350,7 @@ error_code sys_rsxaudio_close_connection(u32 handle)
 {
 	sys_rsxaudio.trace("sys_rsxaudio_close_connection(handle=0x%x)", handle);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{
@@ -367,7 +367,7 @@ error_code sys_rsxaudio_close_connection(u32 handle)
 	{
 		auto& rsxaudio_thread = g_fxo->get<rsx_audio_data>();
 		std::lock_guard ra_obj_lock{rsxaudio_thread.rsxaudio_obj_upd_m};
-		rsxaudio_thread.rsxaudio_obj_ptr = {};
+		rsxaudio_thread.rsxaudio_obj_ptr = null_ptr;
 	}
 
 	for (u32 q_idx = 0; q_idx < SYS_RSXAUDIO_PORT_CNT; q_idx++)
@@ -382,7 +382,7 @@ error_code sys_rsxaudio_prepare_process(u32 handle)
 {
 	sys_rsxaudio.trace("sys_rsxaudio_prepare_process(handle=0x%x)", handle);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{
@@ -413,7 +413,7 @@ error_code sys_rsxaudio_start_process(u32 handle)
 {
 	sys_rsxaudio.trace("sys_rsxaudio_start_process(handle=0x%x)", handle);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{
@@ -463,7 +463,7 @@ error_code sys_rsxaudio_stop_process(u32 handle)
 {
 	sys_rsxaudio.trace("sys_rsxaudio_stop_process(handle=0x%x)", handle);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{
@@ -511,7 +511,7 @@ error_code sys_rsxaudio_get_dma_param(u32 handle, u32 flag, vm::ptr<u64> out)
 {
 	sys_rsxaudio.trace("sys_rsxaudio_get_dma_param(handle=0x%x, flag=0x%x, out=0x%x)", handle, flag, out);
 
-	const auto rsxaudio_obj = idm::get<lv2_obj, lv2_rsxaudio>(handle);
+	const auto rsxaudio_obj = idm::get_unlocked<lv2_obj, lv2_rsxaudio>(handle);
 
 	if (!rsxaudio_obj)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_rsxaudio.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rsxaudio.h
@@ -161,7 +161,7 @@ struct lv2_rsxaudio final : lv2_obj
 
 	vm::addr_t shmem{};
 
-	std::array<std::shared_ptr<lv2_event_queue>, SYS_RSXAUDIO_PORT_CNT> event_queue{};
+	std::array<shared_ptr<lv2_event_queue>, SYS_RSXAUDIO_PORT_CNT> event_queue{};
 
 	// lv2 uses port memory addresses for their names
 	static constexpr std::array<u64, SYS_RSXAUDIO_PORT_CNT> event_port_name{ 0x8000000000400100, 0x8000000000400200, 0x8000000000400300 };
@@ -583,7 +583,7 @@ public:
 	atomic_t<bool> rsxaudio_ctx_allocated = false;
 
 	shared_mutex rsxaudio_obj_upd_m{};
-	std::shared_ptr<lv2_rsxaudio> rsxaudio_obj_ptr{};
+	shared_ptr<lv2_rsxaudio> rsxaudio_obj_ptr{};
 
 	void operator()();
 	rsxaudio_data_thread& operator=(thread_state state);

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -19,10 +19,9 @@ lv2_rwlock::lv2_rwlock(utils::serial& ar)
 	ar(owner);
 }
 
-std::shared_ptr<void> lv2_rwlock::load(utils::serial& ar)
+std::function<void(void*)> lv2_rwlock::load(utils::serial& ar)
 {
-	auto rwlock = std::make_shared<lv2_rwlock>(ar);
-	return lv2_obj::load(rwlock->key, rwlock);
+	return load_func(make_shared<lv2_rwlock>(stx::exact_t<utils::serial&>(ar)));
 }
 
 void lv2_rwlock::save(utils::serial& ar)
@@ -56,7 +55,7 @@ error_code sys_rwlock_create(ppu_thread& ppu, vm::ptr<u32> rw_lock_id, vm::ptr<s
 
 	if (auto error = lv2_obj::create<lv2_rwlock>(_attr.pshared, ipc_key, _attr.flags, [&]
 	{
-		return std::make_shared<lv2_rwlock>(protocol, ipc_key, _attr.name_u64);
+		return make_shared<lv2_rwlock>(protocol, ipc_key, _attr.name_u64);
 	}))
 	{
 		return error;

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.h
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.h
@@ -40,7 +40,7 @@ struct lv2_rwlock final : lv2_obj
 	}
 
 	lv2_rwlock(utils::serial& ar);
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 };
 

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -20,10 +20,9 @@ lv2_sema::lv2_sema(utils::serial& ar)
 	ar(val);
 }
 
-std::shared_ptr<void> lv2_sema::load(utils::serial& ar)
+std::function<void(void*)> lv2_sema::load(utils::serial& ar)
 {
-	auto sema = std::make_shared<lv2_sema>(ar);
-	return lv2_obj::load(sema->key, sema);
+	return load_func(make_shared<lv2_sema>(stx::exact_t<utils::serial&>(ar)));
 }
 
 void lv2_sema::save(utils::serial& ar)
@@ -68,7 +67,7 @@ error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sy
 
 	if (auto error = lv2_obj::create<lv2_sema>(_attr.pshared, ipc_key, _attr.flags, [&]
 	{
-		return std::make_shared<lv2_sema>(protocol, ipc_key, _attr.name_u64, max_val, initial_val);
+		return make_shared<lv2_sema>(protocol, ipc_key, _attr.name_u64, max_val, initial_val);
 	}))
 	{
 		return error;

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.h
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.h
@@ -42,7 +42,7 @@ struct lv2_sema final : lv2_obj
 	}
 
 	lv2_sema(utils::serial& ar);
-	static std::shared_ptr<void> load(utils::serial& ar);
+	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial& ar);
 };
 

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -296,14 +296,14 @@ struct lv2_spu_group
 	class ppu_thread* waiter = nullptr;
 	bool set_terminate = false;
 
-	std::array<std::shared_ptr<named_thread<spu_thread>>, 8> threads; // SPU Threads
+	std::array<shared_ptr<named_thread<spu_thread>>, 8> threads; // SPU Threads
 	std::array<s8, 256> threads_map; // SPU Threads map based number
 	std::array<std::pair<u32, std::vector<sys_spu_segment>>, 8> imgs; // Entry points, SPU image segments
 	std::array<std::array<u64, 4>, 8> args; // SPU Thread Arguments
 
-	std::shared_ptr<lv2_event_queue> ep_run; // port for SYS_SPU_THREAD_GROUP_EVENT_RUN events
-	std::shared_ptr<lv2_event_queue> ep_exception; // TODO: SYS_SPU_THREAD_GROUP_EVENT_EXCEPTION
-	std::shared_ptr<lv2_event_queue> ep_sysmodule; // TODO: SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE
+	shared_ptr<lv2_event_queue> ep_run; // port for SYS_SPU_THREAD_GROUP_EVENT_RUN events
+	shared_ptr<lv2_event_queue> ep_exception; // TODO: SYS_SPU_THREAD_GROUP_EVENT_EXCEPTION
+	shared_ptr<lv2_event_queue> ep_sysmodule; // TODO: SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE
 
 	lv2_spu_group(std::string name, u32 num, s32 _prio, s32 type, lv2_memory_container* ct, bool uses_scheduler, u32 mem_size) noexcept
 		: name(std::move(name))
@@ -344,7 +344,7 @@ struct lv2_spu_group
 		return ep_sysmodule ? ep_sysmodule->send(SYS_SPU_THREAD_GROUP_EVENT_SYSTEM_MODULE_KEY, data1, data2, data3) : CELL_ENOTCONN;
 	}
 
-	static std::pair<named_thread<spu_thread>*, std::shared_ptr<lv2_spu_group>> get_thread(u32 id);
+	static std::pair<named_thread<spu_thread>*, shared_ptr<lv2_spu_group>> get_thread(u32 id);
 };
 
 class ppu_thread;

--- a/rpcs3/Emu/Cell/lv2/sys_storage.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_storage.cpp
@@ -16,7 +16,7 @@ namespace
 	struct storage_manager
 	{
 		// This is probably wrong and should be assigned per fd or something
-		atomic_ptr<std::shared_ptr<lv2_event_queue>> asyncequeue;
+		atomic_ptr<shared_ptr<lv2_event_queue>> asyncequeue;
 	};
 }
 
@@ -65,7 +65,7 @@ error_code sys_storage_read(u32 fd, u32 mode, u32 start_sector, u32 num_sectors,
 	}
 
 	std::memset(bounce_buf.get_ptr(), 0, num_sectors * 0x200ull);
-	const auto handle = idm::get<lv2_storage>(fd);
+	const auto handle = idm::get_unlocked<lv2_storage>(fd);
 
 	if (!handle)
 	{
@@ -94,7 +94,7 @@ error_code sys_storage_write(u32 fd, u32 mode, u32 start_sector, u32 num_sectors
 		return CELL_EFAULT;
 	}
 
-	const auto handle = idm::get<lv2_storage>(fd);
+	const auto handle = idm::get_unlocked<lv2_storage>(fd);
 
 	if (!handle)
 	{
@@ -119,7 +119,7 @@ error_code sys_storage_async_configure(u32 fd, u32 io_buf, u32 equeue_id, u32 un
 
 	auto& manager = g_fxo->get<storage_manager>();
 
-	if (auto queue = idm::get<lv2_obj, lv2_event_queue>(equeue_id))
+	if (auto queue = idm::get_unlocked<lv2_obj, lv2_event_queue>(equeue_id))
 	{
 		manager.asyncequeue.store(queue);
 	}

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -20,7 +20,7 @@ LOG_CHANNEL(sys_timer);
 struct lv2_timer_thread
 {
 	shared_mutex mutex;
-	std::deque<std::shared_ptr<lv2_timer>> timers;
+	std::deque<shared_ptr<lv2_timer>> timers;
 
 	lv2_timer_thread();
 	void operator()();
@@ -31,7 +31,7 @@ struct lv2_timer_thread
 };
 
 lv2_timer::lv2_timer(utils::serial& ar)
-	: lv2_obj{1}
+	: lv2_obj(1)
 	, state(ar)
 	, port(lv2_event_queue::load_ptr(ar, port, "timer"))
 	, source(ar)
@@ -368,7 +368,7 @@ error_code sys_timer_connect_event_queue(ppu_thread& ppu, u32 timer_id, u32 queu
 
 	const auto timer = idm::check<lv2_obj, lv2_timer>(timer_id, [&](lv2_timer& timer) -> CellError
 	{
-		const auto found = idm::find_unlocked<lv2_obj, lv2_event_queue>(queue_id);
+		auto found = idm::get_unlocked<lv2_obj, lv2_event_queue>(queue_id);
 
 		if (!found)
 		{
@@ -383,7 +383,7 @@ error_code sys_timer_connect_event_queue(ppu_thread& ppu, u32 timer_id, u32 queu
 		}
 
 		// Connect event queue
-		timer.port   = std::static_pointer_cast<lv2_event_queue>(found->second);
+		timer.port   = found;
 		timer.source = name ? name : (u64{process_getpid() + 0u} << 32) | u64{timer_id};
 		timer.data1  = data1;
 		timer.data2  = data2;

--- a/rpcs3/Emu/Cell/lv2/sys_timer.h
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.h
@@ -28,7 +28,7 @@ struct lv2_timer : lv2_obj
 	shared_mutex mutex;
 	atomic_t<u32> state{SYS_TIMER_STATE_STOP};
 
-	std::shared_ptr<lv2_event_queue> port;
+	shared_ptr<lv2_event_queue> port;
 	u64 source;
 	u64 data1;
 	u64 data2;
@@ -40,7 +40,7 @@ struct lv2_timer : lv2_obj
 	u64 check_unlocked(u64 _now) noexcept;
 
 	lv2_timer() noexcept
-		: lv2_obj{1}
+		: lv2_obj(1)
 	{
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -64,7 +64,7 @@ error_code sys_vm_memory_map(ppu_thread& ppu, u64 vsize, u64 psize, u32 cid, u64
 		return CELL_EINVAL;
 	}
 
-	const auto idm_ct = idm::get<lv2_memory_container>(cid);
+	const auto idm_ct = idm::get_unlocked<lv2_memory_container>(cid);
 
 	const auto ct = cid == SYS_MEMORY_CONTAINER_ID_INVALID ? &g_fxo->get<lv2_memory_container>() : idm_ct.get();
 
@@ -260,7 +260,7 @@ error_code sys_vm_lock(ppu_thread& ppu, u32 addr, u32 size)
 		return CELL_EINVAL;
 	}
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
 	{
@@ -281,7 +281,7 @@ error_code sys_vm_unlock(ppu_thread& ppu, u32 addr, u32 size)
 		return CELL_EINVAL;
 	}
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
 	{
@@ -302,7 +302,7 @@ error_code sys_vm_touch(ppu_thread& ppu, u32 addr, u32 size)
 		return CELL_EINVAL;
 	}
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
 	{
@@ -323,7 +323,7 @@ error_code sys_vm_flush(ppu_thread& ppu, u32 addr, u32 size)
 		return CELL_EINVAL;
 	}
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
 	{
@@ -344,7 +344,7 @@ error_code sys_vm_invalidate(ppu_thread& ppu, u32 addr, u32 size)
 		return CELL_EINVAL;
 	}
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
 	{
@@ -365,7 +365,7 @@ error_code sys_vm_store(ppu_thread& ppu, u32 addr, u32 size)
 		return CELL_EINVAL;
 	}
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
 	{
@@ -386,7 +386,7 @@ error_code sys_vm_sync(ppu_thread& ppu, u32 addr, u32 size)
 		return CELL_EINVAL;
 	}
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
 	{
@@ -402,7 +402,7 @@ error_code sys_vm_test(ppu_thread& ppu, u32 addr, u32 size, vm::ptr<u64> result)
 
 	sys_vm.warning("sys_vm_test(addr=0x%x, size=0x%x, result=*0x%x)", addr, size, result);
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || u64{addr} + size > u64{block->addr} + block->size)
 	{
@@ -421,7 +421,7 @@ error_code sys_vm_get_statistics(ppu_thread& ppu, u32 addr, vm::ptr<sys_vm_stati
 
 	sys_vm.warning("sys_vm_get_statistics(addr=0x%x, stat=*0x%x)", addr, stat);
 
-	const auto block = idm::get<sys_vm_t>(sys_vm_t::find_id(addr));
+	const auto block = idm::get_unlocked<sys_vm_t>(sys_vm_t::find_id(addr));
 
 	if (!block || block->addr != addr)
 	{

--- a/rpcs3/Emu/GDB.h
+++ b/rpcs3/Emu/GDB.h
@@ -16,7 +16,7 @@ class gdb_thread
 
 	int server_socket = -1;
 	int client_socket = -1;
-	std::weak_ptr<cpu_thread> selected_thread{};
+	shared_ptr<cpu_thread> selected_thread{};
 	u64 continue_ops_thread_id = ANY_THREAD;
 	u64 general_ops_thread_id = ANY_THREAD;
 

--- a/rpcs3/Emu/NP/np_contexts.cpp
+++ b/rpcs3/Emu/NP/np_contexts.cpp
@@ -9,6 +9,7 @@ LOG_CHANNEL(sceNp2);
 
 generic_async_transaction_context::generic_async_transaction_context(const SceNpCommunicationId& communicationId, const SceNpCommunicationPassphrase& passphrase, u64 timeout)
 	: communicationId(communicationId), passphrase(passphrase), timeout(timeout)
+	, idm_id(idm::last_id())
 {
 }
 
@@ -73,12 +74,12 @@ bool destroy_tus_context(s32 ctx_id)
 	return idm::remove<tus_ctx>(static_cast<u32>(ctx_id));
 }
 
-tus_transaction_ctx::tus_transaction_ctx(const std::shared_ptr<tus_ctx>& tus)
+tus_transaction_ctx::tus_transaction_ctx(const shared_ptr<tus_ctx>& tus)
 	: generic_async_transaction_context(tus->communicationId, tus->passphrase, tus->timeout)
 {
 }
 
-s32 create_tus_transaction_context(const std::shared_ptr<tus_ctx>& tus)
+s32 create_tus_transaction_context(const shared_ptr<tus_ctx>& tus)
 {
 	s32 tus_id = idm::make<tus_transaction_ctx>(tus);
 
@@ -116,13 +117,13 @@ bool destroy_score_context(s32 ctx_id)
 	return idm::remove<score_ctx>(static_cast<u32>(ctx_id));
 }
 
-score_transaction_ctx::score_transaction_ctx(const std::shared_ptr<score_ctx>& score)
+score_transaction_ctx::score_transaction_ctx(const shared_ptr<score_ctx>& score)
 	: generic_async_transaction_context(score->communicationId, score->passphrase, score->timeout)
 {
 	pcId = score->pcId;
 }
 
-s32 create_score_transaction_context(const std::shared_ptr<score_ctx>& score)
+s32 create_score_transaction_context(const shared_ptr<score_ctx>& score)
 {
 	s32 trans_id = idm::make<score_transaction_ctx>(score);
 
@@ -158,11 +159,11 @@ bool destroy_match2_context(u16 ctx_id)
 }
 bool check_match2_context(u16 ctx_id)
 {
-	return (idm::check<match2_ctx>(ctx_id) != nullptr);
+	return (idm::check_unlocked<match2_ctx>(ctx_id) != nullptr);
 }
-std::shared_ptr<match2_ctx> get_match2_context(u16 ctx_id)
+shared_ptr<match2_ctx> get_match2_context(u16 ctx_id)
 {
-	return idm::get<match2_ctx>(ctx_id);
+	return idm::get_unlocked<match2_ctx>(ctx_id);
 }
 
 lookup_title_ctx::lookup_title_ctx(vm::cptr<SceNpCommunicationId> communicationId)
@@ -207,9 +208,9 @@ bool destroy_commerce2_context(u32 ctx_id)
 {
 	return idm::remove<commerce2_ctx>(static_cast<u32>(ctx_id));
 }
-std::shared_ptr<commerce2_ctx> get_commerce2_context(u16 ctx_id)
+shared_ptr<commerce2_ctx> get_commerce2_context(u16 ctx_id)
 {
-	return idm::get<commerce2_ctx>(ctx_id);
+	return idm::get_unlocked<commerce2_ctx>(ctx_id);
 }
 
 signaling_ctx::signaling_ctx(vm::ptr<SceNpId> npid, vm::ptr<SceNpSignalingHandler> handler, vm::ptr<void> arg)
@@ -226,9 +227,9 @@ bool destroy_signaling_context(u32 ctx_id)
 {
 	return idm::remove<signaling_ctx>(static_cast<u32>(ctx_id));
 }
-std::shared_ptr<signaling_ctx> get_signaling_context(u32 ctx_id)
+shared_ptr<signaling_ctx> get_signaling_context(u32 ctx_id)
 {
-	return idm::get<signaling_ctx>(ctx_id);
+	return idm::get_unlocked<signaling_ctx>(ctx_id);
 }
 
 matching_ctx::matching_ctx(vm::ptr<SceNpId> npId, vm::ptr<SceNpMatchingHandler> handler, vm::ptr<void> arg)
@@ -266,9 +267,9 @@ s32 create_matching_context(vm::ptr<SceNpId> npId, vm::ptr<SceNpMatchingHandler>
 	ctx->ctx_id = ctx_id;
 	return static_cast<s32>(ctx_id);
 }
-std::shared_ptr<matching_ctx> get_matching_context(u32 ctx_id)
+shared_ptr<matching_ctx> get_matching_context(u32 ctx_id)
 {
-	return idm::get<matching_ctx>(ctx_id);
+	return idm::get_unlocked<matching_ctx>(ctx_id);
 }
 bool destroy_matching_context(u32 ctx_id)
 {

--- a/rpcs3/Emu/NP/np_contexts.h
+++ b/rpcs3/Emu/NP/np_contexts.h
@@ -20,7 +20,7 @@
 // Used By Score and Tus
 struct generic_async_transaction_context
 {
-	virtual ~generic_async_transaction_context();
+	~generic_async_transaction_context();
 
 	generic_async_transaction_context(const SceNpCommunicationId& communicationId, const SceNpCommunicationPassphrase& passphrase, u64 timeout);
 
@@ -37,6 +37,8 @@ struct generic_async_transaction_context
 	u64 timeout;
 
 	std::thread thread;
+
+	u32 idm_id;
 };
 
 struct tdata_invalid
@@ -137,8 +139,7 @@ bool destroy_tus_context(s32 ctx_id);
 
 struct tus_transaction_ctx : public generic_async_transaction_context
 {
-	tus_transaction_ctx(const std::shared_ptr<tus_ctx>& tus);
-	virtual ~tus_transaction_ctx() = default;
+	tus_transaction_ctx(const shared_ptr<tus_ctx>& tus);
 
 	static const u32 id_base  = 0x8001;
 	static const u32 id_step  = 1;
@@ -148,7 +149,7 @@ struct tus_transaction_ctx : public generic_async_transaction_context
 	std::variant<tdata_invalid, tdata_tus_get_variables_generic, tdata_tus_get_variable_generic, tdata_tus_set_data, tdata_tus_get_data, tdata_tus_get_datastatus_generic> tdata;
 };
 
-s32 create_tus_transaction_context(const std::shared_ptr<tus_ctx>& tus);
+s32 create_tus_transaction_context(const shared_ptr<tus_ctx>& tus);
 bool destroy_tus_transaction_context(s32 ctx_id);
 
 // Score related
@@ -172,8 +173,7 @@ bool destroy_score_context(s32 ctx_id);
 
 struct score_transaction_ctx : public generic_async_transaction_context
 {
-	score_transaction_ctx(const std::shared_ptr<score_ctx>& score);
-	virtual ~score_transaction_ctx() = default;
+	score_transaction_ctx(const shared_ptr<score_ctx>& score);
 
 	static const u32 id_base  = 0x1001;
 	static const u32 id_step  = 1;
@@ -183,7 +183,7 @@ struct score_transaction_ctx : public generic_async_transaction_context
 	std::variant<tdata_invalid, tdata_get_board_infos, tdata_record_score, tdata_record_score_data, tdata_get_score_data, tdata_get_score_generic> tdata;
 	s32 pcId = 0;
 };
-s32 create_score_transaction_context(const std::shared_ptr<score_ctx>& score);
+s32 create_score_transaction_context(const shared_ptr<score_ctx>& score);
 bool destroy_score_transaction_context(s32 ctx_id);
 
 // Match2 related
@@ -214,7 +214,7 @@ struct match2_ctx
 };
 u16 create_match2_context(vm::cptr<SceNpCommunicationId> communicationId, vm::cptr<SceNpCommunicationPassphrase> passphrase, s32 option);
 bool check_match2_context(u16 ctx_id);
-std::shared_ptr<match2_ctx> get_match2_context(u16 ctx_id);
+shared_ptr<match2_ctx> get_match2_context(u16 ctx_id);
 bool destroy_match2_context(u16 ctx_id);
 
 struct lookup_title_ctx
@@ -261,7 +261,7 @@ struct commerce2_ctx
 	vm::ptr<void> context_callback_param{};
 };
 s32 create_commerce2_context(u32 version, vm::cptr<SceNpId> npid, vm::ptr<SceNpCommerce2Handler> handler, vm::ptr<void> arg);
-std::shared_ptr<commerce2_ctx> get_commerce2_context(u16 ctx_id);
+shared_ptr<commerce2_ctx> get_commerce2_context(u16 ctx_id);
 bool destroy_commerce2_context(u32 ctx_id);
 
 struct signaling_ctx
@@ -282,7 +282,7 @@ struct signaling_ctx
 	vm::ptr<void> ext_arg{};
 };
 s32 create_signaling_context(vm::ptr<SceNpId> npid, vm::ptr<SceNpSignalingHandler> handler, vm::ptr<void> arg);
-std::shared_ptr<signaling_ctx> get_signaling_context(u32 ctx_id);
+shared_ptr<signaling_ctx> get_signaling_context(u32 ctx_id);
 bool destroy_signaling_context(u32 ctx_id);
 
 struct matching_ctx
@@ -315,5 +315,5 @@ struct matching_ctx
 	atomic_t<bool> get_room_limit_version = false;
 };
 s32 create_matching_context(vm::ptr<SceNpId> npid, vm::ptr<SceNpMatchingHandler> handler, vm::ptr<void> arg);
-std::shared_ptr<matching_ctx> get_matching_context(u32 ctx_id);
+shared_ptr<matching_ctx> get_matching_context(u32 ctx_id);
 bool destroy_matching_context(u32 ctx_id);

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -502,7 +502,7 @@ namespace np
 
 	np_handler::~np_handler()
 	{
-		std::unordered_map<u32, std::shared_ptr<generic_async_transaction_context>> moved_trans;
+		std::unordered_map<u32, shared_ptr<generic_async_transaction_context>> moved_trans;
 		{
 			std::lock_guard lock(mutex_async_transactions);
 			moved_trans = std::move(async_transactions);
@@ -999,7 +999,7 @@ namespace np
 		return CELL_OK;
 	}
 
-	std::optional<std::shared_ptr<std::pair<std::string, message_data>>> np_handler::get_message(u64 id)
+	std::optional<shared_ptr<std::pair<std::string, message_data>>> np_handler::get_message(u64 id)
 	{
 		return get_rpcn()->get_message(id);
 	}
@@ -1019,7 +1019,7 @@ namespace np
 		}
 	}
 
-	std::optional<std::shared_ptr<std::pair<std::string, message_data>>> np_handler::get_message_selected(SceNpBasicAttachmentDataId id)
+	std::optional<shared_ptr<std::pair<std::string, message_data>>> np_handler::get_message_selected(SceNpBasicAttachmentDataId id)
 	{
 		switch (id)
 		{
@@ -1672,7 +1672,7 @@ namespace np
 		return ctx_id;
 	}
 
-	std::shared_ptr<matching_ctx> np_handler::take_pending_gui_request(u32 req_id)
+	shared_ptr<matching_ctx> np_handler::take_pending_gui_request(u32 req_id)
 	{
 		const u32 ctx_id = take_gui_request(req_id);
 

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -150,9 +150,9 @@ namespace np
 		error_code get_basic_event(vm::ptr<s32> event, vm::ptr<SceNpUserInfo> from, vm::ptr<u8> data, vm::ptr<u32> size);
 
 		// Messages-related functions
-		std::optional<std::shared_ptr<std::pair<std::string, message_data>>> get_message(u64 id);
+		std::optional<shared_ptr<std::pair<std::string, message_data>>> get_message(u64 id);
 		void set_message_selected(SceNpBasicAttachmentDataId id, u64 msg_id);
-		std::optional<std::shared_ptr<std::pair<std::string, message_data>>> get_message_selected(SceNpBasicAttachmentDataId id);
+		std::optional<shared_ptr<std::pair<std::string, message_data>>> get_message_selected(SceNpBasicAttachmentDataId id);
 		void clear_message_selected(SceNpBasicAttachmentDataId id);
 		void send_message(const message_data& msg_data, const std::set<std::string>& npids);
 
@@ -206,29 +206,29 @@ namespace np
 		void set_current_gui_ctx_id(u32 id);
 
 		// Score requests
-		void transaction_async_handler(std::unique_lock<shared_mutex> lock, const std::shared_ptr<generic_async_transaction_context>& trans_ctx, u32 req_id, bool async);
-		void get_board_infos(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, vm::ptr<SceNpScoreBoardInfo> boardInfo, bool async);
-		void record_score(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreValue score, vm::cptr<SceNpScoreComment> scoreComment, const u8* data, u32 data_size, vm::ptr<SceNpScoreRankNumber> tmpRank, bool async);
-		void record_score_data(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreValue score, u32 totalSize, u32 sendSize, const u8* score_data, bool async);
-		void get_score_data(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, const SceNpId& npId, vm::ptr<u32> totalSize, u32 recvSize, vm::ptr<void> score_data, bool async);
-		void get_score_range(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreRankNumber startSerialRank, vm::ptr<SceNpScoreRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated);
-		void get_score_npid(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, const std::vector<std::pair<SceNpId, s32>>& npid_vec, vm::ptr<SceNpScorePlayerRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated);
-		void get_score_friend(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, bool include_self, vm::ptr<SceNpScoreRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated);
+		void transaction_async_handler(std::unique_lock<shared_mutex> lock, const shared_ptr<generic_async_transaction_context>& trans_ctx, u32 req_id, bool async);
+		void get_board_infos(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, vm::ptr<SceNpScoreBoardInfo> boardInfo, bool async);
+		void record_score(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreValue score, vm::cptr<SceNpScoreComment> scoreComment, const u8* data, u32 data_size, vm::ptr<SceNpScoreRankNumber> tmpRank, bool async);
+		void record_score_data(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreValue score, u32 totalSize, u32 sendSize, const u8* score_data, bool async);
+		void get_score_data(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, const SceNpId& npId, vm::ptr<u32> totalSize, u32 recvSize, vm::ptr<void> score_data, bool async);
+		void get_score_range(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreRankNumber startSerialRank, vm::ptr<SceNpScoreRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated);
+		void get_score_npid(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, const std::vector<std::pair<SceNpId, s32>>& npid_vec, vm::ptr<SceNpScorePlayerRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated);
+		void get_score_friend(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, bool include_self, vm::ptr<SceNpScoreRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated);
 
 		// TUS requests
-		void tus_set_multislot_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::cptr<s64> variableArray, s32 arrayNum, bool vuser, bool async);
-		void tus_get_multislot_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::ptr<SceNpTusVariable> variableArray, s32 arrayNum, bool vuser, bool async);
-		void tus_get_multiuser_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, std::vector<SceNpOnlineId> targetNpIdArray, SceNpTusSlotId slotId, vm::ptr<SceNpTusVariable> variableArray, s32 arrayNum, bool vuser, bool async);
-		void tus_get_friends_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, SceNpTusSlotId slotId, s32 includeSelf, s32 sortType, vm::ptr<SceNpTusVariable> variableArray,s32 arrayNum, bool async);
-		void tus_add_and_get_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, s64 inVariable, vm::ptr<SceNpTusVariable> outVariable, vm::ptr<SceNpTusAddAndGetVariableOptParam> option, bool vuser, bool async);
-		void tus_try_and_set_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, s32 opeType, s64 variable, vm::ptr<SceNpTusVariable> resultVariable, vm::ptr<SceNpTusTryAndSetVariableOptParam> option, bool vuser, bool async);
-		void tus_delete_multislot_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, s32 arrayNum, bool vuser, bool async);
-		void tus_set_data(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, u32 totalSize, u32 sendSize, vm::cptr<void> data, vm::cptr<SceNpTusDataInfo> info, vm::ptr<SceNpTusSetDataOptParam> option, bool vuser, bool async);
-		void tus_get_data(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, vm::ptr<SceNpTusDataStatus> dataStatus, vm::ptr<void> data, u32 recvSize, bool vuser, bool async);
-		void tus_get_multislot_data_status(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool vuser, bool async);
-		void tus_get_multiuser_data_status(std::shared_ptr<tus_transaction_ctx>& trans_ctx, std::vector<SceNpOnlineId> targetNpIdArray, SceNpTusSlotId slotId, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool vuser, bool async);
-		void tus_get_friends_data_status(std::shared_ptr<tus_transaction_ctx>& trans_ctx, SceNpTusSlotId slotId, s32 includeSelf, s32 sortType, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool async);
-		void tus_delete_multislot_data(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, s32 arrayNum, bool vuser, bool async);
+		void tus_set_multislot_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::cptr<s64> variableArray, s32 arrayNum, bool vuser, bool async);
+		void tus_get_multislot_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::ptr<SceNpTusVariable> variableArray, s32 arrayNum, bool vuser, bool async);
+		void tus_get_multiuser_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, std::vector<SceNpOnlineId> targetNpIdArray, SceNpTusSlotId slotId, vm::ptr<SceNpTusVariable> variableArray, s32 arrayNum, bool vuser, bool async);
+		void tus_get_friends_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, SceNpTusSlotId slotId, s32 includeSelf, s32 sortType, vm::ptr<SceNpTusVariable> variableArray,s32 arrayNum, bool async);
+		void tus_add_and_get_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, s64 inVariable, vm::ptr<SceNpTusVariable> outVariable, vm::ptr<SceNpTusAddAndGetVariableOptParam> option, bool vuser, bool async);
+		void tus_try_and_set_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, s32 opeType, s64 variable, vm::ptr<SceNpTusVariable> resultVariable, vm::ptr<SceNpTusTryAndSetVariableOptParam> option, bool vuser, bool async);
+		void tus_delete_multislot_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, s32 arrayNum, bool vuser, bool async);
+		void tus_set_data(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, u32 totalSize, u32 sendSize, vm::cptr<void> data, vm::cptr<SceNpTusDataInfo> info, vm::ptr<SceNpTusSetDataOptParam> option, bool vuser, bool async);
+		void tus_get_data(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, vm::ptr<SceNpTusDataStatus> dataStatus, vm::ptr<void> data, u32 recvSize, bool vuser, bool async);
+		void tus_get_multislot_data_status(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool vuser, bool async);
+		void tus_get_multiuser_data_status(shared_ptr<tus_transaction_ctx>& trans_ctx, std::vector<SceNpOnlineId> targetNpIdArray, SceNpTusSlotId slotId, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool vuser, bool async);
+		void tus_get_friends_data_status(shared_ptr<tus_transaction_ctx>& trans_ctx, SceNpTusSlotId slotId, s32 includeSelf, s32 sortType, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool async);
+		void tus_delete_multislot_data(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, s32 arrayNum, bool vuser, bool async);
 
 		// Local functions
 		std::pair<error_code, std::optional<SceNpId>> local_get_npid(u64 room_id, u16 member_id);
@@ -494,7 +494,7 @@ namespace np
 
 		// Async transaction threads
 		shared_mutex mutex_async_transactions;
-		std::unordered_map<u32, std::shared_ptr<generic_async_transaction_context>> async_transactions; // (req_id, transaction_ctx)
+		std::unordered_map<u32, shared_ptr<generic_async_transaction_context>> async_transactions; // (req_id, transaction_ctx)
 
 		// RPCN
 		shared_mutex mutex_rpcn;
@@ -529,7 +529,7 @@ namespace np
 		void add_gui_request(u32 req_id, u32 ctx_id);
 		void remove_gui_request(u32 req_id);
 		u32 take_gui_request(u32 req_id);
-		std::shared_ptr<matching_ctx> take_pending_gui_request(u32 req_id);
+		shared_ptr<matching_ctx> take_pending_gui_request(u32 req_id);
 
 		shared_mutex mutex_quickmatching;
 		std::map<SceNpRoomId, u32> pending_quickmatching;

--- a/rpcs3/Emu/NP/np_notifications.cpp
+++ b/rpcs3/Emu/NP/np_notifications.cpp
@@ -348,7 +348,7 @@ namespace np
 		return generic_gui_notification_handler(data, "UserKickedGUI", SCE_NP_MATCHING_EVENT_ROOM_KICKED);
 	}
 
-	void gui_epilog(const std::shared_ptr<matching_ctx>& ctx);
+	void gui_epilog(const shared_ptr<matching_ctx>& ctx);
 
 	void np_handler::notif_quickmatch_complete_gui(std::vector<u8>& data)
 	{

--- a/rpcs3/Emu/NP/np_requests.cpp
+++ b/rpcs3/Emu/NP/np_requests.cpp
@@ -802,7 +802,7 @@ namespace np
 		return true;
 	}
 
-	void np_handler::transaction_async_handler(std::unique_lock<shared_mutex> lock, const std::shared_ptr<generic_async_transaction_context>& trans_ctx, u32 req_id, bool async)
+	void np_handler::transaction_async_handler(std::unique_lock<shared_mutex> lock, const shared_ptr<generic_async_transaction_context>& trans_ctx, u32 req_id, bool async)
 	{
 		auto worker_function = [trans_ctx = trans_ctx, req_id, this](std::unique_lock<shared_mutex> lock)
 		{
@@ -842,7 +842,7 @@ namespace np
 		cpu_thread.check_state();
 	}
 
-	void np_handler::get_board_infos(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, vm::ptr<SceNpScoreBoardInfo> boardInfo, bool async)
+	void np_handler::get_board_infos(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, vm::ptr<SceNpScoreBoardInfo> boardInfo, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 
@@ -877,7 +877,7 @@ namespace np
 			return false;
 		}
 
-		auto score_trans = std::dynamic_pointer_cast<score_transaction_ctx>(::at32(async_transactions, req_id));
+		auto score_trans = idm::get_unlocked<score_transaction_ctx>(::at32(async_transactions, req_id)->idm_id);
 		ensure(score_trans);
 
 		std::lock_guard lock(score_trans->mutex);
@@ -892,7 +892,7 @@ namespace np
 		return true;
 	}
 
-	void np_handler::record_score(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreValue score, vm::cptr<SceNpScoreComment> scoreComment, const u8* data, u32 data_size, vm::ptr<SceNpScoreRankNumber> tmpRank, bool async)
+	void np_handler::record_score(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreValue score, vm::cptr<SceNpScoreComment> scoreComment, const u8* data, u32 data_size, vm::ptr<SceNpScoreRankNumber> tmpRank, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::SCORE);
@@ -920,7 +920,7 @@ namespace np
 			return false;
 		}
 
-		auto score_trans = std::dynamic_pointer_cast<score_transaction_ctx>(::at32(async_transactions, req_id));
+		auto score_trans = idm::get_unlocked<score_transaction_ctx>(::at32(async_transactions, req_id)->idm_id);
 		ensure(score_trans);
 
 		std::lock_guard lock(score_trans->mutex);
@@ -961,7 +961,7 @@ namespace np
 		return true;
 	}
 
-	void np_handler::record_score_data(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreValue score, u32 totalSize, u32 sendSize, const u8* score_data, bool async)
+	void np_handler::record_score_data(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreValue score, u32 totalSize, u32 sendSize, const u8* score_data, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 
@@ -1021,7 +1021,7 @@ namespace np
 		return set_result_and_wake(CELL_OK);
 	}
 
-	void np_handler::get_score_data(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, const SceNpId& npId, vm::ptr<u32> totalSize, u32 recvSize, vm::ptr<void> score_data, bool async)
+	void np_handler::get_score_data(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, const SceNpId& npId, vm::ptr<u32> totalSize, u32 recvSize, vm::ptr<void> score_data, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 
@@ -1062,7 +1062,7 @@ namespace np
 			return false;
 		}
 
-		auto score_trans = std::dynamic_pointer_cast<score_transaction_ctx>(::at32(async_transactions, req_id));
+		auto score_trans = idm::get_unlocked<score_transaction_ctx>(::at32(async_transactions, req_id)->idm_id);
 		ensure(score_trans);
 		std::lock_guard lock(score_trans->mutex);
 
@@ -1098,7 +1098,7 @@ namespace np
 		return score_trans->set_result_and_wake(not_an_error(to_copy));
 	}
 
-	void np_handler::get_score_range(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreRankNumber startSerialRank, vm::ptr<SceNpScoreRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, [[maybe_unused]] u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated)
+	void np_handler::get_score_range(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, SceNpScoreRankNumber startSerialRank, vm::ptr<SceNpScoreRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, [[maybe_unused]] u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::SCORE);
@@ -1152,7 +1152,7 @@ namespace np
 			return false;
 		}
 
-		auto score_trans = std::dynamic_pointer_cast<score_transaction_ctx>(::at32(async_transactions, req_id));
+		auto score_trans = idm::get_unlocked<score_transaction_ctx>(::at32(async_transactions, req_id)->idm_id);
 		ensure(score_trans);
 		std::lock_guard lock(score_trans->mutex);
 
@@ -1280,7 +1280,7 @@ namespace np
 		return handle_GetScoreResponse(req_id, reply_data);
 	}
 
-	void np_handler::get_score_friend(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, bool include_self, vm::ptr<SceNpScoreRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, [[maybe_unused]] u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated)
+	void np_handler::get_score_friend(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, bool include_self, vm::ptr<SceNpScoreRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, [[maybe_unused]] u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::SCORE);
@@ -1309,7 +1309,7 @@ namespace np
 		return handle_GetScoreResponse(req_id, reply_data);
 	}
 
-	void np_handler::get_score_npid(std::shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, const std::vector<std::pair<SceNpId, s32>>& npid_vec, vm::ptr<SceNpScorePlayerRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, [[maybe_unused]] u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated)
+	void np_handler::get_score_npid(shared_ptr<score_transaction_ctx>& trans_ctx, SceNpScoreBoardId boardId, const std::vector<std::pair<SceNpId, s32>>& npid_vec, vm::ptr<SceNpScorePlayerRankData> rankArray, u32 rankArraySize, vm::ptr<SceNpScoreComment> commentArray, [[maybe_unused]] u32 commentArraySize, vm::ptr<void> infoArray, u32 infoArraySize, u32 arrayNum, vm::ptr<CellRtcTick> lastSortDate, vm::ptr<SceNpScoreRankNumber> totalRecord, bool async, bool deprecated)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::SCORE);
@@ -1380,7 +1380,7 @@ namespace np
 			return false;
 		}
 
-		auto tus_trans = std::dynamic_pointer_cast<tus_transaction_ctx>(::at32(async_transactions, req_id));
+		auto tus_trans = idm::get_unlocked<tus_transaction_ctx>(::at32(async_transactions, req_id)->idm_id);
 		ensure(tus_trans);
 		std::lock_guard lock(tus_trans->mutex);
 
@@ -1448,7 +1448,7 @@ namespace np
 			return false;
 		}
 
-		auto tus_trans = std::dynamic_pointer_cast<tus_transaction_ctx>(::at32(async_transactions, req_id));
+		auto tus_trans = idm::get_unlocked<tus_transaction_ctx>(::at32(async_transactions, req_id)->idm_id);
 		ensure(tus_trans);
 		std::lock_guard lock(tus_trans->mutex);
 
@@ -1506,7 +1506,7 @@ namespace np
 			return false;
 		}
 
-		auto tus_trans = std::dynamic_pointer_cast<tus_transaction_ctx>(::at32(async_transactions, req_id));
+		auto tus_trans = idm::get_unlocked<tus_transaction_ctx>(::at32(async_transactions, req_id)->idm_id);
 		ensure(tus_trans);
 		std::lock_guard lock(tus_trans->mutex);
 
@@ -1568,7 +1568,7 @@ namespace np
 		return true;
 	}
 
-	void np_handler::tus_set_multislot_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::cptr<s64> variableArray, s32 arrayNum, bool vuser, bool async)
+	void np_handler::tus_set_multislot_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::cptr<s64> variableArray, s32 arrayNum, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1582,7 +1582,7 @@ namespace np
 		return handle_tus_no_data(req_id, reply_data);
 	}
 
-	void np_handler::tus_get_multislot_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::ptr<SceNpTusVariable> variableArray, s32 arrayNum, bool vuser, bool async)
+	void np_handler::tus_get_multislot_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::ptr<SceNpTusVariable> variableArray, s32 arrayNum, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1601,7 +1601,7 @@ namespace np
 		return handle_TusVarResponse(req_id, reply_data);
 	}
 
-	void np_handler::tus_get_multiuser_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, std::vector<SceNpOnlineId> targetNpIdArray, SceNpTusSlotId slotId, vm::ptr<SceNpTusVariable> variableArray, s32 arrayNum, bool vuser, bool async)
+	void np_handler::tus_get_multiuser_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, std::vector<SceNpOnlineId> targetNpIdArray, SceNpTusSlotId slotId, vm::ptr<SceNpTusVariable> variableArray, s32 arrayNum, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1620,7 +1620,7 @@ namespace np
 		return handle_TusVarResponse(req_id, reply_data);
 	}
 
-	void np_handler::tus_get_friends_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, SceNpTusSlotId slotId, s32 includeSelf, s32 sortType, vm::ptr<SceNpTusVariable> variableArray,s32 arrayNum, bool async)
+	void np_handler::tus_get_friends_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, SceNpTusSlotId slotId, s32 includeSelf, s32 sortType, vm::ptr<SceNpTusVariable> variableArray,s32 arrayNum, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1639,7 +1639,7 @@ namespace np
 		return handle_TusVarResponse(req_id, reply_data);
 	}
 
-	void np_handler::tus_add_and_get_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, s64 inVariable, vm::ptr<SceNpTusVariable> outVariable, vm::ptr<SceNpTusAddAndGetVariableOptParam> option, bool vuser, bool async)
+	void np_handler::tus_add_and_get_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, s64 inVariable, vm::ptr<SceNpTusVariable> outVariable, vm::ptr<SceNpTusAddAndGetVariableOptParam> option, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1657,7 +1657,7 @@ namespace np
 		return handle_TusVariable(req_id, reply_data);
 	}
 
-	void np_handler::tus_try_and_set_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, s32 opeType, s64 variable, vm::ptr<SceNpTusVariable> resultVariable, vm::ptr<SceNpTusTryAndSetVariableOptParam> option, bool vuser, bool async)
+	void np_handler::tus_try_and_set_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, s32 opeType, s64 variable, vm::ptr<SceNpTusVariable> resultVariable, vm::ptr<SceNpTusTryAndSetVariableOptParam> option, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1675,7 +1675,7 @@ namespace np
 		return handle_TusVariable(req_id, reply_data);
 	}
 
-	void np_handler::tus_delete_multislot_variable(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, s32 arrayNum, bool vuser, bool async)
+	void np_handler::tus_delete_multislot_variable(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, s32 arrayNum, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1689,7 +1689,7 @@ namespace np
 		return handle_tus_no_data(req_id, reply_data);
 	}
 
-	void np_handler::tus_set_data(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, u32 totalSize, u32 sendSize, vm::cptr<void> data, vm::cptr<SceNpTusDataInfo> info, vm::ptr<SceNpTusSetDataOptParam> option, bool vuser, bool async)
+	void np_handler::tus_set_data(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, u32 totalSize, u32 sendSize, vm::cptr<void> data, vm::cptr<SceNpTusDataInfo> info, vm::ptr<SceNpTusSetDataOptParam> option, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 
@@ -1723,7 +1723,7 @@ namespace np
 		return handle_tus_no_data(req_id, reply_data);
 	}
 
-	void np_handler::tus_get_data(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, vm::ptr<SceNpTusDataStatus> dataStatus, vm::ptr<void> data, u32 recvSize, bool vuser, bool async)
+	void np_handler::tus_get_data(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, SceNpTusSlotId slotId, vm::ptr<SceNpTusDataStatus> dataStatus, vm::ptr<void> data, u32 recvSize, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 
@@ -1762,7 +1762,7 @@ namespace np
 			return false;
 		}
 
-		auto tus_trans = std::dynamic_pointer_cast<tus_transaction_ctx>(::at32(async_transactions, req_id));
+		auto tus_trans = idm::get_unlocked<tus_transaction_ctx>(::at32(async_transactions, req_id)->idm_id);
 		ensure(tus_trans);
 		std::lock_guard lock(tus_trans->mutex);
 
@@ -1835,7 +1835,7 @@ namespace np
 		return true;
 	}
 
-	void np_handler::tus_get_multislot_data_status(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool vuser, bool async)
+	void np_handler::tus_get_multislot_data_status(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1854,7 +1854,7 @@ namespace np
 		return handle_TusDataStatusResponse(req_id, reply_data);
 	}
 
-	void np_handler::tus_get_multiuser_data_status(std::shared_ptr<tus_transaction_ctx>& trans_ctx, std::vector<SceNpOnlineId> targetNpIdArray, SceNpTusSlotId slotId, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool vuser, bool async)
+	void np_handler::tus_get_multiuser_data_status(shared_ptr<tus_transaction_ctx>& trans_ctx, std::vector<SceNpOnlineId> targetNpIdArray, SceNpTusSlotId slotId, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1873,7 +1873,7 @@ namespace np
 		return handle_TusDataStatusResponse(req_id, reply_data);
 	}
 
-	void np_handler::tus_get_friends_data_status(std::shared_ptr<tus_transaction_ctx>& trans_ctx, SceNpTusSlotId slotId, s32 includeSelf, s32 sortType, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool async)
+	void np_handler::tus_get_friends_data_status(shared_ptr<tus_transaction_ctx>& trans_ctx, SceNpTusSlotId slotId, s32 includeSelf, s32 sortType, vm::ptr<SceNpTusDataStatus> statusArray, s32 arrayNum, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);
@@ -1892,7 +1892,7 @@ namespace np
 		return handle_TusDataStatusResponse(req_id, reply_data);
 	}
 
-	void np_handler::tus_delete_multislot_data(std::shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, s32 arrayNum, bool vuser, bool async)
+	void np_handler::tus_delete_multislot_data(shared_ptr<tus_transaction_ctx>& trans_ctx, const SceNpOnlineId& targetNpId, vm::cptr<SceNpTusSlotId> slotIdArray, s32 arrayNum, bool vuser, bool async)
 	{
 		std::unique_lock lock(trans_ctx->mutex);
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::TUS);

--- a/rpcs3/Emu/NP/np_requests_gui.cpp
+++ b/rpcs3/Emu/NP/np_requests_gui.cpp
@@ -14,7 +14,7 @@ LOG_CHANNEL(rpcn_log, "rpcn");
 
 namespace np
 {
-	std::pair<error_code, std::shared_ptr<matching_ctx>> gui_prelude(u32 ctx_id, vm::ptr<SceNpMatchingGUIHandler> handler, vm::ptr<void> arg)
+	std::pair<error_code, shared_ptr<matching_ctx>> gui_prelude(u32 ctx_id, vm::ptr<SceNpMatchingGUIHandler> handler, vm::ptr<void> arg)
 	{
 		auto ctx = get_matching_context(ctx_id);
 
@@ -33,7 +33,7 @@ namespace np
 		return {CELL_OK, ctx};
 	}
 
-	void gui_epilog(const std::shared_ptr<matching_ctx>& ctx)
+	void gui_epilog(const shared_ptr<matching_ctx>& ctx)
 	{
 		ensure(ctx->busy.compare_and_swap_test(1, 0), "Matching context wasn't busy in gui_epilog");
 		ctx->queue_gui_callback(SCE_NP_MATCHING_GUI_EVENT_COMMON_UNLOAD, 0);
@@ -662,7 +662,7 @@ namespace np
 				if (ctx->wakey == 0)
 				{
 					// Verify that the context is still valid
-					if (!idm::check<matching_ctx>(ctx->ctx_id))
+					if (!idm::check_unlocked<matching_ctx>(ctx->ctx_id))
 						return;
 
 					rpcn_log.notice("QuickMatch timeout");

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -2775,7 +2775,7 @@ namespace rpcn
 		{
 			std::lock_guard lock(mutex_messages);
 			const u64 msg_id = message_counter++;
-			auto id_and_msg  = std::make_shared<std::pair<std::string, message_data>>(std::make_pair(std::move(sender), std::move(mdata)));
+			auto id_and_msg  = stx::make_shared<std::pair<std::string, message_data>>(std::make_pair(std::move(sender), std::move(mdata)));
 			messages.emplace(msg_id, id_and_msg);
 			new_messages.push_back(msg_id);
 			active_messages.insert(msg_id);
@@ -2791,7 +2791,7 @@ namespace rpcn
 		}
 	}
 
-	std::optional<std::shared_ptr<std::pair<std::string, message_data>>> rpcn_client::get_message(u64 id)
+	std::optional<shared_ptr<std::pair<std::string, message_data>>> rpcn_client::get_message(u64 id)
 	{
 		{
 			std::lock_guard lock(mutex_messages);
@@ -2803,9 +2803,9 @@ namespace rpcn
 		}
 	}
 
-	std::vector<std::pair<u64, std::shared_ptr<std::pair<std::string, message_data>>>> rpcn_client::get_messages_and_register_cb(SceNpBasicMessageMainType type_filter, bool include_bootable, message_cb_func cb_func, void* cb_param)
+	std::vector<std::pair<u64, shared_ptr<std::pair<std::string, message_data>>>> rpcn_client::get_messages_and_register_cb(SceNpBasicMessageMainType type_filter, bool include_bootable, message_cb_func cb_func, void* cb_param)
 	{
-		std::vector<std::pair<u64, std::shared_ptr<std::pair<std::string, message_data>>>> vec_messages;
+		std::vector<std::pair<u64, shared_ptr<std::pair<std::string, message_data>>>> vec_messages;
 		{
 			std::lock_guard lock(mutex_messages);
 			for (auto id : active_messages)

--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -331,7 +331,7 @@ namespace rpcn
 	};
 
 	using friend_cb_func  = void (*)(void* param, NotificationType ntype, const std::string& username, bool status);
-	using message_cb_func = void (*)(void* param, const std::shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id);
+	using message_cb_func = void (*)(void* param, const shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id);
 
 	struct friend_online_data
 	{
@@ -463,8 +463,8 @@ namespace rpcn
 		std::map<std::string, friend_online_data> get_presence_states();
 
 		std::vector<u64> get_new_messages();
-		std::optional<std::shared_ptr<std::pair<std::string, message_data>>> get_message(u64 id);
-		std::vector<std::pair<u64, std::shared_ptr<std::pair<std::string, message_data>>>> get_messages_and_register_cb(SceNpBasicMessageMainType type, bool include_bootable, message_cb_func cb_func, void* cb_param);
+		std::optional<shared_ptr<std::pair<std::string, message_data>>> get_message(u64 id);
+		std::vector<std::pair<u64, shared_ptr<std::pair<std::string, message_data>>>> get_messages_and_register_cb(SceNpBasicMessageMainType type, bool include_bootable, message_cb_func cb_func, void* cb_param);
 		void remove_message_cb(message_cb_func cb_func, void* cb_param);
 		void mark_message_used(u64 id);
 
@@ -595,7 +595,7 @@ namespace rpcn
 		};
 		shared_mutex mutex_messages;
 		std::set<message_cb_t> message_cbs;
-		std::unordered_map<u64, std::shared_ptr<std::pair<std::string, message_data>>> messages; // msg id / (sender / message)
+		std::unordered_map<u64, shared_ptr<std::pair<std::string, message_data>>> messages; // msg id / (sender / message)
 		std::set<u64> active_messages;                                                           // msg id of messages that have not been discarded
 		std::vector<u64> new_messages;                                                           // list of msg_id used to inform np_handler of new messages
 		u64 message_counter = 3;                                                                 // id counter

--- a/rpcs3/Emu/RSX/GL/GLCompute.h
+++ b/rpcs3/Emu/RSX/GL/GLCompute.h
@@ -381,7 +381,7 @@ namespace gl
 	template<class T>
 	T* get_compute_task()
 	{
-		u32 index = id_manager::typeinfo::get_index<T>();
+		u32 index = stx::typeindex<id_manager::typeinfo, T>();
 		auto &e = g_compute_tasks[index];
 
 		if (!e)

--- a/rpcs3/Emu/RSX/GL/GLOverlays.h
+++ b/rpcs3/Emu/RSX/GL/GLOverlays.h
@@ -112,7 +112,7 @@ namespace gl
 	template<class T>
 	T* get_overlay_pass()
 	{
-		u32 index = id_manager::typeinfo::get_index<T>();
+		u32 index = stx::typeindex<id_manager::typeinfo, T>();
 		auto &e = g_overlay_passes[index];
 
 		if (!e)

--- a/rpcs3/Emu/RSX/Overlays/Network/overlay_recvmessage_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Network/overlay_recvmessage_dialog.cpp
@@ -9,7 +9,7 @@ namespace rsx
 {
 	namespace overlays
 	{
-		void recvmessage_callback(void* param, std::shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id)
+		void recvmessage_callback(void* param, shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id)
 		{
 			auto* dlg = static_cast<recvmessage_dialog*>(param);
 			dlg->callback_handler(std::move(new_msg), msg_id);
@@ -319,7 +319,7 @@ namespace rsx
 			return result;
 		}
 
-		void recvmessage_dialog::callback_handler(std::shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id)
+		void recvmessage_dialog::callback_handler(shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id)
 		{
 			ensure(new_msg);
 

--- a/rpcs3/Emu/RSX/Overlays/Network/overlay_recvmessage_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/Network/overlay_recvmessage_dialog.h
@@ -36,7 +36,7 @@ namespace rsx
 			compiled_resource get_compiled() override;
 
 			error_code Exec(SceNpBasicMessageMainType type, SceNpBasicMessageRecvOptions options, SceNpBasicMessageRecvAction& recv_result, u64& chosen_msg_id) override;
-			void callback_handler(const std::shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id) override;
+			void callback_handler(const shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id) override;
 		};
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -52,7 +52,7 @@ namespace rsx
 				std::lock_guard lock(m_list_mutex);
 
 				entry->uid = m_uid_ctr.fetch_add(1);
-				entry->type_index = id_manager::typeinfo::get_index<T>();
+				entry->type_index = stx::typeindex<id_manager::typeinfo, T>();
 
 				if (remove_existing)
 				{
@@ -88,7 +88,7 @@ namespace rsx
 			template <typename T>
 			void remove()
 			{
-				const auto type_id = id_manager::typeinfo::get_index<T>();
+				const auto type_id = stx::typeindex<id_manager::typeinfo, T>();
 				if (m_list_mutex.try_lock())
 				{
 					remove_type(type_id);
@@ -138,7 +138,7 @@ namespace rsx
 			{
 				reader_lock lock(m_list_mutex);
 
-				const auto type_id = id_manager::typeinfo::get_index<T>();
+				const auto type_id = stx::typeindex<id_manager::typeinfo, T>();
 				for (const auto& iface : m_iface_list)
 				{
 					if (iface->type_index == type_id)

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -269,7 +269,7 @@ namespace rsx
 		const backend_configuration& get_backend_config() const { return backend_config; }
 
 	public:
-		std::shared_ptr<named_thread<class ppu_thread>> intr_thread;
+		shared_ptr<named_thread<ppu_thread>> intr_thread;
 
 		// I hate this flag, but until hle is closer to lle, its needed
 		bool isHLE{ false };

--- a/rpcs3/Emu/RSX/VK/VKCompute.h
+++ b/rpcs3/Emu/RSX/VK/VKCompute.h
@@ -668,7 +668,7 @@ namespace vk
 	template<class T>
 	T* get_compute_task()
 	{
-		u32 index = id_manager::typeinfo::get_index<T>();
+		u32 index = stx::typeindex<id_manager::typeinfo, T>();
 		auto &e = g_compute_tasks[index];
 
 		if (!e)

--- a/rpcs3/Emu/RSX/VK/VKOverlays.h
+++ b/rpcs3/Emu/RSX/VK/VKOverlays.h
@@ -237,7 +237,7 @@ namespace vk
 	template<class T>
 	T* get_overlay_pass()
 	{
-		u32 index = id_manager::typeinfo::get_index<T>();
+		u32 index = stx::typeindex<id_manager::typeinfo, T>();
 		auto& e = g_overlay_passes[index];
 
 		if (!e)

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -401,7 +401,7 @@ private:
 	struct savestate_stage
 	{
 		bool prepared = false;
-		std::vector<std::pair<std::shared_ptr<named_thread<spu_thread>>, u32>> paused_spus;
+		std::vector<std::pair<shared_ptr<named_thread<spu_thread>>, u32>> paused_spus;
 	};
 public:
 

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -949,7 +949,7 @@ bool vfs::host::rename(const std::string& from, const std::string& to, const lv2
 	// Lock mount point, close file descriptors, retry
 	const auto from0 = std::string_view(from).substr(0, from.find_last_not_of(fs::delim) + 1);
 
-	std::vector<std::pair<std::shared_ptr<lv2_file>, std::string>> escaped_real;
+	std::vector<std::pair<shared_ptr<lv2_file>, std::string>> escaped_real;
 
 	std::unique_lock mp_lock(mp->mutex, std::defer_lock);
 

--- a/rpcs3/Emu/cache_utils.cpp
+++ b/rpcs3/Emu/cache_utils.cpp
@@ -3,6 +3,7 @@
 #include "system_utils.hpp"
 #include "system_config.h"
 #include "IdManager.h"
+#include "Emu/Cell/lv2/sys_sync.h"
 #include "Emu/Cell/PPUAnalyser.h"
 #include "Emu/Cell/PPUThread.h"
 
@@ -12,7 +13,7 @@ namespace rpcs3::cache
 {
 	std::string get_ppu_cache()
 	{
-		const auto _main = g_fxo->try_get<main_ppu_module>();
+		const auto _main = g_fxo->try_get<main_ppu_module<lv2_obj>>();
 
 		if (!_main || _main->cache.empty())
 		{

--- a/rpcs3/Emu/perf_meter.cpp
+++ b/rpcs3/Emu/perf_meter.cpp
@@ -26,13 +26,13 @@ void perf_stat_base::print(const char* name) const noexcept
 {
 	if (u64 num_total = m_log[0].load())
 	{
-		perf_log.notice(u8"Perf stats for %s: total events: %u (total time %.4fs, avg %.4fµs)", name, num_total, m_log[65].load() / 1000'000'000., m_log[65].load() / 1000. / num_total);
+		perf_log.notice(u8"Perf stats for %s: total events: %u (total time %.4fs, avg %.4fus)", name, num_total, m_log[65].load() / 1000'000'000., m_log[65].load() / 1000. / num_total);
 
 		for (u32 i = 0; i < 13; i++)
 		{
 			if (u64 count = m_log[i + 1].load())
 			{
-				perf_log.notice(u8"Perf stats for %s: events < %.3fµs: %u", name, std::pow(2., i) / 1000., count);
+				perf_log.notice(u8"Perf stats for %s: events < %.3fus: %u", name, std::pow(2., i) / 1000., count);
 			}
 		}
 
@@ -84,7 +84,7 @@ SAFE_BUFFERS(void) perf_stat_base::push(u64 data[66], u64 start_time, const char
 	// Print in microseconds
 	if (static_cast<u64>(diff * 1000'000.) >= g_cfg.core.perf_report_threshold)
 	{
-		perf_log.notice(u8"%s: %.3fµs", name, diff * 1000'000.);
+		perf_log.notice(u8"%s: %.3fus", name, diff * 1000'000.);
 	}
 
 	data[0] += ns != 0;

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -42,7 +42,7 @@ static std::array<serial_ver_t, 27> s_serial_versions;
 		return ::s_serial_versions[identifier].current_version;\
 	}
 
-SERIALIZATION_VER(global_version, 0,                            17) // For stuff not listed here
+SERIALIZATION_VER(global_version, 0,                            18) // For stuff not listed here
 SERIALIZATION_VER(ppu, 1,                                       1, 2/*PPU sleep order*/, 3/*PPU FNID and module*/)
 SERIALIZATION_VER(spu, 2,                                       1)
 SERIALIZATION_VER(lv2_sync, 3,                                  1)

--- a/rpcs3/rpcs3qt/cheat_manager.cpp
+++ b/rpcs3/rpcs3qt/cheat_manager.cpp
@@ -15,6 +15,7 @@
 #include "Emu/IdManager.h"
 #include "Emu/Cell/PPUAnalyser.h"
 #include "Emu/Cell/PPUFunction.h"
+#include "Emu/Cell/lv2/sys_sync.h"
 
 #include "util/yaml.hpp"
 #include "util/asm.hpp"
@@ -441,7 +442,7 @@ bool cheat_engine::is_addr_safe(const u32 offset)
 	if (Emu.IsStopped())
 		return false;
 
-	const auto ppum = g_fxo->try_get<main_ppu_module>();
+	const auto ppum = g_fxo->try_get<main_ppu_module<lv2_obj>>();
 
 	if (!ppum)
 	{

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -54,14 +54,14 @@ extern bool is_using_interpreter(thread_class t_class)
 	}
 }
 
-extern std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu, std::shared_ptr<cpu_thread> handle)
+extern std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu, shared_ptr<cpu_thread> handle)
 {
 	if (!handle)
 	{
 		switch (cpu->get_class())
 		{
-		case thread_class::ppu: handle = idm::get<named_thread<ppu_thread>>(cpu->id); break;
-		case thread_class::spu: handle = idm::get<named_thread<spu_thread>>(cpu->id); break;
+		case thread_class::ppu: handle = idm::get_unlocked<named_thread<ppu_thread>>(cpu->id); break;
+		case thread_class::spu: handle = idm::get_unlocked<named_thread<spu_thread>>(cpu->id); break;
 		default: break;
 		}
 	}
@@ -850,7 +850,7 @@ std::function<cpu_thread*()> debugger_frame::make_check_cpu(cpu_thread* cpu, boo
 
 	const auto type = cpu ? cpu->get_class() : thread_class::general;
 
-	std::shared_ptr<cpu_thread> shared;
+	shared_ptr<cpu_thread> shared;
 
 	if (g_fxo->is_init<id_manager::id_map<named_thread<ppu_thread>>>() && g_fxo->is_init<id_manager::id_map<named_thread<spu_thread>>>())
 	{
@@ -869,11 +869,11 @@ std::function<cpu_thread*()> debugger_frame::make_check_cpu(cpu_thread* cpu, boo
 		{
 			if (type == thread_class::ppu)
 			{
-				shared = idm::get<named_thread<ppu_thread>>(cpu->id);
+				shared = idm::get_unlocked<named_thread<ppu_thread>>(cpu->id);
 			}
 			else if (type == thread_class::spu)
 			{
-				shared = idm::get<named_thread<spu_thread>>(cpu->id);
+				shared = idm::get_unlocked<named_thread<spu_thread>>(cpu->id);
 			}
 		}
 	}
@@ -1153,7 +1153,7 @@ void debugger_frame::OnSelectUnit()
 		{
 		case 1:
 		{
-			m_cpu = idm::get<named_thread<ppu_thread>>(cpu_id);
+			m_cpu = idm::get_unlocked<named_thread<ppu_thread>>(cpu_id);
 
 			if (selected == m_cpu.get())
 			{
@@ -1164,7 +1164,7 @@ void debugger_frame::OnSelectUnit()
 		}
 		case 2:
 		{
-			m_cpu = idm::get<named_thread<spu_thread>>(cpu_id);
+			m_cpu = idm::get_unlocked<named_thread<spu_thread>>(cpu_id);
 
 			if (selected == m_cpu.get())
 			{
@@ -1179,7 +1179,7 @@ void debugger_frame::OnSelectUnit()
 
 			if (get_cpu())
 			{
-				m_disasm = make_disasm(m_rsx, nullptr);
+				m_disasm = make_disasm(m_rsx, null_ptr);
 			}
 
 			break;

--- a/rpcs3/rpcs3qt/debugger_frame.h
+++ b/rpcs3/rpcs3qt/debugger_frame.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "util/types.hpp"
+#include "util/shared_ptr.hpp"
 
 #include "custom_dock_widget.h"
 
@@ -75,7 +76,7 @@ class debugger_frame : public custom_dock_widget
 	bool m_thread_list_pending_update = false;
 
 	std::shared_ptr<CPUDisAsm> m_disasm; // Only shared to allow base/derived functionality
-	std::shared_ptr<cpu_thread> m_cpu;
+	shared_ptr<cpu_thread> m_cpu;
 	rsx::thread* m_rsx = nullptr;
 	std::shared_ptr<utils::shm> m_spu_disasm_memory;
 	u32 m_spu_disasm_origin_eal = 0;

--- a/rpcs3/rpcs3qt/kernel_explorer.cpp
+++ b/rpcs3/rpcs3qt/kernel_explorer.cpp
@@ -317,7 +317,7 @@ void kernel_explorer::update()
 
 	add_solid_node(find_node(root, additional_nodes::process_info), qstr(fmt::format("Process Info, Sdk Version: 0x%08x, PPC SEG: %#x, SFO Category: %s (Fake: %s)", g_ps3_process_info.sdk_ver, g_ps3_process_info.ppc_seg, Emu.GetCat(), Emu.GetFakeCat())));
 
-	auto display_program_segments = [this](QTreeWidgetItem* tree, const ppu_module& m)
+	auto display_program_segments = [this](QTreeWidgetItem* tree, const ppu_module<lv2_obj>& m)
 	{
 		for (usz i = 0; i < m.segs.size(); i++)
 		{
@@ -528,7 +528,7 @@ void kernel_explorer::update()
 			auto& timer = static_cast<lv2_timer&>(obj);
 
 			u32 timer_state{SYS_TIMER_STATE_STOP};
-			std::shared_ptr<lv2_event_queue> port;
+			shared_ptr<lv2_event_queue> port;
 			u64 source = 0;
 			u64 data1 = 0;
 			u64 data2 = 0;

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -660,11 +660,11 @@ std::string memory_viewer_panel::getHeaderAtAddr(u32 addr) const
 
 	if (spu_boundary <= addr + m_colcount * 4 - 1)
 	{
-		std::shared_ptr<named_thread<spu_thread>> spu;
+		shared_ptr<named_thread<spu_thread>> spu;
 
 		if (const u32 raw_spu_index = (spu_boundary - RAW_SPU_BASE_ADDR) / SPU_LS_SIZE; raw_spu_index < 5)
 		{
-			spu = idm::get<named_thread<spu_thread>>(spu_thread::find_raw_spu(raw_spu_index));
+			spu = idm::get_unlocked<named_thread<spu_thread>>(spu_thread::find_raw_spu(raw_spu_index));
 
 			if (spu && spu->get_type() == spu_type::threaded)
 			{
@@ -673,7 +673,7 @@ std::string memory_viewer_panel::getHeaderAtAddr(u32 addr) const
 		}
 		else if (const u32 spu_index = (spu_boundary - SPU_FAKE_BASE_ADDR) / SPU_LS_SIZE; spu_index < spu_thread::id_count)
 		{
-			spu = idm::get<named_thread<spu_thread>>(spu_thread::id_base | spu_index);
+			spu = idm::get_unlocked<named_thread<spu_thread>>(spu_thread::id_base | spu_index);
 
 			if (spu && spu->get_type() != spu_type::threaded)
 			{

--- a/rpcs3/rpcs3qt/recvmessage_dialog_frame.cpp
+++ b/rpcs3/rpcs3qt/recvmessage_dialog_frame.cpp
@@ -12,7 +12,7 @@
 
 LOG_CHANNEL(recvmessage_dlg_log, "recvmessage dlg");
 
-void recvmessage_callback(void* param, std::shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id)
+void recvmessage_callback(void* param, shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id)
 {
 	auto* dlg = static_cast<recvmessage_dialog_frame*>(param);
 	dlg->callback_handler(std::move(new_msg), msg_id);
@@ -132,7 +132,7 @@ error_code recvmessage_dialog_frame::Exec(SceNpBasicMessageMainType type, SceNpB
 	return result;
 }
 
-void recvmessage_dialog_frame::add_message(const std::shared_ptr<std::pair<std::string, message_data>>& msg, u64 msg_id)
+void recvmessage_dialog_frame::add_message(const shared_ptr<std::pair<std::string, message_data>>& msg, u64 msg_id)
 {
 	ensure(msg);
 	auto new_item = new QListWidgetItem(QString::fromStdString(msg->first));
@@ -145,7 +145,7 @@ void recvmessage_dialog_frame::slot_new_message(recvmessage_signal_struct msg_an
 	add_message(msg_and_id.msg, msg_and_id.msg_id);
 }
 
-void recvmessage_dialog_frame::callback_handler(std::shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id)
+void recvmessage_dialog_frame::callback_handler(shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id)
 {
 	recvmessage_signal_struct signal_struct = {
 		.msg    = new_msg,

--- a/rpcs3/rpcs3qt/recvmessage_dialog_frame.h
+++ b/rpcs3/rpcs3qt/recvmessage_dialog_frame.h
@@ -9,7 +9,7 @@
 
 struct recvmessage_signal_struct
 {
-	std::shared_ptr<std::pair<std::string, message_data>> msg;
+	shared_ptr<std::pair<std::string, message_data>> msg;
 	u64 msg_id;
 };
 
@@ -23,10 +23,10 @@ public:
 	recvmessage_dialog_frame() = default;
 	~recvmessage_dialog_frame();
 	error_code Exec(SceNpBasicMessageMainType type, SceNpBasicMessageRecvOptions options, SceNpBasicMessageRecvAction& recv_result, u64& chosen_msg_id) override;
-	void callback_handler(const std::shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id) override;
+	void callback_handler(const shared_ptr<std::pair<std::string, message_data>> new_msg, u64 msg_id) override;
 
 private:
-	void add_message(const std::shared_ptr<std::pair<std::string, message_data>>& msg, u64 msg_id);
+	void add_message(const shared_ptr<std::pair<std::string, message_data>>& msg, u64 msg_id);
 
 Q_SIGNALS:
 	void signal_new_message(const recvmessage_signal_struct msg_and_id);

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -789,7 +789,7 @@ void logs::file_listener::log(u64 stamp, const logs::message& msg, const std::st
 	case level::trace:   text = reinterpret_cast<const char*>(u8"·T "); break;
 	}
 
-	// Print µs timestamp
+	// Print microsecond timestamp
 	const u64 hours = stamp / 3600'000'000;
 	const u64 mins = (stamp % 3600'000'000) / 60'000'000;
 	const u64 secs = (stamp % 60'000'000) / 1'000'000;


### PR DESCRIPTION
Replaces `std::shared_pointer` with `stx::atomic_ptr` and `stx::shared_ptr`.

Notes to programmers:

* This pr kills the use of `dynamic_cast`, `std::dynamic_pointer_cast` and `std::weak_ptr` on IDM objects, possible replacement is to save the object ID on the base object, then use idm::check/get_unlocked to the destination type via the saved ID which may be null. Null pointer check is how you can tell type mismatch (as dynamic cast) or object destruction (as weak_ptr locking).
* Double-inheritance on IDM objects should be used with care, `stx::shared_ptr` does not support constant-evaluated pointer offsetting to parent/child type.
* `idm::check/get_unlocked` can now be used anywhere.

Misc fixes:
* Fixes some segfaults with RPCN with interaction with IDM.
* Fix deadlocks in access violation handler due locking recursion.
* Fixes race condition in process exit-spawn on memory containers read.
* Fix bug that theoretically can prevent RPCS3 from booting - fix `id_manager::typeinfo` comparison to compare members instead of `memcmp` which can fail spuriously on padding bytes.
* Ensure all IDM inherited types of base, either has `id_base` or `id_type` defined locally, this allows to make getters such as `idm::get_unlocked<lv2_socket, lv2_socket_raw>()` which were broken before. (requires save-states invalidation)
* Removes broken operator[] overload of `stx::shared_ptr` and `stx::single_ptr` for non-array types.
