### PR TITLE
PPU LLVM: Memory Consumption Enhancements

### DIFF
--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -514,8 +514,8 @@ class jit_compiler final
 	atomic_t<usz> m_disk_space = umax;
 
 public:
-	jit_compiler(const std::unordered_map<std::string, u64>& _link, const std::string& _cpu, u32 flags = 0);
-	~jit_compiler();
+	jit_compiler(const std::unordered_map<std::string, u64>& _link, const std::string& _cpu, u32 flags = 0, std::function<u64(const std::string&)> symbols_cement = {}) noexcept;
+	~jit_compiler() noexcept;
 
 	// Get LLVM context
 	auto& get_context()

--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -93,6 +93,10 @@ struct jit_runtime final : jit_runtime_base
 	// Allocate memory
 	static u8* alloc(usz size, usz align, bool exec = true) noexcept;
 
+	// Allocate 0 bytes, observe memory location
+	// Same as alloc(0, 1, exec)
+	static u8* peek(bool exec = true) noexcept;
+
 	// Should be called at least once after global initialization
 	static void initialize();
 

--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -77,7 +77,7 @@ struct jit_runtime_base
 	jit_runtime_base& operator=(const jit_runtime_base&) = delete;
 
 	const asmjit::Environment& environment() const noexcept;
-	void* _add(asmjit::CodeHolder* code) noexcept;
+	void* _add(asmjit::CodeHolder* code, usz align = 64) noexcept;
 	virtual uchar* _alloc(usz size, usz align) noexcept = 0;
 };
 
@@ -432,7 +432,7 @@ namespace asmjit
 
 // Build runtime function with asmjit::X86Assembler
 template <typename FT, typename Asm = native_asm, typename F>
-inline FT build_function_asm(std::string_view name, F&& builder, ::jit_runtime* custom_runtime = nullptr)
+inline FT build_function_asm(std::string_view name, F&& builder, ::jit_runtime* custom_runtime = nullptr, bool reduced_size = false)
 {
 #ifdef __APPLE__
 	pthread_jit_write_protect_np(false);
@@ -484,7 +484,7 @@ inline FT build_function_asm(std::string_view name, F&& builder, ::jit_runtime* 
 		compiler();
 	}
 
-	const auto result = rt._add(&code);
+	const auto result = rt._add(&code, reduced_size ? 16 : 64);
 	jit_announce(result, code.codeSize(), name);
 	return reinterpret_cast<FT>(uptr(result));
 }

--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -467,6 +467,7 @@ inline FT build_function_asm(std::string_view name, F&& builder, ::jit_runtime* 
 
 	Asm compiler(&code);
 	compiler.addEncodingOptions(EncodingOptions::kOptimizedAlign);
+	compiler.addEncodingOptions(EncodingOptions::kOptimizeForSize);
 	if constexpr (std::is_invocable_r_v<bool, F, Asm&, native_args&>)
 	{
 		if (!builder(compiler, args))

--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -498,6 +498,8 @@ namespace llvm
 	class StringRef;
 }
 
+enum class thread_state : u32;
+
 // Temporary compiler interface
 class jit_compiler final
 {
@@ -515,6 +517,7 @@ class jit_compiler final
 
 public:
 	jit_compiler(const std::unordered_map<std::string, u64>& _link, const std::string& _cpu, u32 flags = 0, std::function<u64(const std::string&)> symbols_cement = {}) noexcept;
+	jit_compiler& operator=(thread_state) noexcept;
 	~jit_compiler() noexcept;
 
 	// Get LLVM context

--- a/Utilities/JITASM.cpp
+++ b/Utilities/JITASM.cpp
@@ -231,6 +231,11 @@ void* jit_runtime_base::_add(asmjit::CodeHolder* code, usz align) noexcept
 
 		for (asmjit::Section* section : code->_sections)
 		{
+			if (section->offset() + section->bufferSize() > utils::align<usz>(codeSize, align))
+			{
+				fmt::throw_exception("CodeHolder section exceeds range: Section->offset: 0x%x, Section->bufferSize: 0x%x, alloted-memory=0x%x", section->offset(), section->bufferSize(), utils::align<usz>(codeSize, align));
+			}
+
 			std::memcpy(p + section->offset(), section->data(), section->bufferSize());
 		}
 	}

--- a/Utilities/JITASM.cpp
+++ b/Utilities/JITASM.cpp
@@ -211,7 +211,7 @@ const asmjit::Environment& jit_runtime_base::environment() const noexcept
 	return g_env;
 }
 
