### PR TITLE
libusb: support hotplug

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -1033,7 +1033,7 @@ void handle_hotplug_event(bool connected)
 {
 	if (auto usbh = g_fxo->try_get<named_thread<usb_handler_thread>>())
 	{
-		usbh.usb_hotplug_timeout = get_system_time() + (connected ? 500'000ull : 0);
+		usbh->usb_hotplug_timeout = get_system_time() + (connected ? 500'000ull : 0);
 	}
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -613,7 +613,7 @@ void usb_handler_thread::operator()()
 			// every 4 seconds.
 			// On systems where hotplug is native, we wait a little bit for devices to settle before we start the scan
 			perform_scan();
-			usb_hotplug_timeout = hotplug_supported ? UINT64_MAX : get_system_time() + 4'000'000ull;
+			usb_hotplug_timeout = hotplug_supported ? umax : get_system_time() + 4'000'000ull;
 		}
 
 		// Process asynchronous requests that are pending

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -1033,7 +1033,7 @@ void handle_hotplug_event(bool connected)
 {
 	if (auto usbh = g_fxo->try_get<named_thread<usb_handler_thread>>())
 	{
-		usbh->usb_hotplug_timeout = get_system_time() + (connected ? 500'000ull : 0);
+		usbh->usb_hotplug_timeout = get_system_time() + (connected ? 1'000'000ull : 0);
 	}
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -73,6 +73,19 @@ struct UsbPipe
 	u8 endpoint = 0;
 };
 
+struct usb_allow_list_entry
+{
+	u16 id_vendor;
+	u16 id_product_min;
+	u16 id_product_max;
+	std::string_view device_name;
+	u16(*max_device_count)(void);
+	std::shared_ptr<usb_device>(*make_instance)(u32, const std::array<u8, 7>&);
+	auto operator<(const usb_allow_list_entry& r) const
+	{
+		return std::tuple(id_vendor, id_product_min, id_product_max, device_name, max_device_count, make_instance) < std::tuple(r.id_vendor, r.id_product_min, r.id_product_max, device_name, max_device_count, make_instance);
+	}
+};
 class usb_handler_thread
 {
 public:
@@ -132,6 +145,8 @@ public:
 	shared_mutex mutex_sq;
 	ppu_thread* sq{};
 
+	atomic_t<u64> usb_hotplug_timeout = UINT64_MAX;
+
 	static constexpr auto thread_name = "Usb Manager Thread"sv;
 
 private:
@@ -140,6 +155,7 @@ private:
 	u32 get_free_transfer_id();
 
 	void send_message(u32 message, u32 tr_id);
+	void perform_scan();
 
 private:
 	// Counters for device IDs, transfer IDs and pipe IDs
@@ -149,6 +165,101 @@ private:
 
 	// List of device drivers
 	std::unordered_map<std::string, UsbLdd, fmt::string_hash, std::equal_to<>> ldds;
+
+	const std::vector<usb_allow_list_entry> device_allow_list
+	{
+		// Portals
+		{0x1430, 0x0150, 0x0150, "Skylanders Portal", &usb_device_skylander::get_num_emu_devices, &usb_device_skylander::make_instance},
+		{0x0E6F, 0x0129, 0x0129, "Disney Infinity Base", &usb_device_infinity::get_num_emu_devices, &usb_device_infinity::make_instance},
+		{0x0E6F, 0x0241, 0x0241, "Lego Dimensions Portal", &usb_device_dimensions::get_num_emu_devices, &usb_device_dimensions::make_instance},
+		{0x0E6F, 0x200A, 0x200A, "Kamen Rider Summonride Portal", nullptr, nullptr},
+
+		// Cameras
+		// {0x1415, 0x0020, 0x2000, "Sony Playstation Eye", nullptr, nullptr}, // TODO: verifiy
+
+		// Music devices
+		{0x1415, 0x0000, 0x0000, "Singstar Microphone", nullptr, nullptr},
+		// {0x1415, 0x0020, 0x0020, "SingStar Microphone Wireless", nullptr, nullptr}, // TODO: verifiy
+
+		{0x12BA, 0x00FF, 0x00FF, "Rocksmith Guitar Adapter", nullptr, nullptr},
+		{0x12BA, 0x0100, 0x0100, "Guitar Hero Guitar", nullptr, nullptr},
+		{0x12BA, 0x0120, 0x0120, "Guitar Hero Drums", nullptr, nullptr},
+		{0x12BA, 0x074B, 0x074B, "Guitar Hero Live Guitar", &usb_device_ghltar::get_num_emu_devices, &usb_device_ghltar::make_instance},
+
+		{0x12BA, 0x0140, 0x0140, "DJ Hero Turntable", &usb_device_turntable::get_num_emu_devices, &usb_device_turntable::make_instance},
+		{0x12BA, 0x0200, 0x020F, "Harmonix Guitar", nullptr, nullptr},
+		{0x12BA, 0x0210, 0x021F, "Harmonix Drums", nullptr, nullptr},
+		{0x12BA, 0x2330, 0x233F, "Harmonix Keyboard", nullptr, nullptr},
+		{0x12BA, 0x2430, 0x243F, "Harmonix Button Guitar", nullptr, nullptr},
+		{0x12BA, 0x2530, 0x253F, "Harmonix Real Guitar", nullptr, nullptr},
+
+		{0x1BAD, 0x0004, 0x0004, "Harmonix RB1 Guitar - Wii", nullptr, nullptr},
+		{0x1BAD, 0x0005, 0x0005, "Harmonix RB1 Drums - Wii", nullptr, nullptr},
+		{0x1BAD, 0x3010, 0x301F, "Harmonix RB2 Guitar - Wii", nullptr, nullptr},
+		{0x1BAD, 0x3110, 0x313F, "Harmonix RB2 Drums - Wii", nullptr, nullptr},
+		{0x1BAD, 0x3330, 0x333F, "Harmonix Keyboard - Wii", nullptr, nullptr},
+		{0x1BAD, 0x3430, 0x343F, "Harmonix Button Guitar - Wii", nullptr, nullptr},
+		{0x1BAD, 0x3530, 0x353F, "Harmonix Real Guitar - Wii", nullptr, nullptr},
+
+		//Top Shot Elite controllers
+		{0x12BA, 0x04A0, 0x04A0, "Top Shot Elite", nullptr, nullptr},
+		{0x12BA, 0x04A1, 0x04A1, "Top Shot Fearmaster", nullptr, nullptr},
+		{0x12BA, 0x04B0, 0x04B0, "Rapala Fishing Rod", nullptr, nullptr},
+
+
+		// GT5 Wheels&co
+		{0x046D, 0xC283, 0xC29B, "lgFF_c283_c29b", nullptr, nullptr},
+		{0x044F, 0xB653, 0xB653, "Thrustmaster RGT FFB Pro", nullptr, nullptr},
+		{0x044F, 0xB65A, 0xB65A, "Thrustmaster F430", nullptr, nullptr},
+		{0x044F, 0xB65D, 0xB65D, "Thrustmaster FFB", nullptr, nullptr},
+		{0x044F, 0xB65E, 0xB65E, "Thrustmaster TRS", nullptr, nullptr},
+		{0x044F, 0xB660, 0xB660, "Thrustmaster T500 RS Gear Shift", nullptr, nullptr},
+
+		// GT6
+		{0x2833, 0x0001, 0x0001, "Oculus", nullptr, nullptr},
+		{0x046D, 0xCA03, 0xCA03, "lgFF_ca03_ca03", nullptr, nullptr},
+
+		// Buzz controllers
+		{0x054C, 0x1000, 0x1040, "buzzer0", &usb_device_buzz::get_num_emu_devices, &usb_device_buzz::make_instance},
+		{0x054C, 0x0001, 0x0041, "buzzer1", nullptr, nullptr},
+		{0x054C, 0x0042, 0x0042, "buzzer2", nullptr, nullptr},
+		{0x046D, 0xC220, 0xC220, "buzzer9", nullptr, nullptr},
+
+		// GCon3 Gun
+		{0x0B9A, 0x0800, 0x0800, "guncon3", nullptr, nullptr},
+
+		// uDraw GameTablet
+		{0x20D6, 0xCB17, 0xCB17, "uDraw GameTablet", nullptr, nullptr},
+
+		// DVB-T
+		{0x1415, 0x0003, 0x0003, "PlayTV SCEH-0036", nullptr, nullptr},
+
+		// PSP Devices
+		{0x054C, 0x01C8, 0x01C8, "PSP Type A", nullptr, nullptr},
+		{0x054C, 0x01C9, 0x01C9, "PSP Type B", nullptr, nullptr},
+		{0x054C, 0x01CA, 0x01CA, "PSP Type C", nullptr, nullptr},
+		{0x054C, 0x01CB, 0x01CB, "PSP Type D", nullptr, nullptr},
+		{0x054C, 0x02D2, 0x02D2, "PSP Slim", nullptr, nullptr},
+
+		// 0x0900: "H050 USJ(C) PCB rev00", 0x0910: "USIO PCB rev00"
+		{0x0B9A, 0x0900, 0x0910, "PS3A-USJ", &usb_device_usio::get_num_emu_devices, &usb_device_usio::make_instance},
+
+		// Densha de GO! controller
+		{0x0AE4, 0x0004, 0x0004, "Densha de GO! Type 2 Controller", nullptr, nullptr},
+
+		// EA Active 2 dongle for connecting wristbands & legband
+		{0x21A4, 0xAC27, 0xAC27, "EA Active 2 Dongle", nullptr, nullptr},
+
+		// Tony Hawk RIDE Skateboard
+		{0x12BA, 0x0400, 0x0400, "Tony Hawk RIDE Skateboard Controller", nullptr, nullptr},
+
+		// PSP in UsbPspCm mode
+		{0x054C, 0x01CB, 0x01CB, "UsbPspcm", nullptr, nullptr},
+
+		// Sony Stereo Headsets
+		{0x12BA, 0x0032, 0x0032, "Wireless Stereo Headset", nullptr, nullptr},
+		{0x12BA, 0x0042, 0x0042, "Wireless Stereo Headset", nullptr, nullptr},
+	};
 
 	// List of pipes
 	std::map<u32, UsbPipe> open_pipes;
@@ -163,8 +274,15 @@ private:
 	// List of devices "connected" to the ps3
 	std::array<u8, 7> location{};
 	std::vector<std::shared_ptr<usb_device>> usb_devices;
+	std::unordered_map<uint64_t, std::shared_ptr<usb_device>> usb_passthrough_devices;
 
 	libusb_context* ctx = nullptr;
+
+#if LIBUSB_API_VERSION >= 0x01000102
+	libusb_hotplug_callback_handle callback_handle {};
+#endif
+
+	bool hotplug_supported = false;
 };
 
 void LIBUSB_CALL callback_transfer(struct libusb_transfer* transfer)
@@ -176,6 +294,14 @@ void LIBUSB_CALL callback_transfer(struct libusb_transfer* transfer)
 
 	usbh.transfer_complete(transfer);
 }
+
+#if LIBUSB_API_VERSION >= 0x01000102
+static int LIBUSB_CALL hotplug_callback(libusb_context* /*ctx*/, libusb_device * /*dev*/, libusb_hotplug_event event, void * /*user_data*/)
+{
+	handle_hotplug_event(event == LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED);
+	return 0;
+}
+#endif
 
 #if LIBUSB_API_VERSION >= 0x0100010A
 static void LIBUSB_CALL log_cb(libusb_context* /*ctx*/, enum libusb_log_level level, const char* str)
@@ -205,6 +331,93 @@ static void LIBUSB_CALL log_cb(libusb_context* /*ctx*/, enum libusb_log_level le
 }
 #endif
 
+void usb_handler_thread::perform_scan()
+{
+	// look if any device which we could be interested in is actually connected
+	libusb_device** list = nullptr;
+	const ssize_t ndev   = libusb_get_device_list(ctx, &list);
+	std::set<uint64_t> seen_usb_devices;
+
+	if (ndev < 0)
+	{
+		sys_usbd.error("Failed to get device list: %s", libusb_error_name(static_cast<s32>(ndev)));
+		return;
+	}
+
+	for (ssize_t index = 0; index < ndev; index++)
+	{
+		libusb_device* dev = list[index];
+		libusb_device_descriptor desc;
+		if (int res = libusb_get_device_descriptor(dev, &desc); res < 0)
+		{
+			sys_usbd.error("Failed to get device descriptor: %s", libusb_error_name(res));
+			continue;
+		}
+
+		const u8 port = libusb_get_port_number(dev);
+		const u8 address = libusb_get_device_address(dev);
+		const u64 usb_id = (static_cast<uint64_t>(desc.idVendor) << 48) | (static_cast<uint64_t>(desc.idProduct) << 32) | (static_cast<uint64_t>(port) << 8) | address;
+
+		seen_usb_devices.insert(usb_id);
+		if (usb_passthrough_devices.contains(usb_id))
+		{
+			continue;
+		}
+
+		for (const auto& entry : device_allow_list)
+		{
+			// attach
+			if (desc.idVendor == entry.id_vendor
+				&& desc.idProduct >= entry.id_product_min
+				&& desc.idProduct <= entry.id_product_max)
+			{
+				sys_usbd.success("Found device: %s", std::basic_string(entry.device_name));
+				libusb_ref_device(dev);
+				std::shared_ptr<usb_device_passthrough> usb_dev = std::make_shared<usb_device_passthrough>(dev, desc, get_new_location());
+				connect_usb_device(usb_dev, true);
+				usb_passthrough_devices[usb_id] = usb_dev;
+			}
+		}
+
+		if (desc.idVendor == 0x1209 && desc.idProduct == 0x2882)
+		{
+			sys_usbd.success("Found device: Santroller");
+			// Send the device a specific control transfer so that it jumps to a RPCS3 compatible mode
+			libusb_device_handle* lusb_handle;
+			if (libusb_open(dev, &lusb_handle) == LIBUSB_SUCCESS)
+			{
+#ifdef __linux__
+				libusb_set_auto_detach_kernel_driver(lusb_handle, true);
+				libusb_claim_interface(lusb_handle, 2);
+#endif
+				libusb_control_transfer(lusb_handle, +LIBUSB_ENDPOINT_IN | +LIBUSB_REQUEST_TYPE_CLASS | +LIBUSB_RECIPIENT_INTERFACE, 0x01, 0x03f2, 2, nullptr, 0, 5000);
+				libusb_close(lusb_handle);
+			}
+			else
+			{
+				sys_usbd.error("Unable to open Santroller device, make sure Santroller isn't open in the background.");
+			}
+		}
+	}
+
+	for (auto it = usb_passthrough_devices.begin(); it != usb_passthrough_devices.end();)
+	{
+		auto& dev = *it;
+		// If a device is no longer visible, disconnect it
+		if (seen_usb_devices.contains(dev.first))
+		{
+			++it;
+		}
+		else
+		{
+			disconnect_usb_device(dev.second, true);
+			it = usb_passthrough_devices.erase(it);
+		}
+
+	}
+	libusb_free_device_list(list, 1);
+}
+
 usb_handler_thread::usb_handler_thread()
 {
 #if LIBUSB_API_VERSION >= 0x0100010A
@@ -230,201 +443,103 @@ usb_handler_thread::usb_handler_thread()
 		return;
 	}
 
+#ifdef _WIN32
+	hotplug_supported = true;
+#elif LIBUSB_API_VERSION >= 0x01000102
+	if (libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG))
+	{
+		if (int res = libusb_hotplug_register_callback(ctx, static_cast<libusb_hotplug_event>(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED |
+			LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT), static_cast<libusb_hotplug_flag>(0), LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
+			LIBUSB_HOTPLUG_MATCH_ANY, static_cast<libusb_hotplug_callback_fn>(hotplug_callback), nullptr,
+			&callback_handle); res < 0)
+		{
+			sys_usbd.error("Failed to initialize sys_usbd hotplug: %s", libusb_error_name(res));
+		}
+		else
+		{
+			hotplug_supported = true;
+		}
+	}
+#endif
+
 	for (u32 index = 0; index < MAX_SYS_USBD_TRANSFERS; index++)
 	{
 		transfers[index].transfer    = libusb_alloc_transfer(8);
 		transfers[index].transfer_id = index;
 	}
 
-	// look if any device which we could be interested in is actually connected
-	libusb_device** list = nullptr;
-	ssize_t ndev         = libusb_get_device_list(ctx, &list);
-
-	if (ndev < 0)
+	if (!g_cfg_usio.load())
 	{
-		sys_usbd.error("Failed to get device list: %s", libusb_error_name(static_cast<s32>(ndev)));
-		return;
+		sys_usbd.notice("Could not load usio config. Using defaults.");
 	}
 
-	bool found_skylander = false;
-	bool found_infinity  = false;
-	bool found_dimension = false;	
-	bool found_usj       = false;
+	sys_usbd.notice("USIO config=\n", g_cfg_usio.to_string());
 
-	for (ssize_t index = 0; index < ndev; index++)
+	if (g_cfg.io.ghltar == ghltar_handler::one_controller || g_cfg.io.ghltar == ghltar_handler::two_controllers)
 	{
-		libusb_device_descriptor desc;
-		if (int res = libusb_get_device_descriptor(list[index], &desc); res < 0)
+		if (!g_cfg_ghltar.load())
 		{
-			sys_usbd.error("Failed to get device descriptor: %s", libusb_error_name(res));
-			continue;
+			sys_usbd.notice("Could not load ghltar config. Using defaults.");
 		}
 
-		auto check_device = [&](const u16 id_vendor, const u16 id_product_min, const u16 id_product_max, const char* s_name) -> bool
-		{
-			if (desc.idVendor == id_vendor && desc.idProduct >= id_product_min && desc.idProduct <= id_product_max)
-			{
-				sys_usbd.success("Found device: %s", s_name);
-				libusb_ref_device(list[index]);
-				std::shared_ptr<usb_device_passthrough> usb_dev = std::make_shared<usb_device_passthrough>(list[index], desc, get_new_location());
-				usb_devices.push_back(usb_dev);
-				return true;
-			}
-			return false;
-		};
-
-		// Portals
-		if (check_device(0x1430, 0x0150, 0x0150, "Skylanders Portal"))
-		{
-			found_skylander = true;
-		}
-
-		if (check_device(0x0E6F, 0x0129, 0x0129, "Disney Infinity Base"))
-		{
-			found_infinity = true;
-		}
-
-		if (check_device(0x0E6F, 0x0241, 0x0241, "Lego Dimensions Portal"))
-		{
-			found_dimension = true;
-		}
-
-		check_device(0x0E6F, 0x200A, 0x200A, "Kamen Rider Summonride Portal");
-
-		// Cameras
-		// check_device(0x1415, 0x0020, 0x2000, "Sony Playstation Eye"); // TODO: verifiy
-
-		// Music devices
-		check_device(0x1415, 0x0000, 0x0000, "SingStar Microphone");
-		// check_device(0x1415, 0x0020, 0x0020, "SingStar Microphone Wireless"); // TODO: verifiy
-		check_device(0x12BA, 0x0100, 0x0100, "Guitar Hero Guitar");
-		check_device(0x12BA, 0x0120, 0x0120, "Guitar Hero Drums");
-		check_device(0x12BA, 0x074B, 0x074B, "Guitar Hero Live Guitar");
-
-		check_device(0x12BA, 0x0140, 0x0140, "DJ Hero Turntable");
-		check_device(0x12BA, 0x0200, 0x020F, "Harmonix Guitar");
-		check_device(0x12BA, 0x0210, 0x021F, "Harmonix Drums");
-		check_device(0x12BA, 0x2330, 0x233F, "Harmonix Keyboard");
-		check_device(0x12BA, 0x2430, 0x243F, "Harmonix Button Guitar");
-		check_device(0x12BA, 0x2530, 0x253F, "Harmonix Real Guitar");
-
-		check_device(0x1BAD, 0x0004, 0x0004, "Harmonix RB1 Guitar - Wii");
-		check_device(0x1BAD, 0x0005, 0x0005, "Harmonix RB1 Drums - Wii");
-		check_device(0x1BAD, 0x3010, 0x301F, "Harmonix RB2 Guitar - Wii");
-		check_device(0x1BAD, 0x3110, 0x313F, "Harmonix RB2 Drums - Wii");
-		check_device(0x1BAD, 0x3330, 0x333F, "Harmonix Keyboard - Wii");
-		check_device(0x1BAD, 0x3430, 0x343F, "Harmonix Button Guitar - Wii");
-		check_device(0x1BAD, 0x3530, 0x353F, "Harmonix Real Guitar - Wii");
-
-		if (desc.idVendor == 0x1209 && desc.idProduct == 0x2882)
-		{
-			sys_usbd.success("Found device: Santroller");
-			// Send the device a specific control transfer so that it jumps to a RPCS3 compatible mode
-			libusb_device_handle* lusb_handle;
-			if (libusb_open(list[index], &lusb_handle) == LIBUSB_SUCCESS)
-			{
-#ifdef __linux__
-				libusb_set_auto_detach_kernel_driver(lusb_handle, true);
-				libusb_claim_interface(lusb_handle, 2);
-#endif
-				libusb_control_transfer(lusb_handle, +LIBUSB_ENDPOINT_IN | +LIBUSB_REQUEST_TYPE_CLASS | +LIBUSB_RECIPIENT_INTERFACE, 0x01, 0x03f2, 2, nullptr, 0, 5000);
-				libusb_close(lusb_handle);
-			}
-			else
-			{
-				sys_usbd.error("Unable to open Santroller device, make sure Santroller isn't open in the background.");
-			}
-		}
-
-		// Top Shot Elite controllers
-		check_device(0x12BA, 0x04A0, 0x04A0, "Top Shot Elite");
-		check_device(0x12BA, 0x04A1, 0x04A1, "Top Shot Fearmaster");
-		check_device(0x12BA, 0x04B0, 0x04B0, "Rapala Fishing Rod");
-
-		// GT5 Wheels&co
-		check_device(0x046D, 0xC283, 0xC29B, "lgFF_c283_c29b");
-		check_device(0x044F, 0xB653, 0xB653, "Thrustmaster RGT FFB Pro");
-		check_device(0x044F, 0xB65A, 0xB65A, "Thrustmaster F430");
-		check_device(0x044F, 0xB65D, 0xB65D, "Thrustmaster FFB");
-		check_device(0x044F, 0xB65E, 0xB65E, "Thrustmaster TRS");
-		check_device(0x044F, 0xB660, 0xB660, "Thrustmaster T500 RS Gear Shift");
-
-		// GT6
-		check_device(0x2833, 0x0001, 0x0001, "Oculus");
-		check_device(0x046D, 0xCA03, 0xCA03, "lgFF_ca03_ca03");
-
-		// Buzz controllers
-		check_device(0x054C, 0x1000, 0x1040, "buzzer0");
-		check_device(0x054C, 0x0001, 0x0041, "buzzer1");
-		check_device(0x054C, 0x0042, 0x0042, "buzzer2");
-		check_device(0x046D, 0xC220, 0xC220, "buzzer9");
-
-		// GunCon3 Gun
-		check_device(0x0B9A, 0x0800, 0x0800, "GunCon3");
-
-		// uDraw GameTablet
-		check_device(0x20D6, 0xCB17, 0xCB17, "uDraw GameTablet");
-
-		// DVB-T
-		check_device(0x1415, 0x0003, 0x0003, "PlayTV SCEH-0036");
-
-		// 0x0900: "H050 USJ(C) PCB rev00", 0x0910: "USIO PCB rev00"
-		if (check_device(0x0B9A, 0x0900, 0x0910, "PS3A-USJ"))
-		{
-			found_usj = true;
-		}
-
-		// Densha de GO! controller
-		check_device(0x0AE4, 0x0004, 0x0004, "Densha de GO! Type 2 Controller");
-
-		// EA Active 2 dongle for connecting wristbands & legband
-		check_device(0x21A4, 0xAC27, 0xAC27, "EA Active 2 Dongle");
-
-		// Tony Hawk RIDE Skateboard
-		check_device(0x12BA, 0x0400, 0x0400, "Tony Hawk RIDE Skateboard Controller");
-
-		// PSP in UsbPspCm mode
-		check_device(0x054C, 0x01CB, 0x01CB, "UsbPspcm");
+		sys_usbd.notice("Ghltar config=\n", g_cfg_ghltar.to_string());
 	}
 
-	libusb_free_device_list(list, 1);
+	if (g_cfg.io.turntable == turntable_handler::one_controller || g_cfg.io.turntable == turntable_handler::two_controllers)
+	{
+		if (!g_cfg_turntable.load())
+		{
+			sys_usbd.notice("Could not load turntable config. Using defaults.");
+		}
+
+		sys_usbd.notice("Turntable config=\n", g_cfg_turntable.to_string());
+	}
+
+	if (g_cfg.io.buzz == buzz_handler::one_controller || g_cfg.io.buzz == buzz_handler::two_controllers)
+	{
+		if (!g_cfg_buzz.load())
+		{
+			sys_usbd.notice("Could not load buzz config. Using defaults.");
+		}
+
+		sys_usbd.notice("Buzz config=\n", g_cfg_buzz.to_string());
+	}
+
+	perform_scan();
+
+	// Set up emulated devices for any devices that are not already being passed through
+	std::map<usb_allow_list_entry, int> emulate_device_check;
+	for (const auto& dev : usb_devices)
+	{
+		for (const auto& entry : device_allow_list)
+		{
+			const u16 idVendor = dev->device._device.idVendor;
+			const u16 idProduct = dev->device._device.idProduct;
+			if (entry.max_device_count != nullptr && (idVendor == entry.id_vendor && idProduct >= entry.id_product_min && idProduct <= entry.id_product_max))
+			{
+				emulate_device_check[entry]++;
+			}
+		}
+	}
+
+	for (const auto& [entry, count] : emulate_device_check)
+	{
+		if (entry.max_device_count && entry.make_instance)
+		{
+			for (int i = count; i < entry.max_device_count(); i++)
+			{
+				sys_usbd.success("Emulating device: %s (%d)", std::basic_string(entry.device_name), i);
+				auto usb_dev = entry.make_instance(i, get_new_location());
+				connect_usb_device(usb_dev, true);
+			}
+		}
+	}
 
 	for (int i = 0; i < 8; i++) // Add VFS USB mass storage devices (/dev_usbXXX) to the USB device list
 	{
 		const auto usb_info = g_cfg_vfs.get_device(g_cfg_vfs.dev_usb, fmt::format("/dev_usb%03d", i));
 		if (fs::is_dir(usb_info.path))
 			usb_devices.push_back(std::make_shared<usb_device_vfs>(usb_info, get_new_location()));
-	}
-
-	if (!found_skylander)
-	{
-		sys_usbd.notice("Adding emulated skylander");
-		usb_devices.push_back(std::make_shared<usb_device_skylander>(get_new_location()));
-	}
-
-	if (!found_infinity)
-	{
-		sys_usbd.notice("Adding emulated infinity base");
-		usb_devices.push_back(std::make_shared<usb_device_infinity>(get_new_location()));
-	}
-
-	if (!found_dimension)
-	{
-		sys_usbd.notice("Adding emulated dimension toypad");
-		usb_devices.push_back(std::make_shared<usb_device_dimensions>(get_new_location()));
-	}
-
-	if (!found_usj)
-	{
-		if (!g_cfg_usio.load())
-		{
-			sys_usbd.notice("Could not load usio config. Using defaults.");
-		}
-
-		sys_usbd.notice("Adding emulated USIO");
-		usb_devices.push_back(std::make_shared<usb_device_usio>(get_new_location()));
-
-		sys_usbd.notice("USIO config=\n", g_cfg_usio.to_string());
 	}
 
 	const std::vector<std::string> devices_list = fmt::split(g_cfg.io.midi_devices.to_string(), { "@@@" });
@@ -458,65 +573,6 @@ usb_handler_thread::usb_handler_thread()
 			break;
 		}
 	}
