### PR TITLE
input: issue basic mouse move event on window leave

### DIFF
--- a/rpcs3/Emu/Io/MouseHandler.cpp
+++ b/rpcs3/Emu/Io/MouseHandler.cpp
@@ -31,12 +31,12 @@ void MouseHandlerBase::save(utils::serial& ar)
 	ar(inited ? m_info.max_connect : 0);
 }
 
-bool MouseHandlerBase::is_time_for_update(double elapsed_time)
+bool MouseHandlerBase::is_time_for_update(double elapsed_time_ms)
 {
 	steady_clock::time_point now = steady_clock::now();
-	const double elapsed = (now - last_update).count() / 1000'000.;
+	const double elapsed_ms = (now - last_update).count() / 1'000'000.;
 
-	if (elapsed > elapsed_time)
+	if (elapsed_ms > elapsed_time_ms)
 	{
 		last_update = now;
 		return true;

--- a/rpcs3/Emu/Io/MouseHandler.h
+++ b/rpcs3/Emu/Io/MouseHandler.h
@@ -127,7 +127,7 @@ protected:
 	std::vector<Mouse> m_mice;
 	steady_clock::time_point last_update{};
 
-	bool is_time_for_update(double elapsed_time = 10.0); // 4-10 ms, let's use 10 for now
+	bool is_time_for_update(double elapsed_time_ms = 10.0); // 4-10 ms, let's use 10 for now
 
 public:
 	shared_mutex mutex;

--- a/rpcs3/Input/basic_mouse_handler.h
+++ b/rpcs3/Input/basic_mouse_handler.h
@@ -24,6 +24,7 @@ public:
 	void MouseButton(QMouseEvent* event, bool pressed);
 	void MouseScroll(QWheelEvent* event);
 	void MouseMove(QMouseEvent* event);
+	void MouseMove(const QPoint& e_pos);
 
 	bool eventFilter(QObject* obj, QEvent* ev) override;
 private:


### PR DESCRIPTION
- Issue a basic mouse move event on window leave (moving the mouse out of the window)
- This may help with moving the mouse to the screen borders in windowed mode