### PR TITLE
use concepts instead of std::enable_if

### DIFF
--- a/Utilities/BitField.h
+++ b/Utilities/BitField.h
@@ -256,7 +256,7 @@ struct ff_t : bf_base<T, N>
 #endif
 
 template <typename T, uint I, uint N>
-struct fmt_unveil<bf_t<T, I, N>, void>
+struct fmt_unveil<bf_t<T, I, N>>
 {
 	using type = typename fmt_unveil<std::common_type_t<T>>::type;
 
@@ -267,7 +267,7 @@ struct fmt_unveil<bf_t<T, I, N>, void>
 };
 
 template <typename F, typename... Fields>
-struct fmt_unveil<cf_t<F, Fields...>, void>
+struct fmt_unveil<cf_t<F, Fields...>>
 {
 	using type = typename fmt_unveil<std::common_type_t<typename F::type>>::type;
 
@@ -278,7 +278,7 @@ struct fmt_unveil<cf_t<F, Fields...>, void>
 };
 
 template <typename T, T V, uint N>
-struct fmt_unveil<ff_t<T, V, N>, void>
+struct fmt_unveil<ff_t<T, V, N>>
 {
 	using type = typename fmt_unveil<std::common_type_t<T>>::type;
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -1,5 +1,6 @@
 #pragma once // No BOM and only basic ASCII in this header, or a neko will die
 
+#include "util/serialization.hpp"
 #include "util/types.hpp"
 #include "util/shared_ptr.hpp"
 #include "bit_set.h"
@@ -78,6 +79,8 @@ namespace fs
 		constexpr bool operator==(const stat_t&) const = default;
 	};
 
+	static_assert(utils::Bitcopy<stat_t>);
+
 	// Helper, layout is equal to iovec struct
 	struct iovec_clone
 	{
@@ -125,6 +128,8 @@ namespace fs
 
 		using enable_bitcopy = std::false_type;
 	};
+
+	static_assert(!utils::Bitcopy<dir_entry>);
 
 	// Directory handle base
 	struct dir_base

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -22,7 +22,7 @@ namespace fmt
 #endif
 }
 
-template <typename T, typename = void>
+template <typename T>
 struct fmt_unveil
 {
 	static_assert(sizeof(T) > 0, "fmt_unveil<> error: incomplete type");
@@ -54,7 +54,8 @@ struct fmt_unveil
 };
 
 template <typename T>
-struct fmt_unveil<T, std::enable_if_t<std::is_integral_v<T> && sizeof(T) <= 8 && alignof(T) <= 8>>
+	requires(std::is_integral_v<T> && sizeof(T) <= 8 && alignof(T) <= 8)
+struct fmt_unveil<T>
 {
 	using type = T;
 
@@ -65,7 +66,8 @@ struct fmt_unveil<T, std::enable_if_t<std::is_integral_v<T> && sizeof(T) <= 8 &&
 };
 
 template <typename T>
-struct fmt_unveil<T, std::enable_if_t<std::is_floating_point_v<T> && sizeof(T) <= 8 && alignof(T) <= 8>>
+	requires(std::is_floating_point_v<T> && sizeof(T) <= 8 && alignof(T) <= 8)
+struct fmt_unveil<T>
 {
 	using type = T;
 
@@ -77,7 +79,8 @@ struct fmt_unveil<T, std::enable_if_t<std::is_floating_point_v<T> && sizeof(T) <
 };
 
 template <typename T>
-struct fmt_unveil<T, std::enable_if_t<std::is_enum_v<T>>>
+	requires std::is_enum_v<T>
+struct fmt_unveil<T>
 {
 	using type = T;
 
@@ -88,7 +91,7 @@ struct fmt_unveil<T, std::enable_if_t<std::is_enum_v<T>>>
 };
 
 template <typename T>
-struct fmt_unveil<T*, void>
+struct fmt_unveil<T*>
 {
 	using type = std::add_const_t<T>*;
 
@@ -105,7 +108,7 @@ namespace fmt
 }
 
 template <fmt::CharT T, usz N>
