### PR TITLE
[Minor] Report filesizes on macOS as decimal multiples

### DIFF
--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -627,11 +627,11 @@ namespace gui
 			usz divisor = 1;
 #if defined(__APPLE__)
 			constexpr multiplier = 1000; 
+			static const QString s_units[]{"B", "kB", "MB", "GB", "TB", "PB"};
 #else
 			constexpr multiplier = 1024;
+			static const QString s_units[]{"B", "KiB", "MiB", "GiB", "TiB", "PiB"};
 #endif
-
-			static const QString s_units[]{"B", "KB", "MB", "GB", "TB", "PB"};
 
 			while (byte_unit < std::size(s_units) - 1 && size / divisor >= multiplier)
 			{

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -626,9 +626,9 @@ namespace gui
 			usz byte_unit = 0;
 			usz divisor = 1;
 #if defined(__APPLE__)
-			usz multiplier = 1000; 
+			constexpr multiplier = 1000; 
 #else
-			usz multiplier = 1024;
+			constexpr multiplier = 1024;
 #endif
 
 			static const QString s_units[]{"B", "KB", "MB", "GB", "TB", "PB"};

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -626,10 +626,10 @@ namespace gui
 			usz byte_unit = 0;
 			usz divisor = 1;
 #if defined(__APPLE__)
-			constexpr multiplier = 1000; 
+			constexpr usz multiplier = 1000; 
 			static const QString s_units[]{"B", "kB", "MB", "GB", "TB", "PB"};
 #else
-			constexpr multiplier = 1024;
+			constexpr usz multiplier = 1024;
 			static const QString s_units[]{"B", "KiB", "MiB", "GiB", "TiB", "PiB"};
 #endif
 

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -625,13 +625,18 @@ namespace gui
 		{
 			usz byte_unit = 0;
 			usz divisor = 1;
+#if defined(__APPLE__)
+			usz multiplier = 1000; 
+#else
+			usz multiplier = 1024;
+#endif
 
 			static const QString s_units[]{"B", "KB", "MB", "GB", "TB", "PB"};
 
-			while (byte_unit < std::size(s_units) - 1 && size / divisor >= 1024)
+			while (byte_unit < std::size(s_units) - 1 && size / divisor >= multiplier)
 			{
 				byte_unit++;
-				divisor *= 1024;
+				divisor *= multiplier;
 			}
 
 			return QStringLiteral("%0 %1").arg(QString::number((size + 0.) / divisor, 'f', 2)).arg(s_units[byte_unit]);


### PR DESCRIPTION
macOS uses decimal multiples (i.e. 1KB = 1000B) for filesizes system-wide, prior to this PR it could lead to RPCS3 reporting very different values for, e.g., free disk space than what macOS itself reports elsewhere.
<img width="792" alt="image" src="https://github.com/user-attachments/assets/83bf3f17-04a3-41ed-9470-0d42aa126b53" />
With the PR it'll be within a few GBs of what macOS reports in Settings (the rest of the difference is 'purgeable space' nonsense).
( I have a feeling other OSes may also report decimal multiples like macOS, and that Windows may be the odd one out in reporting binary multiples. If so then the include guards could be more broadly adjusted to only use multiples of 1024 on WIN32. )
