### PR TITLE
rsx: Shader and MSAA fixes

### DIFF
--- a/rpcs3/Emu/RSX/Core/RSXDrawCommands.cpp
+++ b/rpcs3/Emu/RSX/Core/RSXDrawCommands.cpp
@@ -790,7 +790,7 @@ namespace rsx
 
 			const int translated_offset = full_reupload
 				? instance_config.patch_load_offset
-				: prog->TranslateConstantsRange(instance_config.patch_load_offset, instance_config.patch_load_count);
+				: prog->translate_constants_range(instance_config.patch_load_offset, instance_config.patch_load_count);
 
 			if (translated_offset >= 0)
 			{

--- a/rpcs3/Emu/RSX/Core/RSXDrawCommands.cpp
+++ b/rpcs3/Emu/RSX/Core/RSXDrawCommands.cpp
@@ -735,7 +735,7 @@ namespace rsx
 		utils::stream_vector(dst + 4, 0u, fog_mode, std::bit_cast<u32>(wpos_scale), std::bit_cast<u32>(wpos_bias));
 	}
 
-	void draw_command_processor::fill_constants_instancing_buffer(rsx::io_buffer& indirection_table_buf, rsx::io_buffer& constants_data_array_buffer, const VertexProgramBase& prog) const
+	void draw_command_processor::fill_constants_instancing_buffer(rsx::io_buffer& indirection_table_buf, rsx::io_buffer& constants_data_array_buffer, const VertexProgramBase* prog) const
 	{
 		auto& draw_call = REGS(m_ctx)->current_draw_clause;
 
@@ -745,8 +745,9 @@ namespace rsx
 		// Temp indirection table. Used to track "running" updates.
 		rsx::simple_array<u32> instancing_indirection_table;
 		// indirection table size
-		const auto reloc_table = prog.has_indexed_constants ? decltype(prog.constant_ids){} : prog.constant_ids;
-		const auto redirection_table_size = prog.has_indexed_constants ? 468u : ::size32(prog.constant_ids);
+		const auto full_reupload = !prog || prog->has_indexed_constants;
+		const auto reloc_table = full_reupload ? decltype(prog->constant_ids){} : prog->constant_ids;
+		const auto redirection_table_size = full_reupload ? 468u : ::size32(prog->constant_ids);
 		instancing_indirection_table.resize(redirection_table_size);
 
 		// Temp constants data
@@ -787,9 +788,9 @@ namespace rsx
 				continue;
 			}
 
-			const int translated_offset = prog.has_indexed_constants
+			const int translated_offset = full_reupload
 				? instance_config.patch_load_offset
-				: prog.TranslateConstantsRange(instance_config.patch_load_offset, instance_config.patch_load_count);
+				: prog->TranslateConstantsRange(instance_config.patch_load_offset, instance_config.patch_load_count);
 
 			if (translated_offset >= 0)
 			{
@@ -809,14 +810,14 @@ namespace rsx
 				continue;
 			}
 
-			ensure(!prog.has_indexed_constants);
+			ensure(!full_reupload);
 
 			// Sparse update. Update records individually instead of bulk
 			// FIXME: Range batching optimization
 			const auto load_end = instance_config.patch_load_offset + instance_config.patch_load_count;
 			for (u32 i = 0; i < redirection_table_size; ++i)
 			{
-				const auto read_index = prog.constant_ids[i];
+				const auto read_index = prog->constant_ids[i];
 				if (read_index < instance_config.patch_load_offset || read_index >= load_end)
 				{
 					// Reading outside "hot" range.

--- a/rpcs3/Emu/RSX/Core/RSXDrawCommands.h
+++ b/rpcs3/Emu/RSX/Core/RSXDrawCommands.h
@@ -105,6 +105,6 @@ namespace rsx
 
 		// Fill instancing buffers. A single iobuf is used for both. 256byte alignment enforced to allow global bind
 		// Returns offsets to the index redirection lookup table and constants field array
-		void fill_constants_instancing_buffer(rsx::io_buffer& indirection_table_buf, rsx::io_buffer& constants_data_array_buffer, const VertexProgramBase& prog) const;
+		void fill_constants_instancing_buffer(rsx::io_buffer& indirection_table_buf, rsx::io_buffer& constants_data_array_buffer, const VertexProgramBase* prog) const;
 	};
 }

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -878,7 +878,7 @@ void GLGSRender::load_program_env()
 		}
 	}
 
