### PR TITLE
[WIP] np: Stub functionality for Simulated NP

### DIFF
--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -1470,12 +1470,26 @@ namespace np
 
 	u32 np_handler::get_num_friends()
 	{
-		return get_rpcn()->get_num_friends();
+		if (g_cfg.net.psn_status != np_psn_status::psn_rpcn)
+		{
+			return 0;
+		}
+		else
+		{
+			return get_rpcn()->get_num_friends();
+		}
 	}
 
 	u32 np_handler::get_num_blocks()
 	{
-		return get_rpcn()->get_num_blocks();
+		if (g_cfg.net.psn_status != np_psn_status::psn_rpcn)
+		{
+			return 0;
+		}
+		else
+		{
+			return get_rpcn()->get_num_blocks();
+		}
 	}
 
 	std::pair<error_code, std::optional<SceNpId>> np_handler::get_friend_by_index(u32 index)

--- a/rpcs3/Emu/NP/np_requests.cpp
+++ b/rpcs3/Emu/NP/np_requests.cpp
@@ -765,6 +765,21 @@ namespace np
 			cookie_vec.assign(cookie, cookie + cookie_size);
 		}
 
+		if (g_cfg.net.psn_status != np_psn_status::psn_rpcn)
+		{
+			// TODO(InvoxiPlayGames): generate ticket data that is valid, for games that need to dig into the data
+			std::vector<u8> ticketdata = {0x41, 0x42, 0x43, 0x44};
+			current_ticket = ticket(std::move(ticketdata));
+			auto ticket_size = static_cast<s32>(current_ticket.size());
+
+			sysutil_register_cb([manager_cb = this->manager_cb, ticket_size, manager_cb_arg = this->manager_cb_arg](ppu_thread& cb_ppu) -> s32
+				{
+					manager_cb(cb_ppu, SCE_NP_MANAGER_EVENT_GOT_TICKET, ticket_size, manager_cb_arg);
+					return 0;
+				});
+			return;
+		}
+
 		if (!get_rpcn()->req_ticket(req_id, service_id_str, cookie_vec))
 		{
 			rpcn_log.error("Disconnecting from RPCN!");


### PR DESCRIPTION
With the network mode set to "Simulated" for a game, almost any attempt to actually use NP functions results in the emulator throwing an exception from the game thread since RPCN tries to be accessed. Since if a game thinks it's connected it's probably going to use NP features, the game should at the very least *not crash* and be fed dummy data.

Since a full implementation would be a larger undertaking and might need codebase changes, I'm sending in as a draft for opinions on how it should be implemented. Currently it's just checking if the current PSN status isn't RPCN and then returning a fake response in the np_handler functions.

PR status: sceNpBasicGetBlockListEntryCount, sceNpBasicGetFriendListEntryCount and sceNpManagerRequestTicket2 no longer crash the guest (required for BLES01222), other functions (creating lobbies etc) probably do.