-void* jit_runtime_base::_add(asmjit::CodeHolder* code) noexcept
+void* jit_runtime_base::_add(asmjit::CodeHolder* code, usz align) noexcept
 {
 	ensure(!code->flatten());
 	ensure(!code->resolveUnresolvedLinks());
@@ -219,7 +219,7 @@ void* jit_runtime_base::_add(asmjit::CodeHolder* code) noexcept
 	if (!codeSize)
 		return nullptr;
 
-	auto p = ensure(this->_alloc(codeSize, 64));
+	auto p = ensure(this->_alloc(codeSize, align));
 	ensure(!code->relocateToBase(uptr(p)));
 
 	{

--- a/Utilities/JITASM.cpp
+++ b/Utilities/JITASM.cpp
@@ -147,6 +147,12 @@ static u8* add_jit_memory(usz size, usz align)
 		return pointer;
 	}
 
+	if (!size && align == 1)
+	{
+		// Return memory top address
+		return pointer + (Ctr.load() & 0xffff'ffff);
+	}
+
 	u64 olda, newa;
 
 	// Simple allocation by incrementing pointer to the next free data
@@ -270,6 +276,18 @@ u8* jit_runtime::alloc(usz size, usz align, bool exec) noexcept
 	else
 	{
 		return add_jit_memory<s_data_pos, 0x40000000, utils::protection::rw>(size, align);
+	}
+}
+
+u8* jit_runtime::peek(bool exec) noexcept
+{
+	if (exec)
+	{
+		return add_jit_memory<s_code_pos, 0x0, utils::protection::wx>(0, 1);
+	}
+	else
+	{
+		return add_jit_memory<s_data_pos, 0x40000000, utils::protection::rw>(0, 1);
 	}
 }
 

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -565,6 +565,18 @@ jit_compiler::jit_compiler(const std::unordered_map<std::string, u64>& _link, co
 	: m_context(new llvm::LLVMContext)
 	, m_cpu(cpu(_cpu))
 {
+	static const bool s_install_llvm_error_handler = []()
+	{
+		llvm::remove_fatal_error_handler();
+		llvm::install_fatal_error_handler([](void*, const char* msg, bool)
+		{
+			const std::string_view out = msg ? msg : "";
+			fmt::throw_exception("LLVM Emergency Exit Invoked: '%s'", out);
+		}, nullptr);
+
+		return true;
+	}();
+
 	std::string result;
 
 	auto null_mod = std::make_unique<llvm::Module> ("null_", *m_context);

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -1,5 +1,6 @@
 #include "util/types.hpp"
 #include "util/sysinfo.hpp"
+#include "Utilities/Thread.h"
 #include "JIT.h"
 #include "StrFmt.h"
 #include "File.h"
@@ -716,6 +717,18 @@ jit_compiler::jit_compiler(const std::unordered_map<std::string, u64>& _link, co
 	{
 		m_disk_space = stats.avail_free / 4;
 	}
+}
+
+jit_compiler& jit_compiler::operator=(thread_state s) noexcept
+{
+	if (s == thread_state::destroying_context)
+	{
+		// Release resources explicitly
+		m_engine.reset();
+		m_context.reset();
+	}
+
+	return *this;
 }
 
 jit_compiler::~jit_compiler() noexcept

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1818,6 +1818,11 @@ static LONG exception_filter(PEXCEPTION_POINTERS pExp) noexcept
 			pExp->ExceptionRecord->ExceptionInformation[0] == 1 ? "writing" : "reading";
 
 		fmt::append(msg, "Segfault %s location %p at %p.\n", cause, pExp->ExceptionRecord->ExceptionInformation[1], pExp->ExceptionRecord->ExceptionAddress);
+
+		if (vm::try_get_addr(reinterpret_cast<u8*>(pExp->ExceptionRecord->ExceptionInformation[1])).second)
+		{
+			fmt::append(msg, "Sudo Addr: %p, VM Addr: %p\n", vm::g_sudo_addr, vm::g_base_addr);
+		}
 	}
 	else
 	{
@@ -1998,6 +2003,11 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 	}
 
 	std::string msg = fmt::format("Segfault %s location %p at %p.\n", cause, info->si_addr, RIP(context));
+
+	if (vm::try_get_addr(info->si_addr).second)
+	{
+		fmt::append(msg, "Sudo Addr: %p, VM Addr: %p\n", vm::g_sudo_addr, vm::g_base_addr);
+	}
 
 	append_thread_name(msg);
 

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1703,23 +1703,58 @@ bool handle_access_violation(u32 addr, bool is_writing, ucontext_t* context) noe
 		cpu->state += cpu_flag::wait;
 	}
 
-	Emu.Pause(true);
-
-	if (!g_tls_access_violation_recovered)
-	{
-		vm_log.notice("\n%s", dump_useful_thread_info());
-	}
-
 	// Note: a thread may access violate more than once after hack_alloc recovery
 	// Do not log any further access violations in this case.
 	if (!g_tls_access_violation_recovered)
 	{
+		vm_log.notice("\n%s", dump_useful_thread_info());
 		vm_log.fatal("Access violation %s location 0x%x (%s)", is_writing ? "writing" : (cpu && cpu->get_class() == thread_class::ppu && cpu->get_pc() == addr ? "executing" : "reading"), addr, (is_writing && vm::check_addr(addr)) ? "read-only memory" : "unmapped memory");
 	}
 
+	while (Emu.IsPausedOrReady())
+	{
+		if (cpu)
+		{
+			auto state = +cpu->state;
+
+			if (::is_paused(state) && !::is_stopped(state))
+			{
+				thread_ctrl::wait_on(cpu->state, state);
+			}
+			else
+			{
+				// Temporary until Emulator updates state
+				std::this_thread::yield();
+			}
+		}
+		else
+		{
+			thread_ctrl::wait_for(1000);
+		}
+	}
+
+	Emu.Pause(true);
+
 	while (Emu.IsPaused())
 	{
-		thread_ctrl::wait();
+		if (cpu)
+		{
+			auto state = +cpu->state;
+
+			if (::is_paused(state) && !::is_stopped(state))
+			{
+				thread_ctrl::wait_on(cpu->state, state);
+			}
+			else
+			{
+				// Temporary until Emulator updates state
+				std::this_thread::yield();
+			}
+		}
+		else
+		{
+			thread_ctrl::wait_for(1000);
+		}
 	}
 
 	if (Emu.IsStopped() && !hack_alloc())

--- a/Utilities/Thread.h
+++ b/Utilities/Thread.h
@@ -769,7 +769,7 @@ public:
 		}
 
 		// Move the context (if movable)
