### PR TITLE
Use ccache on Windows CI build

### DIFF
--- a/.ci/deploy-windows.sh
+++ b/.ci/deploy-windows.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -ex
 
+# First let's see print some info about our caches
+"$(cygpath -u "$CCACHE_BIN_DIR")"/ccache.exe --show-stats -v
+
 # BUILD_blablabla is Azure specific, so we wrap it for portability
 ARTIFACT_DIR="$BUILD_ARTIFACTSTAGINGDIRECTORY"
 

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -114,7 +114,12 @@ jobs:
       QT_DATE: '202501260838'
       VULKAN_VER: '1.3.268.0'
       VULKAN_SDK_SHA: '8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5'
-      CACHE_DIR: ./cache
+      CCACHE_SHA: '6252f081876a9a9f700fae13a5aec5d0d486b28261d7f1f72ac11c7ad9df4da9'
+      CCACHE_BIN_DIR: 'C:\ccache_bin'
+      CCACHE_DIR: 'C:\ccache'
+      CCACHE_INODECACHE: 'true'
+      CCACHE_SLOPPINESS: 'time_macros'
+      DEPS_CACHE_DIR: ./dependency_cache
     steps:
 
       - name: Checkout repository
@@ -131,15 +136,19 @@ jobs:
         shell: bash
         run: .ci/get_keys-windows.sh
 
-      - name: Setup Cache
+      - name: Setup Build Ccache
         uses: actions/cache@main
         with:
-          path: ${{ env.CACHE_DIR }}
-          key: "${{ runner.os }}-${{ env.COMPILER }}-${{ env.QT_VER }}-${{ env.VULKAN_SDK_SHA }}-${{ hashFiles('llvm.lock') }}-${{ hashFiles('glslang.lock') }}-${{github.run_id}}"
-          restore-keys: |
-            "${{ runner.os }}-${{ env.COMPILER }}-${{ env.QT_VER }}-${{ env.VULKAN_SDK_SHA }}-"
-            "${{ runner.os }}-${{ env.COMPILER }}-${{ env.QT_VER }}-"
-            "${{ runner.os }}-${{ env.COMPILER }}-"
+          path: ${{ env.CCACHE_DIR }}
+          key: "${{ runner.os }}-ccache-${{ env.COMPILER }}-${{github.run_id}}"
+          restore-keys: ${{ runner.os }}-ccache-${{ env.COMPILER }}-
+      
+      - name: Setup Dependencies Cache
+        uses: actions/cache@main
+        with:
+          path: ${{ env.DEPS_CACHE_DIR }}
+          key: "${{ runner.os }}-${{ env.COMPILER }}-${{ env.QT_VER }}-${{ env.VULKAN_SDK_SHA }}-${{ env.CCACHE_SHA }}-${{ hashFiles('llvm.lock') }}-${{ hashFiles('glslang.lock') }}"
+          restore-keys: ${{ runner.os }}-${{ env.COMPILER }}-
 
       - name: Download and unpack dependencies
         shell: bash
@@ -158,7 +167,7 @@ jobs:
         uses: microsoft/setup-msbuild@main
 
       - name: Compile RPCS3
-        run: msbuild rpcs3.sln /p:Configuration=Release /p:Platform=x64
+        run: msbuild rpcs3.sln /p:Configuration=Release /p:Platform=x64 /p:CLToolPath=${{ env.CCACHE_BIN_DIR }} /p:UseMultiToolTask=true /p:CustomAfterMicrosoftCommonTargets="${{ github.workspace }}\buildfiles\msvc\ci_no_debug_info.targets"
 
       - name: Pack up build artifacts
         shell: bash

--- a/3rdparty/libpng/libpng.vcxproj
+++ b/3rdparty/libpng/libpng.vcxproj
@@ -68,7 +68,6 @@
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <PrecompiledHeaderFile>pngpriv.h</PrecompiledHeaderFile>
-      <BrowseInformation>true</BrowseInformation>
       <CompileAs>CompileAsC</CompileAs>
       <StringPooling>true</StringPooling>
       <DisableSpecificWarnings>$(DisableSpecificWarnings)</DisableSpecificWarnings>
