### PR TITLE
cellMic: Implement SIGSTATE_MICENG

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -8,6 +8,7 @@
 #include <Emu/Cell/lv2/sys_event.h>
 
 #include <numeric>
+#include <cmath>
 
 #include "3rdparty/OpenAL/openal-soft/include/AL/alext.h"
 

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -289,6 +289,8 @@ public:
 	void update_audio();
 	bool has_data() const;
 
+	f32 calculate_energy_level();
+
 	bool is_registered() const { return mic_registered; }
 	bool is_opened() const { return mic_opened; }
 	bool is_started() const { return mic_started; }


### PR DESCRIPTION
Attempt to calculate a reasonable decibel value (40 to 90 dB) for a microphones audio level.

Allows voice chat to work in Metal Gear Online, which expects values between 45 and 72 depending on the player's game settings. MGO2 only allows 2 players to speak at any given time, so hardcoding a value from within that range wasn't a viable solution.