### PR TITLE
input: Allow mapping keyboard keys to basic mouse buttons

### DIFF
--- a/rpcs3/Emu/Io/MouseHandler.cpp
+++ b/rpcs3/Emu/Io/MouseHandler.cpp
@@ -34,7 +34,7 @@ void MouseHandlerBase::save(utils::serial& ar)
 bool MouseHandlerBase::is_time_for_update(double elapsed_time)
 {
 	steady_clock::time_point now = steady_clock::now();
-	double elapsed = (now - last_update).count() / 1000'000.;
+	const double elapsed = (now - last_update).count() / 1000'000.;
 
 	if (elapsed > elapsed_time)
 	{

--- a/rpcs3/Input/basic_mouse_handler.h
+++ b/rpcs3/Input/basic_mouse_handler.h
@@ -20,8 +20,8 @@ public:
 	void Init(const u32 max_connect) override;
 
 	void SetTargetWindow(QWindow* target);
-	void MouseButtonDown(QMouseEvent* event);
-	void MouseButtonUp(QMouseEvent* event);
+	void Key(QKeyEvent* event, bool pressed);
+	void MouseButton(QMouseEvent* event, bool pressed);
 	void MouseScroll(QWheelEvent* event);
 	void MouseMove(QMouseEvent* event);
 
@@ -29,8 +29,14 @@ public:
 private:
 	void reload_config();
 	bool get_mouse_lock_state() const;
-	static int get_mouse_button(const cfg::string& button);
+
+	struct mouse_button
+	{
+		int code = Qt::MouseButton::NoButton;
+		bool is_key = false;
+	};
+	static mouse_button get_mouse_button(const cfg::string& button);
 
 	QWindow* m_target = nullptr;
-	std::map<u8, int> m_buttons;
+	std::map<u8, mouse_button> m_buttons;
 };

--- a/rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp
@@ -190,6 +190,26 @@ void basic_mouse_settings_dialog::on_button_click(int id)
 	m_remap_timer.start(1000);
 }
 
+void basic_mouse_settings_dialog::keyPressEvent(QKeyEvent* event)
+{
+	if (m_button_id < 0)
+	{
+		// We are not remapping a button, so pass the event to the base class.
+		QDialog::keyPressEvent(event);
+		return;
+	}
+
+	const std::string name = keyboard_pad_handler::GetKeyName(event, false);
+	g_cfg_mouse.get_button(m_button_id).from_string(name);
+
+	if (auto button = m_buttons->button(m_button_id))
+	{
+		button->setText(QString::fromStdString(name));
+	}
+
+	reactivate_buttons();
+}
+
 void basic_mouse_settings_dialog::mouseReleaseEvent(QMouseEvent* event)
 {
 	if (m_button_id < 0)

--- a/rpcs3/rpcs3qt/basic_mouse_settings_dialog.h
+++ b/rpcs3/rpcs3qt/basic_mouse_settings_dialog.h
@@ -39,6 +39,7 @@ private:
 	QTimer m_remap_timer;
 
 protected:
+	void keyPressEvent(QKeyEvent* event) override;
 	void mouseReleaseEvent(QMouseEvent* event) override;
 	bool eventFilter(QObject* object, QEvent* event) override;
 };


### PR DESCRIPTION
- Allow mapping keyboard keys to basic mouse buttons

This gives the user more freedom when trying to emulate certain devices such as the ps move

fixes #16018