### PR TITLE
rsx: Shader decompiler improvements

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -558,6 +558,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/Program/CgBinaryFragmentProgram.cpp
     RSX/Program/CgBinaryVertexProgram.cpp
     RSX/Program/FragmentProgramDecompiler.cpp
+    RSX/Program/FragmentProgramRegister.cpp
     RSX/Program/GLSLCommon.cpp
     RSX/Program/ProgramStateCache.cpp
     RSX/Program/program_util.cpp

--- a/rpcs3/Emu/RSX/Common/surface_store.cpp
+++ b/rpcs3/Emu/RSX/Common/surface_store.cpp
@@ -18,7 +18,21 @@ namespace rsx
 			case surface_target::surfaces_a_b_c: return{ 0, 1, 2 };
 			case surface_target::surfaces_a_b_c_d: return{ 0, 1, 2, 3 };
 			}
-			fmt::throw_exception("Wrong color_target");
+			fmt::throw_exception("Invalid color target %d", static_cast<int>(color_target));
+		}
+
+		u8 get_mrt_buffers_count(surface_target color_target)
+		{
+			switch (color_target)
+			{
+			case surface_target::none: return 0;
+			case surface_target::surface_a: return 1;
+			case surface_target::surface_b: return 1;
+			case surface_target::surfaces_a_b: return 2;
+			case surface_target::surfaces_a_b_c: return 3;
+			case surface_target::surfaces_a_b_c_d: return 4;
+			}
+			fmt::throw_exception("Invalid color target %d", static_cast<int>(color_target));
 		}
 
 		usz get_aligned_pitch(surface_color_format format, u32 width)

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -17,6 +17,7 @@ namespace rsx
 	namespace utility
 	{
 		std::vector<u8> get_rtt_indexes(surface_target color_target);
+		u8 get_mrt_buffers_count(surface_target color_target);
 		usz get_aligned_pitch(surface_color_format format, u32 width);
 		usz get_packed_pitch(surface_color_format format, u32 width);
 	}

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -39,7 +39,7 @@ u64 GLGSRender::get_cycles()
 
 GLGSRender::GLGSRender(utils::serial* ar) noexcept : GSRender(ar)
 {
-	m_shaders_cache = std::make_unique<gl::shader_cache>(m_prog_buffer, "opengl", "v1.94");
+	m_shaders_cache = std::make_unique<gl::shader_cache>(m_prog_buffer, "opengl", "v1.95");
 
 	if (g_cfg.video.disable_vertex_cache)
 		m_vertex_cache = std::make_unique<gl::null_vertex_cache>();
@@ -984,6 +984,11 @@ void GLGSRender::load_program_env()
 		rsx::pipeline_state::transform_constants_dirty |
 		rsx::pipeline_state::fragment_constants_dirty |
 		rsx::pipeline_state::fragment_texture_state_dirty);
+}
+
+bool GLGSRender::is_current_program_interpreted() const
+{
+	return m_program && m_shader_interpreter.is_interpreter(m_program);
 }
 
 void GLGSRender::upload_transform_constants(const rsx::io_buffer& buffer)

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -206,6 +206,9 @@ public:
 	// GRAPH backend
 	void patch_transform_constants(rsx::context* ctx, u32 index, u32 count) override;
 
+	// Misc
+	bool is_current_program_interpreted() const override;
+
 protected:
 	void clear_surface(u32 arg) override;
 	void begin() override;

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
@@ -347,7 +347,7 @@ namespace gl
 		return data;
 	}
 
-	bool shader_interpreter::is_interpreter(const glsl::program* program)
+	bool shader_interpreter::is_interpreter(const glsl::program* program) const
 	{
 		return (program == &m_current_interpreter->prog);
 	}

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.h
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.h
@@ -84,6 +84,6 @@ namespace gl
 		void update_fragment_textures(const std::array<std::unique_ptr<rsx::sampled_image_descriptor_base>, 16>& descriptors, u16 reference_mask, u32* out);
 
 		glsl::program* get(const interpreter::program_metadata& fp_metadata);
-		bool is_interpreter(const glsl::program* program);
+		bool is_interpreter(const glsl::program* program) const;
 	};
 }

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
@@ -22,6 +22,15 @@ namespace rsx
 
 using namespace rsx::fragment_program;
 
+// SIMD vector lanes
+enum VectorLane : u8
+{
+	X = 0,
+	Y = 1,
+	Z = 2,
+	W = 3,
+};
+
 FragmentProgramDecompiler::FragmentProgramDecompiler(const RSXFragmentProgram &prog, u32& size)
 	: m_size(size)
 	, m_prog(prog)