-
-	if (g_cfg.io.ghltar == ghltar_handler::one_controller || g_cfg.io.ghltar == ghltar_handler::two_controllers)
-	{
-		if (!g_cfg_ghltar.load())
-		{
-			sys_usbd.notice("Could not load ghltar config. Using defaults.");
-		}
-
-		sys_usbd.notice("Adding emulated GHLtar (1 player)");
-		usb_devices.push_back(std::make_shared<usb_device_ghltar>(0, get_new_location()));
-
-		if (g_cfg.io.ghltar == ghltar_handler::two_controllers)
-		{
-			sys_usbd.notice("Adding emulated GHLtar (2 players)");
-			usb_devices.push_back(std::make_shared<usb_device_ghltar>(1, get_new_location()));
-		}
-
-		sys_usbd.notice("Ghltar config=\n", g_cfg_ghltar.to_string());
-	}
-
-	if (g_cfg.io.turntable == turntable_handler::one_controller || g_cfg.io.turntable == turntable_handler::two_controllers)
-	{
-		if (!g_cfg_turntable.load())
-		{
-			sys_usbd.notice("Could not load turntable config. Using defaults.");
-		}
-
-		sys_usbd.notice("Adding emulated turntable (1 player)");
-		usb_devices.push_back(std::make_shared<usb_device_turntable>(0, get_new_location()));
-
-		if (g_cfg.io.turntable == turntable_handler::two_controllers)
-		{
-			sys_usbd.notice("Adding emulated turntable (2 players)");
-			usb_devices.push_back(std::make_shared<usb_device_turntable>(1, get_new_location()));
-		}
-
-		sys_usbd.notice("Turntable config=\n", g_cfg_turntable.to_string());
-	}
-
-	if (g_cfg.io.buzz == buzz_handler::one_controller || g_cfg.io.buzz == buzz_handler::two_controllers)
-	{
-		if (!g_cfg_buzz.load())
-		{
-			sys_usbd.notice("Could not load buzz config. Using defaults.");
-		}
-
-		sys_usbd.notice("Adding emulated Buzz! buzzer (1-4 players)");
-		usb_devices.push_back(std::make_shared<usb_device_buzz>(0, 3, get_new_location()));
-
-		if (g_cfg.io.buzz == buzz_handler::two_controllers)
-		{
-			// The current buzz emulation piggybacks on the pad input.
-			// Since there can only be 7 pads connected on a PS3 the 8th player is currently not supported
-			sys_usbd.notice("Adding emulated Buzz! buzzer (5-7 players)");
-			usb_devices.push_back(std::make_shared<usb_device_buzz>(4, 6, get_new_location()));
-		}
-
-		sys_usbd.notice("Buzz config=\n", g_cfg_buzz.to_string());
-	}
 }
 
 usb_handler_thread::~usb_handler_thread()
