### PR TITLE
sys_prx: implement get_module_id_by_name, module_info_v2

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sys_prx_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_prx_.cpp
@@ -221,7 +221,7 @@ error_code sys_prx_get_module_info(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<s
 	opt->info = info;
 
 	// Call the syscall
-	return _sys_prx_get_module_info(ppu, id, 0, opt);
+	return _sys_prx_get_module_info(ppu, id, flags, opt);
 }
 
 error_code sys_prx_get_module_id_by_name(ppu_thread& ppu, vm::cptr<char> name, u64 flags, vm::ptr<sys_prx_get_module_id_by_name_option_t> pOpt)

--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -1816,6 +1816,9 @@ shared_ptr<lv2_prx> ppu_load_prx(const ppu_prx_object& elf, bool virtual_load, c
 		prx->module_info_version[1] = lib_info->version[1];
 		prx->module_info_attributes = lib_info->attributes;
 
+		prx->imports_start = lib_info->imports_start;
+		prx->imports_end = lib_info->imports_end;
+
 		prx->exports_start = lib_info->exports_start;
 		prx->exports_end = lib_info->exports_end;
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -1089,9 +1089,15 @@ error_code _sys_prx_get_module_id_by_name(ppu_thread& ppu, vm::cptr<char> name, 
 
 	sys_prx.warning("_sys_prx_get_module_id_by_name(name=%s, flags=%d, pOpt=*0x%x)", name, flags, pOpt);
 
+	std::string module_name;
+	if (!vm::read_string(name.addr(), 28, module_name))
+	{
+		return CELL_EINVAL;
+	}
+
 	const auto [prx, id] = idm::select<lv2_obj, lv2_prx>([&](u32 id, lv2_prx& prx) -> u32
 	{
-		if (strncmp(name.get_ptr(), prx.module_info_name, sizeof(prx.module_info_name)) == 0)
+		if (strncmp(module_name.c_str(), prx.module_info_name, sizeof(prx.module_info_name)) == 0)
 		{
 			return id;
 		}

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -1034,7 +1034,7 @@ error_code _sys_prx_get_module_info(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<
 		return CELL_EFAULT;
 	}
 
-	if (pOpt->info->size != pOpt->info.size())
+	if (pOpt->info->size != pOpt->info.size() && pOpt->info_v2->size != pOpt->info_v2.size())
 	{
 		return CELL_EINVAL;
 	}
@@ -1072,6 +1072,14 @@ error_code _sys_prx_get_module_info(ppu_thread& ppu, u32 id, u64 flags, vm::ptr<
 		pOpt->info->segments_num = i;
 	}
 
+	if (pOpt->info_v2->size == pOpt->info_v2.size())
+	{
+		pOpt->info_v2->exports_addr = prx->exports_start;
+		pOpt->info_v2->exports_size = prx->exports_end - prx->exports_start;
+		pOpt->info_v2->imports_addr = prx->imports_start;
+		pOpt->info_v2->imports_size = prx->imports_end - prx->imports_start;
+	}
+
 	return CELL_OK;
 }
 
@@ -1079,11 +1087,24 @@ error_code _sys_prx_get_module_id_by_name(ppu_thread& ppu, vm::cptr<char> name, 
 {
 	ppu.state += cpu_flag::wait;
 
-	sys_prx.todo("_sys_prx_get_module_id_by_name(name=%s, flags=%d, pOpt=*0x%x)", name, flags, pOpt);
+	sys_prx.warning("_sys_prx_get_module_id_by_name(name=%s, flags=%d, pOpt=*0x%x)", name, flags, pOpt);
 
-	//if (realName == "?") ...
+	const auto [prx, id] = idm::select<lv2_obj, lv2_prx>([&](u32 id, lv2_prx& prx) -> u32
+	{
+		if (strncmp(name.get_ptr(), prx.module_info_name, sizeof(prx.module_info_name)) == 0)
+		{
+			return id;
+		}
 
-	return not_an_error(CELL_PRX_ERROR_UNKNOWN_MODULE);
+		return 0;
+	});
+
+	if (!id)
+	{
+		return CELL_PRX_ERROR_UNKNOWN_MODULE;
+	}
+
+	return not_an_error(id);
 }
 
 error_code _sys_prx_get_module_id_by_address(ppu_thread& ppu, u32 addr)

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -76,10 +76,22 @@ struct sys_prx_module_info_t
 	be_t<u32> segments_num; // 0x44
 };
 
+struct sys_prx_module_info_v2_t : sys_prx_module_info_t
+{
+	be_t<u32> exports_addr; // 0x48
+	be_t<u32> exports_size; // 0x4C
+	be_t<u32> imports_addr; // 0x50
+	be_t<u32> imports_size; // 0x54
+};
+
 struct sys_prx_module_info_option_t
 {
 	be_t<u64> size; // 0x10
-	vm::bptr<sys_prx_module_info_t> info;
+	union
+	{
+		vm::bptr<sys_prx_module_info_t> info;
+		vm::bptr<sys_prx_module_info_v2_t> info_v2;
+	};
 };
 
 struct sys_prx_start_module_option_t
@@ -191,6 +203,9 @@ struct lv2_prx final : ppu_module<lv2_obj>
 	char module_info_name[28]{};
 	u8 module_info_version[2]{};
 	be_t<u16> module_info_attributes{};
+
+	u32 imports_start = umax;
+	u32 imports_end = 0;
 
 	u32 exports_start = umax;
 	u32 exports_end = 0;


### PR DESCRIPTION
Implements 2 sys_prx features:

* sys_prx_get_module_id_by_name, self explanatory
* version 2 of sys_prx_module_info, which includes addresses to the import/export stub tables