### PR TITLE
PPU LLVM: Function table dependent resolver hashing

### DIFF
--- a/Utilities/bin_patch.cpp
+++ b/Utilities/bin_patch.cpp
@@ -1449,6 +1449,8 @@ static usz apply_modification(std::vector<u32>& applied, patch_engine::patch_inf
 
 void patch_engine::apply(std::vector<u32>& applied_total, const std::string& name, std::function<u8*(u32, u32)> mem_translate, u32 filesz, u32 min_addr)
 {
+	applied_total.clear();
+
 	if (!m_map.contains(name))
 	{
 		return;
@@ -1597,6 +1599,9 @@ void patch_engine::apply(std::vector<u32>& applied_total, const std::string& nam
 			}
 		}
 	}
+
+	// Ensure consistent order
+	std::sort(applied_total.begin(), applied_total.end());
 }
 
 void patch_engine::unload(const std::string& name)

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -96,6 +96,7 @@ struct ppu_module : public Type
 	std::vector<ppu_segment> segs{};
 	std::vector<ppu_segment> secs{};
 	std::vector<ppu_function> funcs{};
+	std::vector<u32> applied_patches;
 	std::deque<std::shared_ptr<void>> allocations;
 	std::map<u32, u32> addr_to_seg_index;
 
@@ -185,7 +186,6 @@ struct main_ppu_module : public ppu_module<T>
 {
 	u32 elf_entry{};
 	u32 seg0_code_end{};
-	std::vector<u32> applied_patches;
 
 	// Disable inherited savestate ordering
 	void save(utils::serial&) = delete;

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1947,6 +1947,7 @@ shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, bool virtual_load, c
 		ppu_check_patch_spu_images(*prx, seg);
 	}
 
+	prx->applied_patches = applied;
 	prx->analyse(toc, 0, end, applied, exported_funcs);
 
 	if (!ar && !virtual_load)

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.h
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.h
@@ -11,7 +11,6 @@ struct lv2_overlay final : ppu_module<lv2_obj>
 
 	u32 entry{};
 	u32 seg0_code_end{};
-	std::vector<u32> applied_patches;
 
 	lv2_overlay() = default;
 	lv2_overlay(utils::serial&){}


### PR DESCRIPTION
Symbol resolver function is located on the last PPU module. Previously, its hash was dependent on its hosting module code alone. This led to potential misses of PPU code flow changes in other modules.
Include all the PPU function table addresses when hashing the last module for it.

Fixes #16517  