-struct fmt_unveil<T[N], void>
+struct fmt_unveil<T[N]>
 {
 	using type = std::add_const_t<T>*;
 
@@ -116,7 +119,7 @@ struct fmt_unveil<T[N], void>
 };
 
 template <typename T, bool Se, usz Align>
-struct fmt_unveil<se_t<T, Se, Align>, void>
+struct fmt_unveil<se_t<T, Se, Align>>
 {
 	using type = typename fmt_unveil<T>::type;
 
@@ -200,13 +203,13 @@ struct fmt_class_string
 };
 
 template <>
-struct fmt_class_string<const void*, void>
+struct fmt_class_string<const void*>
 {
 	static void format(std::string& out, u64 arg);
 };
 
 template <typename T>
-struct fmt_class_string<T*, void> : fmt_class_string<const void*, void>
+struct fmt_class_string<T*> : fmt_class_string<const void*>
 {
 	// Classify all pointers as const void*
 };
@@ -218,18 +221,18 @@ struct fmt_class_string<const char*, void>
 };
 
 template <>
-struct fmt_class_string<char*, void> : fmt_class_string<const char*>
+struct fmt_class_string<char*> : fmt_class_string<const char*>
 {
 	// Classify char* as const char*
 };
 
 template <>
-struct fmt_class_string<const char8_t*, void> : fmt_class_string<const char*>
+struct fmt_class_string<const char8_t*> : fmt_class_string<const char*>
 {
 };
 
 template <>
-struct fmt_class_string<char8_t*, void> : fmt_class_string<const char8_t*>
+struct fmt_class_string<char8_t*> : fmt_class_string<const char8_t*>
 {
 };
 
@@ -240,7 +243,7 @@ struct fmt_class_string<const wchar_t*, void>
 };
 
 template <>
-struct fmt_class_string<wchar_t*, void> : fmt_class_string<const wchar_t*>
+struct fmt_class_string<wchar_t*> : fmt_class_string<const wchar_t*>
 {
 };
 

--- a/Utilities/StrFmt.h
+++ b/Utilities/StrFmt.h
@@ -130,7 +130,7 @@ struct fmt_unveil<se_t<T, Se, Align>>
 };
 
 // String type format provider, also type classifier (format() called if an argument is formatted as "%s")
-template <typename T, typename = void>
+template <typename T>
 struct fmt_class_string
 {
 	// Formatting function (must be explicitly specialized)
@@ -215,7 +215,7 @@ struct fmt_class_string<T*> : fmt_class_string<const void*>
 };
 
 template <>
-struct fmt_class_string<const char*, void>
+struct fmt_class_string<const char*>
 {
 	static void format(std::string& out, u64 arg);
 };
@@ -237,7 +237,7 @@ struct fmt_class_string<char8_t*> : fmt_class_string<const char8_t*>
 };
 
 template <>
-struct fmt_class_string<const wchar_t*, void>
+struct fmt_class_string<const wchar_t*>
 {
 	static void format(std::string& out, u64 arg);
 };
@@ -257,7 +257,7 @@ namespace fmt
 }
 
 template <fmt::StringConvertible T>
