### PR TITLE
cellCamera: try to fix internal state after camera stop

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -784,26 +784,26 @@ s32 cellCameraIsAttached(s32 dev_num)
 
 	if (g_cfg.io.camera == camera_handler::null)
 	{
-		return false;
+		return 0;
 	}
 
 	auto& g_camera = g_fxo->get<camera_thread>();
 
 	if (!g_camera.init)
 	{
-		return false;
+		return 0;
 	}
 
 	if (!check_dev_num(dev_num))
 	{
-		return false;
+		return 0;
 	}
 
 	vm::var<s32> type;
 
 	if (cellCameraGetType(dev_num, type) != CELL_OK)
 	{
-		return false;
+		return 0;
 	}
 
 	std::lock_guard lock(g_camera.mutex);
@@ -821,12 +821,12 @@ s32 cellCameraIsAttached(s32 dev_num)
 		}
 	}
 
-	return is_attached;
+	return is_attached ? 1 : 0;
 }
 
 s32 cellCameraIsOpen(s32 dev_num)
 {
-	cellCamera.notice("cellCameraIsOpen(dev_num=%d)", dev_num);
+	cellCamera.trace("cellCameraIsOpen(dev_num=%d)", dev_num);
 
 	if (g_cfg.io.camera == camera_handler::null)
 	{
@@ -852,7 +852,7 @@ s32 cellCameraIsOpen(s32 dev_num)
 
 s32 cellCameraIsStarted(s32 dev_num)
 {
-	cellCamera.notice("cellCameraIsStarted(dev_num=%d)", dev_num);
+	cellCamera.trace("cellCameraIsStarted(dev_num=%d)", dev_num);
 
 	if (g_cfg.io.camera == camera_handler::null)
 	{

--- a/rpcs3/Emu/Io/Null/null_camera_handler.h
+++ b/rpcs3/Emu/Io/Null/null_camera_handler.h
@@ -7,10 +7,10 @@ class null_camera_handler final : public camera_handler_base
 public:
 	null_camera_handler() : camera_handler_base() {}
 
-	void open_camera() override { m_state = camera_handler_state::open; }
-	void close_camera() override { m_state = camera_handler_state::closed; }
-	void start_camera() override { m_state = camera_handler_state::running; }
-	void stop_camera() override { m_state = camera_handler_state::open; }
+	void open_camera() override { set_state(camera_handler_state::open); }
+	void close_camera() override { set_state(camera_handler_state::closed); }
+	void start_camera() override { set_state(camera_handler_state::running); }
+	void stop_camera() override { set_state(camera_handler_state::open); }
 
 	void set_format(s32 format, u32 bytesize) override
 	{
@@ -45,6 +45,6 @@ public:
 		height = 0;
 		frame_number = 0;
 		bytes_read = 0;
-		return m_state;
+		return get_state();
 	}
 };

--- a/rpcs3/Emu/Io/camera_handler_base.h
+++ b/rpcs3/Emu/Io/camera_handler_base.h
@@ -30,22 +30,29 @@ public:
 	virtual u64 frame_number() const = 0; // Convenience function to check if there's a new frame.
 	virtual camera_handler_state get_image(u8* buf, u64 size, u32& width, u32& height, u64& frame_number, u64& bytes_read) = 0;
 
-	camera_handler_state get_state() const { return m_state.load(); };
+	camera_handler_state get_state() const { return m_state.load(); }
+	void set_state(camera_handler_state state) { m_state = m_state_expected = state; }
 
-	bool mirrored() const { return m_mirrored; };
-	s32 format() const { return m_format; };
-	u32 bytesize() const { return m_bytesize; };
-	u32 width() const { return m_width; };
-	u32 height() const { return m_height; };
-	u32 frame_rate() const { return m_frame_rate; };
+	camera_handler_state get_expected_state() const { return m_state_expected.load(); }
+	void set_expected_state(camera_handler_state state) { m_state_expected = state; }
+
+	bool mirrored() const { return m_mirrored; }
+	s32 format() const { return m_format; }
+	u32 bytesize() const { return m_bytesize; }
+	u32 width() const { return m_width; }
+	u32 height() const { return m_height; }
+	u32 frame_rate() const { return m_frame_rate; }
 
 protected:
 	std::mutex m_mutex;
-	atomic_t<camera_handler_state> m_state = camera_handler_state::closed;
 	bool m_mirrored = false;
 	s32 m_format = 2; // CELL_CAMERA_RAW8
 	u32 m_bytesize = 0;
 	u32 m_width = 640;
 	u32 m_height = 480;
 	u32 m_frame_rate = 30;
+
+private:
+	atomic_t<camera_handler_state> m_state = camera_handler_state::closed;
+	atomic_t<camera_handler_state> m_state_expected = camera_handler_state::closed;
 };

--- a/rpcs3/rpcs3qt/qt_camera_handler.h
+++ b/rpcs3/rpcs3qt/qt_camera_handler.h
@@ -17,8 +17,6 @@ public:
 	qt_camera_handler();
 	virtual ~qt_camera_handler();
 
-	void set_camera(const QCameraDevice& camera_info);
-
 	void open_camera() override;
 	void close_camera() override;
 	void start_camera() override;
@@ -31,11 +29,12 @@ public:
 	camera_handler_state get_image(u8* buf, u64 size, u32& width, u32& height, u64& frame_number, u64& bytes_read) override;
 
 private:
+	void set_camera(const QCameraDevice& camera_info);
 	void reset();
 	void update_camera_settings();
 
 	std::string m_camera_id;
-	std::shared_ptr<QCamera> m_camera;
+	std::unique_ptr<QCamera> m_camera;
 	std::unique_ptr<QMediaCaptureSession> m_media_capture_session;
 	std::unique_ptr<qt_camera_video_sink> m_video_sink;
 


### PR DESCRIPTION
- Set camera state to open on cellCameraStop (it was set to closed whenever the camera gets inactive)
- Add some more logging if the camera changes activity unexpectedly

maybe fixes #16404