### PR TITLE
rsx: Fix shader cache loading

### DIFF
--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -400,6 +400,7 @@ namespace rsx
 			fp.texture_state.multisampled_textures = data.fp_multisampled_textures;
 			fp.texcoord_control_mask = data.fp_texcoord_control;
 			fp.two_sided_lighting = !!(data.fp_lighting_flags & 0x1);
+			fp.mrt_buffers_count = data.fp_mrt_count;
 
 			return result;
 		}


### PR DESCRIPTION
Correct shaders are cached but the broken loading makes it so that most shaders will fail the comparison later and force a recompilation anyway.

Closes https://github.com/RPCS3/rpcs3/issues/16565
Closes https://github.com/RPCS3/rpcs3/issues/16562