@@ -525,12 +581,17 @@ usb_handler_thread::~usb_handler_thread()
 	handled_devices.clear();
 	open_pipes.clear();
 	usb_devices.clear();
+	usb_passthrough_devices.clear();
 
 	for (u32 index = 0; index < MAX_SYS_USBD_TRANSFERS; index++)
 	{
 		if (transfers[index].transfer)
 			libusb_free_transfer(transfers[index].transfer);
 	}
+
+#if LIBUSB_API_VERSION >= 0x01000102
+	libusb_hotplug_deregister_callback(ctx, callback_handle);
+#endif
 
 	if (ctx)
 		libusb_exit(ctx);
@@ -539,10 +600,21 @@ usb_handler_thread::~usb_handler_thread()
 void usb_handler_thread::operator()()
 {
 	timeval lusb_tv{0, 0};
-
+	if (!hotplug_supported)
+	{
+		usb_hotplug_timeout = get_system_time() + 4'000'000ull;
+	}
 	while (ctx && thread_ctrl::state() != thread_state::aborting)
 	{
-		// Todo: Hotplug here?
+		const u64 now = get_system_time();
+		if (now > usb_hotplug_timeout)
+		{
+			// If we did the hotplug scan each cycle the game performance was significantly degraded, so we only perform this scan
+			// every 4 seconds.
+			// On systems where hotplug is native, we wait a little bit for devices to settle before we start the scan
+			perform_scan();
+			usb_hotplug_timeout = hotplug_supported ? UINT64_MAX : get_system_time() + 4'000'000ull;
+		}
 
 		// Process asynchronous requests that are pending
 		libusb_handle_events_timeout_completed(ctx, &lusb_tv, nullptr);
@@ -836,6 +908,7 @@ void usb_handler_thread::connect_usb_device(std::shared_ptr<usb_device> dev, boo
 			if (!dev->open_device())
 			{
 				sys_usbd.error("Failed to open USB device(VID=0x%04x, PID=0x%04x) for LDD <%s>", dev->device._device.idVendor, dev->device._device.idProduct, name);
+				disconnect_usb_device(dev);
 				return;
 			}
 
@@ -844,6 +917,7 @@ void usb_handler_thread::connect_usb_device(std::shared_ptr<usb_device> dev, boo
 			handled_devices.emplace(dev->assigned_number, std::pair(UsbInternalDevice{0x00, narrow<u8>(dev->assigned_number), 0x02, 0x40}, dev));
 			send_message(SYS_USBD_ATTACH, dev->assigned_number);
 			sys_usbd.success("USB device(VID=0x%04x, PID=0x%04x) matches up with LDD <%s>, assigned as handled_device=0x%x", dev->device._device.idVendor, dev->device._device.idProduct, name, dev->assigned_number);
+			return;
 		}
 	}
 }
@@ -855,10 +929,18 @@ void usb_handler_thread::disconnect_usb_device(std::shared_ptr<usb_device> dev, 
 		send_message(SYS_USBD_DETACH, dev->assigned_number);
 		sys_usbd.success("USB device(VID=0x%04x, PID=0x%04x) unassigned, handled_device=0x%x", dev->device._device.idVendor, dev->device._device.idProduct, dev->assigned_number);
 		dev->assigned_number = 0;
+		std::erase_if(open_pipes, [&](const auto& val)
+		{
+			return val.second.device == dev;
+		});
 	}
-
 	if (update_usb_devices)
-		usb_devices.erase(find(usb_devices.begin(), usb_devices.end(), dev));
+	{
+		std::erase_if(usb_devices, [&](const auto& val)
+		{
+			return val == dev;
+		});
+	}
 }
 
 void connect_usb_controller(u8 index, input::product_type type)
