### PR TITLE
Qt/input: fix raw mouse button assignment

### DIFF
--- a/rpcs3/Input/raw_mouse_config.cpp
+++ b/rpcs3/Input/raw_mouse_config.cpp
@@ -4,22 +4,6 @@
 
 LOG_CHANNEL(cfg_log, "CFG");
 
-std::string mouse_button_id(int code)
-{
-	switch (code)
-	{
-	case CELL_MOUSE_BUTTON_1: return "Button 1";
-	case CELL_MOUSE_BUTTON_2: return "Button 2";
-	case CELL_MOUSE_BUTTON_3: return "Button 3";
-	case CELL_MOUSE_BUTTON_4: return "Button 4";
-	case CELL_MOUSE_BUTTON_5: return "Button 5";
-	case CELL_MOUSE_BUTTON_6: return "Button 6";
-	case CELL_MOUSE_BUTTON_7: return "Button 7";
-	case CELL_MOUSE_BUTTON_8: return "Button 8";
-	}
-	return "";
-}
-
 cfg::string& raw_mouse_config::get_button_by_index(int index)
 {
 	switch (index)
@@ -50,6 +34,28 @@ cfg::string& raw_mouse_config::get_button(int code)
 	case CELL_MOUSE_BUTTON_8: return mouse_button_8;
 	default: fmt::throw_exception("Invalid code %d", code);
 	}
+}
+
+std::string raw_mouse_config::get_button_name(std::string_view value)
+{
+	if (raw_mouse_button_map.contains(value))
+	{
+		return std::string(value);
+	}
+
+	return "";
+}
+
+std::string raw_mouse_config::get_button_name(s32 button_code)
+{
+	for (const auto& [name, code] : raw_mouse_button_map)
+	{
+		if (code == button_code)
+		{
+			return std::string(name);
+		}
+	}
+	return "";
 }
 
 raw_mice_config::raw_mice_config()

--- a/rpcs3/Input/raw_mouse_config.h
+++ b/rpcs3/Input/raw_mouse_config.h
@@ -5,7 +5,21 @@
 
 #include <array>
 
-std::string mouse_button_id(int code);
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+static const std::map<std::string_view, int> raw_mouse_button_map
+{
+	{ "", 0 },
+#ifdef _WIN32
+	{ "Button 1", RI_MOUSE_BUTTON_1_UP },
+	{ "Button 2", RI_MOUSE_BUTTON_2_UP },
+	{ "Button 3", RI_MOUSE_BUTTON_3_UP },
+	{ "Button 4", RI_MOUSE_BUTTON_4_UP },
+	{ "Button 5", RI_MOUSE_BUTTON_5_UP },
+#endif
+};
 
 struct raw_mouse_config : cfg::node
 {
@@ -27,6 +41,9 @@ public:
 
 	cfg::string& get_button_by_index(int index);
 	cfg::string& get_button(int code);
+
+	static std::string get_button_name(std::string_view value);
+	static std::string get_button_name(s32 button_code);
 };
 
 struct raw_mice_config : cfg::node

--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -148,45 +148,29 @@ void raw_mouse::update_values(const RAWMOUSE& state)
 			// Only update the value if either down or up flags are present
 			if ((state.usButtonFlags & btn.down))
 			{
-				m_handler->mouse_press_callback(m_device_name, 0, up, true);
+				m_handler->mouse_press_callback(m_device_name, up, true);
 			}
 			else if ((state.usButtonFlags & btn.up))
 			{
-				m_handler->mouse_press_callback(m_device_name, 0, up, false);
+				m_handler->mouse_press_callback(m_device_name, up, false);
 			}
 		}
 		return;
 	}
 
