### PR TITLE
rsx: Shader interpreter improvements

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -595,6 +595,7 @@ if(TARGET 3rdparty_vulkan)
         RSX/VK/VKAsyncScheduler.cpp
         RSX/VK/VKCommandStream.cpp
         RSX/VK/VKCommonDecompiler.cpp
+        RSX/VK/VKCommonPipelineLayout.cpp
         RSX/VK/VKCompute.cpp
         RSX/VK/VKDMA.cpp
         RSX/VK/VKDraw.cpp

--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -427,5 +427,17 @@ namespace rsx
 			}
 			return result;
 		}
+
+		template <typename F, typename U>
+			requires std::is_invocable_r_v<U, F, const U&, const Ty&>
+		U reduce(U initial_value, F&& reducer) const
+		{
+			U accumulate = initial_value;
+			for (auto it = begin(); it != end(); ++it)
+			{
+				accumulate = reducer(accumulate, *it);
+			}
+			return accumulate;
+		}
 	};
 }

--- a/rpcs3/Emu/RSX/VK/VKCommonPipelineLayout.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommonPipelineLayout.cpp
@@ -1,0 +1,160 @@
+#include "stdafx.h"
+#include "vkutils/device.h"
+#include "vkutils/descriptors.h"
+#include "VKCommonPipelineLayout.h"
+#include "VKHelpers.h"
+
+#include "Emu/RSX/Common/simple_array.hpp"
+
+namespace vk
+{
+	rsx::simple_array<VkDescriptorSetLayoutBinding> get_common_binding_table()
+	{
+		const auto& binding_table = vk::get_current_renderer()->get_pipeline_binding_table();
+		rsx::simple_array<VkDescriptorSetLayoutBinding> bindings(binding_table.instancing_constants_buffer_slot + 1);
+
+		u32 idx = 0;
+
+		// Vertex stream, one stream for cacheable data, one stream for transient data
+		for (int i = 0; i < 3; i++)
+		{
+			bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+			bindings[idx].descriptorCount = 1;
+			bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+			bindings[idx].binding = binding_table.vertex_buffers_first_bind_slot + i;
+			bindings[idx].pImmutableSamplers = nullptr;
+			idx++;
+		}
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+		bindings[idx].binding = binding_table.fragment_constant_buffers_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+		bindings[idx].binding = binding_table.fragment_state_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+		bindings[idx].binding = binding_table.fragment_texture_params_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+		bindings[idx].binding = binding_table.vertex_constant_buffers_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS;
+		bindings[idx].binding = binding_table.vertex_params_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+		bindings[idx].binding = binding_table.conditional_render_predicate_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+		bindings[idx].binding = binding_table.rasterizer_env_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+		bindings[idx].binding = binding_table.instancing_lookup_table_bind_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+		bindings[idx].descriptorCount = 1;
+		bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+		bindings[idx].binding = binding_table.instancing_constants_buffer_slot;
+		bindings[idx].pImmutableSamplers = nullptr;
+
+		idx++;
+
+		return bindings;
+	}
+
+	std::tuple<VkPipelineLayout, VkDescriptorSetLayout> get_common_pipeline_layout(VkDevice dev)
+	{
+		const auto& binding_table = vk::get_current_renderer()->get_pipeline_binding_table();
+		auto bindings = get_common_binding_table();
+		u32 idx = ::size32(bindings);
+
+		bindings.resize(binding_table.total_descriptor_bindings);
+
+		for (auto binding = binding_table.textures_first_bind_slot;
+			binding < binding_table.vertex_textures_first_bind_slot;
+			binding++)
+		{
+			bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			bindings[idx].descriptorCount = 1;
+			bindings[idx].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+			bindings[idx].binding = binding;
+			bindings[idx].pImmutableSamplers = nullptr;
+			idx++;
+		}
+
+		for (int i = 0; i < rsx::limits::vertex_textures_count; i++)
+		{
+			bindings[idx].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			bindings[idx].descriptorCount = 1;
+			bindings[idx].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+			bindings[idx].binding = binding_table.vertex_textures_first_bind_slot + i;
+			bindings[idx].pImmutableSamplers = nullptr;
+			idx++;
+		}
+
+		ensure(idx == binding_table.total_descriptor_bindings);
+
+		std::array<VkPushConstantRange, 1> push_constants;
+		push_constants[0].offset = 0;
+		push_constants[0].size = 16;
+		push_constants[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+
+		if (vk::emulate_conditional_rendering())
+		{
+			// Conditional render toggle
+			push_constants[0].size = 20;
+		}
+
+		const auto set_layout = vk::descriptors::create_layout(bindings);
+
+		VkPipelineLayoutCreateInfo layout_info = {};
+		layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+		layout_info.setLayoutCount = 1;
+		layout_info.pSetLayouts = &set_layout;
+		layout_info.pushConstantRangeCount = 1;
+		layout_info.pPushConstantRanges = push_constants.data();
+
+		VkPipelineLayout result;
+		CHECK_RESULT(vkCreatePipelineLayout(dev, &layout_info, nullptr, &result));
+		return std::make_tuple(result, set_layout);
+	}
+}

--- a/rpcs3/Emu/RSX/VK/VKCommonPipelineLayout.h
+++ b/rpcs3/Emu/RSX/VK/VKCommonPipelineLayout.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "vkutils/shared.h"
+#include "Emu/RSX/Common/simple_array.hpp"
+
+namespace vk
+{
+	// Grab standard layout for decompiled RSX programs. Also used by the interpreter.
+	// FIXME: This generates a bloated monstrosity that needs to die.
+	std::tuple<VkPipelineLayout, VkDescriptorSetLayout> get_common_pipeline_layout(VkDevice dev);
+
+	// Returns the standard binding layout without texture slots. Those have special handling depending on the consumer.
+	rsx::simple_array<VkDescriptorSetLayoutBinding> get_common_binding_table();
+}

--- a/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
@@ -63,7 +63,7 @@ namespace vk
 			const std::vector<glsl::program_input>& vs_inputs, const std::vector<glsl::program_input>& fs_inputs)
 	{
 		VkPipeline pipeline;
-		CHECK_RESULT(vkCreateGraphicsPipelines(*m_device, nullptr, 1, &create_info, NULL, &pipeline));
+		CHECK_RESULT(vkCreateGraphicsPipelines(*m_device, VK_NULL_HANDLE, 1, &create_info, nullptr, &pipeline));
 		auto result = std::make_unique<vk::glsl::program>(*m_device, pipeline, pipe_layout, vs_inputs, fs_inputs);
 		result->link();
 		return result;

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.h
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.h
@@ -41,6 +41,7 @@ namespace vk
 
 		std::unordered_map<pipeline_key, std::unique_ptr<glsl::program>, key_hasher> m_program_cache;
 		std::unordered_map<u64, std::unique_ptr<glsl::shader>> m_fs_cache;
+		rsx::simple_array<VkDescriptorPoolSize> m_descriptor_pool_sizes;
 		vk::descriptor_pool m_descriptor_pool;
 
 		u32 m_vertex_instruction_start = 0;

--- a/rpcs3/VKGSRender.vcxproj
+++ b/rpcs3/VKGSRender.vcxproj
@@ -36,6 +36,7 @@
     <ClInclude Include="Emu\RSX\VK\VKResolveHelper.h" />
     <ClInclude Include="Emu\RSX\VK\VKResourceManager.h" />
     <ClInclude Include="Emu\RSX\VK\VKShaderInterpreter.h" />
+    <ClInclude Include="Emu\RSX\VK\VKCommonPipelineLayout.h" />
     <ClInclude Include="Emu\RSX\VK\VKTextureCache.h" />
     <ClInclude Include="Emu\RSX\VK\vkutils\buffer_object.h" />
     <ClInclude Include="Emu\RSX\VK\vkutils\chip_class.h" />
@@ -84,6 +85,7 @@
     <ClCompile Include="Emu\RSX\VK\VKResolveHelper.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKResourceManager.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKShaderInterpreter.cpp" />
+    <ClCompile Include="Emu\RSX\VK\VKCommonPipelineLayout.cpp" />
     <ClCompile Include="Emu\RSX\VK\VKTexture.cpp" />
     <ClCompile Include="Emu\RSX\VK\vkutils\barriers.cpp" />
     <ClCompile Include="Emu\RSX\VK\vkutils\buffer_object.cpp" />

--- a/rpcs3/VKGSRender.vcxproj.filters
+++ b/rpcs3/VKGSRender.vcxproj.filters
@@ -72,6 +72,7 @@
     <ClCompile Include="Emu\RSX\VK\upscalers\fsr1\fsr_pass.cpp">
       <Filter>upscalers\fsr1</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\VK\VKCommonPipelineLayout.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Emu\RSX\VK\VKCommonDecompiler.h" />
@@ -173,6 +174,7 @@
     <ClInclude Include="Emu\RSX\VK\vkutils\garbage_collector.h">
       <Filter>vkutils</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\VK\VKCommonPipelineLayout.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="vkutils">


### PR DESCRIPTION
1. Reworks descriptor binding layout so that we can reuse the same code for both main RSX shaders and the interpreter.
2. Fixes a texturing regression in the interpreter that caused most textures to be black.

Closes https://github.com/RPCS3/rpcs3/issues/16374