### PR TITLE
util/shared_ptr.hpp: STX pointers library fixes

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2555,13 +2555,13 @@ std::string thread_ctrl::get_name_cached()
 	return *name_cache;
 }
 
-thread_base::thread_base(native_entry entry, std::string name)
+thread_base::thread_base(native_entry entry, std::string name) noexcept
 	: entry_point(entry)
 	, m_tname(make_single_value(std::move(name)))
 {
 }
 
-thread_base::~thread_base()
+thread_base::~thread_base() noexcept
 {
 	// Cleanup abandoned tasks: initialize default results and signal
 	this->exec();
@@ -2602,7 +2602,7 @@ bool thread_base::join(bool dtor) const
 
 		if (i >= 16 && !(i & (i - 1)) && timeout != atomic_wait_timeout::inf)
 		{
-			sig_log.error(u8"Thread [%s] is too sleepy. Waiting for it %.3fus already!", *m_tname.load(), (utils::get_tsc() - stamp0) / (utils::get_tsc_freq() / 1000000.));
+			sig_log.error("Thread [%s] is too sleepy. Waiting for it %.3fus already!", *m_tname.load(), (utils::get_tsc() - stamp0) / (utils::get_tsc_freq() / 1000000.));
 		}
 	}
 

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -693,7 +693,7 @@ public:
 
 		if constexpr (std::is_assignable_v<Context&, thread_state>)
 		{
-			static_cast<Context&>(*this) = s;
+			static_cast<Context&>(*this) = thread_state::aborting;
 		}
 
 		if (notify_sync)
@@ -706,6 +706,11 @@ public:
 		{
 			// This participates in emulation stopping, use destruction-alike semantics
 			thread::join(true);
+
+			if constexpr (std::is_assignable_v<Context&, thread_state>)
+			{
+				static_cast<Context&>(*this) = thread_state::finished;
+			}
 		}
 
 		return *this;

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -172,9 +172,9 @@ private:
 	friend class named_thread;
 
 protected:
-	thread_base(native_entry, std::string name);
+	thread_base(native_entry, std::string name) noexcept;
 
-	~thread_base();
+	~thread_base() noexcept;
 
 public:
 	// Get CPU cycles since last time this function was called. First call returns 0.
@@ -351,7 +351,7 @@ public:
 	// Sets the native thread priority and returns it to zero at destructor
 	struct scoped_priority
 	{
-		explicit scoped_priority(int prio)
+		explicit scoped_priority(int prio) noexcept
 		{
 			set_native_priority(prio);
 		}
@@ -360,7 +360,7 @@ public:
 
 		scoped_priority& operator=(const scoped_priority&) = delete;
 
-		~scoped_priority()
+		~scoped_priority() noexcept
 		{
 			set_native_priority(0);
 		}
@@ -388,7 +388,7 @@ class thread_future_t : public thread_future, result_storage<Ctx, std::condition
 	using future = thread_future_t;
 
 public:
-	thread_future_t(Ctx&& func, Args&&... args)
+	thread_future_t(Ctx&& func, Args&&... args) noexcept
 		: m_args(std::forward<Args>(args)...)
 		, m_func(std::forward<Ctx>(func))
 	{
@@ -417,7 +417,7 @@ public:
 		};
 	}
 