-	const auto get_button_pressed = [this](u8 button, int button_flags)
+	// Get mouse buttons
+	for (const auto& [button, btn] : m_buttons)
 	{
-		const auto it = m_buttons.find(button);
-		if (it == m_buttons.cend()) return;
-
-		const mouse_button& btn = it->second;
-
 		// Only update the value if either down or up flags are present
-		if ((button_flags & btn.down))
+		if ((state.usButtonFlags & btn.down))
 		{
 			m_handler->Button(m_index, button, true);
-			m_handler->mouse_press_callback(m_device_name, button, btn.up, true);
 		}
-		else if ((button_flags & btn.up))
+		else if ((state.usButtonFlags & btn.up))
 		{
 			m_handler->Button(m_index, button, false);
-			m_handler->mouse_press_callback(m_device_name, button, btn.up, false);
 		}
-	};
-
-	// Get mouse buttons
-	get_button_pressed(CELL_MOUSE_BUTTON_1, state.usButtonFlags);
-	get_button_pressed(CELL_MOUSE_BUTTON_2, state.usButtonFlags);
-	get_button_pressed(CELL_MOUSE_BUTTON_3, state.usButtonFlags);
-	get_button_pressed(CELL_MOUSE_BUTTON_4, state.usButtonFlags);
-	get_button_pressed(CELL_MOUSE_BUTTON_5, state.usButtonFlags);
-	get_button_pressed(CELL_MOUSE_BUTTON_6, state.usButtonFlags);
-	get_button_pressed(CELL_MOUSE_BUTTON_7, state.usButtonFlags);
-	get_button_pressed(CELL_MOUSE_BUTTON_8, state.usButtonFlags);
+	}
 
 	// Get mouse wheel
 	if ((state.usButtonFlags & RI_MOUSE_WHEEL))

--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -6,22 +6,6 @@
 #include "Utilities/mutex.h"
 #include "Utilities/Thread.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
-static const std::map<std::string, int> raw_mouse_button_map
-{
-	{ "", 0 },
-#ifdef _WIN32
-	{ "Button 1", RI_MOUSE_BUTTON_1_UP },
-	{ "Button 2", RI_MOUSE_BUTTON_2_UP },
-	{ "Button 3", RI_MOUSE_BUTTON_3_UP },
-	{ "Button 4", RI_MOUSE_BUTTON_4_UP },
-	{ "Button 5", RI_MOUSE_BUTTON_5_UP },
-#endif
-};
-
 class raw_mouse_handler;
 
 class raw_mouse
@@ -43,11 +27,21 @@ public:
 	const std::string& device_name() const { return m_device_name; }
 	u32 index() const { return m_index; }
 	void set_index(u32 index);
-	void request_reload() { reload_requested = true; }
+	void request_reload() { m_reload_requested = true; }
 
 private:
+	struct mouse_button
+	{
+		int down = 0;
+		int up = 0;
+	};
+
+#ifdef _WIN32
+	static const std::unordered_map<int, raw_mouse::mouse_button> btn_pairs;
+#endif
+
 	void reload_config();
-	static std::pair<int, int> get_mouse_button(const cfg::string& button);
+	static mouse_button get_mouse_button(const cfg::string& button);
 
 	u32 m_index = 0;
 	std::string m_device_name;
@@ -61,8 +55,8 @@ private:
 	int m_pos_y{};
 	float m_mouse_acceleration = 1.0f;
 	raw_mouse_handler* m_handler{};
-	std::map<u8, std::pair<int, int>> m_buttons;
-	bool reload_requested = false;
+	std::map<u8, mouse_button> m_buttons;
+	bool m_reload_requested = false;
 };
 
 class raw_mouse_handler final : public MouseHandlerBase
@@ -74,23 +68,21 @@ public:
 
 	void Init(const u32 max_connect) override;
 
-	void SetIsForGui(bool value)
-	{
-		m_is_for_gui = value;
-	}
+	void set_is_for_gui(bool value) { m_is_for_gui = value; }
+	bool is_for_gui() const { return m_is_for_gui; }
 
 	const std::map<void*, raw_mouse>& get_mice() const { return m_raw_mice; };
 