@@ -141,8 +150,7 @@ void FragmentProgramDecompiler::SetDst(std::string code, u32 flags)
 		AddCode(m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), "cc" + std::to_string(src0.cond_mod_reg_index)) + "$m = " + dest + ";");
 	}
 
-	u32 reg_index = dst.fp16 ? dst.dest_reg >> 1 : dst.dest_reg;
-
+	const u32 reg_index = dst.fp16 ? (dst.dest_reg >> 1) : dst.dest_reg;
 	ensure(reg_index < temp_registers.size());
 
 	if (dst.opcode == RSX_FP_OPCODE_MOV &&
@@ -754,14 +762,26 @@ std::string FragmentProgramDecompiler::BuildCode()
 	const std::string init_value = float4_type + "(0.)";
 	std::array<std::string, 4> output_register_names;
 	std::array<u32, 4> ouput_register_indices = { 0, 2, 3, 4 };
-	bool shader_is_valid = false;
+
+	// Holder for any "cleanup" before exiting main
+	std::stringstream main_epilogue;
 
 	// Check depth export
 	if (m_ctrl & CELL_GCM_SHADER_CONTROL_DEPTH_EXPORT)
 	{
 		// Hw tests show that the depth export register is default-initialized to 0 and not wpos.z!!
 		m_parr.AddParam(PF_PARAM_NONE, getFloatTypeName(4), "r1", init_value);
-		shader_is_valid = (!!temp_registers[1].h1_writes);
+
+		auto& r1 = temp_registers[1];
+		if (r1.requires_gather(VectorLane::Z))
+		{
+			// r1.zw was not written to
+			properties.has_gather_op = true;
+			main_epilogue << "	r1.z = " << float4_type << r1.gather_r() << ".z;\n";
+
+			// Emit debug warning. Useful to diagnose regressions, but should be removed in future.
+			rsx_log.warning("ROP reads from shader depth without writing to it. Final value will be gathered.");
+		}
 	}
 
 	// Add the color output registers. They are statically written to and have guaranteed initialization (except r1.z which == wpos.z)
@@ -777,26 +797,41 @@ std::string FragmentProgramDecompiler::BuildCode()
 
 	for (int n = 0; n < 4; ++n)
 	{
-		if (!m_parr.HasParam(PF_PARAM_NONE, float4_type, output_register_names[n]))
+		const auto& reg_name = output_register_names[n];
+		if (!m_parr.HasParam(PF_PARAM_NONE, float4_type, reg_name))
 		{
-			m_parr.AddParam(PF_PARAM_NONE, float4_type, output_register_names[n], init_value);
-			continue;
+			m_parr.AddParam(PF_PARAM_NONE, float4_type, reg_name, init_value);
 		}
 
 		const auto block_index = ouput_register_indices[n];
-		shader_is_valid |= (!!temp_registers[block_index].h0_writes);
-	}
+		auto& r = temp_registers[block_index];
 
-	if (!shader_is_valid)
-	{
-		properties.has_no_output = true;
-
-		if (!properties.has_discard_op)
+		if (fp16_out)
 		{
-			// NOTE: Discard operation overrides output
-			rsx_log.warning("Shader does not write to any output register and will be NOPed");
-			main = "/*" + main + "*/";
+			// Check if we need a split/extract op
+			if (r.requires_split(0))
+			{
+				main_epilogue << "	" << reg_name << " = " << float4_type << r.split_h0() << ";\n";
+
+				// Emit debug warning. Useful to diagnose regressions, but should be removed in future.
+				rsx_log.warning("ROP reads from %s without writing to it. Final value will be extracted from the 32-bit register.", reg_name);
+			}
+
+			continue;
 		}
+
+		if (!r.requires_gather128())
+		{
+			// Nothing to do
+			continue;
+		}
+
+		// We need to gather the data from existing registers
+		main_epilogue << "	" << reg_name << " = " << float4_type << r.gather_r() << ";\n";
+		properties.has_gather_op = true;
+
+		// Emit debug warning. Useful to diagnose regressions, but should be removed in future.
+		rsx_log.warning("ROP reads from %s without writing to it. Final value will be gathered.", reg_name);
 	}
 
 	if (properties.has_dynamic_register_load)
@@ -822,6 +857,9 @@ std::string FragmentProgramDecompiler::BuildCode()
 		OS << "#endif\n";
 		OS << "	discard;\n";
 		OS << "}\n";
+
+		// Don't consume any args
+		m_parr.Clear();
 		return OS.str();
 	}
 