-	~thread_future_t()
+	~thread_future_t() noexcept
 	{
 		if constexpr (!future::empty && !Discard)
 		{
@@ -570,7 +570,7 @@ public:
 	named_thread& operator=(const named_thread&) = delete;
 
 	// Wait for the completion and access result (if not void)
-	[[nodiscard]] decltype(auto) operator()()
+	[[nodiscard]] decltype(auto) operator()() noexcept
 	{
 		thread::join();
 
@@ -581,7 +581,7 @@ public:
 	}
 
 	// Wait for the completion and access result (if not void)
-	[[nodiscard]] decltype(auto) operator()() const
+	[[nodiscard]] decltype(auto) operator()() const noexcept
 	{
 		thread::join();
 
@@ -593,7 +593,7 @@ public:
 
 	// Send command to the thread to invoke directly (references should be passed via std::ref())
 	template <bool Discard = true, typename Arg, typename... Args>
-	auto operator()(Arg&& arg, Args&&... args)
+	auto operator()(Arg&& arg, Args&&... args) noexcept
 	{
 		// Overloaded operator() of the Context.
 		constexpr bool v1 = std::is_invocable_v<Context, Arg&&, Args&&...>;
@@ -667,12 +667,12 @@ public:
 	}
 
 	// Access thread state
-	operator thread_state() const
+	operator thread_state() const noexcept
 	{
 		return static_cast<thread_state>(thread::m_sync.load() & 3);
 	}
 
-	named_thread& operator=(thread_state s)
+	named_thread& operator=(thread_state s) noexcept
 	{
 		if (s == thread_state::created)
 		{
@@ -717,7 +717,7 @@ public:
 	}
 
 	// Context type doesn't need virtual destructor
-	~named_thread()
+	~named_thread() noexcept
 	{
 		// Assign aborting state forcefully and join thread
 		operator=(thread_state::finished);

--- a/rpcs3/Emu/Cell/lv2/sys_config.h
+++ b/rpcs3/Emu/Cell/lv2/sys_config.h
@@ -390,13 +390,9 @@ public:
 	}
 
 	// Destructor
-	~lv2_config_service_event() noexcept
-	{
-		if (auto global = g_fxo->try_get<lv2_config>())
-		{
-			global->remove_service_event(id);
-		}
-	}
+	lv2_config_service_event& operator=(thread_state s) noexcept;
+
+	~lv2_config_service_event() noexcept = default;
 
 	// Notify queue that this event exists
 	bool notify() const;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.cpp
@@ -175,3 +175,14 @@ void lv2_socket::queue_wake(ppu_thread* ppu)
 		break;
 	}
 }
+
+lv2_socket& lv2_socket::operator=(thread_state s) noexcept
+{
+	if (s == thread_state::finished)
+	{
+		close();
+	}
+
+	return *this;
+}
+

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
@@ -27,6 +27,8 @@ using socket_type = uptr;
 using socket_type = int;
 #endif
 
+enum class thread_state : u32;
+
 class lv2_socket
 {
 public:
@@ -62,7 +64,8 @@ public:
 	lv2_socket(utils::serial&, lv2_socket_type type);
 	static std::function<void(void*)> load(utils::serial& ar);
 	void save(utils::serial&, bool save_only_this_class = false);
-	virtual ~lv2_socket() = default;
+	~lv2_socket() noexcept = default;
+	lv2_socket& operator=(thread_state s) noexcept;
 
 	std::unique_lock<shared_mutex> lock();
 

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
@@ -35,7 +35,6 @@ public:
 	lv2_socket_native(lv2_socket_family family, lv2_socket_type type, lv2_ip_protocol protocol);
 	lv2_socket_native(utils::serial& ar, lv2_socket_type type);
 	void save(utils::serial& ar);
-	~lv2_socket_native();
 	s32 create_socket();
 
 	std::tuple<bool, s32, shared_ptr<lv2_socket>, sys_net_sockaddr> accept(bool is_lock = true) override;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
@@ -330,8 +330,9 @@ void lv2_socket_p2p::close()
 		return;
 	}
 
-	auto& nc = g_fxo->get<p2p_context>();
+	if (g_fxo->is_init<p2p_context>())
 	{
+		auto& nc = g_fxo->get<p2p_context>();
 		std::lock_guard lock(nc.list_p2p_ports_mutex);
 
 		if (!nc.list_p2p_ports.contains(port))

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
@@ -944,8 +944,9 @@ void lv2_socket_p2ps::close()
 		return;
 	}
 
-	auto& nc = g_fxo->get<p2p_context>();
+	if (g_fxo->is_init<p2p_context>())
 	{
+		auto& nc = g_fxo->get<p2p_context>();
 		std::lock_guard lock(nc.list_p2p_ports_mutex);
 		auto& p2p_port = ::at32(nc.list_p2p_ports, port);
 		{
@@ -973,8 +974,10 @@ void lv2_socket_p2ps::close()
 		}
 	}
 
-	auto& tcpm = g_fxo->get<named_thread<tcp_timeout_monitor>>();
-	tcpm.clear_all_messages(lv2_id);
+	if (const auto tcpm = g_fxo->try_get<named_thread<tcp_timeout_monitor>>())
+	{
+		tcpm->clear_all_messages(lv2_id);
+	}
 }
 
 s32 lv2_socket_p2ps::shutdown([[maybe_unused]] s32 how)

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -434,9 +434,12 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 		using namespace id_manager;
 
 		shared_ptr<utils::serial> idm_capture = make_shared<utils::serial>();
+
+		if (!is_real_reboot)
 		{
-			reader_lock rlock{g_mutex};
+			reader_lock rlock{id_manager::g_mutex};
 			g_fxo->get<id_map<lv2_memory_container>>().save(*idm_capture);
+			stx::serial_breathe_and_tag(*idm_capture, "id_map<lv2_memory_container>", false);
 		}
 
 		idm_capture->set_reading_state();

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -587,7 +587,7 @@ bool gdb_thread::cmd_thread_info(gdb_cmd&)
 
 bool gdb_thread::cmd_current_thread(gdb_cmd&)
 {
-	return send_cmd_ack(selected_thread && selected_thread->state.none_of(cpu_flag::exit) ? "" : ("QC" + u64_to_padded_hex(selected_thread->id)));
+	return send_cmd_ack(selected_thread && selected_thread->state.none_of(cpu_flag::exit) ? ("QC" + u64_to_padded_hex(selected_thread->id)) : "");
 }
 
 bool gdb_thread::cmd_read_register(gdb_cmd& cmd)
@@ -733,7 +733,7 @@ bool gdb_thread::cmd_read_all_registers(gdb_cmd&)
 		return send_cmd_ack(result);
 	}
 
