### PR TITLE
ps move: allow to configure mouse move handler buttons

### DIFF
--- a/rpcs3/Emu/Io/Buzz.cpp
+++ b/rpcs3/Emu/Io/Buzz.cpp
@@ -161,7 +161,7 @@ void usb_device_buzz::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint*/
 		}
 
 		const auto& cfg = g_cfg_buzz.players[i];
-		cfg->handle_input(pad, true, [&buf, &index](buzz_btn btn, u16 /*value*/, bool pressed)
+		cfg->handle_input(pad, true, [&buf, &index](buzz_btn btn, pad_button /*pad_btn*/, u16 /*value*/, bool pressed, bool& /*abort*/)
 			{
 				if (!pressed)
 					return;

--- a/rpcs3/Emu/Io/GHLtar.cpp
+++ b/rpcs3/Emu/Io/GHLtar.cpp
@@ -147,7 +147,7 @@ void usb_device_ghltar::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpoint
 	}
 
 	const auto& cfg = ::at32(g_cfg_ghltar.players, m_controller_index);
-	cfg->handle_input(pad, true, [&buf](ghltar_btn btn, u16 value, bool pressed)
+	cfg->handle_input(pad, true, [&buf](ghltar_btn btn, pad_button /*pad_btn*/, u16 value, bool pressed, bool& /*abort*/)
 		{
 			if (!pressed)
 				return;

--- a/rpcs3/Emu/Io/GunCon3.cpp
+++ b/rpcs3/Emu/Io/GunCon3.cpp
@@ -227,7 +227,7 @@ void usb_device_guncon3::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint,
 		return;
 	}
 
-	const auto input_callback = [&gc](guncon3_btn btn, u16 value, bool pressed)
+	const auto input_callback = [&gc](guncon3_btn btn, pad_button /*pad_button*/, u16 value, bool pressed, bool& /*abort*/)
 	{
 		if (!pressed)
 			return;

--- a/rpcs3/Emu/Io/TopShotElite.cpp
+++ b/rpcs3/Emu/Io/TopShotElite.cpp
@@ -280,7 +280,7 @@ void usb_device_topshotelite::interrupt_transfer(u32 buf_size, u8* buf, u32 /*en
 	}
 
 	bool up = false, right = false, down = false, left = false;
-	const auto input_callback = [&ts, &up, &down, &left, &right](topshotelite_btn btn, u16 value, bool pressed)
+	const auto input_callback = [&ts, &up, &down, &left, &right](topshotelite_btn btn, pad_button /*pad_button*/, u16 value, bool pressed, bool& /*abort*/)
 	{
 		if (!pressed)
 			return;

--- a/rpcs3/Emu/Io/TopShotFearmaster.cpp
+++ b/rpcs3/Emu/Io/TopShotFearmaster.cpp
@@ -308,7 +308,7 @@ void usb_device_topshotfearmaster::interrupt_transfer(u32 buf_size, u8* buf, u32
 	}
 
 	bool up = false, right = false, down = false, left = false;
-	const auto input_callback = [&ts, &up, &down, &left, &right](topshotfearmaster_btn btn, u16 value, bool pressed)
+	const auto input_callback = [&ts, &up, &down, &left, &right](topshotfearmaster_btn btn, pad_button /*pad_button*/, u16 value, bool pressed, bool& /*abort*/)
 	{
 		if (!pressed)
 			return;

--- a/rpcs3/Emu/Io/Turntable.cpp
+++ b/rpcs3/Emu/Io/Turntable.cpp
@@ -159,7 +159,7 @@ void usb_device_turntable::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endpo
 		return;
 
 	const auto& cfg = ::at32(g_cfg_turntable.players, m_controller_index);
-	cfg->handle_input(pad, true, [&buf](turntable_btn btn, u16 value, bool pressed)
+	cfg->handle_input(pad, true, [&buf](turntable_btn btn, pad_button /*pad_btn*/, u16 value, bool pressed, bool& /*abort*/)
 		{
 			if (!pressed)
 				return;

--- a/rpcs3/Emu/Io/gem_config.h
+++ b/rpcs3/Emu/Io/gem_config.h
@@ -4,7 +4,7 @@
 
 #include <array>
 
-enum class gem_btn
+enum class gem_btn : u32
 {
 	start,
 	select,
@@ -16,6 +16,18 @@ enum class gem_btn
 	t,
 	x_axis,
 	y_axis,
+
+	combo_begin,
+	combo = combo_begin,
+	combo_start,
+	combo_select,
+	combo_triangle,
+	combo_circle,
+	combo_cross,
+	combo_square,
+	combo_move,
+	combo_t,
+	combo_end = combo_t,
 
 	count
 };
@@ -41,6 +53,34 @@ struct cfg_fake_gems final : public emulated_pads_config<cfg_fake_gem, 4>
 	cfg_fake_gems() : emulated_pads_config<cfg_fake_gem, 4>("gem") {};
 };
 
+struct cfg_mouse_gem final : public emulated_pad_config<gem_btn>
+{
+	cfg_mouse_gem(node* owner, const std::string& name) : emulated_pad_config(owner, name) {}
+
+	cfg_pad_btn<gem_btn> start{ this, "Start", gem_btn::start, pad_button::mouse_button_6 };
+	cfg_pad_btn<gem_btn> select{ this, "Select", gem_btn::select, pad_button::mouse_button_7 };
+	cfg_pad_btn<gem_btn> triangle{ this, "Triangle", gem_btn::triangle, pad_button::mouse_button_8 };
+	cfg_pad_btn<gem_btn> circle{ this, "Circle", gem_btn::circle, pad_button::mouse_button_4 };
+	cfg_pad_btn<gem_btn> cross{ this, "Cross", gem_btn::cross, pad_button::mouse_button_5 };
+	cfg_pad_btn<gem_btn> square{ this, "Square", gem_btn::square, pad_button::mouse_button_3 };
+	cfg_pad_btn<gem_btn> move{ this, "Move", gem_btn::move, pad_button::mouse_button_2 };
+	cfg_pad_btn<gem_btn> t{ this, "T", gem_btn::t, pad_button::mouse_button_1 };
+	cfg_pad_btn<gem_btn> combo{ this, "Combo", gem_btn::combo, pad_button::pad_button_max_enum };
+	cfg_pad_btn<gem_btn> combo_start{ this, "Combo Start", gem_btn::combo_start, pad_button::pad_button_max_enum };
+	cfg_pad_btn<gem_btn> combo_select{ this, "Combo Select", gem_btn::combo_select, pad_button::pad_button_max_enum };
+	cfg_pad_btn<gem_btn> combo_triangle{ this, "Combo Triangle", gem_btn::combo_triangle, pad_button::pad_button_max_enum };
+	cfg_pad_btn<gem_btn> combo_circle{ this, "Combo Circle", gem_btn::combo_circle, pad_button::pad_button_max_enum };
+	cfg_pad_btn<gem_btn> combo_cross{ this, "Combo Cross", gem_btn::combo_cross, pad_button::pad_button_max_enum };
+	cfg_pad_btn<gem_btn> combo_square{ this, "Combo Square", gem_btn::combo_square, pad_button::pad_button_max_enum };
+	cfg_pad_btn<gem_btn> combo_move{ this, "Combo Move", gem_btn::combo_move, pad_button::pad_button_max_enum };
+	cfg_pad_btn<gem_btn> combo_t{ this, "Combo T", gem_btn::combo_t, pad_button::pad_button_max_enum };
+};
+
+struct cfg_mouse_gems final : public emulated_pads_config<cfg_mouse_gem, 4>
+{
+	cfg_mouse_gems() : emulated_pads_config<cfg_mouse_gem, 4>("gem_mouse") {};
+};
+
 struct cfg_gem final : public emulated_pad_config<gem_btn>
 {
 	cfg_gem(node* owner, const std::string& name) : emulated_pad_config(owner, name) {}
@@ -62,3 +102,4 @@ struct cfg_gems final : public emulated_pads_config<cfg_gem, 4>
 
 extern cfg_gems g_cfg_gem_real;
 extern cfg_fake_gems g_cfg_gem_fake;
+extern cfg_mouse_gems g_cfg_gem_mouse;

--- a/rpcs3/Emu/Io/pad_types.cpp
+++ b/rpcs3/Emu/Io/pad_types.cpp
@@ -39,7 +39,7 @@ void fmt_class_string<pad_button>::format(std::string& out, u64 arg)
 		case pad_button::rs_right: return "Right Stick Right";
 		case pad_button::rs_x: return "Right Stick X-Axis";
 		case pad_button::rs_y: return "Right Stick Y-Axis";
-		case pad_button::pad_button_max_enum: return "MAX_ENUM";
+		case pad_button::pad_button_max_enum: return "";
 		case pad_button::mouse_button_1: return "Mouse Button 1";
 		case pad_button::mouse_button_2: return "Mouse Button 2";
 		case pad_button::mouse_button_3: return "Mouse Button 3";

--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -203,7 +203,7 @@ void usb_device_usio::translate_input_taiko()
 		if (const auto& pad = ::at32(handler->GetPads(), pad_number); (pad->m_port_status & CELL_PAD_STATUS_CONNECTED) && is_input_allowed())
 		{
 			const auto& cfg = ::at32(g_cfg_usio.players, pad_number);
-			cfg->handle_input(pad, false, [&](usio_btn btn, u16 /*value*/, bool pressed)
+			cfg->handle_input(pad, false, [&](usio_btn btn, pad_button /*pad_btn*/, u16 /*value*/, bool pressed, bool& /*abort*/)
 			{
 				switch (btn)
 				{
@@ -288,7 +288,7 @@ void usb_device_usio::translate_input_tekken()
 		if (const auto& pad = ::at32(handler->GetPads(), pad_number); (pad->m_port_status & CELL_PAD_STATUS_CONNECTED) && is_input_allowed())
 		{
 			const auto& cfg = ::at32(g_cfg_usio.players, pad_number);
-			cfg->handle_input(pad, false, [&](usio_btn btn, u16 /*value*/, bool pressed)
+			cfg->handle_input(pad, false, [&](usio_btn btn, pad_button /*pad_btn*/, u16 /*value*/, bool pressed, bool& /*abort*/)
 			{
 				switch (btn)
 				{

--- a/rpcs3/Emu/RSX/Overlays/Trophies/overlay_trophy_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/Trophies/overlay_trophy_list_dialog.cpp
@@ -265,7 +265,6 @@ namespace rsx
 			fade_animation.end = color4f(1.f);
 			fade_animation.active = true;
 
-			this->on_close = std::move(on_close);
 			visible = true;
 
 			const auto notify = std::make_shared<atomic_t<u32>>(0);

--- a/rpcs3/Input/raw_mouse_config.cpp
+++ b/rpcs3/Input/raw_mouse_config.cpp
@@ -2,6 +2,8 @@
 #include "raw_mouse_config.h"
 #include "Emu/Io/MouseHandler.h"
 
+LOG_CHANNEL(cfg_log, "CFG");
+
 std::string mouse_button_id(int code)
 {
 	switch (code)

--- a/rpcs3/Input/raw_mouse_config.h
+++ b/rpcs3/Input/raw_mouse_config.h
@@ -5,8 +5,6 @@
 
 #include <array>
 
-LOG_CHANNEL(cfg_log, "CFG");
-
 std::string mouse_button_id(int code);
 
 struct raw_mouse_config : cfg::node

--- a/rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp
@@ -92,6 +92,10 @@ emulated_pad_settings_dialog::emulated_pad_settings_dialog(pad_type type, QWidge
 		setWindowTitle(tr("Configure Emulated PS Move (Fake)"));
 		add_tabs<gem_btn>(tabs);
 		break;
+	case emulated_pad_settings_dialog::pad_type::mousegem:
+		setWindowTitle(tr("Configure Emulated PS Move (Mouse)"));
+		add_tabs<gem_btn>(tabs);
+		break;
 	case emulated_pad_settings_dialog::pad_type::guncon3:
 		setWindowTitle(tr("Configure Emulated GunCon 3"));
 		add_tabs<guncon3_btn>(tabs);
@@ -116,8 +120,12 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 {
 	ensure(!!tabs);
 
-	constexpr u32 max_items_per_column = 6;
-	int count = static_cast<int>(T::count);
+	std::set<int> ignored_values;
+
+	const auto remove_value = [&ignored_values](int value)
+	{
+		ignored_values.insert(static_cast<int>(value));
+	};
 
 	usz players = 0;
 	switch (m_type)
@@ -137,13 +145,29 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 	case pad_type::gem:
 		players = g_cfg_gem_real.players.size();
 
-		// Ignore x and y axis
-		static_assert(static_cast<int>(gem_btn::y_axis) == static_cast<int>(gem_btn::count) - 1);
-		static_assert(static_cast<int>(gem_btn::x_axis) == static_cast<int>(gem_btn::count) - 2);
-		count -= 2;
+		// Ignore combo, x and y axis
+		remove_value(static_cast<int>(gem_btn::x_axis));
+		remove_value(static_cast<int>(gem_btn::y_axis));
+		for (int i = static_cast<int>(gem_btn::combo_begin); i <= static_cast<int>(gem_btn::combo_end); i++)
+		{
+			remove_value(i);
+		}
 		break;
 	case pad_type::ds3gem:
 		players = g_cfg_gem_fake.players.size();
+
+		// Ignore combo
+		for (int i = static_cast<int>(gem_btn::combo_begin); i <= static_cast<int>(gem_btn::combo_end); i++)
+		{
+			remove_value(i);
+		}
+		break;
+	case pad_type::mousegem:
+		players = g_cfg_gem_mouse.players.size();
+
+		// Ignore x and y axis
+		remove_value(static_cast<int>(gem_btn::x_axis));
+		remove_value(static_cast<int>(gem_btn::y_axis));
 		break;
 	case pad_type::guncon3:
 		players = g_cfg_guncon3.players.size();
@@ -156,6 +180,8 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 		break;
 	}
 
+	constexpr u32 max_items_per_column = 6;
+	const int count = static_cast<int>(T::count) - static_cast<int>(ignored_values.size());
 	int rows = count;
 
 	for (u32 cols = 1; utils::aligned_div(static_cast<u32>(count), cols) > max_items_per_column;)
@@ -170,8 +196,10 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 		QWidget* widget = new QWidget(this);
 		QGridLayout* grid_layout = new QGridLayout(this);
 
-		for (int i = 0, row = 0, col = 0; i < count; i++, row++)
+		for (int i = 0, row = 0, col = 0; i < static_cast<int>(T::count); i++)
 		{
+			if (ignored_values.contains(i)) continue;
+
 			const T id = static_cast<T>(i);
 			const QString name = QString::fromStdString(fmt::format("%s", id));
 
@@ -179,16 +207,35 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 			QGroupBox* gb = new QGroupBox(name, this);
 			QComboBox* combo = new QComboBox;
 
-			for (int p = 0; p < static_cast<int>(pad_button::pad_button_max_enum); p++)
+			if constexpr (std::is_same_v<T, gem_btn>)
 			{
-				const QString translated = localized_emu::translated_pad_button(static_cast<pad_button>(p));
-				combo->addItem(translated);
-				const int index = combo->findText(translated);
-				combo->setItemData(index, p, button_role::button);
-				combo->setItemData(index, i, button_role::emulated_button);
+				const gem_btn btn = static_cast<gem_btn>(i);
+				if (btn >= gem_btn::combo_begin && btn <= gem_btn::combo_end)
+				{
+					gb->setToolTip(tr("Press the \"Combo\" button in combination with any of the other combo buttons to trigger their related PS Move button.\n"
+					                  "This can be useful if your device does not have enough regular buttons."));
+				}
 			}
 
-			if constexpr (std::is_same_v<T, guncon3_btn> || std::is_same_v<T, topshotelite_btn> || std::is_same_v<T, topshotfearmaster_btn>)
+			// Add empty value
+			combo->addItem("");
+			const int index = combo->findText("");
+			combo->setItemData(index, static_cast<int>(pad_button::pad_button_max_enum), button_role::button);
+			combo->setItemData(index, i, button_role::emulated_button);
+
+			if (m_type != pad_type::mousegem)
+			{
+				for (int p = 0; p < static_cast<int>(pad_button::pad_button_max_enum); p++)
+				{
+					const QString translated = localized_emu::translated_pad_button(static_cast<pad_button>(p));
+					combo->addItem(translated);
+					const int index = combo->findText(translated);
+					combo->setItemData(index, p, button_role::button);
+					combo->setItemData(index, i, button_role::emulated_button);
+				}
+			}
+
+			if (std::is_same_v<T, guncon3_btn> || std::is_same_v<T, topshotelite_btn> || std::is_same_v<T, topshotfearmaster_btn> || m_type == pad_type::mousegem)
 			{
 				for (int p = static_cast<int>(pad_button::mouse_button_1); p <= static_cast<int>(pad_button::mouse_button_8); p++)
 				{
@@ -220,6 +267,9 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 				break;
 			case pad_type::ds3gem:
 				saved_btn_id = ::at32(g_cfg_gem_fake.players, player)->get_pad_button(static_cast<gem_btn>(id));
+				break;
+			case pad_type::mousegem:
+				saved_btn_id = ::at32(g_cfg_gem_mouse.players, player)->get_pad_button(static_cast<gem_btn>(id));
 				break;
 			case pad_type::guncon3:
 				saved_btn_id = ::at32(g_cfg_guncon3.players, player)->get_pad_button(static_cast<guncon3_btn>(id));
@@ -265,6 +315,9 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 				case pad_type::ds3gem:
 					::at32(g_cfg_gem_fake.players, player)->set_button(static_cast<gem_btn>(id), btn_id);
 					break;
+				case pad_type::mousegem:
+					::at32(g_cfg_gem_mouse.players, player)->set_button(static_cast<gem_btn>(id), btn_id);
+					break;
 				case pad_type::guncon3:
 					::at32(g_cfg_guncon3.players, player)->set_button(static_cast<guncon3_btn>(id), btn_id);
 					break;
@@ -287,6 +340,8 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 			h_layout->addWidget(combo);
 			gb->setLayout(h_layout);
 			grid_layout->addWidget(gb, row, col);
+
+			row++;
 		}
 
 		widget->setLayout(grid_layout);
@@ -334,6 +389,12 @@ void emulated_pad_settings_dialog::load_config()
 			cfg_log.notice("Could not load fake gem config. Using defaults.");
 		}
 		break;
+	case emulated_pad_settings_dialog::pad_type::mousegem:
+		if (!g_cfg_gem_mouse.load())
+		{
+			cfg_log.notice("Could not load mouse gem config. Using defaults.");
+		}
+		break;
 	case emulated_pad_settings_dialog::pad_type::guncon3:
 		if (!g_cfg_guncon3.load())
 		{
@@ -377,6 +438,9 @@ void emulated_pad_settings_dialog::save_config()
 	case emulated_pad_settings_dialog::pad_type::ds3gem:
 		g_cfg_gem_fake.save();
 		break;
+	case emulated_pad_settings_dialog::pad_type::mousegem:
+		g_cfg_gem_mouse.save();
+		break;
 	case emulated_pad_settings_dialog::pad_type::guncon3:
 		g_cfg_guncon3.save();
 		break;
@@ -410,6 +474,9 @@ void emulated_pad_settings_dialog::reset_config()
 		break;
 	case emulated_pad_settings_dialog::pad_type::ds3gem:
 		g_cfg_gem_fake.from_default();
+		break;
+	case emulated_pad_settings_dialog::pad_type::mousegem:
+		g_cfg_gem_mouse.from_default();
 		break;
 	case emulated_pad_settings_dialog::pad_type::guncon3:
 		g_cfg_guncon3.from_default();
@@ -453,6 +520,9 @@ void emulated_pad_settings_dialog::reset_config()
 				break;
 			case pad_type::ds3gem:
 				def_btn_id = ::at32(g_cfg_gem_fake.players, player)->default_pad_button(static_cast<gem_btn>(data.toInt()));
+				break;
+			case pad_type::mousegem:
+				def_btn_id = ::at32(g_cfg_gem_mouse.players, player)->default_pad_button(static_cast<gem_btn>(data.toInt()));
 				break;
 			case pad_type::guncon3:
 				def_btn_id = ::at32(g_cfg_guncon3.players, player)->default_pad_button(static_cast<guncon3_btn>(data.toInt()));

--- a/rpcs3/rpcs3qt/emulated_pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/emulated_pad_settings_dialog.h
@@ -21,6 +21,7 @@ public:
 		usio,
 		gem,
 		ds3gem,
+		mousegem,
 		guncon3,
 		topshotelite,
 		topshotfearmaster,

--- a/rpcs3/rpcs3qt/localized_emu.cpp
+++ b/rpcs3/rpcs3qt/localized_emu.cpp
@@ -36,14 +36,14 @@ QString localized_emu::translated_pad_button(pad_button btn)
 	case pad_button::rs_x: return tr("Right Stick X-Axis");
 	case pad_button::rs_y: return tr("Right Stick Y-Axis");
 	case pad_button::pad_button_max_enum: return "";
-	case pad_button::mouse_button_1: return tr("Mouse Button 1");
-	case pad_button::mouse_button_2: return tr("Mouse Button 2");
-	case pad_button::mouse_button_3: return tr("Mouse Button 3");
-	case pad_button::mouse_button_4: return tr("Mouse Button 4");
-	case pad_button::mouse_button_5: return tr("Mouse Button 5");
-	case pad_button::mouse_button_6: return tr("Mouse Button 6");
-	case pad_button::mouse_button_7: return tr("Mouse Button 7");
-	case pad_button::mouse_button_8: return tr("Mouse Button 8");
+	case pad_button::mouse_button_1: return tr("Mouse 1");
+	case pad_button::mouse_button_2: return tr("Mouse 2");
+	case pad_button::mouse_button_3: return tr("Mouse 3");
+	case pad_button::mouse_button_4: return tr("Mouse 4");
+	case pad_button::mouse_button_5: return tr("Mouse 5");
+	case pad_button::mouse_button_6: return tr("Mouse 6");
+	case pad_button::mouse_button_7: return tr("Mouse 7");
+	case pad_button::mouse_button_8: return tr("Mouse 8");
 	}
 	return "";
 }

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2911,6 +2911,12 @@ void main_window::CreateConnects()
 		dlg->show();
 	});
 
+	connect(ui->confPSMoveMouseAct, &QAction::triggered, this, [this]
+	{
+		emulated_pad_settings_dialog* dlg = new emulated_pad_settings_dialog(emulated_pad_settings_dialog::pad_type::mousegem, this);
+		dlg->show();
+	});
+
 	connect(ui->confPSMoveDS3Act, &QAction::triggered, this, [this]
 	{
 		emulated_pad_settings_dialog* dlg = new emulated_pad_settings_dialog(emulated_pad_settings_dialog::pad_type::ds3gem, this);

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -244,6 +244,7 @@
      <addaction name="confUSIOAct"/>
      <addaction name="confPSMoveAct"/>
      <addaction name="confPSMoveDS3Act"/>
+     <addaction name="confPSMoveMouseAct"/>
      <addaction name="confGunCon3Act"/>
      <addaction name="confTopShotEliteAct"/>
      <addaction name="confTopShotFearmasterAct"/>
@@ -1331,6 +1332,11 @@
   <action name="confPSMoveDS3Act">
    <property name="text">
     <string>PS Move (Fake)</string>
+   </property>
+  </action>
+  <action name="confPSMoveMouseAct">
+   <property name="text">
+    <string>PS Move (Mouse)</string>
    </property>
   </action>
   <action name="confGunCon3Act">

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
@@ -11,6 +11,8 @@
 #include <QMessageBox>
 #include <QVBoxLayout>
 
+LOG_CHANNEL(cfg_log, "CFG");
+
 constexpr u32 button_count = 8;
 
 raw_mouse_settings_dialog::raw_mouse_settings_dialog(QWidget* parent)


### PR DESCRIPTION
- Adds a new configuration dialog for "PS Move (mouse)" to the usb device settings
- You can use this to configure the previously hardcoded mouse buttons
- Combos are still possible with the extra button configuration
- Add empty dropdown item to usb device settings. This can be used to clear the button.

![image](https://github.com/user-attachments/assets/53b12013-236b-4d40-b6ba-b7dc8d504b7d)
