### PR TITLE
Qt/input: reset gui pad thread when closing pad settings

### DIFF
--- a/rpcs3/Input/gui_pad_thread.h
+++ b/rpcs3/Input/gui_pad_thread.h
@@ -23,6 +23,11 @@ public:
 	static std::shared_ptr<PadHandlerBase> GetHandler(pad_handler type);
 	static void InitPadConfig(cfg_pad& cfg, pad_handler type, std::shared_ptr<PadHandlerBase>& handler);
 
+	static void reset()
+	{
+		m_reset = true;
+	}
+
 protected:
 	bool init();
 	void run();
@@ -60,6 +65,7 @@ protected:
 	std::unique_ptr<std::thread> m_thread;
 	atomic_t<bool> m_terminate = false;
 	atomic_t<bool> m_allow_global_input = false;
+	static atomic_t<bool> m_reset;
 
 	std::array<bool, static_cast<u32>(pad_button::pad_button_max_enum)> m_last_button_state{};
 

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/File.h"
 
 #include "Input/pad_thread.h"
+#include "Input/gui_pad_thread.h"
 #include "Input/product_info.h"
 #include "Input/keyboard_pad_handler.h"
 
@@ -244,6 +245,8 @@ pad_settings_dialog::~pad_settings_dialog()
 		m_input_thread_state = input_thread_state::pausing;
 		*m_input_thread = thread_state::finished;
 	}
+
+	gui_pad_thread::reset();
 
 	if (!Emu.IsStopped())
 	{


### PR DESCRIPTION
- Reset gui pad thread when closing pad settings in order to apply the new settings
- Log gui pad thread pad configs

fixes #16595