### PR TITLE
Qt/Patches: only consider bootable games in patch manager dialog

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -757,6 +757,7 @@
     <ClCompile Include="rpcs3qt\breakpoint_list.cpp" />
     <ClCompile Include="rpcs3qt\call_stack_list.cpp" />
     <ClCompile Include="rpcs3qt\camera_settings_dialog.cpp" />
+    <ClCompile Include="rpcs3qt\gui_game_info.cpp" />
     <ClCompile Include="rpcs3qt\permissions.cpp" />
     <ClCompile Include="rpcs3qt\ps_move_tracker_dialog.cpp" />
     <ClCompile Include="rpcs3qt\cheat_manager.cpp" />
@@ -1368,6 +1369,7 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWIN32_LEAN_AND_MEAN -DHAVE_VULKAN -DMINIUPNP_STATICLIB -DHAVE_SDL2 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_WINEXTRAS_LIB -DQT_CONCURRENT_LIB -DQT_MULTIMEDIA_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_SVG_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\SoundTouch\soundtouch\include" "-I.\..\3rdparty\cubeb\extra" "-I.\..\3rdparty\cubeb\cubeb\include" "-I.\..\3rdparty\flatbuffers\include" "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I.\..\3rdparty\libsdl-org\SDL\include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtANGLE" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I$(QTDIR)\mkspecs\win32-msvc2015" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtWinExtras" "-I$(QTDIR)\include\QtConcurrent" "-I$(QTDIR)\include\QtMultimedia" "-I$(QTDIR)\include\QtMultimediaWidgets" "-I$(QTDIR)\include\QtSvg"</Command>
     </CustomBuild>
+    <ClInclude Include="rpcs3qt\gui_game_info.h" />
     <ClInclude Include="rpcs3qt\gui_save.h" />
     <CustomBuild Include="rpcs3qt\patch_manager_dialog.h">
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -1164,6 +1164,9 @@
     <ClCompile Include="rpcs3qt\permissions.cpp">
       <Filter>Gui\utils</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\gui_game_info.cpp">
+      <Filter>Gui\game list</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">
@@ -1369,6 +1372,9 @@
     </ClInclude>
     <ClInclude Include="rpcs3qt\permissions.h">
       <Filter>Gui\utils</Filter>
+    </ClInclude>
+    <ClInclude Include="rpcs3qt\gui_game_info.h">
+      <Filter>Gui\game list</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(rpcs3_ui STATIC
     gui_application.cpp
     gl_gs_frame.cpp
     gs_frame.cpp
+    gui_game_info.cpp
     gui_settings.cpp
     infinity_dialog.cpp
     input_dialog.cpp

--- a/rpcs3/rpcs3qt/game_list_base.cpp
+++ b/rpcs3/rpcs3qt/game_list_base.cpp
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "game_list_base.h"
-#include "localized.h"
 
 #include <QDir>
 #include <QPainter>
@@ -187,17 +186,6 @@ QColor game_list_base::GetGridCompatibilityColor(const QString& string) const
 		return QColor(string);
 	}
 	return QColor();
-}
-
-std::string game_list_base::GetGameVersion(const game_info& game)
-{
-	if (game->info.app_ver == Localized().category.unknown.toStdString())
-	{
-		// Fall back to Disc/Pkg Revision
-		return game->info.version;
-	}
-
-	return game->info.app_ver;
 }
 
 QIcon game_list_base::GetCustomConfigIcon(const game_info& game)

--- a/rpcs3/rpcs3qt/game_list_base.h
+++ b/rpcs3/rpcs3qt/game_list_base.h
@@ -1,30 +1,9 @@
 #pragma once
 
-#include "movie_item_base.h"
-#include "game_compatibility.h"
-#include "Emu/GameInfo.h"
+#include "gui_game_info.h"
 
 #include <QIcon>
-#include <QPixmap>
 #include <QWidget>
