### PR TITLE
PPU Analyzer, MGS4: Firmware/import caller analysis and KLIC finding pass

### DIFF
--- a/rpcs3/Crypto/decrypt_binaries.cpp
+++ b/rpcs3/Crypto/decrypt_binaries.cpp
@@ -96,7 +96,7 @@ usz decrypt_binaries_t::decrypt(std::string_view klic_input)
 				case "SCE\0"_u32:
 				{
 					// First KLIC is no KLIC
-					elf_file = decrypt_self(std::move(elf_file), key_it != 0 ? reinterpret_cast<u8*>(&m_klics[key_it]) : nullptr);
+					elf_file = decrypt_self(elf_file, key_it != 0 ? reinterpret_cast<u8*>(&m_klics[key_it]) : nullptr);
 
 					if (!elf_file)
 					{

--- a/rpcs3/Crypto/key_vault.cpp
+++ b/rpcs3/Crypto/key_vault.cpp
@@ -20,6 +20,7 @@ SELF_KEY::SELF_KEY(u64 ver_start, u64 ver_end, u16 rev, u32 type, const std::str
 
 KeyVault::KeyVault()
 {
+	std::memcpy(klicensee_key, NP_KLIC_FREE, sizeof(klicensee_key));
 }
 
 void KeyVault::LoadSelfLV0Keys()
@@ -751,15 +752,14 @@ SELF_KEY KeyVault::FindSelfKey(u32 type, u16 revision, u64 version)
 	return key;
 }
 
-void KeyVault::SetKlicenseeKey(u8* key)
+void KeyVault::SetKlicenseeKey(const u8* key)
 {
-	klicensee_key = std::make_unique<u8[]>(0x10);
-	memcpy(klicensee_key.get(), key, 0x10);
+	std::memcpy(klicensee_key, key, 0x10);
 }
 
-u8* KeyVault::GetKlicenseeKey() const
+const u8* KeyVault::GetKlicenseeKey() const
 {
-	return klicensee_key.get();
+	return klicensee_key;
 }
 
 void rap_to_rif(unsigned char* rap, unsigned char* rif)

--- a/rpcs3/Crypto/key_vault.h
+++ b/rpcs3/Crypto/key_vault.h
@@ -319,13 +319,13 @@ class KeyVault
 	std::vector<SELF_KEY> sk_LDR_arr{};
 	std::vector<SELF_KEY> sk_UNK7_arr{};
 	std::vector<SELF_KEY> sk_NPDRM_arr{};
-	std::unique_ptr<u8[]> klicensee_key{};
+	u8 klicensee_key[16]{};
 
 public:
 	KeyVault();
 	SELF_KEY FindSelfKey(u32 type, u16 revision, u64 version);
-	void SetKlicenseeKey(u8* key);
-	u8* GetKlicenseeKey() const;
+	void SetKlicenseeKey(const u8* key);
+	const u8* GetKlicenseeKey() const;
 
 private:
 	void LoadSelfLV0Keys();

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -476,7 +476,7 @@ public:
 	fs::file MakeElf(bool isElf32);
 	bool LoadHeaders(bool isElf32, SelfAdditionalInfo* out_info = nullptr);
 	void ShowHeaders(bool isElf32);
-	bool LoadMetadata(u8* klic_key);
+	bool LoadMetadata(const u8* klic_key);
 	bool DecryptData();
 	bool DecryptNPDRM(u8 *metadata, u32 metadata_size);
 	const NPD_HEADER* GetNPDHeader() const;
@@ -559,7 +559,7 @@ private:
 	}
 };
 
-fs::file decrypt_self(fs::file elf_or_self, u8* klic_key = nullptr, SelfAdditionalInfo* additional_info = nullptr, bool require_encrypted = false);
+fs::file decrypt_self(const fs::file& elf_or_self, const u8* klic_key = nullptr, SelfAdditionalInfo* additional_info = nullptr);
 bool verify_npdrm_self_headers(const fs::file& self, u8* klic_key = nullptr, NPD_HEADER* npd_out = nullptr);
 bool get_npdrm_self_header(const fs::file& self, NPD_HEADER& npd);
 