@@ -91,7 +90,6 @@
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <PrecompiledHeaderFile>pngpriv.h</PrecompiledHeaderFile>
-      <BrowseInformation>true</BrowseInformation>
       <CompileAs>CompileAsC</CompileAs>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>false</MinimalRebuild>

--- a/3rdparty/zlib/zlib.vcxproj
+++ b/3rdparty/zlib/zlib.vcxproj
@@ -84,7 +84,6 @@
       <WarningLevel>$(WarningLevel)</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
-      <BrowseInformation>true</BrowseInformation>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <DisableSpecificWarnings>$(DisableSpecificWarnings);4127;4131;4242;4244</DisableSpecificWarnings>
       <TreatWarningAsError>$(TreatWarningAsError)</TreatWarningAsError>
@@ -102,7 +101,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <BufferSecurityCheck>false</BufferSecurityCheck>
-      <BrowseInformation>true</BrowseInformation>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <DisableSpecificWarnings>$(DisableSpecificWarnings);4127;4131;4242;4244</DisableSpecificWarnings>
       <TreatWarningAsError>$(TreatWarningAsError)</TreatWarningAsError>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,12 @@ jobs:
     VULKAN_VER: '1.3.268.0'
     VULKAN_SDK_SHA: '8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5'
     VULKAN_SDK: C:\VulkanSDK\$(VULKAN_VER)
-    CACHE_DIR: ./cache
+    CCACHE_SHA: '6252f081876a9a9f700fae13a5aec5d0d486b28261d7f1f72ac11c7ad9df4da9'
+    CCACHE_BIN_DIR: 'C:\ccache_bin'
+    CCACHE_DIR: 'C:\ccache'
+    CCACHE_INODECACHE: 'true'
+    CCACHE_SLOPPINESS: 'time_macros'
+    DEPS_CACHE_DIR: ./dependency_cache
     UPLOAD_COMMIT_HASH: 7d09e3be30805911226241afbb14f8cdc2eb054e
     UPLOAD_REPO_FULL_NAME: "RPCS3/rpcs3-binaries-win"
 
@@ -91,13 +96,17 @@ jobs:
 
     - task: Cache@2
       inputs:
-        key: $(Agent.OS) | $(COMPILER) | "$(QT_VER)" | $(VULKAN_SDK_SHA) | llvm.lock | glslang.lock | $(Build.SourceVersion)
-        path: $(CACHE_DIR)
-        restoreKeys: |
-          $(Agent.OS) | $(COMPILER) | "$(QT_VER)" | $(VULKAN_SDK_SHA)
-          $(Agent.OS) | $(COMPILER) | "$(QT_VER)"
-          $(Agent.OS) | $(COMPILER)
-      displayName: Cache
+        key: ccache | $(Agent.OS) | $(COMPILER) | "$(Build.SourceVersion)"
+        path: $(CCACHE_DIR)
+        restoreKeys: 
+          ccache | $(Agent.OS) | $(COMPILER)
+      displayName: Build Ccache
+    
+    - task: Cache@2
+      inputs:
+        key: $(Agent.OS) | $(COMPILER) | "$(QT_VER)" | $(VULKAN_SDK_SHA) | $(CCACHE_SHA) | llvm.lock | glslang.lock
+        path: $(DEPS_CACHE_DIR)
+      displayName: Dependencies Cache
 
     - bash: .ci/setup-windows.sh
       displayName: Download and unpack dependencies
@@ -111,6 +120,7 @@ jobs:
         maximumCpuCount: true
         platform: x64
         configuration: 'Release'
+        msbuildArgs: /p:CLToolPath=$(CCACHE_BIN_DIR) /p:UseMultiToolTask=true /p:CustomAfterMicrosoftCommonTargets="$(Build.SourcesDirectory)\buildfiles\msvc\ci_no_debug_info.targets"
       displayName: Compile RPCS3
 
     - bash: .ci/deploy-windows.sh

--- a/buildfiles/msvc/ci_no_debug_info.targets
+++ b/buildfiles/msvc/ci_no_debug_info.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <DebugInformationFormat>None</DebugInformationFormat>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
This properly caches our Windows builds using ccache, instead of just caching dependencies, this will drastically reduce build times on a warm cache.
Ccache doesn't support the /Zi flag, so I added a .targets file that removes it from the CI build. We don't ship .pdbs in our official releases so this won't change anything for users or developers.