@@ -1019,6 +1057,12 @@ std::string FragmentProgramDecompiler::BuildCode()
 
 	insertMainStart(OS);
 	OS << main << std::endl;
+
+	if (const auto epilogue = main_epilogue.str(); !epilogue.empty())
+	{
+		OS << "	// Epilogue\n";
+		OS << epilogue << std::endl;
+	}
 	insertMainEnd(OS);
 
 	return OS.str();
@@ -1360,12 +1404,12 @@ std::string FragmentProgramDecompiler::Decompile()
 
 		switch (opcode)
 		{
-		case RSX_FP_OPCODE_NOP: break;
+		case RSX_FP_OPCODE_NOP:
+			break;
 		case RSX_FP_OPCODE_KIL:
 			properties.has_discard_op = true;
 			AddFlowOp("_kill()");
 			break;
-
 		default:
 			int prev_force_unit = forced_unit;
 

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
@@ -795,12 +795,18 @@ std::string FragmentProgramDecompiler::BuildCode()
 		output_register_names = { "h0", "h4", "h6", "h8" };
 	}
 
-	for (int n = 0; n < 4; ++n)
+	for (u32 n = 0; n < 4; ++n)
 	{
 		const auto& reg_name = output_register_names[n];
 		if (!m_parr.HasParam(PF_PARAM_NONE, float4_type, reg_name))
 		{
 			m_parr.AddParam(PF_PARAM_NONE, float4_type, reg_name, init_value);
+		}
+
+		if (n >= m_prog.mrt_buffers_count)
+		{
+			// Skip gather
+			continue;
 		}
 
 		const auto block_index = ouput_register_indices[n];

--- a/rpcs3/Emu/RSX/Program/FragmentProgramRegister.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramRegister.cpp
@@ -1,0 +1,196 @@
+#include "stdafx.h"
+#include "FragmentProgramRegister.h"
+
+namespace rsx
+{
+	MixedPrecisionRegister::MixedPrecisionRegister()
+	{
+		std::fill(content_mask.begin(), content_mask.end(), data_type_bits::undefined);
+	}
+
+	void MixedPrecisionRegister::tag_h0(bool x, bool y, bool z, bool w)
+	{
+		if (x) content_mask[0] = data_type_bits::f16;
+		if (y) content_mask[1] = data_type_bits::f16;
+		if (z) content_mask[2] = data_type_bits::f16;
+		if (w) content_mask[3] = data_type_bits::f16;
+	}
+
+	void MixedPrecisionRegister::tag_h1(bool x, bool y, bool z, bool w)
+	{
+		if (x) content_mask[4] = data_type_bits::f16;
+		if (y) content_mask[5] = data_type_bits::f16;
+		if (z) content_mask[6] = data_type_bits::f16;
+		if (w) content_mask[7] = data_type_bits::f16;
+	}
+
+	void MixedPrecisionRegister::tag_r(bool x, bool y, bool z, bool w)
+	{
+		if (x) content_mask[0] = content_mask[1] = data_type_bits::f32;
+		if (y) content_mask[2] = content_mask[3] = data_type_bits::f32;
+		if (z) content_mask[4] = content_mask[5] = data_type_bits::f32;
+		if (w) content_mask[6] = content_mask[7] = data_type_bits::f32;
+	}
+
+	void MixedPrecisionRegister::tag(u32 index, bool is_fp16, bool x, bool y, bool z, bool w)
+	{
+		if (file_index == umax)
+		{
+			// First-time use. Initialize...
+			const u32 real_index = is_fp16 ? (index >> 1) : index;
+			file_index = real_index;
+		}
+
+		if (is_fp16)
+		{
+			ensure((index / 2) == file_index);
+
+			if (index & 1)
+			{
+				tag_h1(x, y, z, w);
+				return;
+			}
+
+			tag_h0(x, y, z, w);
+			return;
+		}
+
+		tag_r(x, y, z, w);
+	}
+
+	std::string MixedPrecisionRegister::gather_r() const
+	{
+		const auto half_index = file_index << 1;
+		const std::string reg = "r" + std::to_string(file_index);
+		const std::string gather_half_regs[] = {
+			"gather(h" + std::to_string(half_index) + ")",
+			"gather(h" + std::to_string(half_index + 1) + ")"
+		};
+
+		std::string outputs[4];
+		for (int ch = 0; ch < 4; ++ch)
+		{
+			// FIXME: This approach ignores mixed register bits. Not ideal!!!!
+			const auto channel0 = content_mask[ch * 2];
+			const auto is_fp16_ch = channel0 == content_mask[ch * 2 + 1] && channel0 == data_type_bits::f16;
+			outputs[ch] = is_fp16_ch ? gather_half_regs[ch / 2] : reg;
+		}
+
+		// Grouping. Only replace relevant bits...
+		if (outputs[0] == outputs[1]) outputs[0] = "";
+		if (outputs[2] == outputs[3]) outputs[2] = "";
+
+		// Assemble
+		bool group = false;
+		std::string result = "";
+		constexpr std::string_view swz_mask = "xyzw";
+
+		for (int ch = 0; ch < 4; ++ch)
+		{
+			if (outputs[ch].empty())
+			{
+				group = true;
+				continue;
+			}
+
+			if (!result.empty())
+			{
+				result += ", ";
+			}
+
+			if (group)
+			{
+				ensure(ch > 0);
+				group = false;
+
+				if (outputs[ch] == reg)
+				{
+					result += reg + "." + swz_mask[ch - 1] + swz_mask[ch];
+					continue;
+				}
+
+				result += outputs[ch];
+				continue;
+			}
+
+			const int subch = outputs[ch] == reg ? ch : (ch % 2); // Avoid .xyxy.z and other such ugly swizzles
+			result += outputs[ch] + "." + swz_mask[subch];
+		}
+
+		// Optimize dual-gather (128-bit gather) to use special function
+		const std::string double_gather = gather_half_regs[0] + ", " + gather_half_regs[1];
+		if (result == double_gather)
+		{
+			result = "gather(h" + std::to_string(half_index) + ", h" + std::to_string(half_index + 1) + ")";
+		}
+
+		return "(" + result + ")";
+	}
+
+	std::string MixedPrecisionRegister::fetch_halfreg(u32 word_index) const
+	{
+		// Reads half-word 0 (H16x4) from a full real (R32x4) register
+		constexpr std::string_view swz_mask = "xyzw";
+		const std::string reg = "r" + std::to_string(file_index);
+		const std::string hreg = "h" + std::to_string(file_index * 2 + word_index);
+
+		const std::string word0_bits = "floatBitsToUint(" + reg + "." + swz_mask[word_index * 2] + ")";
+		const std::string word1_bits = "floatBitsToUint(" + reg + "." + swz_mask[word_index * 2 + 1] + ")";
+		const std::string words[] = {
+			"unpackHalf2x16(" + word0_bits + ")",
+			"unpackHalf2x16(" + word1_bits + ")"
+		};
+
+		// Assemble
+		std::string outputs[4];
+
+		ensure(word_index <= 1);
+		const int word_offset = word_index * 4;
+		for (int ch = 0; ch < 4; ++ch)
+		{
+			outputs[ch] = content_mask[ch + word_offset] == data_type_bits::f32
+				? words[ch / 2]
+				: hreg;
+		}
+
+		// Grouping. Only replace relevant bits...
+		if (outputs[0] == outputs[1]) outputs[0] = "";
+		if (outputs[2] == outputs[3]) outputs[2] = "";
+
+		// Assemble
+		bool group = false;
+		std::string result = "";
+
+		for (int ch = 0; ch < 4; ++ch)
+		{
+			if (outputs[ch].empty())
+			{
+				group = true;
+				continue;
+			}
+
+			if (!result.empty())
+			{
+				result += ", ";
+			}
+
+			if (group)
+			{
+				ensure(ch > 0);
+				group = false;
+				result += outputs[ch];
+
+				if (outputs[ch] == hreg)
+				{
+					result += std::string(".") + swz_mask[ch - 1] + swz_mask[ch];
+				}
+				continue;
+			}
+
+			const int subch = outputs[ch] == hreg ? ch : (ch % 2); // Avoid .xyxy.z and other such ugly swizzles
+			result += outputs[ch] + "." + swz_mask[subch];
+		}
+
+		return "(" + result + ")";
+	}
+}

--- a/rpcs3/Emu/RSX/Program/FragmentProgramRegister.h
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramRegister.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <util/types.hpp>
+
+namespace rsx
+{
+	class MixedPrecisionRegister
+	{
+		enum data_type_bits
+		{
+			undefined = 0,
+			f16 = 1,
+			f32 = 2
+		};
+
+		std::array<data_type_bits, 8> content_mask; // Content details for each half-word
+		u32 file_index = umax;
+
+		void tag_h0(bool x, bool y, bool z, bool w);
+
+		void tag_h1(bool x, bool y, bool z, bool w);
+
+		void tag_r(bool x, bool y, bool z, bool w);
+
+		std::string fetch_halfreg(u32 word_index) const;
+
+	public:
+		MixedPrecisionRegister();
+
+		void tag(u32 index, bool is_fp16, bool x, bool y, bool z, bool w);
+
+		std::string gather_r() const;
+
+		std::string split_h0() const
+		{
+			return fetch_halfreg(0);
+		}
+
+		std::string split_h1() const
+		{
+			return fetch_halfreg(1);
+		}
+
+		// Getters
+
+		// Return true if all values are unwritten to (undefined)
+		bool floating() const
+		{
+			return file_index == umax;
+		}
+
+		// Return true if the first half register is all undefined
+		bool floating_h0() const
+		{
+			return content_mask[0] == content_mask[1] &&
+				content_mask[1] == content_mask[2] &&
+				content_mask[2] == content_mask[3] &&
+				content_mask[3] == data_type_bits::undefined;
+		}
+
+		// Return true if the second half register is all undefined
+		bool floating_h1() const
+		{
+			return content_mask[4] == content_mask[5] &&
+				content_mask[5] == content_mask[6] &&
+				content_mask[6] == content_mask[7] &&
+				content_mask[7] == data_type_bits::undefined;
+		}
+
+		// Return true if any of the half-words are 16-bit
+		bool requires_gather(u8 channel) const
+		{
+			// Data fetched from the single precision register requires merging of the two half registers
+			const auto channel_offset = channel * 2;
+			ensure(channel_offset <= 6);
+
+			return (content_mask[channel_offset] == data_type_bits::f16 || content_mask[channel_offset + 1] == data_type_bits::f16);
+		}
+
+		// Return true if the entire 128-bit register is filled with 2xfp16x4 data words
+		bool requires_gather128() const
+		{
+			// Full 128-bit check
+			for (const auto& ch : content_mask)
+			{
+				if (ch == data_type_bits::f16)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		// Return true if the half-register is polluted with fp32 data
+		bool requires_split(u32 word_index) const
+		{
+			const u32 content_offset = word_index * 4;
+			for (u32 i = 0; i < 4; ++i)
+			{
+				if (content_mask[content_offset + i] == data_type_bits::f32)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+	};
+}
+

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
@@ -555,10 +555,14 @@ usz fragment_program_storage_hash::operator()(const RSXFragmentProgram& program)
 
 bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, const RSXFragmentProgram& binary2) const
 {
-	if (binary1.ctrl != binary2.ctrl || binary1.texture_state != binary2.texture_state ||
+	if (binary1.ucode_length != binary2.ucode_length ||
+		binary1.ctrl != binary2.ctrl ||
+		binary1.texture_state != binary2.texture_state ||
 		binary1.texcoord_control_mask != binary2.texcoord_control_mask ||
 		binary1.two_sided_lighting != binary2.two_sided_lighting)
+	{
 		return false;
+	}
 
 	const void* instBuffer1 = binary1.get_data();
 	const void* instBuffer2 = binary2.get_data();
@@ -569,7 +573,9 @@ bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, con
 		const auto inst2 = v128::loadu(instBuffer2, instIndex);
 
 		if (inst1._u ^ inst2._u)
+		{
 			return false;
+		}
 
 		instIndex++;
 		// Skip constants
@@ -578,9 +584,11 @@ bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, con
 			fragment_program_utils::is_constant(inst1._u32[3]))
 			instIndex++;
 
-		bool end = ((inst1._u32[0] >> 8) & 0x1) && ((inst2._u32[0] >> 8) & 0x1);
+		const bool end = ((inst1._u32[0] >> 8) & 0x1) && ((inst2._u32[0] >> 8) & 0x1);
 		if (end)
+		{
 			return true;
+		}
 	}
 }
 

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
@@ -340,12 +340,16 @@ vertex_program_utils::vertex_program_metadata vertex_program_utils::analyse_vert
 
 usz vertex_program_storage_hash::operator()(const RSXVertexProgram &program) const
 {
-	usz hash = vertex_program_utils::get_vertex_program_ucode_hash(program);
-	hash ^= program.ctrl;
-	hash ^= program.output_mask;
-	hash ^= program.texture_state.texture_dimensions;
-	hash ^= program.texture_state.multisampled_textures;
-	return hash;
+	const usz ucode_hash = vertex_program_utils::get_vertex_program_ucode_hash(program);
+	const u32 state_params[] =
+	{
+		program.ctrl,
+		program.output_mask,
+		program.texture_state.texture_dimensions,
+		program.texture_state.multisampled_textures,
+	};
+	const usz metadata_hash = rpcs3::hash_array(state_params);
+	return rpcs3::hash64(ucode_hash, metadata_hash);
 }
 
 bool vertex_program_compare::operator()(const RSXVertexProgram &binary1, const RSXVertexProgram &binary2) const
@@ -541,16 +545,20 @@ usz fragment_program_utils::get_fragment_program_ucode_hash(const RSXFragmentPro
 
 usz fragment_program_storage_hash::operator()(const RSXFragmentProgram& program) const
 {
-	usz hash = fragment_program_utils::get_fragment_program_ucode_hash(program);
-	hash ^= program.ctrl;
-	hash ^= +program.two_sided_lighting;
-	hash ^= program.texture_state.texture_dimensions;
-	hash ^= program.texture_state.shadow_textures;
-	hash ^= program.texture_state.redirected_textures;
-	hash ^= program.texture_state.multisampled_textures;
-	hash ^= program.texcoord_control_mask;
-
-	return hash;
+	const usz ucode_hash = fragment_program_utils::get_fragment_program_ucode_hash(program);
+	const u32 state_params[] =
+	{
+		program.ctrl,
+		program.two_sided_lighting ? 1u : 0u,
+		program.texture_state.texture_dimensions,
+		program.texture_state.shadow_textures,
+		program.texture_state.redirected_textures,
+		program.texture_state.multisampled_textures,
+		program.texcoord_control_mask,
+		program.mrt_buffers_count
+	};
+	const usz metadata_hash = rpcs3::hash_array(state_params);
+	return rpcs3::hash64(ucode_hash, metadata_hash);
 }
 
 bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, const RSXFragmentProgram& binary2) const
@@ -559,7 +567,8 @@ bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, con
 		binary1.ctrl != binary2.ctrl ||
 		binary1.texture_state != binary2.texture_state ||
 		binary1.texcoord_control_mask != binary2.texcoord_control_mask ||
-		binary1.two_sided_lighting != binary2.two_sided_lighting)
+		binary1.two_sided_lighting != binary2.two_sided_lighting ||
+		binary1.mrt_buffers_count != binary2.mrt_buffers_count)
 	{
 		return false;
 	}

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.h
@@ -293,10 +293,10 @@ public:
 		bool compile_async,
 		bool allow_notification,
 		Args&& ...args
-		)
+	)
 	{
-		const auto &vp_search = search_vertex_program(vertexShader);
-		const auto &fp_search = search_fragment_program(fragmentShader);
+		const auto& vp_search = search_vertex_program(vertexShader);
+		const auto& fp_search = search_fragment_program(fragmentShader);
 
 		const bool already_existing_fragment_program = std::get<1>(fp_search);
 		const bool already_existing_vertex_program = std::get<1>(vp_search);
@@ -385,7 +385,13 @@ public:
 
 	void fill_fragment_constants_buffer(std::span<f32> dst_buffer, const fragment_program_type& fragment_program, const RSXFragmentProgram& rsx_prog, bool sanitize = false) const
 	{
-		ensure((dst_buffer.size_bytes() >= ::narrow<int>(fragment_program.FragmentConstantOffsetCache.size()) * 16u));
+		if (dst_buffer.size_bytes() < (fragment_program.FragmentConstantOffsetCache.size() * 16))
+		{
+			// This can happen if CELL alters the shader after it has been loaded by RSX.
+			rsx_log.error("Insufficient constants buffer size passed to fragment program! Corrupt shader?");
+			return;
+		}
+
 		rsx::write_fragment_constants_to_buffer(dst_buffer, rsx_prog, fragment_program.FragmentConstantOffsetCache, sanitize);
 	}
 

--- a/rpcs3/Emu/RSX/Program/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/Program/RSXFragmentProgram.h
@@ -300,8 +300,10 @@ struct RSXFragmentProgram
 	u32 ucode_length = 0;
 	u32 total_length = 0;
 	u32 ctrl = 0;
-	bool two_sided_lighting = false;
 	u32 texcoord_control_mask = 0;
+	u32 mrt_buffers_count = 0;
+
+	bool two_sided_lighting = false;
 
 	rsx::fragment_program_texture_state texture_state;
 	rsx::fragment_program_texture_config texture_params;

--- a/rpcs3/Emu/RSX/Program/RSXVertexProgram.h
+++ b/rpcs3/Emu/RSX/Program/RSXVertexProgram.h
@@ -223,10 +223,10 @@ struct RSXVertexProgram
 {
 	std::vector<u32> data;
 	rsx::vertex_program_texture_state texture_state;
-	u32 ctrl;
-	u32 output_mask;
-	u32 base_address;
-	u32 entry;
+	u32 ctrl = 0;
+	u32 output_mask = 0;
+	u32 base_address = 0;
+	u32 entry = 0;
 	std::bitset<rsx::max_vertex_program_instructions> instruction_mask;
 	std::set<u32> jump_table;
 

--- a/rpcs3/Emu/RSX/Program/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Program/ShaderParam.h
@@ -227,6 +227,14 @@ struct ParamArray
 
 		return name;
 	}
+
+	void Clear()
+	{
+		for (auto& param : params)
+		{
+			param.clear();
+		}
+	}
 };
 
 class ShaderVariable

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -436,6 +436,8 @@ namespace rsx
 
 		bool is_current_vertex_program_instanced() const { return !!(current_vertex_program.ctrl & RSX_SHADER_CONTROL_INSTANCED_CONSTANTS); }
 
