### PR TITLE
Batch compilation fixes

### DIFF
--- a/rpcs3/Emu/system_progress.cpp
+++ b/rpcs3/Emu/system_progress.cpp
@@ -41,6 +41,7 @@ void progress_dialog_server::operator()()
 {
 	std::shared_ptr<rsx::overlays::progress_dialog> native_dlg;
 	g_system_progress_stopping = false;
+	g_system_progress_canceled = false;
 
 	const auto get_state = []()
 	{

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2277,10 +2277,12 @@ void game_list_frame::RemoveHDD1Cache(const std::string& base_dir, const std::st
 		game_list_log.fatal("Only %d/%d HDD1 cache directories could be removed in %s (%s)", dirs_removed, dirs_total, base_dir, title_id);
 }
 
-void game_list_frame::BatchActionBySerials(progress_dialog* pdlg, const std::set<std::string>& serials, QString progressLabel, std::function<bool(const std::string&)> action, std::function<void(u32, u32)> cancel_log, bool refresh_on_finish,  bool can_be_concurrent, std::function<bool()> should_wait_cb)
+void game_list_frame::BatchActionBySerials(progress_dialog* pdlg, const std::set<std::string>& serials, QString progressLabel, std::function<bool(const std::string&)> action, std::function<void(u32, u32)> cancel_log, bool refresh_on_finish, bool can_be_concurrent, std::function<bool()> should_wait_cb)
 {
 	// Concurrent tasks should not wait (at least not in current implementation)
 	ensure(!should_wait_cb || !can_be_concurrent);
+
+	g_system_progress_canceled = false;
 
 	const std::shared_ptr<std::function<bool(int)>> iterate_over_serial = std::make_shared<std::function<bool(int)>>();
 
@@ -2297,12 +2299,16 @@ void game_list_frame::BatchActionBySerials(progress_dialog* pdlg, const std::set
 
 		const std::string& serial = *std::next(serials.begin(), index);
 
-		if (pdlg->wasCanceled() || g_system_progress_canceled)
+		if (pdlg->wasCanceled() || g_system_progress_canceled.exchange(false))
 		{
-			cancel_log(index, serials_size);
+			if (cancel_log)
+			{
+				cancel_log(index, serials_size);
+			}
 			return false;
 		}
-		else if (action(serial))
+
+		if (action(serial))
 		{
 			const int done = index_ptr->load();
 			pdlg->setLabelText(progressLabel.arg(done + 1).arg(serials_size));

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2366,19 +2366,17 @@ void game_list_frame::BatchActionBySerials(progress_dialog* pdlg, const std::set
 		if ((*iterate_over_serial)(*index))
 		{
 			QTimer::singleShot(1, this, *periodic_func);
+			return;
 		}
-		else
+
+		pdlg->setLabelText(progressLabel.arg(*index).arg(serials_size));
+		pdlg->setCancelButtonText(tr("OK"));
+		connect(pdlg, &progress_dialog::canceled, this, [pdlg](){ pdlg->deleteLater(); });
+		QApplication::beep();
+
+		if (refresh_on_finish && index)
 		{
-			pdlg->setLabelText(progressLabel.arg(*index).arg(serials_size));
-			pdlg->setCancelButtonText(tr("OK"));
-			QApplication::beep();
-
-			if (refresh_on_finish && index)
-			{
-				Refresh(true);
-			}
-
-			pdlg->deleteLater();
+			Refresh(true);
 		}
 	};
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2414,6 +2414,14 @@ void game_list_frame::BatchCreateCPUCaches(const std::vector<game_info>& game_da
 	pdlg->setAutoReset(false);
 	pdlg->open();
 
+	connect(pdlg, &progress_dialog::canceled, this, []()
+	{
+		if (!Emu.IsStopped())
+		{
+			Emu.GracefulShutdown(false, true);
+		}
+	});
+
 	BatchActionBySerials(pdlg, serials, tr("%0\nProgress: %1/%2 caches compiled").arg(main_label),
 	[&, game_data](const std::string& serial)
 	{


### PR DESCRIPTION
- Stop batch compilation immediately on cancel
- Keep batch progress dialog open until user closed it (as originally intended)
- Fix bug: batch compilation may not always work after a game was running beforehand