-struct fmt_class_string<T, void>
+struct fmt_class_string<T>
 {
 	static FORCE_INLINE SAFE_BUFFERS(const T&) get_object(u64 arg)
 	{
@@ -278,7 +278,7 @@ namespace fmt
 }
 
 template <fmt::ByteArray T>
-struct fmt_class_string<T, void>
+struct fmt_class_string<T>
 {
 	static FORCE_INLINE SAFE_BUFFERS(const T&) get_object(u64 arg)
 	{

--- a/Utilities/bit_set.h
+++ b/Utilities/bit_set.h
@@ -385,7 +385,7 @@ public:
 };
 
 template <typename T>
-struct fmt_unveil<bs_t<T>, void>
+struct fmt_unveil<bs_t<T>>
 {
 	// Format as is
 	using type = bs_t<T>;

--- a/rpcs3/Emu/CPU/CPUDisAsm.h
+++ b/rpcs3/Emu/CPU/CPUDisAsm.h
@@ -110,7 +110,8 @@ protected:
 	virtual u32 DisAsmBranchTarget(s32 /*imm*/);
 
 	// TODO: Add builtin fmt helpper for best performance
-	template <typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
+	template <typename T>
+		requires std::is_integral_v<T>
 	static std::string SignedHex(T value)
 	{
 		const auto v = static_cast<std::make_signed_t<T>>(value);

--- a/rpcs3/Emu/Cell/ErrorCodes.h
+++ b/rpcs3/Emu/Cell/ErrorCodes.h
@@ -82,11 +82,11 @@ constexpr FORCE_INLINE CellNotAnError not_an_error(const T& value)
 	return static_cast<CellNotAnError>(static_cast<s32>(value));
 }
 
-template <typename T, typename>
+template <typename T>
 struct ppu_gpr_cast_impl;
 
 template <>
-struct ppu_gpr_cast_impl<error_code, void>
+struct ppu_gpr_cast_impl<error_code>
 {
 	static inline u64 to(const error_code& code)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellSail.h
+++ b/rpcs3/Emu/Cell/Modules/cellSail.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Emu/Memory/vm_ptr.h"
 #include "cellVpost.h"
 
 // Error Codes

--- a/rpcs3/Emu/Cell/Modules/cellSail.h
+++ b/rpcs3/Emu/Cell/Modules/cellSail.h
@@ -672,11 +672,11 @@ union CellSailEvent
 	be_t<u64> value;
 };
 
-template<typename T, typename>
+template <typename T>
 struct ppu_gpr_cast_impl;
 
-template<>
-struct ppu_gpr_cast_impl<CellSailEvent, void>
+template <>
+struct ppu_gpr_cast_impl<CellSailEvent>
 {
 	static inline u64 to(const CellSailEvent& event)
 	{

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.h
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.h
@@ -3,6 +3,7 @@
 #include "util/types.hpp"
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/Cell/ErrorCodes.h"
+#include <mutex>
 #include <vector>
 #include <mutex>
 

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -382,14 +382,15 @@ public:
 
 static_assert(ppu_join_status::max <= ppu_join_status{ppu_thread::id_base});
 
-template<typename T, typename = void>
+template <typename T>
 struct ppu_gpr_cast_impl
 {
 	static_assert(!sizeof(T), "Invalid type for ppu_gpr_cast<>");
 };
 
-template<typename T>
-struct ppu_gpr_cast_impl<T, std::enable_if_t<std::is_integral_v<T> || std::is_enum_v<T>>>
+template <typename T>
+	requires std::is_integral_v<T> || std::is_enum_v<T>
+struct ppu_gpr_cast_impl<T>
 {
 	static_assert(sizeof(T) <= 8, "Too big integral type for ppu_gpr_cast<>()");
 	static_assert(std::is_same_v<std::decay_t<T>, bool> == false, "bool type is deprecated in ppu_gpr_cast<>(), use b8 instead");
@@ -405,8 +406,8 @@ struct ppu_gpr_cast_impl<T, std::enable_if_t<std::is_integral_v<T> || std::is_en
 	}
 };
 
-template<>
-struct ppu_gpr_cast_impl<b8, void>
+template <>
+struct ppu_gpr_cast_impl<b8>
 {
 	static inline u64 to(const b8& value)
 	{
@@ -419,8 +420,8 @@ struct ppu_gpr_cast_impl<b8, void>
 	}
 };
 
-template<typename T, typename AT>
-struct ppu_gpr_cast_impl<vm::_ptr_base<T, AT>, void>
+template <typename T, typename AT>
+struct ppu_gpr_cast_impl<vm::_ptr_base<T, AT>>
 {
 	static inline u64 to(const vm::_ptr_base<T, AT>& value)
 	{
@@ -433,8 +434,8 @@ struct ppu_gpr_cast_impl<vm::_ptr_base<T, AT>, void>
 	}
 };
 
-template<typename T, typename AT>
-struct ppu_gpr_cast_impl<vm::_ref_base<T, AT>, void>
+template <typename T, typename AT>
+struct ppu_gpr_cast_impl<vm::_ref_base<T, AT>>
 {
 	static inline u64 to(const vm::_ref_base<T, AT>& value)
 	{
@@ -448,7 +449,7 @@ struct ppu_gpr_cast_impl<vm::_ref_base<T, AT>, void>
 };
 
 template <>
-struct ppu_gpr_cast_impl<vm::null_t, void>
+struct ppu_gpr_cast_impl<vm::null_t>
 {
 	static inline u64 to(const vm::null_t& /*value*/)
 	{

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -342,21 +342,24 @@ namespace vm
 		template<typename T, typename AT = u32, typename AT2 = u32> using bcpptr = bpptr<const T, AT, AT2>;
 
 		// Perform static_cast (for example, vm::ptr<void> to vm::ptr<char>)
-		template<typename CT, typename T, typename AT, typename = decltype(static_cast<to_be_t<CT>*>(std::declval<T*>()))>
+		template <typename CT, typename T, typename AT>
+			requires requires(T* t) { static_cast<to_be_t<CT>*>(t); }
 		inline _ptr_base<to_be_t<CT>, u32> static_ptr_cast(const _ptr_base<T, AT>& other)
 		{
 			return vm::cast(other.addr());
 		}
 
 		// Perform const_cast (for example, vm::cptr<char> to vm::ptr<char>)
-		template<typename CT, typename T, typename AT, typename = decltype(const_cast<to_be_t<CT>*>(std::declval<T*>()))>
+		template <typename CT, typename T, typename AT>
+			requires requires(T* t) { const_cast<to_be_t<CT>*>(t); }
 		inline _ptr_base<to_be_t<CT>, u32> const_ptr_cast(const _ptr_base<T, AT>& other)
 		{
 			return vm::cast(other.addr());
 		}
 
 		// Perform reinterpret cast
-		template <typename CT, typename T, typename AT, typename = decltype(reinterpret_cast<to_be_t<CT>*>(std::declval<T*>()))>
+		template <typename CT, typename T, typename AT>
+			requires requires(T* t) { reinterpret_cast<to_be_t<CT>*>(t); }
 		inline _ptr_base<to_be_t<CT>, u32> unsafe_ptr_cast(const _ptr_base<T, AT>& other)
 		{
 			return vm::cast(other.addr());
@@ -426,8 +429,8 @@ struct to_se<vm::_ptr_base<T, AT>, Se>
 };
 
 // Format pointer
-template<typename T, typename AT>
-struct fmt_unveil<vm::_ptr_base<T, AT>, void>
+template <typename T, typename AT>
+struct fmt_unveil<vm::_ptr_base<T, AT>>
 {
 	using type = vm::_ptr_base<T, u32>; // Use only T, ignoring AT
 

--- a/rpcs3/Emu/Memory/vm_ptr.h
+++ b/rpcs3/Emu/Memory/vm_ptr.h
@@ -441,37 +441,37 @@ struct fmt_unveil<vm::_ptr_base<T, AT>>
 };
 
 template <>
-struct fmt_class_string<vm::_ptr_base<const void, u32>, void>
+struct fmt_class_string<vm::_ptr_base<const void, u32>>
 {
 	static void format(std::string& out, u64 arg);
 };
 
 template <typename T>
-struct fmt_class_string<vm::_ptr_base<T, u32>, void> : fmt_class_string<vm::_ptr_base<const void, u32>, void>
+struct fmt_class_string<vm::_ptr_base<T, u32>> : fmt_class_string<vm::_ptr_base<const void, u32>>
 {
 	// Classify all pointers as const void*
 };
 
 template <>
-struct fmt_class_string<vm::_ptr_base<const char, u32>, void>
+struct fmt_class_string<vm::_ptr_base<const char, u32>>
 {
 	static void format(std::string& out, u64 arg);
 };
 
 template <>
-struct fmt_class_string<vm::_ptr_base<char, u32>, void> : fmt_class_string<vm::_ptr_base<const char, u32>>
+struct fmt_class_string<vm::_ptr_base<char, u32>> : fmt_class_string<vm::_ptr_base<const char, u32>>
 {
 	// Classify char* as const char*
 };
 
 template <usz Size>
-struct fmt_class_string<vm::_ptr_base<const char[Size], u32>, void> : fmt_class_string<vm::_ptr_base<const char, u32>>
+struct fmt_class_string<vm::_ptr_base<const char[Size], u32>> : fmt_class_string<vm::_ptr_base<const char, u32>>
 {
 	// Classify const char[] as const char*
 };
 
 template <usz Size>
-struct fmt_class_string<vm::_ptr_base<char[Size], u32>, void> : fmt_class_string<vm::_ptr_base<const char, u32>>
+struct fmt_class_string<vm::_ptr_base<char[Size], u32>> : fmt_class_string<vm::_ptr_base<const char, u32>>
 {
 	// Classify char[] as const char*
 };

--- a/rpcs3/Emu/Memory/vm_ref.h
+++ b/rpcs3/Emu/Memory/vm_ref.h
@@ -193,8 +193,8 @@ struct to_se<vm::_ref_base<T, AT>, Se>
 };
 
 // Forbid formatting
-template<typename T, typename AT>
-struct fmt_unveil<vm::_ref_base<T, AT>, void>
+template <typename T, typename AT>
+struct fmt_unveil<vm::_ref_base<T, AT>>
 {
 	static_assert(!sizeof(T), "vm::_ref_base<>: ambiguous format argument");
 };

--- a/rpcs3/Emu/RSX/Common/expected.hpp
+++ b/rpcs3/Emu/RSX/Common/expected.hpp
@@ -94,11 +94,11 @@ namespace rsx
             return value;
         }
 
-        template<typename = std::enable_if<!std::is_same_v<T, bool>>>
-        operator bool() const
-        {
-            return error.empty();
-        }
+		operator bool() const
+			requires(!std::is_same_v<T, bool>)
+		{
+			return error.empty();
+		}
 
         operator std::pair<T&, E&>() const
         {

--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -376,21 +376,24 @@ namespace utils
 	}
 
 	// Align to power of 2
-	template <typename T, typename U, typename = std::enable_if_t<std::is_unsigned_v<T>>>
+	template <typename T, typename U>
+		requires std::is_unsigned_v<T>
 	constexpr std::make_unsigned_t<std::common_type_t<T, U>> align(T value, U align)
 	{
 		return static_cast<std::make_unsigned_t<std::common_type_t<T, U>>>((value + (align - 1)) & (T{0} - align));
 	}
 
 	// General purpose aligned division, the result is rounded up not truncated
-	template <typename T, typename = std::enable_if_t<std::is_unsigned_v<T>>>
+	template <typename T>
+		requires std::is_unsigned_v<T>
 	constexpr T aligned_div(T value, std::type_identity_t<T> align)
 	{
 		return static_cast<T>(value / align + T{!!(value % align)});
 	}
 
 	// General purpose aligned division, the result is rounded to nearest
-	template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+	template <typename T>
+		requires std::is_integral_v<T>
 	constexpr T rounded_div(T value, std::type_identity_t<T> align)
 	{
 		if constexpr (std::is_unsigned_v<T>)

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -173,7 +173,8 @@ namespace atomic_wait
 
 		constexpr list& operator=(const list&) noexcept = default;
 
-		template <typename... U, typename = std::void_t<decltype(std::declval<U>().wait(any_value))...>>
+		template <typename... U>
+			requires(requires(U& u) { u.wait(any_value); } && ...)
 		constexpr list(U&... vars)
 			: m_info{{&vars, 0}...}
 		{
@@ -190,7 +191,8 @@ namespace atomic_wait
 			return *this;
 		}
 
-		template <uint Index, typename T2, typename U, typename = std::void_t<decltype(std::declval<T2>().wait(any_value))>>
+		template <uint Index, typename T2, typename U>
+			requires(requires(T2& t2) { t2.wait(any_value); })
 		constexpr void set(T2& var, U value)
 		{
 			static_assert(Index < Max);
@@ -229,7 +231,8 @@ namespace atomic_wait
 		}
 	};
 
-	template <typename... T, typename = std::void_t<decltype(std::declval<T>().wait(any_value))...>>
+	template <typename... T>
+		requires(requires(T& t) { t.wait(any_value); } && ...)
 	list(T&... vars) -> list<sizeof...(T), T...>;
 }
 

--- a/rpcs3/util/endian.hpp
+++ b/rpcs3/util/endian.hpp
@@ -267,8 +267,9 @@ private:
 			}
 		}
 
-public:
-		template <typename T2, typename = decltype(+std::declval<const T2&>())>
+	public:
+		template <typename T2>
+			requires requires(const T2& t2) { +t2; }
 		constexpr bool operator==(const T2& rhs) const noexcept
 		{
 			using R = std::common_type_t<T2>;

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -144,7 +144,7 @@ namespace stx
 			}
 
 			template <typename T>
-				requires requires(T& a, utils::serial& ar) { a.save(ar); }
+				requires requires(T& a, utils::serial& ar) { a.save(stx::exact_t<utils::serial&>(ar)); }
 			static void call_save(void* ptr, utils::serial& ar) noexcept
 			{
 				std::launder(static_cast<T*>(ptr))->save(stx::exact_t<utils::serial&>(ar));
@@ -170,7 +170,7 @@ namespace stx
 					r.thread_op = &call_thread_op<T>;
 				}
 
-				if constexpr (!!(requires(T& a, utils::serial& ar) { a.save(ar); }))
+				if constexpr (!!(requires(T& a, utils::serial& ar) { a.save(stx::exact_t<utils::serial&>(ar)); }))
 				{
 					r.save = &call_save<T>;
 				}

--- a/rpcs3/util/fixed_typemap.hpp
+++ b/rpcs3/util/fixed_typemap.hpp
@@ -143,7 +143,8 @@ namespace stx
 				*std::launder(static_cast<T*>(ptr)) = state;
 			}
 
-			template <typename T> requires requires (T& a) { a.save(std::declval<stx::exact_t<utils::serial&>>()); }
+			template <typename T>
+				requires requires(T& a, utils::serial& ar) { a.save(ar); }
 			static void call_save(void* ptr, utils::serial& ar) noexcept
 			{
 				std::launder(static_cast<T*>(ptr))->save(stx::exact_t<utils::serial&>(ar));
@@ -169,7 +170,7 @@ namespace stx
 					r.thread_op = &call_thread_op<T>;
 				}
 
-				if constexpr (!!(requires (T& a) { a.save(std::declval<stx::exact_t<utils::serial&>>()); }))
+				if constexpr (!!(requires(T& a, utils::serial& ar) { a.save(ar); }))
 				{
 					r.save = &call_save<T>;
 				}

--- a/rpcs3/util/fnv_hash.hpp
+++ b/rpcs3/util/fnv_hash.hpp
@@ -14,7 +14,8 @@ namespace rpcs3
 		return static_cast<usz>(value);
 	}
 
