### PR TITLE
Deploy aarch64 builds via via GitHub Actions instead of Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,38 +114,38 @@ freebsd_task:
   install_script: "sh -ex ./.ci/install-freebsd.sh"
   script: "./.ci/build-freebsd.sh"
 
-linux_aarch64_task:
-  env:
-    BUILD_ARTIFACTSTAGINGDIRECTORY: ${CIRRUS_WORKING_DIR}/artifacts
-    ARTDIR: ${CIRRUS_WORKING_DIR}/artifacts/
-    CCACHE_DIR: "/tmp/ccache_dir"
-    CCACHE_MAXSIZE: 300M
-    CI_HAS_ARTIFACTS: true
-    UPLOAD_COMMIT_HASH: a1d35836e8d45bfc6f63c26f0a3e5d46ef622fe1
-    UPLOAD_REPO_FULL_NAME: "rpcs3/rpcs3-binaries-linux-arm64"
-    DEPLOY_APPIMAGE: true
-    APPDIR: "./appdir"
-    RELEASE_MESSAGE: "../GitHubReleaseMessage.txt"
-    COMPILER: clang
-  ccache_cache:
-    folder: "/tmp/ccache_dir"
-  matrix:
-    - name: Cirrus Linux AArch64 Clang
-      arm_container:
-        image: 'docker.io/rpcs3/rpcs3-ci-jammy-aarch64:1.1'
-        cpu: 8
-        memory: 8G
-      clang_script:
-        - mkdir artifacts
-        - "sh -ex ./.ci/build-linux-aarch64.sh"
-  artifacts:
-    name: Artifact
-    path: "artifacts/*"
-  push_script: |
-    if [ "$CIRRUS_REPO_OWNER" = "RPCS3" ] && [ -z "$CIRRUS_PR" ] && [ "$CIRRUS_BRANCH" = "master" ]; then
-      COMM_TAG=$(awk '/version{.*}/ { printf("%d.%d.%d", $5, $6, $7) }' ./rpcs3/rpcs3_version.cpp)
-      COMM_COUNT=$(git rev-list --count HEAD)
-      COMM_HASH=$(git rev-parse --short=8 HEAD)
-      export AVVER="${COMM_TAG}-${COMM_COUNT}"
-      .ci/github-upload.sh
-    fi;
+# linux_aarch64_task:
+#   env:
+#     BUILD_ARTIFACTSTAGINGDIRECTORY: ${CIRRUS_WORKING_DIR}/artifacts
+#     ARTDIR: ${CIRRUS_WORKING_DIR}/artifacts/
+#     CCACHE_DIR: "/tmp/ccache_dir"
+#     CCACHE_MAXSIZE: 300M
+#     CI_HAS_ARTIFACTS: true
+#     UPLOAD_COMMIT_HASH: a1d35836e8d45bfc6f63c26f0a3e5d46ef622fe1
+#     UPLOAD_REPO_FULL_NAME: "rpcs3/rpcs3-binaries-linux-arm64"
+#     DEPLOY_APPIMAGE: true
+#     APPDIR: "./appdir"
+#     RELEASE_MESSAGE: "../GitHubReleaseMessage.txt"
+#     COMPILER: clang
+#   ccache_cache:
+#     folder: "/tmp/ccache_dir"
+#   matrix:
+#     - name: Cirrus Linux AArch64 Clang
+#       arm_container:
+#         image: 'docker.io/rpcs3/rpcs3-ci-jammy-aarch64:1.1'
+#         cpu: 8
+#         memory: 8G
+#       clang_script:
+#         - mkdir artifacts
+#         - "sh -ex ./.ci/build-linux-aarch64.sh"
+#   artifacts:
+#     name: Artifact
+#     path: "artifacts/*"
+#   push_script: |
+#     if [ "$CIRRUS_REPO_OWNER" = "RPCS3" ] && [ -z "$CIRRUS_PR" ] && [ "$CIRRUS_BRANCH" = "master" ]; then
+#       COMM_TAG=$(awk '/version{.*}/ { printf("%d.%d.%d", $5, $6, $7) }' ./rpcs3/rpcs3_version.cpp)
+#       COMM_COUNT=$(git rev-list --count HEAD)
+#       COMM_HASH=$(git rev-parse --short=8 HEAD)
+#       export AVVER="${COMM_TAG}-${COMM_COUNT}"
+#       .ci/github-upload.sh
+#     fi;

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -20,7 +20,8 @@ concurrency:
 env:
   BUILD_REPOSITORY_NAME: ${{ github.repository }}
   BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