--- a/rpcs3/Emu/Cell/PPUAnalyser.h
+++ b/rpcs3/Emu/Cell/PPUAnalyser.h
@@ -106,6 +106,11 @@ struct ppu_segment
 	void* ptr{};
 };
 
+struct ppua_reg_mask_t
+{
+	u64 mask;
+};
+
 // PPU Module Information
 template <typename Type>
 struct ppu_module : public Type
@@ -138,6 +143,8 @@ struct ppu_module : public Type
 	ppu_module* parent = nullptr; // For compilation: refers to original structure (is whole, not partitioned) 
 	std::pair<u32, u32> local_bounds{0, u32{umax}}; // Module addresses range
 	std::shared_ptr<std::pair<u32, u32>> jit_bounds; // JIT instance modules addresses range
+	std::unordered_map<u32, void*> imports; // Imports information for release upon unload (TODO: OVL implementation!) 
+	std::map<u32, std::vector<std::pair<ppua_reg_mask_t, u64>>> stub_addr_to_constant_state_of_registers; // Tells possible constant states of registers of functions
 	bool is_relocatable = false; // Is code relocatable(?)
 
 	template <typename T>

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4162,6 +4162,52 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 	const u32 software_thread_limit = std::min<u32>(g_cfg.core.llvm_threads ? g_cfg.core.llvm_threads : u32{umax}, ::size32(file_queue));
 	const u32 cpu_thread_limit = utils::get_thread_count() > 8u ? std::max<u32>(utils::get_thread_count(), 2) - 1 : utils::get_thread_count(); // One LLVM thread less
 
