### PR TITLE
LV2: Introduce Dynamic Timer signals

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -1449,6 +1449,8 @@ static usz apply_modification(std::vector<u32>& applied, patch_engine::patch_inf
 
 void patch_engine::apply(std::vector<u32>& applied_total, const std::string& name, std::function<u8*(u32, u32)> mem_translate, u32 filesz, u32 min_addr)
 {
+	applied_total.clear();
+
 	if (!m_map.contains(name))
 	{
 		return;
@@ -1597,6 +1599,9 @@ void patch_engine::apply(std::vector<u32>& applied_total, const std::string& nam
 			}
 		}
 	}
+
+	// Ensure consistent order
+	std::stable_sort(applied_total.begin(), applied_total.end());
 }
 
 void patch_engine::unload(const std::string& name)

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -96,6 +96,7 @@ struct ppu_module : public Type
 	std::vector<ppu_segment> segs{};
 	std::vector<ppu_segment> secs{};
 	std::vector<ppu_function> funcs{};
+	std::vector<u32> applied_patches;
 	std::deque<std::shared_ptr<void>> allocations;
 	std::map<u32, u32> addr_to_seg_index;
 
@@ -185,7 +186,6 @@ struct main_ppu_module : public ppu_module<T>
 {
 	u32 elf_entry{};
 	u32 seg0_code_end{};
-	std::vector<u32> applied_patches;
 
 	// Disable inherited savestate ordering
 	void save(utils::serial&) = delete;

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1947,6 +1947,7 @@ shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, bool virtual_load, c
 		ppu_check_patch_spu_images(*prx, seg);
 	}
 
+	prx->applied_patches = applied;
 	prx->analyse(toc, 0, end, applied, exported_funcs);
 
 	if (!ar && !virtual_load)

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -300,6 +300,11 @@ public:
 	const char* last_function{}; // Sticky copy of current_function, is not cleared on function return
 	const char* current_module{}; // Current module name, for savestates.
 
+	// Sycall pattern recognition variables
+	u64 last_lv2_deschedule_cia = umax; // Position of syscall that puts the PPU to sleep
+	u64 last_lv2_deschedule_r3 = umax; // R3 argument of syscall that puts the PPU to sleep
+	u64 last_lv2_deschedule_match_count = 0; // Arguments matching count when PPU puts to sleep
+
 	const bool is_interrupt_thread; // True for interrupts-handler threads
 
 	// Thread name

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.h
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.h
@@ -11,7 +11,6 @@ struct lv2_overlay final : ppu_module<lv2_obj>
 
 	u32 entry{};
 	u32 seg0_code_end{};
-	std::vector<u32> applied_patches;
 
 	lv2_overlay() = default;
 	lv2_overlay(utils::serial&){}

--- a/rpcs3/Emu/Cell/lv2/sys_sync.h
+++ b/rpcs3/Emu/Cell/lv2/sys_sync.h
@@ -454,10 +454,12 @@ public:
 
 	static bool wait_timeout(u64 usec, ppu_thread* cpu = {}, bool scale = true, bool is_usleep = false);
 
-	static void notify_all() noexcept;
+	static void notify_all(cpu_thread* woke_thread = nullptr) noexcept;
 
 	// Can be called before the actual sleep call in order to move it out of mutex scope
 	static void prepare_for_sleep(cpu_thread& cpu);
+
+	static u64 get_avg_timer_reponse_delay();
 
 	struct notify_all_t
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -467,7 +467,7 @@ error_code sys_timer_usleep(ppu_thread& ppu, u64 sleep_time)
 			sleep_time = std::max<u64>(1, utils::sub_saturate<u64>(sleep_time, -add_time));
 		}
 
-		lv2_obj::sleep(ppu, g_cfg.core.sleep_timers_accuracy < sleep_timers_accuracy_level::_usleep ? sleep_time : 0);
+		lv2_obj::sleep(ppu, sleep_time);
 
 		if (!lv2_obj::wait_timeout(sleep_time, &ppu, true, true))
 		{

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -870,11 +870,13 @@ namespace rsx
 		{
 			// Wait 16ms during emulation pause. This reduces cpu load while still giving us the chance to render overlays.
 			do_local_task(rsx::FIFO::state::paused);
+			lv2_obj::notify_all();
 			thread_ctrl::wait_on(state, old, 16000);
 		}
 		else
 		{
 			on_semaphore_acquire_wait();
+			lv2_obj::notify_all();
 			std::this_thread::yield();
 		}
 	}

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -91,11 +91,7 @@ struct cfg_root : cfg::node
 		cfg::uint<0, (1 << 6) - 1> spu_wakeup_delay_mask{ this, "SPU Wake-Up Delay Thread Mask", (1 << 6) - 1, true };
 		cfg::uint<0, 400> max_cpu_preempt_count_per_frame{ this, "Max CPU Preempt Count", 0, true };
 		cfg::_bool allow_rsx_cpu_preempt{ this, "Allow RSX CPU Preemptions", true, true };