-	template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+	template <typename T>
+		requires std::is_integral_v<T>
 	static inline usz hash64(usz hash_value, T data)
 	{
 		hash_value ^= data;

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -18,9 +18,8 @@ namespace utils
 	};
 
 	template <typename T>
-	concept Bitcopy = (std::is_arithmetic_v<T>) || (std::is_enum_v<T>) || Integral<T> || requires ()
-	{
-		std::enable_if_t<std::conjunction_v<typename T::enable_bitcopy>>();
+	concept Bitcopy = (std::is_arithmetic_v<T>) || (std::is_enum_v<T>) || Integral<T> || requires() {
+		typename T::enable_bitcopy;
 	};
 
 	template <typename T>
@@ -30,7 +29,7 @@ namespace utils
 	};
 
 	template <typename T>
-	concept ListAlike = requires (std::remove_cvref_t<T>& obj) { obj.insert(obj.end(), std::declval<typename T::value_type>()); };
+	concept ListAlike = requires(std::remove_cvref_t<T>& obj, T::value_type item) { obj.insert(obj.end(), item); };
 
 	struct serial;
 
@@ -427,7 +426,8 @@ public:
 			return true;
 		}
 
-		template <typename T> requires requires (T& obj) { (obj.*(&T::operator()))(std::declval<stx::exact_t<utils::serial&>>()); }
+		template <typename T>
+			requires requires(T& obj, utils::serial& ar) { (obj.*(&T::operator()))(ar); }
 		bool serialize(T& obj)
 		{
 			obj(*this);

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -18,9 +18,7 @@ namespace utils
 	};
 
 	template <typename T>