@@ -944,6 +1026,14 @@ void connect_usb_controller(u8 index, input::product_type type)
 		default:
 			break;
 		}
+	}
+}
+
+void handle_hotplug_event(bool connected)
+{
+	if (auto usbh = g_fxo->try_get<named_thread<usb_handler_thread>>())
+	{
+		usbh.usb_hotplug_timeout = get_system_time() + (connected ? 500'000ull : 0);
 	}
 }
 

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -145,7 +145,7 @@ public:
 	shared_mutex mutex_sq;
 	ppu_thread* sq{};
 
-	atomic_t<u64> usb_hotplug_timeout = UINT64_MAX;
+	atomic_t<u64> usb_hotplug_timeout = umax;
 
 	static constexpr auto thread_name = "Usb Manager Thread"sv;
 

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.h
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.h
@@ -89,3 +89,4 @@ error_code sys_usbd_register_extra_ldd(ppu_thread& ppu, u32 handle, vm::cptr<cha
 error_code sys_usbd_unregister_extra_ldd(ppu_thread& ppu, u32 handle, vm::cptr<char> s_product, u16 slen_product);
 
 void connect_usb_controller(u8 index, input::product_type);
+void handle_hotplug_event(bool connected);

--- a/rpcs3/Emu/Io/Buzz.cpp
+++ b/rpcs3/Emu/Io/Buzz.cpp
@@ -4,6 +4,7 @@
 #include "Buzz.h"
 #include "Emu/Cell/lv2/sys_usbd.h"
 #include "Emu/Io/buzz_config.h"
+#include "Emu/system_config.h"
 #include "Input/pad_thread.h"
 
 LOG_CHANNEL(buzz_log, "BUZZ");
@@ -83,6 +84,23 @@ usb_device_buzz::usb_device_buzz(u32 first_controller, u32 last_controller, cons
 
 usb_device_buzz::~usb_device_buzz()
 {
+}
+
+std::shared_ptr<usb_device> usb_device_buzz::make_instance(u32 controller_index, const std::array<u8, 7>& location)
+{
+	if (controller_index == 0)
+	{
+		return std::make_shared<usb_device_buzz>(0, 3, location);
+	}
+
+	// The current buzz emulation piggybacks on the pad input.
+	// Since there can only be 7 pads connected on a PS3 the 8th player is currently not supported
+	return std::make_shared<usb_device_buzz>(4, 6, location);
+}
+
+u16 usb_device_buzz::get_num_emu_devices()
+{
+	return static_cast<u16>(g_cfg.io.buzz.get());
 }
 
 void usb_device_buzz::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)

--- a/rpcs3/Emu/Io/Buzz.h
+++ b/rpcs3/Emu/Io/Buzz.h
@@ -8,6 +8,9 @@ public:
 	usb_device_buzz(u32 first_controller, u32 last_controller, const std::array<u8, 7>& location);
 	~usb_device_buzz();
 
+	static std::shared_ptr<usb_device> make_instance(u32 controller_index, const std::array<u8, 7>& location);
+	static u16 get_num_emu_devices();
+
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 

--- a/rpcs3/Emu/Io/Dimensions.cpp
+++ b/rpcs3/Emu/Io/Dimensions.cpp
@@ -573,6 +573,16 @@ usb_device_dimensions::~usb_device_dimensions()
 {
 }
 
+std::shared_ptr<usb_device> usb_device_dimensions::make_instance(u32, const std::array<u8, 7>& location)
+{
+	return std::make_shared<usb_device_dimensions>(location);
+}
+
+u16 usb_device_dimensions::get_num_emu_devices()
+{
+	return 1;
+}
+
 void usb_device_dimensions::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)
 {
 	usb_device_emulated::control_transfer(bmRequestType, bRequest, wValue, wIndex, wLength, buf_size, buf, transfer);

--- a/rpcs3/Emu/Io/Dimensions.h
+++ b/rpcs3/Emu/Io/Dimensions.h
@@ -71,6 +71,9 @@ public:
 	usb_device_dimensions(const std::array<u8, 7>& location);
 	~usb_device_dimensions();
 
+	static std::shared_ptr<usb_device> make_instance(u32 controller_index, const std::array<u8, 7>& location);
+	static u16 get_num_emu_devices();
+
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 	void isochronous_transfer(UsbTransfer* transfer) override;

--- a/rpcs3/Emu/Io/GHLtar.cpp
+++ b/rpcs3/Emu/Io/GHLtar.cpp
@@ -4,6 +4,7 @@
 #include "GHLtar.h"
 #include "Emu/Cell/lv2/sys_usbd.h"
 #include "Emu/Io/ghltar_config.h"
+#include "Emu/system_config.h"
 #include "Input/pad_thread.h"
 
 LOG_CHANNEL(ghltar_log, "GHLTAR");
@@ -50,6 +51,16 @@ usb_device_ghltar::usb_device_ghltar(u32 controller_index, const std::array<u8, 
 
 usb_device_ghltar::~usb_device_ghltar()
 {
+}
+
+std::shared_ptr<usb_device> usb_device_ghltar::make_instance(u32 controller_index, const std::array<u8, 7>& location)
+{
+	return std::make_shared<usb_device_ghltar>(controller_index, location);
+}
+
+u16 usb_device_ghltar::get_num_emu_devices()
+{
+	return static_cast<u16>(g_cfg.io.ghltar.get());
 }
 
 void usb_device_ghltar::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)

--- a/rpcs3/Emu/Io/GHLtar.h
+++ b/rpcs3/Emu/Io/GHLtar.h
@@ -8,6 +8,9 @@ public:
 	usb_device_ghltar(u32 controller_index, const std::array<u8, 7>& location);
 	~usb_device_ghltar();
 
+	static std::shared_ptr<usb_device> make_instance(u32 controller_index, const std::array<u8, 7>& location);
+	static u16 get_num_emu_devices();
+
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 

--- a/rpcs3/Emu/Io/Infinity.cpp
+++ b/rpcs3/Emu/Io/Infinity.cpp
@@ -373,6 +373,16 @@ usb_device_infinity::~usb_device_infinity()
 {
 }
 
+std::shared_ptr<usb_device> usb_device_infinity::make_instance(u32, const std::array<u8, 7>& location)
+{
+	return std::make_shared<usb_device_infinity>(location);
+}
+
+u16 usb_device_infinity::get_num_emu_devices()
+{
+	return 1;
+}
+
 void usb_device_infinity::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)
 {
 	usb_device_emulated::control_transfer(bmRequestType, bRequest, wValue, wIndex, wLength, buf_size, buf, transfer);

--- a/rpcs3/Emu/Io/Infinity.h
+++ b/rpcs3/Emu/Io/Infinity.h
@@ -60,6 +60,9 @@ public:
 	usb_device_infinity(const std::array<u8, 7>& location);
 	~usb_device_infinity();
 
+	static std::shared_ptr<usb_device> make_instance(u32 controller_index, const std::array<u8, 7>& location);
+	static u16 get_num_emu_devices();
+
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 

--- a/rpcs3/Emu/Io/Skylander.cpp
+++ b/rpcs3/Emu/Io/Skylander.cpp
@@ -208,6 +208,16 @@ usb_device_skylander::~usb_device_skylander()
 {
 }
 
+std::shared_ptr<usb_device> usb_device_skylander::make_instance(u32, const std::array<u8, 7>& location)
+{
+	return std::make_shared<usb_device_skylander>(location);
+}
+
+u16 usb_device_skylander::get_num_emu_devices()
+{
+	return 1;
+}
+
 void usb_device_skylander::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)
 {
 	transfer->fake = true;
@@ -342,7 +352,7 @@ void usb_device_skylander::interrupt_transfer(u32 buf_size, u8* buf, u32 endpoin
 	transfer->fake            = true;
 	transfer->expected_count  = buf_size;
 	transfer->expected_result = HC_CC_NOERR;
-	
+
 	if (endpoint == 0x02)
 	{
 		// Audio transfers are fairly quick(~1ms)

--- a/rpcs3/Emu/Io/Skylander.h
+++ b/rpcs3/Emu/Io/Skylander.h
@@ -46,6 +46,9 @@ public:
 	usb_device_skylander(const std::array<u8, 7>& location);
 	~usb_device_skylander();
 
+	static std::shared_ptr<usb_device> make_instance(u32 controller_index, const std::array<u8, 7>& location);
+	static u16 get_num_emu_devices();
+
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 

--- a/rpcs3/Emu/Io/Turntable.cpp
+++ b/rpcs3/Emu/Io/Turntable.cpp
@@ -5,6 +5,7 @@
 #include "Emu/Cell/lv2/sys_usbd.h"
 #include "Emu/Io/turntable_config.h"
 #include "Input/pad_thread.h"
+#include "Emu/system_config.h"
 
 LOG_CHANNEL(turntable_log, "TURN");
 
@@ -51,6 +52,16 @@ usb_device_turntable::usb_device_turntable(u32 controller_index, const std::arra
 
 usb_device_turntable::~usb_device_turntable()
 {
+}
+
+std::shared_ptr<usb_device> usb_device_turntable::make_instance(u32 controller_index, const std::array<u8, 7>& location)
+{
+	return std::make_shared<usb_device_turntable>(controller_index, location);
+}
+
+u16 usb_device_turntable::get_num_emu_devices()
+{
+	return static_cast<u16>(g_cfg.io.turntable.get());
 }
 
 void usb_device_turntable::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)

--- a/rpcs3/Emu/Io/Turntable.h
+++ b/rpcs3/Emu/Io/Turntable.h
@@ -8,6 +8,9 @@ public:
 	usb_device_turntable(u32 controller_index, const std::array<u8, 7>& location);
 	~usb_device_turntable();
 
+	static std::shared_ptr<usb_device> make_instance(u32 controller_index, const std::array<u8, 7>& location);
+	static u16 get_num_emu_devices();
+
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 

--- a/rpcs3/Emu/Io/usio.cpp
+++ b/rpcs3/Emu/Io/usio.cpp
@@ -127,6 +127,16 @@ usb_device_usio::~usb_device_usio()
 	save_backup();
 }
 
+std::shared_ptr<usb_device> usb_device_usio::make_instance(u32, const std::array<u8, 7>& location)
+{
+	return std::make_shared<usb_device_usio>(location);
+}
+
+u16 usb_device_usio::get_num_emu_devices()
+{
+	return 1;
+}
+
 void usb_device_usio::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)
 {
 	transfer->fake = true;

--- a/rpcs3/Emu/Io/usio.h
+++ b/rpcs3/Emu/Io/usio.h
@@ -9,6 +9,9 @@ public:
 	usb_device_usio(const std::array<u8, 7>& location);
 	~usb_device_usio();
 
+	static std::shared_ptr<usb_device> make_instance(u32 controller_index, const std::array<u8, 7>& location);
+	static u16 get_num_emu_devices();
+
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -637,6 +637,8 @@ void pad_thread::UnregisterLddPad(u32 handle)
 	ensure(handle < m_pads.size());
 
 	m_pads[handle]->ldd = false;
+	m_pads[handle]->m_port_status &= ~CELL_PAD_STATUS_CONNECTED;
+	m_pads[handle]->m_port_status |= CELL_PAD_STATUS_ASSIGN_CHANGES;
 
 	num_ldd_pad--;
 }

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -1218,6 +1218,7 @@ bool gui_application::native_event_filter::nativeEventFilter([[maybe_unused]] co
 				}
 				return false;
 			}
+
 			if (auto* handler = g_fxo->try_get<MouseHandlerBase>(); handler && handler->type == mouse_handler::raw)
 			{
 				static_cast<raw_mouse_handler*>(handler)->handle_native_event(*msg);

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -213,6 +213,10 @@ bool gui_application::Init()
 	notification_filter.dbcc_classguid = GUID_DEVINTERFACE_USB_DEVICE;
 
 	m_device_notification_handle = RegisterDeviceNotification(reinterpret_cast<HWND>(m_main_window->winId()), &notification_filter, DEVICE_NOTIFY_WINDOW_HANDLE);
+	if (!m_device_notification_handle )
+	{
+		gui_log.error("RegisterDeviceNotification() failed: %s", fmt::win_error{GetLastError(), nullptr});
+	}
 #endif
 
 	return true;

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -1210,7 +1210,7 @@ bool gui_application::native_event_filter::nativeEventFilter([[maybe_unused]] co
 	{
 		if (MSG* msg = static_cast<MSG*>(message); msg && (msg->message == WM_INPUT || msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_DEVICECHANGE))
 		{
-			if (msg->message == WM_DEVICECHANGE)
+			if (msg->message == WM_DEVICECHANGE && (msg->wParam == DBT_DEVICEARRIVAL || msg->wParam == DBT_DEVICEREMOVECOMPLETE)
 			{
 				if (Emu.IsRunning() || Emu.IsStarting())
 				{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -1210,7 +1210,7 @@ bool gui_application::native_event_filter::nativeEventFilter([[maybe_unused]] co
 	{
 		if (MSG* msg = static_cast<MSG*>(message); msg && (msg->message == WM_INPUT || msg->message == WM_KEYDOWN || msg->message == WM_KEYUP || msg->message == WM_DEVICECHANGE))
 		{
-			if (msg->message == WM_DEVICECHANGE && (msg->wParam == DBT_DEVICEARRIVAL || msg->wParam == DBT_DEVICEREMOVECOMPLETE)
+			if (msg->message == WM_DEVICECHANGE && (msg->wParam == DBT_DEVICEARRIVAL || msg->wParam == DBT_DEVICEREMOVECOMPLETE))
 			{
 				if (Emu.IsRunning() || Emu.IsStarting())
 				{

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -21,6 +21,7 @@
 #include "Emu/Audio/audio_utils.h"
 #include "Emu/Io/Null/null_camera_handler.h"
 #include "Emu/Io/Null/null_music_handler.h"
+#include "Emu/Cell/lv2/sys_usbd.h"
 #include "Emu/vfs_config.h"
 #include "util/init_mutex.hpp"
 #include "util/console.h"
@@ -54,7 +55,8 @@
 #endif
 
 #ifdef _WIN32
-#include "Windows.h"
+#include <Usbiodef.h>
+#include <Dbt.h>
 #endif
 
 LOG_CHANNEL(gui_log, "GUI");
@@ -72,6 +74,12 @@ gui_application::~gui_application()
 {
 #ifdef WITH_DISCORD_RPC
 	discord::shutdown();
+#endif
+#ifdef _WIN32
+	if (m_device_notification_handle && !UnregisterDeviceNotification(m_device_notification_handle))
+	{
+		gui_log.error("UnregisterDeviceNotification() failed: %s", fmt::win_error{GetLastError(), nullptr});
+	}
 #endif
 }
 
@@ -196,6 +204,15 @@ bool gui_application::Init()
 	// Install native event filter
 #ifdef _WIN32 // Currently only needed for raw mouse input on windows
 	installNativeEventFilter(&m_native_event_filter);
+
+	// Enable usb device hotplug events
+	// Currently only needed for hotplug on windows, as libusb handles other platforms
+	DEV_BROADCAST_DEVICEINTERFACE notification_filter {};
+	notification_filter.dbcc_size = sizeof(DEV_BROADCAST_DEVICEINTERFACE);
+	notification_filter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
+	notification_filter.dbcc_classguid = GUID_DEVINTERFACE_USB_DEVICE;
+
+	m_device_notification_handle = RegisterDeviceNotification(reinterpret_cast<HWND>(m_main_window->winId()), &notification_filter, DEVICE_NOTIFY_WINDOW_HANDLE);
 #endif
 
 	return true;
@@ -1180,23 +1197,26 @@ void gui_application::OnAppStateChanged(Qt::ApplicationState state)
 bool gui_application::native_event_filter::nativeEventFilter([[maybe_unused]] const QByteArray& eventType, [[maybe_unused]] void* message, [[maybe_unused]] qintptr* result)
 {
 #ifdef _WIN32
-	if (!Emu.IsRunning() && !g_raw_mouse_handler)
+	if (!Emu.IsRunning() && !Emu.IsStarting())
 	{
 		return false;
 	}
 
 	if (eventType == "windows_generic_MSG")
 	{
-		if (MSG* msg = static_cast<MSG*>(message); msg && (msg->message == WM_INPUT || msg->message == WM_KEYDOWN || msg->message == WM_KEYUP))
+		if (MSG* msg = static_cast<MSG*>(message); msg)
 		{
-			if (auto* handler = g_fxo->try_get<MouseHandlerBase>(); handler && handler->type == mouse_handler::raw)
-			{
-				static_cast<raw_mouse_handler*>(handler)->handle_native_event(*msg);
-			}
-
-			if (g_raw_mouse_handler)
-			{
+			if (g_raw_mouse_handler && (msg->message == WM_INPUT || msg->message == WM_KEYDOWN || msg->message == WM_KEYUP)) {
+				if (auto* handler = g_fxo->try_get<MouseHandlerBase>(); handler && handler->type == mouse_handler::raw)
+				{
+					static_cast<raw_mouse_handler*>(handler)->handle_native_event(*msg);
+				}
 				g_raw_mouse_handler->handle_native_event(*msg);
+			}
+			if (msg->message == WM_DEVICECHANGE)
+			{
+				handle_hotplug_event(msg->wParam == DBT_DEVICEARRIVAL);
+				return false;
 			}
 		}
 	}

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -19,6 +19,10 @@
 #include <functional>
 #include <deque>
 
+#ifdef _WIN32
+#include "Windows.h"
+#endif
+
 class gs_frame;
 class main_window;
 class gui_settings;
@@ -117,7 +121,9 @@ private:
 	u64 m_pause_delayed_tag = 0;
 	typename Emulator::stop_counter_t m_emu_focus_out_emulation_id{};
 	bool m_is_pause_on_focus_loss_active = false;
-
+#ifdef _WIN32
+	HDEVNOTIFY m_device_notification_handle;
+#endif
 private Q_SLOTS:
 	void OnChangeStyleSheetRequest();
 	void OnShortcutChange();

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -122,7 +122,7 @@ private:
 	typename Emulator::stop_counter_t m_emu_focus_out_emulation_id{};
 	bool m_is_pause_on_focus_loss_active = false;
 #ifdef _WIN32
-	HDEVNOTIFY m_device_notification_handle;
+	HDEVNOTIFY m_device_notification_handle {};
 #endif
 private Q_SLOTS:
 	void OnChangeStyleSheetRequest();


### PR DESCRIPTION
Implement hotplug using hotplug events where supported, and a periodic scan where hotplug isn't available

For windows, the periodic scan in some scenarios had negative effects on controller responsiveness, as `libusb_get_device_list` can take a few seconds on some machines, so I've opted to instead hook into the `nativeEventFilter` and implement a native hotplug myself.

* migrated from lambda calls to const whitelist structure, and have merged the emulation aspect into this
* Use a combination of the device port, address and vid and pid for differentiating devices, as suggested by some sample code from libusb
* Implemented native hotplug with a small delay as usb hotplug events tend to arrive before devices are fully enumerated
* If multiple LDDs match a device, only the first LDD wins and creates a device
* Close any open pipes when a device gets disconnected
* Set a pads status to disconnected when unregistering an LDD pad

Changes are based on https://github.com/RPCS3/rpcs3/pull/9096

Fixes #9071
Fixes #15074 
