### PR TITLE
Qt: Fix device notification registration segfault

### DIFF
--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -121,9 +121,13 @@ private:
 	u64 m_pause_delayed_tag = 0;
 	typename Emulator::stop_counter_t m_emu_focus_out_emulation_id{};
 	bool m_is_pause_on_focus_loss_active = false;
+
 #ifdef _WIN32
+	void register_device_notification(WId window_id);
+	void unregister_device_notification();
 	HDEVNOTIFY m_device_notification_handle {};
 #endif
+
 private Q_SLOTS:
 	void OnChangeStyleSheetRequest();
 	void OnShortcutChange();


### PR DESCRIPTION
The main window does not exist if we boot with no-gui.
Needs testing if USB hotplug works on windows with no-gui.

fixes #16612