+		virtual bool is_current_program_interpreted() const { return false; }
+
 	public:
 		void reset();
 		void init(u32 ctrlAddress);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -730,7 +730,7 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	else
 		m_vertex_cache = std::make_unique<vk::weak_vertex_cache>();
 
-	m_shaders_cache = std::make_unique<vk::shader_cache>(*m_prog_buffer, "vulkan", "v1.94");
+	m_shaders_cache = std::make_unique<vk::shader_cache>(*m_prog_buffer, "vulkan", "v1.95");
 
 	for (u32 i = 0; i < m_swapchain->get_swap_image_count(); ++i)
 	{
@@ -2361,6 +2361,11 @@ void VKGSRender::load_program_env()
 	}
 
 	m_graphics_state.clear(handled_flags);
+}
+
+bool VKGSRender::is_current_program_interpreted() const
+{
+	return m_program && m_shader_interpreter.is_interpreter(m_program);
 }
 
 void VKGSRender::upload_transform_constants(const rsx::io_buffer& buffer)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -288,6 +288,9 @@ public:
 	// GRAPH backend
 	void patch_transform_constants(rsx::context* ctx, u32 index, u32 count) override;
 
+	// Misc
+	bool is_current_program_interpreted() const override;
+
 protected:
 	void clear_surface(u32 mask) override;
 	void begin() override;

