### PR TITLE
move texture_cache_types implementation to cpp

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -484,6 +484,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/Common/surface_store.cpp
     RSX/Common/TextureUtils.cpp
     RSX/Common/texture_cache.cpp
+    RSX/Common/texture_cache_types.cpp
     RSX/Core/RSXContext.cpp
     RSX/Core/RSXDisplay.cpp
     RSX/Core/RSXDrawCommands.cpp

--- a/rpcs3/Emu/RSX/Common/texture_cache_types.cpp
+++ b/rpcs3/Emu/RSX/Common/texture_cache_types.cpp
@@ -1,0 +1,37 @@
+#include "stdafx.h"
+#include "texture_cache_types.h"
+#include "Emu/system_config.h"
+
+namespace rsx
+{
+	void invalidation_cause::flag_bits_from_cause(enum_type cause)
+	{
+		constexpr const std::array s_lookup_table
+		{
+			std::make_pair<enum_type, u32>(enum_type::read, flags::cause_is_read),
+			std::make_pair<enum_type, u32>(enum_type::deferred_read, flags::cause_is_read | flags::cause_is_deferred),
+			std::make_pair<enum_type, u32>(enum_type::write, flags::cause_is_write),
+			std::make_pair<enum_type, u32>(enum_type::deferred_write, flags::cause_is_write | flags::cause_is_deferred),
+			std::make_pair<enum_type, u32>(enum_type::unmap, flags::cause_keeps_fault_range_protection | flags::cause_skips_flush),
+			std::make_pair<enum_type, u32>(enum_type::reprotect, flags::cause_keeps_fault_range_protection),
+			std::make_pair<enum_type, u32>(enum_type::superseded_by_fbo, flags::cause_keeps_fault_range_protection | flags::cause_skips_fbos | flags::cause_skips_flush),
+			std::make_pair<enum_type, u32>(enum_type::committed_as_fbo, flags::cause_skips_fbos),
+		};
+
+		m_flag_bits = 0;
+		for (const auto& entry : s_lookup_table)
+		{
+			if (entry.first == cause)
+			{
+				m_flag_bits = entry.second | flags::cause_is_valid;
+				break;
+			}
+		}
+
+		if (cause == enum_type::superseded_by_fbo &&
+			g_cfg.video.strict_texture_flushing) [[ unlikely ]]
+		{
+			m_flag_bits &= ~flags::cause_skips_flush;
+		}
+	}
+}

--- a/rpcs3/Emu/RSX/Common/texture_cache_types.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_types.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Emu/system_config.h"
-
 namespace rsx
 {
 	/**
@@ -131,35 +129,6 @@ namespace rsx
 	private:
 		u32 m_flag_bits = 0;
 
-		void flag_bits_from_cause(enum_type cause)
-		{
-			constexpr std::array s_lookup_table
-			{
-				std::make_pair<enum_type, u32>(enum_type::read, flags::cause_is_read),
-				std::make_pair<enum_type, u32>(enum_type::deferred_read, flags::cause_is_read | flags::cause_is_deferred),
-				std::make_pair<enum_type, u32>(enum_type::write, flags::cause_is_write),
-				std::make_pair<enum_type, u32>(enum_type::deferred_write, flags::cause_is_write | flags::cause_is_deferred),
-				std::make_pair<enum_type, u32>(enum_type::unmap, flags::cause_keeps_fault_range_protection | flags::cause_skips_flush),
-				std::make_pair<enum_type, u32>(enum_type::reprotect, flags::cause_keeps_fault_range_protection),
-				std::make_pair<enum_type, u32>(enum_type::superseded_by_fbo, flags::cause_keeps_fault_range_protection | flags::cause_skips_fbos | flags::cause_skips_flush),
-				std::make_pair<enum_type, u32>(enum_type::committed_as_fbo, flags::cause_skips_fbos),
-			};
-
-			m_flag_bits = 0;
-			for (const auto& entry : s_lookup_table)
-			{
-				if (entry.first == cause)
-				{
-					m_flag_bits = entry.second | flags::cause_is_valid;
-					break;
-				}
-			}
-
-			if (cause == enum_type::superseded_by_fbo &&
-				g_cfg.video.strict_texture_flushing) [[ unlikely ]]
-			{
-				m_flag_bits &= ~flags::cause_skips_flush;
-			}
-		}
+		void flag_bits_from_cause(enum_type cause);
 	};
 }

--- a/rpcs3/Emu/RSX/NV47/HW/nv3089.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv3089.cpp
@@ -462,7 +462,7 @@ namespace rsx
 		}
 
 		void swizzled_copy_2(
-			u8* linear_pixels,
+			const u8* linear_pixels,
 			u8* swizzled_pixels,
 			u32 linear_pitch,
 			u16 out_w,
@@ -480,14 +480,14 @@ namespace rsx
 			sw_height_log2 = sw_height_log2 == 0 ? 1 : sw_height_log2;
 
 			// swizzle based on destination size
-			u16 sw_width = 1 << sw_width_log2;
-			u16 sw_height = 1 << sw_height_log2;
+			const u16 sw_width = 1 << sw_width_log2;
+			const u16 sw_height = 1 << sw_height_log2;
 			*/
 
 			std::vector<u8> sw_temp;
 
-			u32 sw_width = next_pow2(out_w);
-			u32 sw_height = next_pow2(out_h);
+			const u32 sw_width = next_pow2(out_w);
+			const u32 sw_height = next_pow2(out_h);
 
 			// Check and pad texture out if we are given non power of 2 output
 			if (sw_width != out_w || sw_height != out_h)
@@ -641,7 +641,7 @@ namespace rsx
 				}
 
 				// Swizzle_copy_2 only pads the data and encodes it as a swizzled output. Transformation (scaling, rotation, etc) is done in swizzle_copy_1