-	void set_mouse_press_callback(std::function<void(const std::string&, s32, bool)> cb)
+	void set_mouse_press_callback(std::function<void(const std::string&, s32, s32, bool)> cb)
 	{
 		m_mouse_press_callback = std::move(cb);
 	}
 
-	void mouse_press_callback(const std::string& device_name, s32 cell_code, bool pressed)
+	void mouse_press_callback(const std::string& device_name, s32 cell_code, s32 button_code, bool pressed)
 	{
 		if (m_mouse_press_callback)
 		{
-			m_mouse_press_callback(device_name, cell_code, pressed);
+			m_mouse_press_callback(device_name, cell_code, button_code, pressed);
 		}
 	}
 
@@ -114,7 +106,7 @@ private:
 
 	bool m_is_for_gui = false;
 	std::map<void*, raw_mouse> m_raw_mice;
-	std::function<void(const std::string&, s32, bool)> m_mouse_press_callback;
+	std::function<void(const std::string&, s32, s32, bool)> m_mouse_press_callback;
 
 	std::unique_ptr<named_thread<std::function<void()>>> m_thread;
 };

--- a/rpcs3/Input/raw_mouse_handler.h
+++ b/rpcs3/Input/raw_mouse_handler.h
@@ -73,16 +73,16 @@ public:
 
 	const std::map<void*, raw_mouse>& get_mice() const { return m_raw_mice; };
 
-	void set_mouse_press_callback(std::function<void(const std::string&, s32, s32, bool)> cb)
+	void set_mouse_press_callback(std::function<void(const std::string&, s32, bool)> cb)
 	{
 		m_mouse_press_callback = std::move(cb);
 	}
 
-	void mouse_press_callback(const std::string& device_name, s32 cell_code, s32 button_code, bool pressed)
+	void mouse_press_callback(const std::string& device_name, s32 button_code, bool pressed)
 	{
 		if (m_mouse_press_callback)
 		{
-			m_mouse_press_callback(device_name, cell_code, button_code, pressed);
+			m_mouse_press_callback(device_name, button_code, pressed);
 		}
 	}
 
@@ -106,7 +106,7 @@ private:
 
 	bool m_is_for_gui = false;
 	std::map<void*, raw_mouse> m_raw_mice;
-	std::function<void(const std::string&, s32, s32, bool)> m_mouse_press_callback;
+	std::function<void(const std::string&, s32, bool)> m_mouse_press_callback;
 
 	std::unique_ptr<named_thread<std::function<void()>>> m_thread;
 };