-	GDB.warning("Unimplemented thread type %d.", selected_thread ->id_type());
+	GDB.warning("Unimplemented thread type %d.", selected_thread->id_type());
 	return send_cmd_ack("");
 }
 

--- a/rpcs3/Emu/IdManager.h
+++ b/rpcs3/Emu/IdManager.h
@@ -801,6 +801,15 @@ public:
 			}
 		}
 
+		if constexpr (std::is_assignable_v<Get&, thread_state>)
+		{
+			if (ptr)
+			{
+				constexpr thread_state finished{3};
+				*static_cast<Get*>(ptr.get()) = finished;
+			}
+		}
+
 		return true;
 	}
 
@@ -821,6 +830,15 @@ public:
 			else
 			{
 				return false;
+			}
+		}
+
+		if constexpr (std::is_assignable_v<Get&, thread_state>)
+		{
+			if (ptr)
+			{
+				constexpr thread_state finished{3};
+				*static_cast<Get*>(ptr.get()) = finished;
 			}
 		}
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2767,6 +2767,7 @@ bool Emulator::Pause(bool freeze_emulation, bool show_resume_message)
 			std::unique_ptr<named_thread<decltype(refresh_l)>> m_thread;
 		};
 
+		g_fxo->need<thread_t>();
 		g_fxo->get<thread_t>().m_thread.reset();
 		g_fxo->get<thread_t>().m_thread = std::make_unique<named_thread<decltype(refresh_l)>>("Pause Message Thread"sv, std::move(refresh_l));
 	});

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2718,8 +2718,15 @@ bool Emulator::Pause(bool freeze_emulation, bool show_resume_message)
 		cpu.state += cpu_flag::dbg_global_pause;
 	};
 
-	idm::select<named_thread<ppu_thread>>(on_select);
-	idm::select<named_thread<spu_thread>>(on_select);
+	if (g_fxo->is_init<id_manager::id_map<named_thread<ppu_thread>>>())
+	{
+		idm::select<named_thread<ppu_thread>>(on_select);
+	}
+
+	if (g_fxo->is_init<id_manager::id_map<named_thread<spu_thread>>>())
+	{
+		idm::select<named_thread<spu_thread>>(on_select);
+	}
 
 	if (auto rsx = g_fxo->try_get<rsx::thread>())
 	{

--- a/rpcs3/Emu/savestate_utils.cpp
+++ b/rpcs3/Emu/savestate_utils.cpp
@@ -372,6 +372,7 @@ namespace stx
 		{
 			// Reset, probably a new utils::serial object
 			s_tls_call_count = 1;
+			s_tls_object_name = "none"sv;
 		}
 
 		s_tls_current_pos = ar.pos;

--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -1049,8 +1049,15 @@ void debugger_frame::UpdateUnitList()
 
 	if (emu_state != system_state::stopped)
 	{
-		idm::select<named_thread<ppu_thread>>(on_select, idm::unlocked);
-		idm::select<named_thread<spu_thread>>(on_select, idm::unlocked);
+		if (g_fxo->is_init<id_manager::id_map<named_thread<ppu_thread>>>())
+		{
+			idm::select<named_thread<ppu_thread>>(on_select, idm::unlocked);
+		}
+
+		if (g_fxo->is_init<id_manager::id_map<named_thread<spu_thread>>>())
+		{
+			idm::select<named_thread<spu_thread>>(on_select, idm::unlocked);
+		}
 
 		if (const auto render = g_fxo->try_get<rsx::thread>(); render && render->ctrl)
 		{


### PR DESCRIPTION
Bugs fixed:
* stx::shared_ptr::reset() was resetting pointer storage only if reference count became 0. (should always reset pointer storage)
* Fixup serialization in sys_process.
* Move destructor code in sys_config to IDM designated abort notification, operator=(thread_state), where it should be.
Do a similar thing with lv2_socket and spu_thread.

Optimization:
* atomic_ptr constructors were adding a redundant atomic_t::store instead of raw access.

flixes #16447