### PR TITLE
SPU LLVM: Use 512bit xorsum for SPU verification

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -68,7 +68,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<xfloat_accuracy> spu_xfloat_accuracy{ this, "XFloat Accuracy", xfloat_accuracy::approximate, false };
 		cfg::_int<-1, 14> ppu_128_reservations_loop_max_length{ this, "Accurate PPU 128-byte Reservation Op Max Length", 0, true }; // -1: Always accurate, 0: Never accurate, 1-14: max accurate loop length
 		cfg::_int<-64, 64> stub_ppu_traps{ this, "Stub PPU Traps", 0, true }; // Hack, skip PPU traps for rare cases where the trap is continueable (specify relative instructions to skip)
-		cfg::_bool full_width_avx512{ this, "Full Width AVX-512", true };
+		cfg::_bool precise_spu_verification{ this, "Precise SPU Verification", false }; // Disables use of xorsum based spu verification if enabled.
 		cfg::_bool ppu_llvm_nj_fixup{ this, "PPU LLVM Java Mode Handling", true }; // Partially respect current Java Mode for alti-vec ops by PPU LLVM
 		cfg::_bool use_accurate_dfma{ this, "Use Accurate DFMA", true }; // Enable accurate double-precision FMA for CPUs which do not support it natively
 		cfg::_bool ppu_set_sat_bit{ this, "PPU Set Saturation Bit", false }; // Accuracy. If unset, completely disable saturation flag handling.


### PR DESCRIPTION
Use a 512bit wide "xorsum" (even for machines with 128b and 256b simd) hash in place of a full comparison for SPU verification. In theory, hash collision is nearly impossible here, even though a human could create two matching hashes by hand pretty easily, but luckily for us, all PS3 programs were written a long time ago. 

With a true random distribution of numbers, the chance of collision should be astronomically small, (1 in 2^512?) but I'm not sure how the chance changes when we change from true random to valid SPU opcodes. Either way, I don't think that collisions are likely, and the performance uplift is real. Just to be safe, the xorsum path is only taken if there are atleast 3 64byte blocks to hash.

The full_width_avx512 option is also removed, since even on CPUs which experienced severe AVX-512 downclocking, 512-wide spu verification was never an issue, since it only uses simple bitwise instructions, which are very power efficient.

- Provides a 2-3% uplift in SPU limited titles
- Removes the full_width_avx512 option
- Adds a precise spu verification option, for debugging (config file only)

Before: (78.4 FPS)
![image](https://github.com/user-attachments/assets/7b006900-78d9-4056-b11a-ac4b26f88b53)

After: (80.0 FPS)
![image](https://github.com/user-attachments/assets/c3aca4f7-4199-441a-8eb2-134db6ab78b2)

And yes, the uplift is similar on both AVX2 and AVX-512 targets.