-	if (update_fragment_constants && !update_instruction_buffers)
+	if (update_fragment_constants && !m_shader_interpreter.is_interpreter(m_program))
 	{
 		// Fragment constants
 		auto mapping = m_fragment_constants_buffer->alloc_from_heap(fragment_constants_size, m_uniform_buffer_offset_align);
@@ -978,12 +978,18 @@ void GLGSRender::load_program_env()
 		}
 	}
 
-	m_graphics_state.clear(
+	rsx::flags32_t handled_flags =
 		rsx::pipeline_state::fragment_state_dirty |
 		rsx::pipeline_state::vertex_state_dirty |
 		rsx::pipeline_state::transform_constants_dirty |
-		rsx::pipeline_state::fragment_constants_dirty |
-		rsx::pipeline_state::fragment_texture_state_dirty);
+		rsx::pipeline_state::fragment_texture_state_dirty;
+
+	if (update_fragment_constants && !m_shader_interpreter.is_interpreter(m_program))
+	{
+		handled_flags |= rsx::pipeline_state::fragment_constants_dirty;
+	}
+
+	m_graphics_state.clear(handled_flags);
 }
 
 bool GLGSRender::is_current_program_interpreted() const

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOps.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOps.glsl
@@ -34,7 +34,8 @@ vec2 texture2DMSCoord(const in vec2 coords, const in uint flags)
 		return coords;
 	}
 
-	const vec2 wrapped_coords = mod(coords, vec2(1.0));
+	const vec2 wrapped_coords_raw = mod(coords, vec2(1.0));
+	const vec2 wrapped_coords = mod(wrapped_coords_raw + vec2(1.0), vec2(1.0));
 	const bvec2 wrap_control_mask = bvec2(uvec2(flags) & uvec2(WRAP_S_MASK, WRAP_T_MASK));
 	return _select(coords, wrapped_coords, wrap_control_mask);
 }

--- a/rpcs3/Emu/RSX/Program/program_util.cpp
+++ b/rpcs3/Emu/RSX/Program/program_util.cpp
@@ -110,7 +110,7 @@ namespace rsx
 			multisampled_textures == other.multisampled_textures;
 	}
 
-	int VertexProgramBase::TranslateConstantsRange(int first_index, int count) const
+	int VertexProgramBase::translate_constants_range(int first_index, int count) const
 	{
 		// The constant ids should be sorted, so just find the first one and check for continuity
 		int index = -1;
@@ -156,5 +156,32 @@ namespace rsx
 
 		// OOB or partial match
 		return -1;
+	}
+
+	bool VertexProgramBase::overlaps_constants_range(int first_index, int count) const
+	{
+		if (has_indexed_constants)
+		{
+			return true;
+		}
+
+		const int last_index = first_index + count - 1;
+
+		// Early rejection test
+		if (constant_ids.empty() || first_index > constant_ids.back() || last_index < first_index)
+		{
+			return false;
+		}
+
+		// Check for any hits
+		for (auto& idx : constant_ids)
+		{
+			if (idx >= first_index && idx <= last_index)
+			{
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/rpcs3/Emu/RSX/Program/program_util.h
+++ b/rpcs3/Emu/RSX/Program/program_util.h
@@ -67,6 +67,9 @@ namespace rsx
 		// Translates an incoming range of constants against our mapping.
 		// If there is no linear mapping available, return -1, otherwise returns the translated index of the first slot
 		// TODO: Move this somewhere else during refactor
-		int TranslateConstantsRange(int first_index, int count) const;
+		int translate_constants_range(int first_index, int count) const;
+
+		// Returns true if this program consumes any constants in the range [first, first + count - 1]
+		bool overlaps_constants_range(int first_index, int count) const;
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -688,10 +688,10 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	}
 
 	// Initialize optional allocation information with placeholders
-	m_vertex_env_buffer_info = { m_vertex_env_ring_info.heap->value, 0, 32 };
-	m_vertex_constants_buffer_info = { m_transform_constants_ring_info.heap->value, 0, 32 };
-	m_fragment_env_buffer_info = { m_fragment_env_ring_info.heap->value, 0, 32 };
-	m_fragment_texture_params_buffer_info = { m_fragment_texture_params_ring_info.heap->value, 0, 32 };
+	m_vertex_env_buffer_info = { m_vertex_env_ring_info.heap->value, 0, 16 };
+	m_vertex_constants_buffer_info = { m_transform_constants_ring_info.heap->value, 0, 16 };
+	m_fragment_env_buffer_info = { m_fragment_env_ring_info.heap->value, 0, 16 };
+	m_fragment_texture_params_buffer_info = { m_fragment_texture_params_ring_info.heap->value, 0, 16 };
 	m_raster_env_buffer_info = { m_raster_env_ring_info.heap->value, 0, 128 };
 
 	const auto limits = m_device->gpu().get_limits();
@@ -2192,7 +2192,7 @@ void VKGSRender::load_program_env()
 			return std::make_pair(m_instancing_buffer_ring_info.map(constants_data_table_offset, size), size);
 		});
 
