### PR TITLE
cmake: remove "--no-quick" from windeployqt

### DIFF
--- a/3rdparty/wolfssl/CMakeLists.txt
+++ b/3rdparty/wolfssl/CMakeLists.txt
@@ -22,6 +22,5 @@ else()
 
 	add_subdirectory(wolfssl EXCLUDE_FROM_ALL)
 
-	target_compile_definitions(wolfssl PUBLIC WOLFSSL_DES_ECB HAVE_WRITE_DUP)
-	target_compile_definitions(wolfssl PUBLIC FP_MAX_BITS=8192)
+	target_compile_definitions(wolfssl PUBLIC WOLFSSL_DES_ECB HAVE_WRITE_DUP FP_MAX_BITS=8192 WOLFSSL_NO_OPTIONS_H)
 endif()

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -164,7 +164,7 @@ elseif(WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/bin/GuiConfigs $<TARGET_FILE_DIR:rpcs3>/GuiConfigs
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/bin/git $<TARGET_FILE_DIR:rpcs3>/git
         COMMAND "${WINDEPLOYQT_EXECUTABLE}" --no-compiler-runtime --no-opengl-sw --no-patchqt
-            --no-translations --no-quick --no-system-d3d-compiler --no-quick-import
+            --no-translations --no-system-d3d-compiler --no-quick-import
             --plugindir "$<IF:$<CXX_COMPILER_ID:MSVC>,$<TARGET_FILE_DIR:rpcs3>/plugins,$<TARGET_FILE_DIR:rpcs3>/share/qt6/plugins>"
             --verbose 0 "$<TARGET_FILE:rpcs3>")
 endif()


### PR DESCRIPTION
I get and error when I try building on Windows.

```
[608/611] Linking CXX executable bin\rpcs3.exe
FAILED: bin/rpcs3.exe
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\msys64\clang64\bin\clang++.exe -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -gdwarf-aranges -g -mwindows  -Wl,--allow-multiple-definition -Wl,--stack -Wl,8388608 -Wl,--image-base,0x10000 @CMakeFiles\rpcs3.rsp -o bin\rpcs3.exe -Wl,--out-implib,rpcs3\librpcs3.dll.a -Wl,--major-image-version,0,--minor-image-version,0 && C:\WINDOWS\system32\cmd.exe /C "cd /D E:\build-rpcs3-clang\rpcs3 && C:\msys64\clang64\bin\cmake.exe -E copy E:/build-rpcs3-clang/3rdparty/OpenAL/openal-soft/OpenAL32.dll E:/build-rpcs3-clang/bin && C:\msys64\clang64\bin\cmake.exe -E copy_directory C:/src/rpcs3/bin/Icons E:/build-rpcs3-clang/bin/Icons && C:\msys64\clang64\bin\cmake.exe -E copy_directory C:/src/rpcs3/bin/GuiConfigs E:/build-rpcs3-clang/bin/GuiConfigs && C:\msys64\clang64\bin\cmake.exe -E copy_directory C:/src/rpcs3/bin/git E:/build-rpcs3-clang/bin/git && C:\msys64\clang64\bin\windeployqt-qt6.exe --no-compiler-runtime --no-opengl-sw --no-patchqt --no-translations --no-quick --no-system-d3d-compiler --no-quick-import --plugindir E:/build-rpcs3-clang/bin/share/qt6/plugins --verbose 0 E:/build-rpcs3-clang/bin/rpcs3.exe""
Unknown option 'no-quick'.

ninja: build stopped: subcommand failed.
```