--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -51,7 +51,10 @@ namespace rsx
 			u16 fp_shadow_textures;
 			u16 fp_redirected_textures;
 			u16 fp_multisampled_textures;
-			u64 fp_reserved_0;
+			u8  fp_mrt_count;
+			u8  fp_reserved0;
+			u16 fp_reserved1;
+			u32 fp_reserved2;
 
 			pipeline_storage_type pipeline_properties;
 		};
@@ -306,20 +309,24 @@ namespace rsx
 				fs::write_file(vp_name, fs::rewrite, vp.data);
 			}
 
-			u64 state_hash = 0;
-			state_hash ^= rpcs3::hash_base<u32>(data.vp_ctrl0);
-			state_hash ^= rpcs3::hash_base<u32>(data.vp_ctrl1);
-			state_hash ^= rpcs3::hash_base<u32>(data.fp_ctrl);
-			state_hash ^= rpcs3::hash_base<u32>(data.vp_texture_dimensions);
-			state_hash ^= rpcs3::hash_base<u32>(data.fp_texture_dimensions);
-			state_hash ^= rpcs3::hash_base<u32>(data.fp_texcoord_control);
-			state_hash ^= rpcs3::hash_base<u16>(data.fp_height);
-			state_hash ^= rpcs3::hash_base<u16>(data.fp_pixel_layout);
-			state_hash ^= rpcs3::hash_base<u16>(data.fp_lighting_flags);
-			state_hash ^= rpcs3::hash_base<u16>(data.fp_shadow_textures);
-			state_hash ^= rpcs3::hash_base<u16>(data.fp_redirected_textures);
-			state_hash ^= rpcs3::hash_base<u16>(data.vp_multisampled_textures);
-			state_hash ^= rpcs3::hash_base<u16>(data.fp_multisampled_textures);
+			const u32 state_params[] =
+			{
+				data.vp_ctrl0,
+				data.vp_ctrl1,
+				data.fp_ctrl,
+				data.vp_texture_dimensions,
+				data.fp_texture_dimensions,
+				data.fp_texcoord_control,
+				data.fp_height,
+				data.fp_pixel_layout,
+				data.fp_lighting_flags,
+				data.fp_shadow_textures,
+				data.fp_redirected_textures,
+				data.vp_multisampled_textures,
+				data.fp_multisampled_textures,
+				data.fp_mrt_count,
+			};
+			const usz state_hash = rpcs3::hash_array(state_params);
 
 			const std::string pipeline_file_name = fmt::format("%llX+%llX+%llX+%llX.bin", data.vertex_program_hash, data.fragment_program_hash, data.pipeline_storage_hash, state_hash);
 			const std::string pipeline_path = root_path + "/pipelines/" + pipeline_class_name + "/" + version_prefix + "/" + pipeline_file_name;