--- a/rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp
@@ -389,14 +389,14 @@ void emulated_pad_settings_dialog::add_tabs(QTabWidget* tabs)
 			{
 				std::string raw_mouse_settings;
 				const auto& raw_cfg = *ensure(::at32(g_cfg_raw_mouse.players, player));
-				fmt::append(raw_mouse_settings, "1: %s\n", raw_cfg.mouse_button_1.to_string());
-				fmt::append(raw_mouse_settings, "2: %s\n", raw_cfg.mouse_button_2.to_string());
-				fmt::append(raw_mouse_settings, "3: %s\n", raw_cfg.mouse_button_3.to_string());
-				fmt::append(raw_mouse_settings, "4: %s\n", raw_cfg.mouse_button_4.to_string());
-				fmt::append(raw_mouse_settings, "5: %s\n", raw_cfg.mouse_button_5.to_string());
-				fmt::append(raw_mouse_settings, "6: %s\n", raw_cfg.mouse_button_6.to_string());
-				fmt::append(raw_mouse_settings, "7: %s\n", raw_cfg.mouse_button_7.to_string());
-				fmt::append(raw_mouse_settings, "8: %s",   raw_cfg.mouse_button_8.to_string());
+				fmt::append(raw_mouse_settings, "1: %s\n", raw_mouse_config::get_button_name(raw_cfg.mouse_button_1.to_string()));
+				fmt::append(raw_mouse_settings, "2: %s\n", raw_mouse_config::get_button_name(raw_cfg.mouse_button_2.to_string()));
+				fmt::append(raw_mouse_settings, "3: %s\n", raw_mouse_config::get_button_name(raw_cfg.mouse_button_3.to_string()));
+				fmt::append(raw_mouse_settings, "4: %s\n", raw_mouse_config::get_button_name(raw_cfg.mouse_button_4.to_string()));
+				fmt::append(raw_mouse_settings, "5: %s\n", raw_mouse_config::get_button_name(raw_cfg.mouse_button_5.to_string()));
+				fmt::append(raw_mouse_settings, "6: %s\n", raw_mouse_config::get_button_name(raw_cfg.mouse_button_6.to_string()));
+				fmt::append(raw_mouse_settings, "7: %s\n", raw_mouse_config::get_button_name(raw_cfg.mouse_button_7.to_string()));
+				fmt::append(raw_mouse_settings, "8: %s",   raw_mouse_config::get_button_name(raw_cfg.mouse_button_8.to_string()));
 
 				QGroupBox* gb_legend_raw = new QGroupBox(tr("Current Raw Mouse Config"), this);
 				QVBoxLayout* gb_legend_raw_layout = new QVBoxLayout(this);

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
@@ -70,9 +70,9 @@ raw_mouse_settings_dialog::raw_mouse_settings_dialog(QWidget* parent)
 	g_raw_mouse_handler = std::make_unique<raw_mouse_handler>();
 	g_raw_mouse_handler->set_is_for_gui(true);
 	g_raw_mouse_handler->Init(std::max(max_devices, ::size32(g_cfg_raw_mouse.players)));
-	g_raw_mouse_handler->set_mouse_press_callback([this](const std::string& device_name, s32 cell_code, s32 button_code, bool pressed)
+	g_raw_mouse_handler->set_mouse_press_callback([this](const std::string& device_name, s32 button_code, bool pressed)
 	{
-		mouse_press(device_name, cell_code, button_code, pressed);
+		mouse_press(device_name, button_code, pressed);
 	});
 
 	m_buttons = new QButtonGroup(this);
@@ -346,7 +346,7 @@ void raw_mouse_settings_dialog::reset_config()
 	}
 }
 
-void raw_mouse_settings_dialog::mouse_press(const std::string& device_name, s32 /*cell_code*/, s32 button_code, bool pressed)
+void raw_mouse_settings_dialog::mouse_press(const std::string& device_name, s32 button_code, bool pressed)
 {
 	if (m_button_id < 0 || pressed) // Let's only react to mouse releases
 	{

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp
@@ -68,11 +68,11 @@ raw_mouse_settings_dialog::raw_mouse_settings_dialog(QWidget* parent)
 	constexpr u32 max_devices = 16;
 
 	g_raw_mouse_handler = std::make_unique<raw_mouse_handler>();
-	g_raw_mouse_handler->SetIsForGui(true);
+	g_raw_mouse_handler->set_is_for_gui(true);
 	g_raw_mouse_handler->Init(std::max(max_devices, ::size32(g_cfg_raw_mouse.players)));
-	g_raw_mouse_handler->set_mouse_press_callback([this](const std::string& device_name, s32 cell_code, bool pressed)
+	g_raw_mouse_handler->set_mouse_press_callback([this](const std::string& device_name, s32 cell_code, s32 button_code, bool pressed)
 	{
-		mouse_press(device_name, cell_code, pressed);
+		mouse_press(device_name, cell_code, button_code, pressed);
 	});
 
 	m_buttons = new QButtonGroup(this);
@@ -91,7 +91,7 @@ raw_mouse_settings_dialog::raw_mouse_settings_dialog(QWidget* parent)
 				if (const int button_id = m_buttons->id(button); button_id >= 0)
 				{
 					auto& config = ::at32(g_cfg_raw_mouse.players, m_tab_widget->currentIndex());
-					const std::string name = config->get_button_by_index(button_id % button_count).to_string();
+					const std::string name = raw_mouse_config::get_button_name(config->get_button_by_index(button_id % button_count).to_string());
 					button->setText(name.empty() ? QStringLiteral("-") : QString::fromStdString(name));
 				}
 			}
@@ -255,7 +255,7 @@ void raw_mouse_settings_dialog::add_tabs(QTabWidget* tabs)
 
 			insert_button(static_cast<int>(player * button_count + i), pb);
 
-			const std::string saved_btn = config->get_button(cell_code);
+			const std::string saved_btn = raw_mouse_config::get_button_name(config->get_button(cell_code).to_string());
 
 			pb->setText(saved_btn.empty() ? QStringLiteral("-") : QString::fromStdString(saved_btn));
 
@@ -330,8 +330,8 @@ void raw_mouse_settings_dialog::reset_config()
 			if (!pb)
 				continue;
 
-			const QString text = QString::fromStdString(config->get_button(cell_code).def);
-			pb->setText(text.isEmpty() ? QStringLiteral("-") : text);
+			const std::string text = raw_mouse_config::get_button_name(config->get_button(cell_code).def);
+			pb->setText(text.empty() ? QStringLiteral("-") : QString::fromStdString(text));
 		}
 
 		if (QComboBox* combo = ::at32(m_device_combos, player))
@@ -346,7 +346,7 @@ void raw_mouse_settings_dialog::reset_config()
 	}
 }
 