-  BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ github.workspace }}/build
+  BUILD_SOURCEVERSION: ${{ github.sha }}
+  BUILD_ARTIFACTSTAGINGDIRECTORY: ${{ github.workspace }}/artifacts/
 
 jobs:
   Linux_Build:
@@ -40,6 +41,8 @@ jobs:
             docker_img: "rpcs3/rpcs3-ci-jammy-aarch64:1.1"
             build_sh: "/rpcs3/.ci/build-linux-aarch64.sh"
             compiler: clang
+            UPLOAD_COMMIT_HASH: a1d35836e8d45bfc6f63c26f0a3e5d46ef622fe1
+            UPLOAD_REPO_FULL_NAME: "rpcs3/rpcs3-binaries-linux-arm64"
     name: RPCS3 Linux ${{ matrix.os }} ${{ matrix.compiler }}
     runs-on: ${{ matrix.os }}
     env:
@@ -50,7 +53,8 @@ jobs:
       ARTDIR: "/root/artifacts"
       RELEASE_MESSAGE: "/rpcs3/GitHubReleaseMessage.txt"
       COMPILER: ${{ matrix.compiler }}
-
+      UPLOAD_COMMIT_HASH: ${{ matrix.UPLOAD_COMMIT_HASH }}
+      UPLOAD_REPO_FULL_NAME: ${{ matrix.UPLOAD_REPO_FULL_NAME }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@main
@@ -77,18 +81,27 @@ jobs:
             ${{ matrix.build_sh }}
 
       - name: Upload artifacts
-        #TODO: Upload artifact to release repository
-        #condition for release
-        #if: |
-        #  github.event_name != 'pull_request' &&
-        #  github.repository == 'RPCS3/rpcs3' &&
-        #  github.ref == 'refs/heads/master' &&
-        #  matrix.compiler == 'clang'
         uses: actions/upload-artifact@main
         with:
           name: RPCS3 for Linux (${{ runner.arch }}, ${{ matrix.compiler }})
           path: ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}/*.AppImage
           compression-level: 0
+      
+      - name: Deploy master build to GitHub Releases
+        if: |
+          github.event_name != 'pull_request' &&
+          github.repository == 'RPCS3/rpcs3' &&
+          github.ref == 'refs/heads/master' &&
+          matrix.compiler == 'clang' &&
+          runner.arch == 'ARM64'
+        env:
+          RPCS3_TOKEN: ${{ secrets.RPCS3_TOKEN }}
+        run: |
+          COMM_TAG=$(awk '/version{.*}/ { printf("%d.%d.%d", $5, $6, $7) }' ./rpcs3/rpcs3_version.cpp)
+          COMM_COUNT=$(git rev-list --count HEAD)
+          COMM_HASH=$(git rev-parse --short=8 HEAD)
+          export AVVER="${COMM_TAG}-${COMM_COUNT}"
+          .ci/github-upload.sh
 
   Windows_Build:
     name: RPCS3 Windows
@@ -150,7 +163,7 @@ jobs:
       - name: Pack up build artifacts
         shell: bash
         run: |
-          mkdir -p ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}
+          mkdir -p "${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}"
           .ci/deploy-windows.sh
 
       - name: Upload artifacts (7z)
@@ -163,10 +176,6 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: RPCS3 for Windows (MSVC)
-          # 7z
-          # 7z.sha256
-          path: |
-            ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}/${{ env.BUILD }}
-            ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}/${{ env.BUILD }}.sha256
+          path: ${{ env.BUILD_ARTIFACTSTAGINGDIRECTORY }}
           compression-level: 0
           if-no-files-found: error


### PR DESCRIPTION
PR is draft until RPCS3_TOKEN has been set.