### PR TITLE
Windows: log command line args in utf8

### DIFF
--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -587,7 +587,10 @@
     <ClInclude Include="Emu\IPC_socket.h" />
     <ClInclude Include="Emu\localized_string.h" />
     <ClInclude Include="Emu\localized_string_id.h" />
+    <ClInclude Include="Emu\NP\fb_helpers.h" />
     <ClInclude Include="Emu\NP\generated\np2_structs_generated.h" />
+    <ClInclude Include="Emu\NP\np_contexts.h" />
+    <ClInclude Include="Emu\NP\np_gui_cache.h" />
     <ClInclude Include="Emu\NP\np_handler.h" />
     <ClInclude Include="Emu\NP\rpcn_countries.h" />
     <ClInclude Include="Emu\NP\signaling_handler.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2650,6 +2650,15 @@
     <ClInclude Include="Emu\RSX\Host\MM.h">
       <Filter>Emu\GPU\RSX\Host Mini-Driver</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\NP\fb_helpers.h">
+      <Filter>Emu\NP</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\NP\np_contexts.h">
+      <Filter>Emu\NP</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\NP\np_gui_cache.h">
+      <Filter>Emu\NP</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Emu\RSX\Program\GLSLSnippets\GPUDeswizzle.glsl">

--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -33,7 +33,7 @@
 #ifdef _WIN32
 #include "module_verifier.hpp"
 #include "util/dyn_lib.hpp"
-
+#include <shellapi.h>
 
 // TODO(cjj19970505@live.cn)
 // When compiling with WIN32_LEAN_AND_MEAN definition
@@ -620,10 +620,25 @@ int main(int argc, char** argv)
 	std::string argument_str;
 	for (int i = 0; i < argc; i++)
 	{
+		if (i > 0) argument_str += " ";
 		argument_str += '\'' + std::string(argv[i]) + '\'';
-		if (i != argc - 1) argument_str += " ";
 	}
+
 	sys_log.notice("argc: %d, argv: %s", argc, argument_str);
+
+#ifdef _WIN32
+	int n_args = 0;
+	if (LPWSTR* arg_list = CommandLineToArgvW(GetCommandLineW(), &n_args))
+	{
+		std::string utf8_args;
+		for (int i = 0; i < n_args; i++)
+		{
+			if (i > 0) utf8_args += " ";
+			utf8_args += '\'' + wchar_to_utf8(arg_list[i]) + '\'';
+		}
+		sys_log.notice("argv_utf8: %s", utf8_args);
+	}
+#endif
 
 	// Before we proceed, run some sanity checks
 	run_platform_sanity_checks();


### PR DESCRIPTION
Example:
```
! SYS: argc: 1, argv: 'D:\?\rpcs3.exe'
! SYS: argv_utf8: 'D:\Я\rpcs3.exe'
```