### PR TITLE
rsx: Fix graphics corruption when switching between shader interpreter and recompiler at runtime

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -694,6 +694,7 @@ void GLGSRender::begin()
 	if (m_graphics_state & rsx::pipeline_state::invalidate_pipeline_bits)
 	{
 		// Shaders need to be reloaded.
+		m_prev_program = m_program;
 		m_program = nullptr;
 	}
 }

--- a/rpcs3/Emu/RSX/GL/GLGSRender.h
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.h
@@ -78,6 +78,7 @@ class GLGSRender : public GSRender, public ::rsx::reports::ZCULL_control
 	gl::sampler_state m_vs_sampler_states[rsx::limits::vertex_textures_count];           // Vertex textures
 
 	gl::glsl::program *m_program = nullptr;
+	gl::glsl::program* m_prev_program = nullptr;
 	const GLFragmentProgram *m_fragment_prog = nullptr;
 	const GLVertexProgram *m_vertex_prog = nullptr;
 


### PR DESCRIPTION
Gets rid of corrupted visuals when running in hybrid mode (async recompiler + interpreter). This makes the "switching" imperceptible in most games and drastly improves usability of the interpreter.
Technically this is a regression, but it crept in slowly over many changes.

Closes https://github.com/RPCS3/rpcs3/issues/15851