### PR TITLE
rsx: Reupload surface if the surface cache denies knowledge of it

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -381,9 +381,20 @@ namespace rsx
 				{
 					if (!(surface = surface_cache.get_surface_at(ref_address)))
 					{
-						// Compositing op. Just ignore expiry for now
-						ensure(!ref_image);
-						return {};
+						// Surface cache does not have our image. Two possibilities:
+						// 1. It was never a real RTT, just some op like dynamic/static-copy/composite request. image_ref is null in such cases.
+						// 2. It was real but probably deleted some time ago and we have a bogus pointer. Discard it in this case.
+						if (!ref_image)
+						{
+							// Compositing op. Just ignore expiry for now
+							return {};
+						}
+
+						// We have a real image but surface cache says it doesn't exist any more. Force a reupload.
+						// Normally the global samplers dirty flag should have been set to invalidate all references.
+						ensure(external_subresource_desc.op == deferred_request_command::nop);
+						rsx_log.warning("Renderer is holding a stale reference to a surface that no longer exists!");
+						return { true, nullptr };
 					}
 				}
 


### PR DESCRIPTION
The combination of flags observed during debugging (thanks @digant73) really only means one thing - we have a stale pointer. Normally changes in surface cache invalidate samplers, but with all the optimizations done over the years there is a chance that we're holding on to some reference to a surface that was last seen a long time ago (in computing terms, so like a half a second lol).
In such a case, the dynamic cast will fail, and the surface cache will deny knowledge of the image despite the fact that we have a fully compliant descriptor. Simply treat the descriptor as invalid at that point and redo the upload.

Fixes https://github.com/RPCS3/rpcs3/issues/14809