### PR TITLE
RSX: Use checksum with rotated inputs for shader hashing instead of FNV

### DIFF
--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
@@ -3,7 +3,6 @@
 #include "Emu/system_config.h"
 
 #include <stack>
-#include "util/v128.hpp"
 
 #if defined(ARCH_X64)
 #include "emmintrin.h"
@@ -369,13 +368,7 @@ bool vertex_program_compare::operator()(const RSXVertexProgram &binary1, const R
 	usz instIndex = 0;
 	for (unsigned i = 0; i < binary1.data.size() / 4; i++)
 	{
-		const auto active = binary1.instruction_mask[instIndex];
-		if (active != binary2.instruction_mask[instIndex])
-		{
-			return false;
-		}
-
-		if (active)
+		if (binary1.instruction_mask[instIndex])
 		{
 			const auto inst1 = v128::loadu(instBuffer1, instIndex);
 			const auto inst2 = v128::loadu(instBuffer2, instIndex);
@@ -391,10 +384,10 @@ bool vertex_program_compare::operator()(const RSXVertexProgram &binary1, const R
 	return true;
 }
 
-
-bool fragment_program_utils::is_constant(u32 sourceOperand)
+bool fragment_program_utils::is_any_src_constant(v128 sourceOperand)
 {
-	return ((sourceOperand >> 8) & 0x3) == 2;
+	const u64 masked = sourceOperand._u64[1] & 0x30000000300;
+	return (sourceOperand._u32[1] & 0x300) == 0x200 || (static_cast<u32>(masked) == 0x200 || static_cast<u32>(masked >> 32) == 0x200);
 }
 
 usz fragment_program_utils::get_fragment_program_ucode_size(const void* ptr)
@@ -404,12 +397,9 @@ usz fragment_program_utils::get_fragment_program_ucode_size(const void* ptr)
 	while (true)
 	{
 		const v128 inst = v128::loadu(instBuffer, instIndex);
-		bool isSRC0Constant = is_constant(inst._u32[1]);
-		bool isSRC1Constant = is_constant(inst._u32[2]);
-		bool isSRC2Constant = is_constant(inst._u32[3]);
 		bool end = (inst._u32[0] >> 8) & 0x1;
 
-		if (isSRC0Constant || isSRC1Constant || isSRC2Constant)
+		if (is_any_src_constant(inst))
 		{
 			instIndex += 2;
 			if (end)
@@ -483,7 +473,7 @@ fragment_program_utils::fragment_program_metadata fragment_program_utils::analys
 				}
 			}
 
-			if (is_constant(inst._u32[1]) || is_constant(inst._u32[2]) || is_constant(inst._u32[3]))
+		if (is_any_src_constant(inst))
 			{
 				//Instruction references constant, skip one slot occupied by data
 				index++;
@@ -531,9 +521,7 @@ usz fragment_program_utils::get_fragment_program_ucode_hash(const RSXFragmentPro
 		acc1 += tmp1;
 		instIndex++;
 		// Skip constants
-		if (fragment_program_utils::is_constant(inst._u32[1]) ||
-			fragment_program_utils::is_constant(inst._u32[2]) ||
-			fragment_program_utils::is_constant(inst._u32[3]))
+		if (fragment_program_utils::is_any_src_constant(inst))
 			instIndex++;
 
 		bool end = (inst._u32[0] >> 8) & 0x1;
@@ -588,12 +576,10 @@ bool fragment_program_compare::operator()(const RSXFragmentProgram& binary1, con
 
 		instIndex++;
 		// Skip constants
-		if (fragment_program_utils::is_constant(inst1._u32[1]) ||
-			fragment_program_utils::is_constant(inst1._u32[2]) ||
-			fragment_program_utils::is_constant(inst1._u32[3]))
+		if (fragment_program_utils::is_any_src_constant(inst1))
 			instIndex++;
 
-		const bool end = ((inst1._u32[0] >> 8) & 0x1) && ((inst2._u32[0] >> 8) & 0x1);
+		const bool end = ((inst1._u32[0] >> 8) & 0x1);
 		if (end)
 		{
 			return true;

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.h
@@ -6,6 +6,7 @@
 #include "Utilities/mutex.h"
 #include "util/logs.hpp"
 #include "util/fnv_hash.hpp"
+#include "util/v128.hpp"
 
 #include <span>
 #include <unordered_map>
@@ -61,7 +62,8 @@ namespace program_hash_util
 		/**
 		* returns true if the given source Operand is a constant
 		*/
-		static bool is_constant(u32 sourceOperand);
+
+		static bool is_any_src_constant(v128 sourceOperand);
 
 		static usz get_fragment_program_ucode_size(const void* ptr);
 


### PR DESCRIPTION
Raises FPS from ~180 to ~200 in Ninja Gaiden Sigma

It's difficult to verify how good the hashing is myself, so please test with a lot of games, checking for any visual issues and performance improvements. I do think that simpler hashes should be sufficient when we are hashing valid opcodes instead of random data though.

Before:
![image](https://github.com/user-attachments/assets/68942f57-a105-403b-94fa-c708a79a2a30)
After:
![image](https://github.com/user-attachments/assets/fd002b38-8e13-418f-a16e-76f4701cb4a5)

Note: The functions are small enough now that the compiler decided to inline them. In the before screenshot `get_vertex_program_ucode_hash` is using 1.65% of cpu time. In the after screenshot, the function is inlined into `vertex_program_storage_hash` and the combined code is only taking up 0.56% of cpu time.

NoteNote: I tested without the rotation, and none of my games had issues, but I was nervous about instructions getting swapped around, so I added the rotation step.

NoteNoteNote: This code could be trivially vectorized with AVX10 or AVX-512, with masked loads and rotates. (AVX2 doesn't have rotates!)