### PR TITLE
rsx: Fix internal res tracking

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1630,7 +1630,10 @@ namespace rsx
 		layout.aa_factors[1] = aa_factor_v;
 
 		// Log this to frame stats
-		m_frame_stats.framebuffer_stats.add(layout.width, layout.height, aa_mode);
+		if (layout.target != rsx::surface_target::none)
+		{
+			m_frame_stats.framebuffer_stats.add(layout.width, layout.height, aa_mode);
+		}
 
 		// Check if anything has changed
 		bool really_changed = false;


### PR DESCRIPTION
Omit shadowmap passes which just introduce large square dimensions to the tracker.