-				swizzled_copy_2(const_cast<u8*>(pixels_src), dst.pixels, src_pitch, out_w, out_h, dst.bpp);
+				swizzled_copy_2(pixels_src, dst.pixels, src_pitch, out_w, out_h, dst.bpp);
 			}
 
 			if (tiled_region)

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -40,7 +40,7 @@ namespace rsx
 	void clip_image(u8 *dst, const u8 *src, int clip_x, int clip_y, int clip_w, int clip_h, int bpp, int src_pitch, int dst_pitch)
 	{
 		const u8* pixels_src = src + clip_y * src_pitch + clip_x * bpp;
-		u8 *pixels_dst = dst;
+		u8* pixels_dst = dst;
 		const u32 row_length = clip_w * bpp;
 
 		for (int y = 0; y < clip_h; ++y)

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -213,9 +213,9 @@ namespace rsx
 	};
 
 	template <typename T>
-	void pad_texture(void* input_pixels, void* output_pixels, u16 input_width, u16 input_height, u16 output_width, u16 /*output_height*/)
+	void pad_texture(const void* input_pixels, void* output_pixels, u16 input_width, u16 input_height, u16 output_width, u16 /*output_height*/)
 	{
-		T *src = static_cast<T*>(input_pixels);
+		const T *src = static_cast<const T*>(input_pixels);
 		T *dst = static_cast<T*>(output_pixels);
 
 		for (u16 h = 0; h < input_height; ++h)
@@ -336,8 +336,8 @@ namespace rsx
 	template <typename T, bool input_is_swizzled>
 	void convert_linear_swizzle(const void* input_pixels, void* output_pixels, u16 width, u16 height, u32 pitch)
 	{
-		u32 log2width = ceil_log2(width);
-		u32 log2height = ceil_log2(height);
+		const u32 log2width = ceil_log2(width);
+		const u32 log2height = ceil_log2(height);
 
 		// Max mask possible for square texture
 		u32 x_mask = 0x55555555;
@@ -356,7 +356,7 @@ namespace rsx
 		u32 offs_y = 0;
 		u32 offs_x = 0;
 		u32 offs_x0 = 0; //total y-carry offset for x
-		u32 y_incr = limit_mask;
+		const u32 y_incr = limit_mask;
 
 		// NOTE: The swizzled area is always a POT region and we must scan all of it to fill in the linear.
 		// It is assumed that there is no padding on the linear side for simplicity - backend upload/download will crop as needed.
@@ -586,8 +586,8 @@ namespace rsx
 	template <bool clamp = false>
 	static inline const std::pair<u16, u16> apply_resolution_scale(u16 width, u16 height, u16 ref_width = 0, u16 ref_height = 0)
 	{
-		ref_width = (ref_width)? ref_width : width;
-		ref_height = (ref_height)? ref_height : height;
+		ref_width = (ref_width) ? ref_width : width;
+		ref_height = (ref_height) ? ref_height : height;
 		const u16 ref = std::max(ref_width, ref_height);
 
 		if (ref > g_cfg.video.min_scalable_dimension)

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -112,6 +112,7 @@
     <ClCompile Include="Emu\NP\upnp_handler.cpp" />
     <ClCompile Include="Emu\perf_monitor.cpp" />
     <ClCompile Include="Emu\RSX\Common\texture_cache.cpp" />
+    <ClCompile Include="Emu\RSX\Common\texture_cache_types.cpp" />
     <ClCompile Include="Emu\RSX\Core\RSXContext.cpp" />
     <ClCompile Include="Emu\RSX\Core\RSXDisplay.cpp" />
     <ClCompile Include="Emu\RSX\Core\RSXDrawCommands.cpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1351,6 +1351,9 @@
     <ClCompile Include="Emu\RSX\GSFrameBase.cpp">
       <Filter>Emu\GPU\RSX\Game Window</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Common\texture_cache_types.cpp">
+      <Filter>Emu\GPU\RSX\Common</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">


### PR DESCRIPTION
- move texture_cache_types implementation to cpp (removes system_config header in header dependency)
- Make some stuff const