### PR TITLE
unpkg: Add support for IDU packages

### DIFF
--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -365,7 +365,8 @@ private:
 	bool read_header();
 	bool read_metadata();
 	bool read_param_sfo();
-	bool decrypt_data();
+	bool set_decryption_key();
+	bool read_entries(std::vector<PKGEntry>& entries);
 	void archive_seek(s64 new_offset, const fs::seek_mode damode = fs::seek_set);
 	u64 archive_read(void* data_ptr, u64 num_bytes);
 	bool set_install_path();


### PR DESCRIPTION
Add support for NPDRM pkg maker version 0x1500, which seems to be the common maker of IDU packages.
I have added an additional check for empty QA Digest which seems to be a second distinguishing difference.

Closes https://github.com/RPCS3/rpcs3/pull/16730