### PR TITLE
qt6: QT_MIN_VER should be 6.7 because of QCheckBox::checkStateChanged

### DIFF
--- a/3rdparty/qt6.cmake
+++ b/3rdparty/qt6.cmake
@@ -1,6 +1,6 @@
 add_library(3rdparty_qt6 INTERFACE)
 
-set(QT_MIN_VER 6.4.0)
+set(QT_MIN_VER 6.7.0)
 
 find_package(Qt6 ${QT_MIN_VER} CONFIG COMPONENTS Widgets Concurrent Multimedia MultimediaWidgets Svg SvgWidgets)
 if(WIN32)


### PR DESCRIPTION
Check: https://doc.qt.io/qt-6/qcheckbox.html

QCheckBox::checkStateChanged used in
https://github.com/search?q=repo%3ARPCS3%2Frpcs3%20checkStateChanged&type=code
rpcs3/rpcs3qt/emu_settings.cpp
rpcs3/rpcs3qt/settings_dialog.cpp
rpcs3/rpcs3qt/pad_motion_settings_dialog.cpp
rpcs3/rpcs3qt/patch_manager_dialog.cpp
