### PR TITLE
cellMusic: fix some custom music issues

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -556,7 +556,7 @@ error_code cellMusicSetPlaybackCommand2(s32 command, vm::ptr<void> param)
 	auto& music = g_fxo->get<music_state>();
 
 	if (!music.func)
-		return CELL_MUSIC2_ERROR_GENERIC;
+		return { CELL_MUSIC2_ERROR_GENERIC, "Not initialized" };
 
 	error_code result = CELL_OK;
 
@@ -585,7 +585,7 @@ error_code cellMusicSetPlaybackCommand(s32 command, vm::ptr<void> param)
 	auto& music = g_fxo->get<music_state>();
 
 	if (!music.func)
-		return CELL_MUSIC_ERROR_GENERIC;
+		return { CELL_MUSIC_ERROR_GENERIC, "Not initialized" };
 
 	error_code result = CELL_OK;
 

--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -213,19 +213,29 @@ error_code cell_music_select_contents()
 	error_code error = rsx::overlays::show_media_list_dialog(rsx::overlays::media_list_dialog::media_type::audio, vfs_dir_path, title,
 		[&music](s32 status, utils::media_info info)
 		{
-			sysutil_register_cb([&music, info, status](ppu_thread& ppu) -> s32
+			sysutil_register_cb([&music, info = std::move(info), status](ppu_thread& ppu) -> s32
 			{
 				std::lock_guard lock(music.mtx);
 				const u32 result = status >= 0 ? u32{CELL_OK} : u32{CELL_MUSIC_CANCELED};
 				if (result == CELL_OK)
 				{
+					// Let's always choose the whole directory for now
+					std::string track;
+					std::string dir = info.path;
+					if (fs::is_file(info.path))
+					{
+						track = std::move(dir);
+						dir = fs::get_parent_dir(track);
+					}
+
 					music_selection_context context{};
-					context.set_playlist(info.path);
+					context.set_playlist(dir);
+					context.set_track(track);
 					// TODO: context.repeat_mode = CELL_SEARCH_REPEATMODE_NONE;
 					// TODO: context.context_option = CELL_SEARCH_CONTEXTOPTION_NONE;
-					music.current_selection_context = context;
+					music.current_selection_context = std::move(context);
 					music.current_selection_context.create_playlist(music_selection_context::get_next_hash());
-					cellMusic.success("Media list dialog: selected entry '%s'", context.playlist.front());
+					cellMusic.success("Media list dialog: selected entry '%s'", music.current_selection_context.playlist.front());
 				}
 				else
 				{

--- a/rpcs3/Emu/Cell/Modules/cellMusic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.h
@@ -166,6 +166,7 @@ struct music_selection_context
 	void set_playlist(const std::string& path);
 	void create_playlist(const std::string& new_hash);
 	bool load_playlist();
+	void set_track(std::string_view track);
 	u32 step_track(bool next);
 
 	operator bool() const

--- a/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
@@ -140,19 +140,29 @@ error_code cell_music_decode_select_contents()
 	error_code error = rsx::overlays::show_media_list_dialog(rsx::overlays::media_list_dialog::media_type::audio, vfs_dir_path, title,
 		[&dec](s32 status, utils::media_info info)
 		{
-			sysutil_register_cb([&dec, info, status](ppu_thread& ppu) -> s32
+			sysutil_register_cb([&dec, info = std::move(info), status](ppu_thread& ppu) -> s32
 			{
 				std::lock_guard lock(dec.mutex);
 				const u32 result = status >= 0 ? u32{CELL_OK} : u32{CELL_MUSIC_DECODE_CANCELED};
 				if (result == CELL_OK)
 				{
+					// Let's always choose the whole directory for now
+					std::string track;
+					std::string dir = info.path;
+					if (fs::is_file(info.path))
+					{
+						track = std::move(dir);
+						dir = fs::get_parent_dir(track);
+					}
+
 					music_selection_context context{};
-					context.set_playlist(info.path);
+					context.set_playlist(dir);
+					context.set_track(track);
 					// TODO: context.repeat_mode = CELL_SEARCH_REPEATMODE_NONE;
 					// TODO: context.context_option = CELL_SEARCH_CONTEXTOPTION_NONE;
-					dec.current_selection_context = context;
+					dec.current_selection_context = std::move(context);
 					dec.current_selection_context.create_playlist(music_selection_context::get_next_hash());
-					cellMusicDecode.success("Media list dialog: selected entry '%s'", context.playlist.front());
+					cellMusicDecode.success("Media list dialog: selected entry '%s'", dec.current_selection_context.playlist.front());
 				}
 				else
 				{

--- a/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
@@ -248,6 +248,29 @@ bool music_selection_context::load_playlist()
 	return true;
 }
 
+void music_selection_context::set_track(std::string_view track)
+{
+	if (track.empty()) return;
+
+	if (playlist.empty())
+	{
+		cellMusicSelectionContext.error("No tracks to play... (requested path='%s')", track);
+		return;
+	}
+
+	for (usz i = 0; i < playlist.size(); i++)
+	{
+		cellMusicSelectionContext.error("Comparing track '%s' vs '%s'", track, playlist[i]);
+		if (track.ends_with(playlist[i]))
+		{
+			first_track = current_track = static_cast<u32>(i);
+			return;
+		}
+	}
+
+	cellMusicSelectionContext.error("Track '%s' not found...", track);
+}
+
 u32 music_selection_context::step_track(bool next)
 {
 	if (playlist.empty())

--- a/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
@@ -109,6 +109,8 @@ void music_selection_context::set_playlist(const std::string& path)
 		content_type = CELL_SEARCH_CONTENTTYPE_MUSIC;
 		playlist.push_back(dir_path + path.substr(vfs_dir_path.length()));
 	}
+
+	valid = true;
 }
 
 void music_selection_context::create_playlist(const std::string& new_hash)

--- a/rpcs3/Emu/Cell/Modules/cellRtc.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRtc.cpp
@@ -78,7 +78,7 @@ error_code cellRtcGetCurrentTick(ppu_thread& ppu, vm::ptr<CellRtcTick> pTick)
 
 error_code cellRtcGetCurrentClock(ppu_thread& ppu, vm::ptr<CellRtcDateTime> pClock, s32 iTimeZone)
 {
-	cellRtc.notice("cellRtcGetCurrentClock(pClock=*0x%x, iTimeZone=%d)", pClock, iTimeZone);
+	cellRtc.trace("cellRtcGetCurrentClock(pClock=*0x%x, iTimeZone=%d)", pClock, iTimeZone);
 
 	const vm::var<sys_page_attr_t> page_attr;
 
@@ -1505,7 +1505,7 @@ error_code cellRtcGetSystemTime(ppu_thread& ppu, vm::cptr<CellRtcDateTime> pDate
 
 error_code cellRtcGetTime_t(ppu_thread& ppu, vm::cptr<CellRtcDateTime> pDateTime, vm::ptr<s64> piTime)
 {
-	cellRtc.notice("cellRtcGetTime_t(pDateTime=*0x%x, piTime=*0x%x)", pDateTime, piTime);
+	cellRtc.trace("cellRtcGetTime_t(pDateTime=*0x%x, piTime=*0x%x)", pDateTime, piTime);
 
 	const vm::var<sys_page_attr_t> page_attr;
 

--- a/rpcs3/rpcs3qt/qt_music_handler.cpp
+++ b/rpcs3/rpcs3qt/qt_music_handler.cpp
@@ -67,7 +67,7 @@ qt_music_handler::qt_music_handler()
 {
 	music_log.notice("Constructing Qt music handler...");
 
-	m_media_player = std::make_shared<QMediaPlayer>();
+	m_media_player = std::make_unique<QMediaPlayer>();
 	m_media_player->setAudioOutput(new QAudioOutput());
 
 	connect(m_media_player.get(), &QMediaPlayer::mediaStatusChanged, this, &qt_music_handler::handle_media_status);
@@ -164,7 +164,7 @@ void qt_music_handler::fast_reverse(const std::string& path)
 		}
 
 		music_log.notice("Fast-reversing music...");
-		m_media_player->setPlaybackRate(-2.0);
+		m_media_player->setPlaybackRate(-2.0); // NOTE: This doesn't work on the current Qt version
 		m_media_player->play();
 	});
 

--- a/rpcs3/rpcs3qt/qt_music_handler.cpp
+++ b/rpcs3/rpcs3qt/qt_music_handler.cpp
@@ -177,8 +177,8 @@ void qt_music_handler::set_volume(f32 volume)
 
 	Emu.BlockingCallFromMainThread([&volume, this]()
 	{
-		const int new_volume = std::max<int>(0, std::min<int>(volume * 100, 100));
-		music_log.notice("Setting volume to %d%%", new_volume);
+		const f32 new_volume = std::clamp(volume, 0.0f, 1.0f);
+		music_log.notice("Setting volume to %f", new_volume);
 		m_media_player->audioOutput()->setVolume(new_volume);
 	});
 }
@@ -190,8 +190,8 @@ f32 qt_music_handler::get_volume() const
 
 	Emu.BlockingCallFromMainThread([&volume, this]()
 	{
-		volume = std::max(0.f, std::min(m_media_player->audioOutput()->volume(), 1.f));
-		music_log.notice("Getting volume: %d%%", volume);
+		volume = std::clamp(m_media_player->audioOutput()->volume(), 0.0f, 1.0f);
+		music_log.notice("Getting volume: %f", volume);
 	});
 
 	return volume;

--- a/rpcs3/rpcs3qt/qt_music_handler.h
+++ b/rpcs3/rpcs3qt/qt_music_handler.h
@@ -29,6 +29,6 @@ private Q_SLOTS:
 
 private:
 	mutable std::mutex m_mutex;
-	std::shared_ptr<QMediaPlayer> m_media_player;
+	std::unique_ptr<QMediaPlayer> m_media_player;
 	std::string m_path;
 };


### PR DESCRIPTION
- Fix volume of custom music (this was always either on 0% or 100% due to a wrong volume range passed to the player)
- Mark playlists as valid as soon as the playlist is set (this was previously only done after loading them from file)
- Always provide the whole playlist when a track is selected in an overlay dialog (we previously only ever returned the track as a single song playlist)
- Silence some cellRtc log spam

This fixes the music player in LBP3. I hope this doesn't break any other games.
NOTE: rewind doesn't work because Qt doesn't support it. So don't complain about that xD

fixes #16649