-		new (static_cast<void*>(m_threads + m_count - 1)) Thread(std::string(name) + std::to_string(m_count - 1), std::forward<Context>(f));
+		new (static_cast<void*>(m_threads + m_count - 1)) Thread(std::string(name) + std::to_string(m_count), std::forward<Context>(f));
 	}
 
 	// Constructor with a function performed before adding more threads

--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -704,7 +704,7 @@ void cell_audio_thread::operator()()
 
 	thread_ctrl::scoped_priority high_prio(+1);
 
-	while (Emu.IsPaused())
+	while (Emu.IsPausedOrReady())
 	{
 		thread_ctrl::wait_for(5000);
 	}

--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -1640,14 +1640,14 @@ void camera_context::operator()()
 	while (thread_ctrl::state() != thread_state::aborting && !Emu.IsStopped())
 	{
 		// send ATTACH event
-		if (init && is_attached_dirty && !Emu.IsPaused())
+		if (init && is_attached_dirty && !Emu.IsPausedOrReady())
 		{
 			send_attach_state(is_attached);
 		}
 
 		const s32 fps = info.framerate;
 
-		if (!init || !fps || Emu.IsPaused() || g_cfg.io.camera == camera_handler::null)
+		if (!init || !fps || Emu.IsPausedOrReady() || g_cfg.io.camera == camera_handler::null)
 		{
 			thread_ctrl::wait_for(1000); // hack
 			continue;

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -1705,7 +1705,7 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 
 	u32 per_instruction_bytes = 0;
 
-	for (auto&& [_, func] : as_rvalue(fmap))
+	for (auto&& [_, func] : fmap)
 	{
 		if (func.attr & ppu_attr::no_size && entry)
 		{
@@ -2080,8 +2080,10 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 	}
 
 	// Convert map to vector (destructive)
-	for (auto&& [_, block] : as_rvalue(std::move(fmap)))
+	for (auto it = fmap.begin(); it != fmap.end(); it = fmap.begin())
 	{
+		ppu_function block = std::move(fmap.extract(it).mapped());
+
 		if (block.attr & ppu_attr::no_size && block.size > 4 && !used_fallback)
 		{
 			ppu_log.warning("Block 0x%x will be compiled on per-instruction basis (size=0x%x)", block.addr, block.size);

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -21,7 +21,6 @@ void fmt_class_string<ppu_attr>::format(std::string& out, u64 arg)
 	{
 		switch (value)
 		{
-		case ppu_attr::known_addr: return "known_addr";
 		case ppu_attr::known_size: return "known_size";
 		case ppu_attr::no_return: return "no_return";
 		case ppu_attr::no_size: return "no_size";
@@ -786,7 +785,6 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 
 			TOCs.emplace(toc);
 			auto& func = add_func(addr, addr_heap.count(_ptr.addr()) ? toc : 0, 0);
-			func.attr += ppu_attr::known_addr;
 			known_functions.emplace(addr);
 		}
 	}
@@ -924,7 +922,6 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 				}
 
 				//auto& func = add_func(addr, 0, 0);
-				//func.attr += ppu_attr::known_addr;
 				//func.attr += ppu_attr::known_size;
 				//func.size = size;
 				//known_functions.emplace(func);
@@ -1109,7 +1106,6 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 				func.toc = -1;
 				func.size = 0x1C;
 				func.blocks.emplace(func.addr, func.size);
-				func.attr += ppu_attr::known_addr;
 				func.attr += ppu_attr::known_size;
 
 				// Look for another imports to fill gaps (hack)
@@ -1128,7 +1124,6 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 					auto& next = add_func(_p2.addr(), -1, func.addr);
 					next.size = 0x1C;
 					next.blocks.emplace(next.addr, next.size);
-					next.attr += ppu_attr::known_addr;
 					next.attr += ppu_attr::known_size;
 					advance(_p2, p2, 7);
 				}
@@ -1148,8 +1143,9 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 				// Trampoline with TOC
 				const u32 target = (ptr[3] << 16) + s16(ptr[4]);
 				const u32 toc_add = (ptr[1] << 16) + s16(ptr[2]);
+				constexpr u32 func_size = 0x1C;
 
-				if (target >= start && target < end && verify_func((_ptr + 3).addr()))
+				if (target >= start && target < end && verify_func((_ptr + 3).addr()) && target - func.addr >= func_size)
 				{
 					auto& new_func = add_func(target, 0, func.addr);
 
@@ -1247,7 +1243,6 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 				func.toc = -1;
 				func.size = 0x20;
 				func.blocks.emplace(func.addr, func.size);
-				func.attr += ppu_attr::known_addr;
 				known_functions.emplace(func.addr);
 				func.attr += ppu_attr::known_size;
 
@@ -1268,7 +1263,6 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 					auto& next = add_func(_p2.addr(), -1, func.addr);
 					next.size = 0x20;
 					next.blocks.emplace(next.addr, next.size);
-					next.attr += ppu_attr::known_addr;
 					next.attr += ppu_attr::known_size;
 					advance(_p2, p2, 8);
 					known_functions.emplace(next.addr);

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -624,6 +624,14 @@ bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, con
 	// Register new function
 	auto add_func = [&](u32 addr, u32 toc, u32 caller) -> ppu_function_ext&
 	{
+		if (addr < start || addr >= end || s_ppu_itype.decode(*get_ptr<u32>(addr)) == ppu_itype::UNK)
+		{
+			if (!fmap.contains(addr))
+			{
+				ppu_log.error("Potentially invalid function has been added: 0x%x", addr);
+			}
+		}
+
 		ppu_function_ext& func = fmap[addr];
 
 		if (caller)

--- a/rpcs3/Emu/Cell/PPUAnalyser.cpp
+++ b/rpcs3/Emu/Cell/PPUAnalyser.cpp
@@ -534,7 +534,7 @@ namespace ppu_patterns
 template <>
 bool ppu_module<lv2_obj>::analyse(u32 lib_toc, u32 entry, const u32 sec_end, const std::vector<u32>& applied, const std::vector<u32>& exported_funcs, std::function<bool()> check_aborted)
 {
-	if (segs.empty())
+	if (segs.empty() || !segs[0].addr)
 	{
 		return false;
 	}

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -16,7 +16,6 @@
 // PPU Function Attributes
 enum class ppu_attr : u32
 {
-	known_addr,
 	known_size,
 	no_return,
 	no_size,

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -14,7 +14,7 @@
 #include "PPUOpcodes.h"
 
 // PPU Function Attributes
-enum class ppu_attr : u32
+enum class ppu_attr : u8
 {
 	known_size,
 	no_return,
@@ -38,7 +38,6 @@ struct ppu_function
 	std::map<u32, u32> blocks{}; // Basic blocks: addr -> size
 	std::set<u32> calls{}; // Set of called functions
 	std::set<u32> callers{};
-	mutable std::string name{}; // Function name
 
 	struct iterator
 	{

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -30,14 +30,8 @@ struct ppu_function
 	u32 addr = 0;
 	u32 toc = 0;
 	u32 size = 0;
-	bs_t<ppu_attr> attr{};
-
-	//u32 stack_frame = 0;
-	u32 single_target = 0;
-	u32 trampoline = 0;
 
 	std::map<u32, u32> blocks{}; // Basic blocks: addr -> size
-	std::set<u32> callers{};
 
 	struct iterator
 	{

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -32,11 +32,11 @@ struct ppu_function
 	u32 size = 0;
 	bs_t<ppu_attr> attr{};
 
-	u32 stack_frame = 0;
+	//u32 stack_frame = 0;
+	u32 single_target = 0;
 	u32 trampoline = 0;
 
 	std::map<u32, u32> blocks{}; // Basic blocks: addr -> size
-	std::set<u32> calls{}; // Set of called functions
 	std::set<u32> callers{};
 
 	struct iterator

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4908,9 +4908,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 			part.local_bounds.first = std::min<u32>(part.local_bounds.first, func.addr);
 			part.local_bounds.second = std::max<u32>(part.local_bounds.second, func.addr + func.size);
 
-			// Fixup some information
-			func.name = fmt::format("__0x%x", func.addr - reloc);
-
 			bsize += func.size;
 
 			fpos++;
@@ -5473,7 +5470,7 @@ static void ppu_initialize2(jit_compiler& jit, const ppu_module<lv2_obj>& module
 	{
 		if (func.size)
 		{
-			const auto f = cast<Function>(_module->getOrInsertFunction(func.name, _func).getCallee());
+			const auto f = cast<Function>(_module->getOrInsertFunction(fmt::format("__0x%x", func.addr - reloc), _func).getCallee());
 			f->setCallingConv(CallingConv::GHC);
 			f->addParamAttr(1, llvm::Attribute::NoAlias);
 			f->addFnAttr(Attribute::NoUnwind);

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4856,7 +4856,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 			// Execute LLE call
 			c.br(call_target);
 #endif
-		}, runtime.get());
+		}, runtime.get(), true);
 
 		code_ptr = reinterpret_cast<u64>(func);
 		return code_ptr;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5228,7 +5228,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 					std::shared_lock rlock(g_fxo->get<jit_core_allocator>().shared_mtx, std::defer_lock);
 					std::unique_lock lock(g_fxo->get<jit_core_allocator>().shared_mtx, std::defer_lock);
 
-					if (part.jit_bounds && part.parent->funcs.size() >= 0x8000)
+					if (false && part.jit_bounds && part.parent->funcs.size() >= 0x8000)
 					{
 						// Make a large symbol-resolving function compile alone because it has massive memory requirements
 						lock.lock();

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4857,7 +4857,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				ppu_log.error("JIT symbol trampoline failed.");
 			}
 		}
-#else
+#elif 0
 		// Try to make the code fit in 16 bytes, may fail and fallback
 		if (*full_sample && abs_diff(*full_sample, reinterpret_cast<u64>(jit_runtime::peek(true) + 3 * 4)) < (128u << 20))
 		{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3736,6 +3736,25 @@ namespace
 
 			bucket.map.erase(found);
 		}
+
+		jit_module_manager& operator=(thread_state s) noexcept
+		{
+			if (s == thread_state::destroying_context)
+			{
+				for (auto& buck : buckets)
+				{
+					for (auto& mod : buck.map)
+					{
+						for (auto& jit : mod.second.pjit)
+						{
+							*jit = s;
+						}
+					}
+				}
+			}
+
+			return *this;
+		}
 	};
 }
 #endif

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -188,7 +188,7 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 	// Instruction address is (m_addr + base)
 	const u64 base = m_reloc ? m_reloc->addr : 0;
 	m_addr = info.addr - base;
-	m_attr = m_info.attr + info.attr;
+	m_attr = m_info.attr;
 
 	m_function = m_module->getFunction(fmt::format("__0x%x", m_addr));
 

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -114,7 +114,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_mo
 	const auto caddr = m_info.segs[0].addr;
 	const auto cend = caddr + m_info.segs[0].size;
 
-	for (const auto& rel : m_info.relocs)
+	for (const auto& rel : m_info.get_relocs())
 	{
 		if (rel.addr >= caddr && rel.addr < cend)
 		{
@@ -162,7 +162,7 @@ PPUTranslator::PPUTranslator(LLVMContext& context, Module* _module, const ppu_mo
 		}
 	}
 
-	if (!m_info.relocs.empty())
+	if (!m_info.get_relocs().empty())
 	{
 		m_reloc = &m_info.segs[0];
 	}
@@ -196,7 +196,7 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 	// Instruction address is (m_addr + base)
 	const u64 base = m_reloc ? m_reloc->addr : 0;
 	m_addr = info.addr - base;
-	m_attr = info.attr;
+	m_attr = m_info.attr + info.attr;
 
 	// Don't emit check in small blocks without terminator
 	bool need_check = info.size >= 16;
@@ -325,6 +325,9 @@ Function* PPUTranslator::Translate(const ppu_function& info)
 
 Function* PPUTranslator::GetSymbolResolver(const ppu_module<lv2_obj>& info)
 {
+	ensure(m_module->getFunction("__resolve_symbols") == nullptr);
+	ensure(info.jit_bounds);
+
 	m_function = cast<Function>(m_module->getOrInsertFunction("__resolve_symbols", FunctionType::get(get_type<void>(), { get_type<u8*>(), get_type<u64>() }, false)).getCallee());
 
 	IRBuilder<> irb(BasicBlock::Create(m_context, "__entry", m_function));
@@ -351,12 +354,13 @@ Function* PPUTranslator::GetSymbolResolver(const ppu_module<lv2_obj>& info)
 	// This is made in loop instead of inlined because it took tremendous amount of time to compile.
 
 	std::vector<u32> vec_addrs;
-	vec_addrs.reserve(info.funcs.size());
 
 	// Create an array of function pointers
 	std::vector<llvm::Constant*> functions;
 
-	for (const auto& f : info.funcs)
+	const auto [min_addr, max_addr] = *ensure(info.jit_bounds);
+
+	for (const auto& f : info.get_funcs(false, true))
 	{
 		if (!f.size)
 		{
@@ -379,7 +383,7 @@ Function* PPUTranslator::GetSymbolResolver(const ppu_module<lv2_obj>& info)
 	const auto addr_array = new GlobalVariable(*m_module, addr_array_type, false, GlobalValue::PrivateLinkage, ConstantDataArray::get(m_context, vec_addrs));
 
 	// Create an array of function pointers
-	const auto func_table_type = ArrayType::get(ftype->getPointerTo(), info.funcs.size());
+	const auto func_table_type = ArrayType::get(ftype->getPointerTo(), functions.size());
 	const auto init_func_table = ConstantArray::get(func_table_type, functions);
 	const auto func_table = new GlobalVariable(*m_module, func_table_type, false, GlobalVariable::PrivateLinkage, init_func_table);
 

--- a/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rsxaudio.cpp
@@ -825,7 +825,7 @@ void rsxaudio_data_thread::extract_audio_data()
 		return rsxaudio_obj_ptr;
 	}();
 
-	if (Emu.IsPaused() || !rsxaudio_obj)
+	if (Emu.IsPausedOrReady() || !rsxaudio_obj)
 	{
 		advance_all_timers();
 		return;
@@ -1533,7 +1533,7 @@ void rsxaudio_backend_thread::operator()()
 			backend_failed = false;
 		}
 
-		if (!Emu.IsPaused() || !use_aux_ringbuf) // Don't pause if thread is in direct mode
+		if (!Emu.IsPausedOrReady() || !use_aux_ringbuf) // Don't pause if thread is in direct mode
 		{
 			if (!backend_playing())
 			{

--- a/rpcs3/Emu/Cell/lv2/sys_timer.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_timer.cpp
@@ -135,7 +135,7 @@ void lv2_timer_thread::operator()()
 
 		sleep_time = umax;
 
-		if (Emu.IsPaused())
+		if (Emu.IsPausedOrReady())
 		{
 			sleep_time = 10000;
 			continue;

--- a/rpcs3/Emu/Cell/lv2/sys_uart.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_uart.cpp
@@ -1968,7 +1968,7 @@ void vuart_av_thread::operator()()
 {
 	while (thread_ctrl::state() != thread_state::aborting)
 	{
-		if (Emu.IsPaused())
+		if (Emu.IsPausedOrReady())
 		{
 			thread_ctrl::wait_for(5000);
 			continue;

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -830,7 +830,7 @@ bool gdb_thread::cmd_vcont(gdb_cmd& cmd)
 		{
 			Emu.Run(true);
 		}
-		if (Emu.IsPaused())
+		else if (Emu.IsPaused())
 		{
 			Emu.Resume();
 		}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3337,6 +3337,15 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 		static_cast<void>(init_mtx->init());
 
+		// Call explcit semi-destructors (free memory before savestate)
+		for (const auto& [type, data] : *g_fxo)
+		{
+			if (type.thread_op)
+			{
+				type.thread_op(data, thread_state::destroying_context);
+			}
+		}
+
 		auto set_progress_message = [&](std::string_view text)
 		{
 			*verbose_message = stx::make_single<std::string>(text);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -426,7 +426,8 @@ public:
 	static void CleanUp();
 
 	bool IsRunning() const { return m_state == system_state::running; }
-	bool IsPaused()  const { return m_state >= system_state::paused; } // ready/starting are also considered paused by this function
+	bool IsPaused() const { system_state state = m_state; return state >= system_state::paused && state <= system_state::frozen; }
+	bool IsPausedOrReady() const { return m_state >= system_state::paused; }
 	bool IsStopped(bool test_fully = false) const { return test_fully ? m_state == system_state::stopped : m_state <= system_state::stopping; }
 	bool IsReady()   const { return m_state == system_state::ready; }
 	bool IsStarting() const { return m_state == system_state::starting; }

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -310,6 +310,11 @@ namespace utils
 
 	void memory_commit(void* pointer, usz size, protection prot)
 	{
+		if (!size)
+		{
+			return;
+		}
+
 #ifdef _WIN32
 		ensure(::VirtualAlloc(pointer, size, MEM_COMMIT, +prot));
 #else
@@ -329,6 +334,11 @@ namespace utils
 
 	void memory_decommit(void* pointer, usz size)
 	{
+		if (!size)
+		{
+			return;
+		}
+
 #ifdef _WIN32
 		ensure(::VirtualFree(pointer, size, MEM_DECOMMIT));
 #else
@@ -357,6 +367,11 @@ namespace utils
 
 	void memory_reset(void* pointer, usz size, protection prot)
 	{
+		if (!size)
+		{
+			return;
+		}
+
 #ifdef _WIN32
 		memory_decommit(pointer, size);
 		memory_commit(pointer, size, prot);
@@ -390,6 +405,11 @@ namespace utils
 
 	void memory_release(void* pointer, usz size)
 	{
+		if (!size)
+		{
+			return;
+		}
+
 #ifdef _WIN32
 		unmap_mappping_memory(reinterpret_cast<u64>(pointer), size);
 		ensure(::VirtualFree(pointer, 0, MEM_RELEASE));
@@ -400,6 +420,11 @@ namespace utils
 
 	void memory_protect(void* pointer, usz size, protection prot)
 	{
+		if (!size)
+		{
+			return;
+		}
+
 #ifdef _WIN32
 
 		DWORD old;
@@ -429,6 +454,11 @@ namespace utils
 
 	bool memory_lock(void* pointer, usz size)
 	{
+		if (!size)
+		{
+			return true;
+		}
+
 #ifdef _WIN32
 		return ::VirtualLock(pointer, size);
 #else


### PR DESCRIPTION
PPU LLVM's memory manager was not able to handle more than 512MB of data, but at same time instead of reporting an error on outage it reused memory buffers. This resulted in corrupted PPU LLVM cache files for affected titles.

Fixes PES games with their humongous executable file.
Fixes #11469 (you need to remove broken PPU LLVM and SPU LLVM cache)

# Additional impovements
* Reduces RPCS3 RAM memory consumption by 100MB-300MB ingame and more than twice this amount during PPU LLVM compilation. This is because PPU analyzer information is stored much more efficiently, size of data members has been reduced and PPU LLVM compilation no longer makes copies of this memory.

**Before (Demon's Souls)**
![image](https://github.com/user-attachments/assets/89d61d59-9ff8-47ef-be37-2d1599c7ecd7)

**After - Around 160MB reduction in memory!**
![image](https://github.com/user-attachments/assets/89f523df-aae5-46e9-a1d4-db690622124d)

