### PR TITLE
Qt: allow to skip further automatic update notifications for a single…

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -120,6 +120,7 @@ namespace gui
 	const gui_save rg_freeze  = gui_save(main_window, "recentGamesFrozen", false);
 	const gui_save rg_entries = gui_save(main_window, "recentGamesNames",  QVariant::fromValue(q_pair_list()));
 
+	const gui_save ib_skip_version = gui_save(main_window, "infoBoxSkipVersion",       "");
 	const gui_save ib_pkg_success  = gui_save(main_window, "infoBoxEnabledInstallPKG", true);
 	const gui_save ib_pup_success  = gui_save(main_window, "infoBoxEnabledInstallPUP", true);
 	const gui_save ib_show_welcome = gui_save(main_window, "infoBoxEnabledWelcome",    true);


### PR DESCRIPTION
Adds a checkbox to skip further notifications for a specific new version update.
You can still download the update if you press the "Update Available!" button in the main window.

![image](https://github.com/user-attachments/assets/ea664ae7-4380-4c12-b2ee-cf7f365cb07d)


- fixes #16441