### PR TITLE
add a check for kiosk/idu pkgs

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -505,8 +505,8 @@ bool package_reader::decrypt_data()
 	{
 		std::memcpy(m_dec_key.data(), PKG_AES_KEY, m_dec_key.size());
 		decrypt(0, m_header.file_count * sizeof(PKGEntry), m_header.pkg_platform == PKG_PLATFORM_TYPE_PSP_PSVITA ? PKG_AES_KEY2 : m_dec_key.data());
-    }
-	
+	}
+
 	return true;
 }
 

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -478,37 +478,36 @@ bool package_reader::read_metadata()
 	return true;
 }
 
-
 bool package_reader::decrypt_data()
 {
-    if (!m_is_valid)
-    {
-        return false;
-    }
-
-    // kiosk PKGs usually end up with -TE
-    if (m_path.size() > 7 && m_path.compare(m_path.size() - 7, 7, "-TE.pkg") == 0)
-    {
-        std::memcpy(m_dec_key.data(), PKG_AES_KEY_IDU, m_dec_key.size());
-        decrypt(0, m_header.file_count * sizeof(PKGEntry), m_dec_key.data());
-    }
-    else if (m_header.pkg_platform == PKG_PLATFORM_TYPE_PSP_PSVITA && m_metadata.content_type >= 0x15 && m_metadata.content_type <= 0x17)
-    {
-        // PSVita
+	if (!m_is_valid)
+	{
+		return false;
+	}
+	
+	// kiosk PKGs usually end up with -TE
+	if (m_path.size() > 7 && m_path.compare(m_path.size() - 7, 7, "-TE.pkg") == 0)
+	{
+		std::memcpy(m_dec_key.data(), PKG_AES_KEY_IDU, m_dec_key.size());
+		decrypt(0, m_header.file_count * sizeof(PKGEntry), m_dec_key.data());
+	}
+	else if (m_header.pkg_platform == PKG_PLATFORM_TYPE_PSP_PSVITA && m_metadata.content_type >= 0x15 && m_metadata.content_type <= 0x17)
+	{
+		// PSVita
 		// TODO: Not all the keys seem to match the content types. I was only able to install a dlc (0x16) with PKG_AES_KEY_VITA_1
-		
-        aes_context ctx;
-        aes_setkey_enc(&ctx, m_metadata.content_type == 0x15u ? PKG_AES_KEY_VITA_1 : m_metadata.content_type == 0x16u ? PKG_AES_KEY_VITA_2 : PKG_AES_KEY_VITA_3, 128);
-        aes_crypt_ecb(&ctx, AES_ENCRYPT, reinterpret_cast<const uchar*>(&m_header.klicensee), m_dec_key.data());
-        decrypt(0, m_header.file_count * sizeof(PKGEntry), m_dec_key.data());
-    }
-    else
-    {
-        std::memcpy(m_dec_key.data(), PKG_AES_KEY, m_dec_key.size());
-        decrypt(0, m_header.file_count * sizeof(PKGEntry), m_header.pkg_platform == PKG_PLATFORM_TYPE_PSP_PSVITA ? PKG_AES_KEY2 : m_dec_key.data());
-    }
 
-    return true;
+		aes_context ctx;
+		aes_setkey_enc(&ctx, m_metadata.content_type == 0x15u ? PKG_AES_KEY_VITA_1 : m_metadata.content_type == 0x16u ? PKG_AES_KEY_VITA_2 : PKG_AES_KEY_VITA_3, 128);
+		aes_crypt_ecb(&ctx, AES_ENCRYPT, reinterpret_cast<const uchar*>(&m_header.klicensee), m_dec_key.data());
+		decrypt(0, m_header.file_count * sizeof(PKGEntry), m_dec_key.data());
+	}
+	else
+	{
+		std::memcpy(m_dec_key.data(), PKG_AES_KEY, m_dec_key.size());
+		decrypt(0, m_header.file_count * sizeof(PKGEntry), m_header.pkg_platform == PKG_PLATFORM_TYPE_PSP_PSVITA ? PKG_AES_KEY2 : m_dec_key.data());
+    }
+	
+	return true;
 }
 
 bool package_reader::read_param_sfo()


### PR DESCRIPTION
Compared multiple idu/kiosk pkgs to normal ones and didnt really see a way to difference them based on metadata.
Usually kiosk/idu pkgs end with -TE in the name, so based on that we can use PKG_AES_KEY_IDU. Not really a great way to do that since if user renames the PKG they wont be able to install it.