-
-/* Having the icons associated with the game info simplifies logic internally */
-struct gui_game_info
-{
-	GameInfo info{};
-	QString localized_category;
-	compat::status compat;
-	QPixmap icon;
-	QPixmap pxmap;
-	bool hasCustomConfig = false;
-	bool hasCustomPadConfig = false;
-	bool has_hover_gif = false;
-	bool has_hover_pam = false;
-	movie_item_base* item = nullptr;
-};
-
-typedef std::shared_ptr<gui_game_info> game_info;
-Q_DECLARE_METATYPE(game_info)
 
 class game_list_base
 {
@@ -44,9 +23,6 @@ public:
 	void set_draw_compat_status_to_grid(bool enabled) { m_draw_compat_status_to_grid = enabled; }
 
 	virtual void repaint_icons(std::vector<game_info>& game_data, const QColor& icon_color, const QSize& icon_size, qreal device_pixel_ratio);
-
-	// Returns the visible version string in the game list
-	static std::string GetGameVersion(const game_info& game);
 
 	/** Sets the custom config icon. */
 	static QIcon GetCustomConfigIcon(const game_info& game);

--- a/rpcs3/rpcs3qt/game_list_table.cpp
+++ b/rpcs3/rpcs3qt/game_list_table.cpp
@@ -332,7 +332,7 @@ void game_list_table::populate(
 		}
 
 		// Version
-		QString app_version = QString::fromStdString(game_list::GetGameVersion(game));
+		QString app_version = QString::fromStdString(game->GetGameVersion());
 
 		if (game->info.bootable && !game->compat.latest_version.isEmpty())
 		{

--- a/rpcs3/rpcs3qt/gui_game_info.cpp
+++ b/rpcs3/rpcs3qt/gui_game_info.cpp
@@ -1,0 +1,14 @@
+#include "stdafx.h"
+#include "gui_game_info.h"
+#include "localized.h"
+
+std::string gui_game_info::GetGameVersion() const
+{
+	if (info.app_ver == Localized().category.unknown.toStdString())
+	{
+		// Fall back to Disc/Pkg Revision
+		return info.version;
+	}
+
+	return info.app_ver;
+}

--- a/rpcs3/rpcs3qt/gui_game_info.h
+++ b/rpcs3/rpcs3qt/gui_game_info.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "movie_item_base.h"
+#include "game_compatibility.h"
+
+#include "Emu/GameInfo.h"
+
+#include <QPixmap>
+
+/* Having the icons associated with the game info simplifies logic internally */
+struct gui_game_info
+{
+	GameInfo info{};
+	QString localized_category;
+	compat::status compat;
+	QPixmap icon;
+	QPixmap pxmap;
+	bool hasCustomConfig = false;
+	bool hasCustomPadConfig = false;
+	bool has_hover_gif = false;
+	bool has_hover_pam = false;
+	movie_item_base* item = nullptr;
+
+	// Returns the visible version string in the game list
+	std::string GetGameVersion() const;
+};
+
+typedef std::shared_ptr<gui_game_info> game_info;
+Q_DECLARE_METATYPE(game_info)

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3070,18 +3070,7 @@ void main_window::CreateConnects()
 
 	connect(ui->actionManage_Game_Patches, &QAction::triggered, this, [this]
 	{
-		std::unordered_map<std::string, std::set<std::string>> games;
-		if (m_game_list_frame)
-		{
-			for (const game_info& game : m_game_list_frame->GetGameInfo())
-			{
-				if (game)
-				{
-					games[game->info.serial].insert(game_list::GetGameVersion(game));
-				}
-			}
-		}
-		patch_manager_dialog patch_manager(m_gui_settings, games, "", "", this);
+		patch_manager_dialog patch_manager(m_gui_settings, m_game_list_frame ? m_game_list_frame->GetGameInfo() : std::vector<game_info>{}, "", "", this);
 		patch_manager.exec();
  	});
 

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -73,7 +73,7 @@ patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_set
 	// Get owned games
 	for (const auto& game : games)
 	{
-		if (game)
+		if (game && game->info.bootable)
 		{
 			m_owned_games[game->info.serial].insert(game->GetGameVersion());
 		}

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -57,12 +57,11 @@ enum node_level : int
 
 Q_DECLARE_METATYPE(patch_engine::patch_config_value);
 
-patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, const std::string& title_id, const std::string& version, QWidget* parent)
+patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, const std::vector<game_info>& games, const std::string& title_id, const std::string& version, QWidget* parent)
 	: QDialog(parent)
 	, m_gui_settings(std::move(gui_settings))
 	, m_expand_current_match(!title_id.empty() && !version.empty()) // Expand first search results
 	, m_search_version(QString::fromStdString(version))
-	, m_owned_games(std::move(games))
 	, ui(new Ui::patch_manager_dialog)
 {
 	ui->setupUi(this);
@@ -70,6 +69,15 @@ patch_manager_dialog::patch_manager_dialog(std::shared_ptr<gui_settings> gui_set
 
 	// Load gui settings
 	m_show_owned_games_only = m_gui_settings->GetValue(gui::pm_show_owned).toBool();
+
+	// Get owned games
+	for (const auto& game : games)
+	{
+		if (game)
+		{
+			m_owned_games[game->info.serial].insert(game->GetGameVersion());
+		}
+	}
 
 	// Initialize gui controls
 	ui->patch_filter->setText(QString::fromStdString(title_id));

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -5,6 +5,7 @@
 #include <QDragMoveEvent>
 #include <QMimeData>
 
+#include "gui_game_info.h"
 #include "Utilities/bin_patch.h"
 #include <unordered_map>
 
@@ -39,7 +40,7 @@ class patch_manager_dialog : public QDialog
 	const QString tr_all_versions = tr("All versions");
 
 public:
-	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, std::unordered_map<std::string, std::set<std::string>> games, const std::string& title_id, const std::string& version, QWidget* parent = nullptr);
+	explicit patch_manager_dialog(std::shared_ptr<gui_settings> gui_settings, const std::vector<game_info>& games, const std::string& title_id, const std::string& version, QWidget* parent = nullptr);
 	~patch_manager_dialog();
 
 	int exec() override;


### PR DESCRIPTION
- Refactor some code to remove some code duplication
- Only consider bootable games in patch manager

This should fix some issues with showing wrong versions when selecting "show owned games only"