-void raw_mouse_settings_dialog::mouse_press(const std::string& device_name, s32 cell_code, bool pressed)
+void raw_mouse_settings_dialog::mouse_press(const std::string& device_name, s32 /*cell_code*/, s32 button_code, bool pressed)
 {
 	if (m_button_id < 0 || pressed) // Let's only react to mouse releases
 	{
@@ -361,12 +361,14 @@ void raw_mouse_settings_dialog::mouse_press(const std::string& device_name, s32 
 		return;
 	}
 
-	auto& config = ::at32(g_cfg_raw_mouse.players, m_tab_widget->currentIndex());
-	config->get_button_by_index(m_button_id % button_count).from_string(mouse_button_id(cell_code));
+	const std::string button_name = raw_mouse_config::get_button_name(button_code);
+
+	auto& config = ::at32(g_cfg_raw_mouse.players, player);
+	config->get_button_by_index(m_button_id % button_count).from_string(button_name);
 
 	if (auto button = m_buttons->button(m_button_id))
 	{
-		button->setText(localized_emu::translated_mouse_button(cell_code));
+		button->setText(QString::fromStdString(button_name));
 	}
 
 	reactivate_buttons();

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.h
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.h
@@ -30,7 +30,7 @@ private:
 	void on_enumeration();
 	void reset_config();
 	void on_button_click(int id);
-	void mouse_press(const std::string& device_name, s32 cell_code, bool pressed);
+	void mouse_press(const std::string& device_name, s32 cell_code, s32 button_code, bool pressed);
 	void handle_device_change(const std::string& device_name);
 	bool is_device_active(const std::string& device_name);
 	std::string get_current_device_name(int player);

--- a/rpcs3/rpcs3qt/raw_mouse_settings_dialog.h
+++ b/rpcs3/rpcs3qt/raw_mouse_settings_dialog.h
@@ -30,7 +30,7 @@ private:
 	void on_enumeration();
 	void reset_config();
 	void on_button_click(int id);
-	void mouse_press(const std::string& device_name, s32 cell_code, s32 button_code, bool pressed);
+	void mouse_press(const std::string& device_name, s32 button_code, bool pressed);
 	void handle_device_change(const std::string& device_name);
 	bool is_device_active(const std::string& device_name);
 	std::string get_current_device_name(int player);


### PR DESCRIPTION
- Fix raw mouse button assignment.
There was a mixup between cell codes and button codes.
This caused the raw mouse settings dialog to only accept button presses that were already configured.
For example, if you had only assigned buttons 1,2 and 3, you couldn't assign buttons 4 and 5 anymore.
- Only propagate mouse events once in the raw mouse settings dialog.
It was done for all mice, which was unnecessary.