### PR TITLE
vk: Fix border color swizzling behavior

### DIFF
--- a/rpcs3/Emu/RSX/RSXTexture.h
+++ b/rpcs3/Emu/RSX/RSXTexture.h
@@ -142,4 +142,7 @@ namespace rsx
 		rsx::texture_dimension_extended get_extended_texture_dimension() const;
 		u16 get_exact_mipmap_count() const;
 	};
+
+	template<typename T>
+	concept Texture = std::is_same_v<T, fragment_texture> || std::is_same_v<T, vertex_texture>;
 }

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -244,6 +244,14 @@ void VKGSRender::load_texture_env()
 		return false;
 	};
 
+	auto get_border_color = [&](const rsx::Texture auto& tex)
+	{
+		const auto require_border_color_remap = m_device->get_custom_border_color_support().require_border_color_remap;
+		return require_border_color_remap
+			? tex.remapped_border_color()
+			: rsx::decode_border_color(tex.border_color());
+	};
+
 	std::lock_guard lock(m_sampler_mutex);
 
 	for (u32 textures_ref = current_fp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
@@ -304,10 +312,10 @@ void VKGSRender::load_texture_env()
 				const auto wrap_t = vk::vk_wrap_mode(tex.wrap_t());
 				const auto wrap_r = vk::vk_wrap_mode(tex.wrap_r());
 
-				// NOTE: In vulkan, the border color bypasses the swizzling defined in the image view.
-				// It is a direct texel replacement and must be remapped before attaching to the sampler.
+				// NOTE: In vulkan, the border color can bypass the sample swizzle stage.
+				// Check the device properties to determine whether to pre-swizzle the colors or not.
 				const auto border_color = rsx::is_border_clamped_texture(tex)
-					? vk::border_color_t(tex.remapped_border_color())
+					? vk::border_color_t(get_border_color(tex))
 					: vk::border_color_t(VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK);
 
 				// Check if non-point filtering can even be used on this format
@@ -449,10 +457,10 @@ void VKGSRender::load_texture_env()
 				const auto wrap_s = vk::vk_wrap_mode(tex.wrap_s());
 				const auto wrap_t = vk::vk_wrap_mode(tex.wrap_t());
 
-				// NOTE: In vulkan, the border color bypasses the swizzling defined in the image view.
-				// It is a direct texel replacement and must be remapped before attaching to the sampler.
+				// NOTE: In vulkan, the border color can bypass the sample swizzle stage.
+				// Check the device properties to determine whether to pre-swizzle the colors or not.
 				const auto border_color = is_border_clamped_texture(tex)
-					? vk::border_color_t(tex.remapped_border_color())
+					? vk::border_color_t(get_border_color(tex))
 					: vk::border_color_t(VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK);
 
 				if (vs_sampler_handles[i])

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -246,8 +246,7 @@ void VKGSRender::load_texture_env()
 
 	auto get_border_color = [&](const rsx::Texture auto& tex)
 	{
-		const auto require_border_color_remap = m_device->get_custom_border_color_support().require_border_color_remap;
-		return require_border_color_remap
+		return  m_device->get_custom_border_color_support().require_border_color_remap
 			? tex.remapped_border_color()
 			: rsx::decode_border_color(tex.border_color());
 	};

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -49,7 +49,16 @@ namespace vk
 		descriptor_indexing_features(bool supported = false)
 			: supported(supported) {}
 
-		operator bool() { return supported; }
+		operator bool() const { return supported; }
+	};
+
+	struct custom_border_color_features
+	{
+		bool supported = false;
+		bool swizzle_extension_supported = false;
+		bool require_border_color_remap = true;  // Assume that without the swizzle extension and explicit remap the device just samples border color as replacement.
+
+		operator bool() const { return supported; }
 	};
 
 	class physical_device
@@ -68,11 +77,12 @@ namespace vk
 		u32 descriptor_max_draw_calls = DESCRIPTOR_MAX_DRAW_CALLS;
 		descriptor_indexing_features descriptor_indexing_support{};
 
+		custom_border_color_features custom_border_color_support{};
+
 		struct
 		{
 			bool barycentric_coords = false;
 			bool conditional_rendering = false;
-			bool custom_border_color = false;
 			bool debug_utils = false;
 			bool external_memory_host = false;
 			bool framebuffer_loops = false;
@@ -161,6 +171,7 @@ namespace vk
 		const gpu_formats_support& get_formats_support() const { return m_formats_support; }
 		const pipeline_binding_table& get_pipeline_binding_table() const { return m_pipeline_binding_table; }
 		const gpu_shader_types_support& get_shader_types_support() const { return pgpu->shader_types_support; }
+		const custom_border_color_features& get_custom_border_color_support() const { return pgpu->custom_border_color_support; }
 
 		bool get_shader_stencil_export_support() const { return pgpu->optional_features_support.shader_stencil_export; }
 		bool get_depth_bounds_support() const { return pgpu->features.depthBounds != VK_FALSE; }
@@ -175,7 +186,6 @@ namespace vk
 		bool get_descriptor_indexing_support() const { return pgpu->descriptor_indexing_support; }
 		bool get_framebuffer_loops_support() const { return pgpu->optional_features_support.framebuffer_loops; }
 		bool get_barycoords_support() const { return pgpu->optional_features_support.barycentric_coords; }
-		bool get_custom_border_color_support() const { return pgpu->optional_features_support.custom_border_color; }
 		bool get_synchronization2_support() const { return pgpu->optional_features_support.synchronization_2; }
 
 		u64 get_descriptor_update_after_bind_support() const { return pgpu->descriptor_indexing_support.update_after_bind_mask; }


### PR DESCRIPTION
Use VK_EXT_border_color_swizzle to decide whether to preswizzle the border color or not. Different vendors treat the colors differently when using a non-identity mapping.

Closes https://github.com/RPCS3/rpcs3/issues/16345