### PR TITLE
Fix idm remove

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_storage.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_storage.cpp
@@ -16,7 +16,7 @@ namespace
 	struct storage_manager
 	{
 		// This is probably wrong and should be assigned per fd or something
-		atomic_ptr<shared_ptr<lv2_event_queue>> asyncequeue;
+		atomic_ptr<lv2_event_queue> asyncequeue;
 	};
 }
 
@@ -137,7 +137,7 @@ error_code sys_storage_async_send_device_command(u32 dev_handle, u64 cmd, vm::pt
 
 	auto& manager = g_fxo->get<storage_manager>();
 
-	if (auto q = *manager.asyncequeue.load())
+	if (auto q = manager.asyncequeue.load())
 	{
 		q->send(0, unk, unk, unk);
 	}

--- a/rpcs3/Emu/NP/np_contexts.cpp
+++ b/rpcs3/Emu/NP/np_contexts.cpp
@@ -238,7 +238,7 @@ matching_ctx::matching_ctx(vm::ptr<SceNpId> npId, vm::ptr<SceNpMatchingHandler> 
 	this->handler = handler;
 	this->arg = arg;
 }
-void matching_ctx::queue_callback(u32 req_id, s32 event, s32 error_code)
+void matching_ctx::queue_callback(u32 req_id, s32 event, s32 error_code) const
 {
 	if (handler)
 	{
@@ -249,7 +249,7 @@ void matching_ctx::queue_callback(u32 req_id, s32 event, s32 error_code)
 			});
 	}
 }
-void matching_ctx::queue_gui_callback(s32 event, s32 error_code)
+void matching_ctx::queue_gui_callback(s32 event, s32 error_code) const
 {
 	if (gui_handler)
 	{

--- a/rpcs3/Emu/NP/np_contexts.h
+++ b/rpcs3/Emu/NP/np_contexts.h
@@ -289,8 +289,8 @@ struct matching_ctx
 {
 	matching_ctx(vm::ptr<SceNpId> npid, vm::ptr<SceNpMatchingHandler> handler, vm::ptr<void> arg);
 
-	void queue_callback(u32 req_id, s32 event, s32 error_code);
-	void queue_gui_callback(s32 event, s32 error_code);
+	void queue_callback(u32 req_id, s32 event, s32 error_code) const;
+	void queue_gui_callback(s32 event, s32 error_code) const;
 
 	static const u32 id_base = 0x9001;
 	static const u32 id_step = 1;

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -605,10 +605,10 @@ namespace stx
 
 		template <typename T1>
 		static constexpr bool is_stx_pointer = false
-			|| is_instance_of<std::remove_cv_t<T1>, shared_ptr>::value
-			|| is_instance_of<std::remove_cv_t<T1>, single_ptr>::value
-			|| is_instance_of<std::remove_cv_t<T1>, atomic_ptr>::value;
-			|| std::is_same_v<T1, null_ptr_t>;
+			|| is_instance_of<std::remove_cvref_t<T1>, shared_ptr>::value
+			|| is_instance_of<std::remove_cvref_t<T1>, single_ptr>::value
+			|| is_instance_of<std::remove_cvref_t<T1>, atomic_ptr>::value;
+			|| std::is_same_v<std::remove_cvref_t<T1>, null_ptr_t>;
 
 	public:
 		using element_type = std::remove_extent_t<T>;

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -607,7 +607,7 @@ namespace stx
 		static constexpr bool is_stx_pointer = false
 			|| is_instance_of<std::remove_cvref_t<T1>, shared_ptr>::value
 			|| is_instance_of<std::remove_cvref_t<T1>, single_ptr>::value
-			|| is_instance_of<std::remove_cvref_t<T1>, atomic_ptr>::value;
+			|| is_instance_of<std::remove_cvref_t<T1>, atomic_ptr>::value
 			|| std::is_same_v<std::remove_cvref_t<T1>, null_ptr_t>;
 
 	public:

--- a/rpcs3/util/shared_ptr.hpp
+++ b/rpcs3/util/shared_ptr.hpp
@@ -895,6 +895,8 @@ namespace stx
 			return value;
 		}
 
+		[[nodiscard]] shared_type exchange(struct null_ptr_t) noexcept;
+
 		// Ineffective
 		[[nodiscard]] bool compare_exchange(shared_type& cmp_and_old, shared_type exch)
 		{
@@ -1141,6 +1143,18 @@ namespace stx
 		}
 
 	} null_ptr;
+
+	template <typename T>
+	atomic_ptr<T>::shared_type atomic_ptr<T>::exchange(null_ptr_t) noexcept
+	{
+		atomic_ptr old;
+		old.m_val.raw() = m_val.exchange(0);
+		old.m_val.raw() += 1;
+
+		shared_type result;
+		result.m_ptr = std::launder(ptr_to(old.m_val));
+		return result;
+	}
 }
 
 template <typename T>


### PR DESCRIPTION
idm remove calls shared_ptr::exchange with a null_ptr.
This calls the stored object's constructor with null args.
Let's just add an exchange overload for null_ptr

fixes #16457
fixes #16458 