### PR TITLE
CI: Use windows-2025 Runner

### DIFF
--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -88,7 +88,7 @@ jobs:
           compression-level: 0
 
   Windows_Build:
-    runs-on: windows-latest
+    runs-on: windows-2025
     env:
       COMPILER: msvc
       QT_VER_MAIN: '6'


### PR DESCRIPTION
`windows-latest` defaults to `windows-2022` runner, the benefits of updating the runner are to be able to use newer packages like the Windows SDK.

- windows-2022 = 10.0.20348
- windows-2025 = 10.0.26100