### PR TITLE
sys_usbd: Don't detach kernel drivers from santroller devices

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -386,10 +386,6 @@ void usb_handler_thread::perform_scan()
 			libusb_device_handle* lusb_handle;
 			if (libusb_open(dev, &lusb_handle) == LIBUSB_SUCCESS)
 			{
-#ifdef __linux__
-				libusb_set_auto_detach_kernel_driver(lusb_handle, true);
-				libusb_claim_interface(lusb_handle, 2);
-#endif
 				libusb_control_transfer(lusb_handle, +LIBUSB_ENDPOINT_IN | +LIBUSB_REQUEST_TYPE_CLASS | +LIBUSB_RECIPIENT_INTERFACE, 0x01, 0x03f2, 2, nullptr, 0, 5000);
 				libusb_close(lusb_handle);
 			}


### PR DESCRIPTION
It isn't necessary to detach the kernel drivers as we are only using a control transfer, and detaching kernel drivers causes issues if a santroller device is emulating a device that doesn't support passthrough, such as a Guitar Hero guitar.