### PR TITLE
cellGem: add magnetometer support

### DIFF
--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -469,6 +469,8 @@ struct ps_move_data
 	bool calibration_requested = false;
 	bool calibration_succeeded = false;
 
+	bool magnetometer_enabled = false;
+
 	std::array<f32, 4> quaternion { 1.0f, 0.0f, 0.0f, 0.0f }; // quaternion orientation (x,y,z,w) of controller relative to default (facing the camera with buttons up)
 	f32 accelerometer_x = 0.0f; // linear velocity in m/s²
 	f32 accelerometer_y = 0.0f; // linear velocity in m/s²

--- a/rpcs3/Input/ps_move_handler.cpp
+++ b/rpcs3/Input/ps_move_handler.cpp
@@ -678,12 +678,12 @@ void ps_move_handler::get_extended_info(const pad_ensemble& binding)
 
 	if (dev->model == ps_move_model::ZCM1)
 	{
-		accel_x = (input.accel_x_1 + input.accel_x_2) / 2 - zero_shift;
-		accel_y = (input.accel_y_1 + input.accel_y_2) / 2 - zero_shift;
-		accel_z = (input.accel_z_1 + input.accel_z_2) / 2 - zero_shift;
-		gyro_x = (input.gyro_x_1 + input.gyro_x_2) / 2 - zero_shift;
-		gyro_y = (input.gyro_y_1 + input.gyro_y_2) / 2 - zero_shift;
-		gyro_z = (input.gyro_z_1 + input.gyro_z_2) / 2 - zero_shift;
+		accel_x -= zero_shift;
+		accel_y -= zero_shift;
+		accel_z -= zero_shift;
+		gyro_x -= zero_shift;
+		gyro_y -= zero_shift;
+		gyro_z -= zero_shift;
 
 		const ps_move_input_report_ZCM1& input_zcm1 = dev->input_report_ZCM1;
 

--- a/rpcs3/Input/ps_move_handler.h
+++ b/rpcs3/Input/ps_move_handler.h
@@ -54,8 +54,9 @@ namespace reports
 
 		//                                      ID    Size   Description
 		u8 magnetometer_x2{};                // 0x27    1-   X-axis magnetometer
-		u8 magnetometer_y{};                 // 0x28    1+   Z-axis magnetometer
-		u16 magnetometer_z{};                // 0x29    1-   Y-axis magnetometer
+		u8 magnetometer_y{};                 // 0x28    1+   Y-axis magnetometer
+		u8 magnetometer_yz{};                // 0x29    1    XZ-axis magnetometer
+		u8 magnetometer_z{};                 // 0x2A    1-   Z-axis magnetometer
 		u8 timestamp_lower{};                // 0x2B    1    Timestamp (lower byte)
 		std::array<u8, 5> ext_device_data{}; // 0x2C    5    External device data
 	};


### PR DESCRIPTION
- Read magnetometer value from input report (model ZCM1 only)
- Pass magnetometer to fusion algorithm (if enabled)
- Allow cellGem to enable or disable the magnetometer

NOTE: It's not clear yet how all of these sensors are used correctly, which is noticeable by the bad tracking.
This can be the fault of the used library or simply a misconfiguration.
During testing, I sometimes had fantastic results, while having obnoxious drift on the next try.