-	concept Bitcopy = (std::is_arithmetic_v<T>) || (std::is_enum_v<T>) || Integral<T> || requires() {
-		typename T::enable_bitcopy;
-	};
+	concept Bitcopy = (std::is_arithmetic_v<T>) || (std::is_enum_v<T>) || Integral<T> || typename T::enable_bitcopy()();
 
 	template <typename T>
 	concept TupleAlike = (!FastRandomAccess<T>) && requires ()
@@ -29,8 +27,8 @@ namespace utils
 	};
 
 	template <typename T>
-	concept ListAlike = requires(std::remove_cvref_t<T>& obj, T::value_type item) { obj.insert(obj.end(), item); };
 
+	concept ListAlike = requires(std::remove_cvref_t<T>& obj, T::value_type item) { obj.insert(obj.end(), std::move(item)); };
 	struct serial;
 
 	struct serialization_file_handler
@@ -123,7 +121,7 @@ public:
 			m_expect_little_data = value;
 		}
 
-		// Return true if small amounts of both input and output memory are expected (performance hint)  
+		// Return true if small amounts of both input and output memory are expected (performance hint)
 		bool expect_little_data() const
 		{
 			return m_expect_little_data;
@@ -427,7 +425,7 @@ public:
 		}
 
 		template <typename T>