-		m_draw_processor.fill_constants_instancing_buffer(indirection_table_buf, constants_array_buf, *m_vertex_prog);
+		m_draw_processor.fill_constants_instancing_buffer(indirection_table_buf, constants_array_buf, m_vertex_prog);
 		m_instancing_buffer_ring_info.unmap();
 
 		m_instancing_indirection_buffer_info = { m_instancing_buffer_ring_info.heap->value, indirection_table_offset, indirection_table_buf.size() };
@@ -2219,7 +2219,7 @@ void VKGSRender::load_program_env()
 		}
 	}
 
-	if (update_fragment_constants && !update_instruction_buffers)
+	if (update_fragment_constants && !m_shader_interpreter.is_interpreter(m_program))
 	{
 		check_heap_status(VK_HEAP_CHECK_FRAGMENT_CONSTANTS_STORAGE);
 
@@ -2350,14 +2350,19 @@ void VKGSRender::load_program_env()
 	}
 
 	// Clear flags
-	u32 handled_flags = rsx::pipeline_state::fragment_state_dirty |
+	rsx::flags32_t handled_flags =
+		rsx::pipeline_state::fragment_state_dirty |
 		rsx::pipeline_state::vertex_state_dirty |
-		rsx::pipeline_state::fragment_constants_dirty |
 		rsx::pipeline_state::fragment_texture_state_dirty;
 
 	if (!update_instancing_data)
 	{
 		handled_flags |= rsx::pipeline_state::transform_constants_dirty;
+	}
+
+	if (update_fragment_constants && !m_shader_interpreter.is_interpreter(m_program))
+	{
+		handled_flags |= rsx::pipeline_state::fragment_constants_dirty;
 	}
 
 	m_graphics_state.clear(handled_flags);

--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -387,7 +387,7 @@ namespace vk
 
 	struct stencilonly_unresolve : depth_resolve_base
 	{
-		VkClearRect region{};
+		VkClearRect clear_region{};
 		VkClearAttachment clear_info{};
 
 		stencilonly_unresolve()
@@ -402,8 +402,8 @@ namespace vk
 			renderpass_config.set_depth_mask(false);
 
 			clear_info.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
-			region.baseArrayLayer = 0;
-			region.layerCount = 1;
+			clear_region.baseArrayLayer = 0;
+			clear_region.layerCount = 1;
 
 			static_parameters_width = 3;
 
@@ -425,7 +425,7 @@ namespace vk
 
 		void emit_geometry(vk::command_buffer& cmd) override
 		{
-			vkCmdClearAttachments(cmd, 1, &clear_info, 1, &region);
+			vkCmdClearAttachments(cmd, 1, &clear_info, 1, &clear_region);
 
 			for (s32 write_mask = 0x1; write_mask <= 0x80; write_mask <<= 1)
 			{
@@ -444,8 +444,8 @@ namespace vk
 
 			auto stencil_view = resolve_image->get_view(rsx::default_remap_vector.with_encoding(VK_REMAP_IDENTITY), VK_IMAGE_ASPECT_STENCIL_BIT);
 
-			region.rect.extent.width = resolve_image->width();
-			region.rect.extent.height = resolve_image->height();
+			clear_region.rect.extent.width = msaa_image->width();
+			clear_region.rect.extent.height = msaa_image->height();
 
 			overlay_pass::run(
 				cmd,


### PR DESCRIPTION
1. Fixes some crashes when using shader interpreter.
2. Fix emulated MSAA sampling in "wrap" mode when coords have negative sign.
3. Fix out-of-bounds write in MSAA resolve pass that can cause GPU crash.

Closes https://github.com/RPCS3/rpcs3/issues/16541
Closes https://github.com/RPCS3/rpcs3/issues/16539

TODO:
- [x] Pull GTX900 branch fixes