@@ -439,6 +446,7 @@ namespace rsx
 			data_block.fp_shadow_textures = fp.texture_state.shadow_textures;
 			data_block.fp_redirected_textures = fp.texture_state.redirected_textures;
 			data_block.fp_multisampled_textures = fp.texture_state.multisampled_textures;
+			data_block.fp_mrt_count = fp.mrt_buffers_count;
 
 			return data_block;
 		}

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\Shaders\shader_loading_dialog_native.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\Trophies\overlay_trophy_list_dialog.cpp" />
+    <ClCompile Include="Emu\RSX\Program\FragmentProgramRegister.cpp" />
     <ClCompile Include="Emu\RSX\Program\ProgramStateCache.cpp" />
     <ClCompile Include="Emu\RSX\Program\program_util.cpp" />
     <ClCompile Include="Emu\RSX\Program\SPIRVCommon.cpp" />
@@ -669,6 +670,7 @@
     <ClInclude Include="Emu\RSX\Overlays\overlay_media_list_dialog.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_progress_bar.hpp" />
     <ClInclude Include="Emu\RSX\Overlays\Trophies\overlay_trophy_list_dialog.h" />
+    <ClInclude Include="Emu\RSX\Program\FragmentProgramRegister.h" />
     <ClInclude Include="Emu\RSX\Program\GLSLTypes.h" />
     <ClInclude Include="Emu\RSX\Program\ProgramStateCache.h" />
     <ClInclude Include="Emu\RSX\Program\program_util.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1330,6 +1330,9 @@
     <ClCompile Include="Emu\Cell\ErrorCodes.cpp">
       <Filter>Emu\Cell</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Program\FragmentProgramRegister.cpp">
