### PR TITLE
PPU: Report encrypted modules with KLIC in main file, opportunistic compilation at exit-spawn

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4282,14 +4282,14 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				if (src) 
 				{
 					ppu_log.error("Possible missed KLIC for precompilation of '%s', please report to developers.", path);
-				}
 
-				// Ignore executables larger than 500KB to prevent a long pause on exitspawn
-				if (src.size() >= 500000)
-				{
-					g_progr_ftotal_bits -= file_size;
+					// Ignore executables larger than 500KB to prevent a long pause on exitspawn
+					if (src.size() >= 500000)
+					{
+						g_progr_ftotal_bits -= file_size;
 
-					continue;
+						continue;
+					}
 				}
 			}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4275,9 +4275,14 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				}
 			}
 
-			if (!src && Emu.klic.size() > 0 && src.open(path))
+			if (!src && !Emu.klic.empty() && src.open(path))
 			{
-				src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&Emu.klic[0]), nullptr, true);
+				src = decrypt_self(src, reinterpret_cast<u8*>(&Emu.klic[0]));
+				
+				if (src) 
+				{
+					ppu_log.error("Possible missed KLIC for precompilation of '%s', please report to developers.", path);
+				}
 			}
 
 			if (!src)
@@ -4467,9 +4472,14 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				}
 			}
 
-			if (!src && Emu.klic.size() > 0 && src.open(path))
+			if (!src && !Emu.klic.empty() && src.open(path))
 			{
-				src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&Emu.klic[0]), nullptr, true);
+				src = decrypt_self(src, reinterpret_cast<u8*>(&Emu.klic[0]));
+				
+				if (src) 
+				{
+					ppu_log.error("Possible missed KLIC for precompilation of '%s', please report to developers.", path);
+				}
 			}
 
 			if (!src)
@@ -4647,7 +4657,7 @@ extern void ppu_initialize()
 	}
 
 	// Avoid compilation if main's cache exists or it is a standalone SELF with no PARAM.SFO
-	if (compile_main && g_cfg.core.llvm_precompilation && !Emu.GetTitleID().empty())
+	if (compile_main && g_cfg.core.llvm_precompilation && !Emu.GetTitleID().empty() && !Emu.IsChildProcess())
 	{
 		// Try to add all related directories
 		const std::set<std::string> dirs = Emu.GetGameDirs();

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4284,8 +4284,8 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 					ppu_log.error("Possible missed KLIC for precompilation of '%s', please report to developers.", path);
 				}
 
-				// Ignore executables larger thaan 500KB to prevent a long pause on exitspawn
-				if (src.size() > 500000)
+				// Ignore executables larger than 500KB to prevent a long pause on exitspawn
+				if (src.size() >= 500000)
 				{
 					g_progr_ftotal_bits -= file_size;
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4275,9 +4275,17 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				}
 			}
 
+			if (!src && Emu.klic.size() > 0 && src.open(path))
+			{
+				src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&Emu.klic[0]), nullptr, true);
+			}
+
 			if (!src)
 			{
 				ppu_log.notice("Failed to decrypt '%s'", path);
+
+				g_progr_ftotal_bits -= file_size;
+
 				continue;
 			}
 
@@ -4459,9 +4467,17 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				}
 			}
 
+			if (!src && Emu.klic.size() > 0 && src.open(path))
+			{
+				src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&Emu.klic[0]), nullptr, true);
+			}
+
 			if (!src)
 			{
 				ppu_log.notice("Failed to decrypt '%s'", path);
+
+				g_progr_ftotal_bits -= file_size;
+
 				continue;
 			}
 
@@ -4631,7 +4647,7 @@ extern void ppu_initialize()
 	}
 
 	// Avoid compilation if main's cache exists or it is a standalone SELF with no PARAM.SFO
-	if (compile_main && g_cfg.core.llvm_precompilation && !Emu.GetTitleID().empty() && !Emu.IsChildProcess())
+	if (compile_main && g_cfg.core.llvm_precompilation && !Emu.GetTitleID().empty())
 	{
 		// Try to add all related directories
 		const std::set<std::string> dirs = Emu.GetGameDirs();

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4283,6 +4283,14 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				{
 					ppu_log.error("Possible missed KLIC for precompilation of '%s', please report to developers.", path);
 				}
+
+				// Ignore executables larger thaan 500KB to prevent a long pause on exitspawn
+				if (src.size() > 500000)
+				{
+					g_progr_ftotal_bits -= file_size;
+
+					continue;
+				}
 			}
 
 			if (!src)


### PR DESCRIPTION
Improves on: https://github.com/RPCS3/rpcs3/issues/12320

Also fixes an issue where the progress bar was not updating correctly when a self failed to decrypt.

Possible solutions to precompile encrypted modules:

1. Get the key at runtime df0d4a458863b1530b08e1b289971c173bcda066
2. Use pattern matching 77812a7ad7f47fd4d524969c12442bff9f0a9f8b
3. module hash / key or elf address lookup (this is probably the best solution for targeting a handful of games where it would matter)