### PR TITLE
vk: Do not force strict query scopes by default

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKHelpers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKHelpers.cpp
@@ -29,7 +29,7 @@ namespace vk
 	bool g_drv_sanitize_fp_values = false;
 	bool g_drv_disable_fence_reset = false;
 	bool g_drv_emulate_cond_render = false;
-	bool g_drv_strict_query_scopes = true;
+	bool g_drv_strict_query_scopes = false;
 	bool g_drv_force_reuse_query_pools = false;
 
 	u64 g_num_processed_frames = 0;


### PR DESCRIPTION
Not required for most drivers and has a measurable performance impact.
Fixes a minor performance regression introduced in OGL MSAA PR.