+      <Filter>Emu\GPU\RSX\Program</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -2685,6 +2688,9 @@
     </ClInclude>
     <ClInclude Include="Emu\Audio\audio_utils.h">
       <Filter>Emu\Audio</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Program\FragmentProgramRegister.h">
+      <Filter>Emu\GPU\RSX\Program</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/util/fnv_hash.hpp
+++ b/rpcs3/util/fnv_hash.hpp
@@ -61,4 +61,29 @@ namespace rpcs3
 
 		return hash_struct_base<T, u8>(value);
 	}
+
+	template <typename T, size_t N>
+		requires std::is_integral_v<T>
+	static inline usz hash_array(const T(&arr)[N])
+	{
+		usz hash = fnv_seed;
+		for (size_t i = 0; i < N; ++i)
+		{
+			hash = hash64(hash, arr[i]);
+		}
+		return hash;
+	}
+
+	template <typename T, size_t N>
+		requires std::is_class_v<T>
+	static inline usz hash_array(const T(&arr)[N])
+	{
+		usz hash = fnv_seed;
+		for (size_t i = 0; i < N; ++i)
+		{
+			const u64 item_hash = hash_struct(arr[i]);
+			hash = hash64(hash, item_hash);
+		}
+		return hash;
+	}
 }


### PR DESCRIPTION
Gathers aliased registers when writing to output for ROP operations. This phenomenon was observed when messing around in real hardware a while ago. Technically you can do perfectly ok rendering without ever touching the output registers if the corresponding half-registers are written to (and vice-versa).

Closes https://github.com/RPCS3/rpcs3/issues/15651