+	std::vector<u128> decrypt_klics;
+
+	if (loaded_modules)
+	{
+		for (auto mod : *loaded_modules)
+		{
+			for (const auto& [stub, data_vec] : mod->stub_addr_to_constant_state_of_registers)
+			{
+				if (decrypt_klics.size() >= 4u)
+				{
+					break;
+				}
+
+				for (const auto& [reg_mask, constant_value] : data_vec)
+				{
+					if (decrypt_klics.size() >= 4u)
+					{
+						break;
+					}
+
+					if (constant_value > u32{umax})
+					{
+						continue;
+					}
+
+					// R3 - first argument
+					if (reg_mask.mask & (1u << 3))
+					{
+						// Sizeof KLIC
+						if (auto klic_ptr = mod->get_ptr<const u8>(static_cast<u32>(constant_value), 16))
+						{
+							// Try to read from that address
+							if (const u128 klic_value = read_from_ptr<u128>(klic_ptr))
+							{
+								if (!std::count_if(decrypt_klics.begin(), decrypt_klics.end(), FN(std::memcmp(&x, &klic_value, 16) == 0)))
+								{
+									decrypt_klics.emplace_back(klic_value);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	named_thread_group workers("SPRX Worker ", std::min<u32>(software_thread_limit, cpu_thread_limit), [&]
 	{
 #ifdef __APPLE__
@@ -4211,8 +4257,23 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				fmt::append(path, "_x%x", off);
 			}
 
-			// Some files may fail to decrypt due to the lack of klic
-			src = decrypt_self(std::move(src));
+			for (usz i = 0;; i++)
+			{
+				if (i > decrypt_klics.size())
+				{
+					src.close();
+					break;
+				}
+
+				// Some files may fail to decrypt due to the lack of klic
+				u128 key = i == decrypt_klics.size() ? u128{} : decrypt_klics[i];
+
+				if (auto result = decrypt_self(src, i == decrypt_klics.size() ? nullptr : reinterpret_cast<const u8*>(&key)))
+				{
+					src = std::move(result);
+					break;
+				}
+			}
 
 			if (!src)
 			{
@@ -4380,8 +4441,23 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 				continue;
 			}
 
-			// Some files may fail to decrypt due to the lack of klic
-			src = decrypt_self(std::move(src), nullptr, nullptr, true);
+			for (usz i = 0;; i++)
+			{
+				if (i > decrypt_klics.size())
+				{
+					src.close();
+					break;
+				}
+
+				// Some files may fail to decrypt due to the lack of klic
+				u128 key = i == decrypt_klics.size() ? u128{} : decrypt_klics[i];
+
+				if (auto result = decrypt_self(src, i == decrypt_klics.size() ? nullptr : reinterpret_cast<const u8*>(&key)))
+				{
+					src = std::move(result);
+					break;
+				}
+			}
 
 			if (!src)
 			{
@@ -4484,6 +4560,7 @@ extern void ppu_initialize()
 	}
 
 	std::vector<ppu_module<lv2_obj>*> module_list;
+	module_list.emplace_back(&g_fxo->get<main_ppu_module<lv2_obj>>());
 
 	const std::string firmware_sprx_path = vfs::get("/dev_flash/sys/external/");
 

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -36,7 +36,7 @@ static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vp
 
 	u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 
-	src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic), nullptr, true);
+	src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic));
 
 	if (!src)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -265,7 +265,7 @@ static error_code prx_load_module(const std::string& vpath, u64 flags, vm::ptr<s
 
 	u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 
-	src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic), nullptr, true);
+	src = decrypt_self(std::move(src), reinterpret_cast<u8*>(&klic));
 
 	if (!src)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.h
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.h
@@ -192,7 +192,6 @@ struct lv2_prx final : ppu_module<lv2_obj>
 	shared_mutex mutex;
 
 	std::unordered_map<u32, u32> specials;
-	std::unordered_map<u32, void*> imports;
 
 	vm::ptr<s32(u32 argc, vm::ptr<void> argv)> start = vm::null;
 	vm::ptr<s32(u32 argc, vm::ptr<void> argv)> stop = vm::null;

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -566,14 +566,14 @@ public:
 			}
 			else if constexpr (TupleAlike<T>)
 			{
-				constexpr usz tup_size = c_tup_size<type>;
+				constexpr int tup_size = c_tup_size<type>;
 
 				static_assert(tup_size == 2 || tup_size == 4, "Unimplemented tuple serialization!");
 
-				using first_t = std::remove_cvref_t<decltype(std::get<std::min<usz>(0, tup_size - 1)>(std::declval<type&>()))>;
-				using second_t = std::remove_cvref_t<decltype(std::get<std::min<usz>(1, tup_size - 1)>(std::declval<type&>()))>;
-				using third_t = std::remove_cvref_t<decltype(std::get<std::min<usz>(2, tup_size - 1)>(std::declval<type&>()))>;
-				using fourth_t = std::remove_cvref_t<decltype(std::get<std::min<usz>(3, tup_size - 1)>(std::declval<type&>()))>;
+				using first_t  = typename std::tuple_element<std::min(0, tup_size - 1), type>::type;
+				using second_t = typename std::tuple_element<std::min(1, tup_size - 1), type>::type;
+				using third_t  = typename std::tuple_element<std::min(2, tup_size - 1), type>::type;
+				using fourth_t = typename std::tuple_element<std::min(3, tup_size - 1), type>::type;
 
 				first_t first = this->operator first_t();
 


### PR DESCRIPTION
This pull request implements initial import / firmware functions caller analysis.
While many uses are now possible, I implemented one use for Metal Gear Solid 4. 
The use here is to statically analyse the firmware calls to sceNpDrm which contain the key in passed arguments to the function to decrypt its executable.
This is required in order to precompile its PPU LLVM cache properly for all its executables.

Implements #16748  
Fixes #12320 