### PR TITLE
cellGem: Split horizontal and vertical mouse rotation cone setting

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellPhotoDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoDecode.cpp
@@ -144,9 +144,9 @@ error_code cellPhotoDecodeFromFile(vm::cptr<char> srcHddDir, vm::cptr<char> srcH
 	const std::string vpath = fmt::format("%s/%s", srcHddDir.get_ptr(), srcHddFile.get_ptr());
 	const std::string path = vfs::get(vpath);
 
-	if (!vpath.starts_with("/dev_hdd0") && !vpath.starts_with("/dev_hdd1"))
+	if (!vpath.starts_with("/dev_hdd0") && !vpath.starts_with("/dev_hdd1") && !vpath.starts_with("/dev_bdvd"))
 	{
-		cellPhotoDecode.error("Source '%s' is not inside dev_hdd0 or dev_hdd1", vpath);
+		cellPhotoDecode.error("Source '%s' is not inside dev_hdd0 or dev_hdd1 or dev_bdvd", vpath);
 		return CELL_PHOTO_DECODE_ERROR_ACCESS_ERROR; // TODO: is this correct?
 	}
 


### PR DESCRIPTION
- Use the existing cone setting for horizontal mouse movement
- Add a second cone setting for vertical mouse movement

This pretty much allows you to configure the mouse cursor to match the mouse position perfectly in certain games like yoostar 2