-#if defined (__linux__) || defined (__APPLE__)
-		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy", sleep_timers_accuracy_level::_as_host, true };
-#else
-		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy", sleep_timers_accuracy_level::_usleep, true };
-#endif
+		cfg::_enum<sleep_timers_accuracy_level> sleep_timers_accuracy{ this, "Sleep Timers Accuracy 2", sleep_timers_accuracy_level::_dynamic, true };
 		cfg::_int<-1000, 1500> usleep_addend{ this, "Usleep Time Addend", 0, true };
 
 		cfg::uint64 perf_report_threshold{this, "Performance Report Threshold", 500, true}; // In µs, 0.5ms = default, 0 = everything

--- a/rpcs3/Emu/system_config_types.cpp
+++ b/rpcs3/Emu/system_config_types.cpp
@@ -237,6 +237,7 @@ void fmt_class_string<sleep_timers_accuracy_level>::format(std::string& out, u64
 		switch (value)
 		{
 		case sleep_timers_accuracy_level::_as_host: return "As Host";
+		case sleep_timers_accuracy_level::_dynamic: return "Dynamic";
 		case sleep_timers_accuracy_level::_usleep: return "Usleep Only";
 		case sleep_timers_accuracy_level::_all_timers: return "All Timers";
 		}

--- a/rpcs3/Emu/system_config_types.h
+++ b/rpcs3/Emu/system_config_types.h
@@ -24,6 +24,7 @@ enum class spu_block_size_type
 enum class sleep_timers_accuracy_level
 {
 	_as_host,
+	_dynamic,
 	_usleep,
 	_all_timers,
 };

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -1202,6 +1202,7 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 		switch (static_cast<sleep_timers_accuracy_level>(index))
 		{
 		case sleep_timers_accuracy_level::_as_host: return tr("As Host", "Sleep timers accuracy");
+		case sleep_timers_accuracy_level::_dynamic: return tr("Dynamic", "Sleep timers accuracy");
 		case sleep_timers_accuracy_level::_usleep: return tr("Usleep Only", "Sleep timers accuracy");
 		case sleep_timers_accuracy_level::_all_timers: return tr("All Timers", "Sleep timers accuracy");
 		}

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -233,7 +233,7 @@ inline static const std::map<emu_settings_type, cfg_location> settings_location 
 	{ emu_settings_type::SPUCache,                 { "Core", "SPU Cache"}},
 	{ emu_settings_type::DebugConsoleMode,         { "Core", "Debug Console Mode"}},
 	{ emu_settings_type::MaxSPURSThreads,          { "Core", "Max SPURS Threads"}},
-	{ emu_settings_type::SleepTimersAccuracy,      { "Core", "Sleep Timers Accuracy"}},
+	{ emu_settings_type::SleepTimersAccuracy,      { "Core", "Sleep Timers Accuracy 2"}},
 	{ emu_settings_type::ClocksScale,              { "Core", "Clocks scale"}},
 	{ emu_settings_type::AccuratePPU128Loop,       { "Core", "Accurate PPU 128-byte Reservation Op Max Length"}},
 	{ emu_settings_type::PerformanceReport,        { "Core", "Enable Performance Report"}},


### PR DESCRIPTION
For a while, the emulator has dealt with LV2 timed syscalls pretty inefficiently:
* With "Usleep" setting: the emulator would keep the thread awake for the last 500 (on Windows, 100 for the rest) microseconds of the syscall duration awake, which had increased CPU time significantly while also not actually working as expected in a highly active threading environment due to forced operating systems preemptions.
* With "As Host" setting: none of the above, but the delay in the syscall schedule was huge! leading to various performance issues as well.

Instead, try a new thing: we know that direct thread notifications are very fast on every operaing systems, so try to systematically check for time-outs by other emulationh threads when they have little to no work themeselfs. This would eliminate the delay and cut on CPU time!
But hold on! what about times when other emulation threads do have work to be ?
The truth is that we cannot predict such cases with full accuracy, but what we can do is calculate the avarage response time of other threads to this in the past in games and see if it is valueable to opt for this mechanis instead. At the times when not, fallback to "Useleep" setting behaviour. This would provide accuracy in the "not well suited" cases too!

This adds the setting value "Dynamic" for LV2 timers accuracy, while it being the new default.

What to test:

1. PPU usage.
2. CPU usage.
3. Framerate
4. If Nier works properly.

Results: around 20% in CPU time specifically used by PPU in usleep syscalls is saved now, it's nice but it's a bit disappointing because there may be more potential there. That's it for this pr though. 