-			requires requires(T& obj, utils::serial& ar) { (obj.*(&T::operator()))(ar); }
+			requires requires(T& obj, utils::serial& ar) { (obj.*(&T::operator()))(stx::exact_t<utils::serial&>(ar)); }
 		bool serialize(T& obj)
 		{
 			obj(*this);

--- a/rpcs3/util/to_endian.hpp
+++ b/rpcs3/util/to_endian.hpp
@@ -6,17 +6,18 @@
 union v128;
 
 // Type converter: converts native endianness arithmetic/enum types to appropriate se_t<> type
-template <typename T, bool Se, typename = void>
+template <typename T, bool Se>
 struct to_se
 {
-	template <typename T2, typename = void>
+	template <typename T2>
 	struct to_se_
 	{
 		using type = T2;
 	};
 
 	template <typename T2>
-	struct to_se_<T2, std::enable_if_t<std::is_arithmetic_v<T2> || std::is_enum_v<T2>>>
+		requires std::is_arithmetic_v<T2> || std::is_enum_v<T2>
+	struct to_se_<T2>
 	{
 		using type = std::conditional_t<(sizeof(T2) > 1), se_t<T2, Se>, T2>;
 	};
@@ -44,14 +45,16 @@ struct to_se<s128, Se>
 };
 
 template <typename T, bool Se>
-struct to_se<const T, Se, std::enable_if_t<!std::is_array_v<T>>>
+	requires(!std::is_array_v<T>)
+struct to_se<const T, Se>
 {
 	// Move const qualifier
 	using type = const typename to_se<T, Se>::type;
 };
 
 template <typename T, bool Se>
-struct to_se<volatile T, Se, std::enable_if_t<!std::is_array_v<T> && !std::is_const_v<T>>>
+	requires(!std::is_array_v<T> && !std::is_const_v<T>)
+struct to_se<volatile T, Se>
 {
 	// Move volatile qualifier
 	using type = volatile typename to_se<T, Se>::type;

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -272,14 +272,16 @@ struct alignas(16) u128
 
 	u128() noexcept = default;
 
-	template <typename T, std::enable_if_t<std::is_unsigned_v<T>, u64> = 0>
+	template <typename T>
+		requires std::is_unsigned_v<T>
 	constexpr u128(T arg) noexcept
 		: lo(arg)
 		, hi(0)
 	{
 	}
 
-	template <typename T, std::enable_if_t<std::is_signed_v<T>, s64> = 0>
+	template <typename T>
+		requires std::is_signed_v<T>
 	constexpr u128(T arg) noexcept
 		: lo(s64{arg})
 		, hi(s64{arg} >> 63)


### PR DESCRIPTION
I was learning C++ concepts and decided to replace usages of `std::enable_if` and `std::void_t` with concepts.