### PR TITLE
Qt: Hide legacy shader mode interpreter_only unless it is selected or the debug mode is active

### DIFF
--- a/rpcs3/main.cpp
+++ b/rpcs3/main.cpp
@@ -410,7 +410,7 @@ int find_arg(const char* to_search, std::span<char* const> argv)
 
 		if (argp[0] == '-' && argp[1] == '-' && !std::strcmp(to_search, argp + 2))
 		{
-			return i;
+			return ::narrow<int>(i);
 		}
 	}
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -703,6 +703,12 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	m_emu_settings->EnhanceRadioButton(shader_mode_bg, emu_settings_type::ShaderMode);
 
+	// Hide interpreter_only unless it is selected or the debug mode is active
+	if (!ui->rb_shader_interpreter_only->isChecked() && !m_gui_settings->GetValue(gui::m_showDebugTab).toBool())
+	{
+		ui->rb_shader_interpreter_only->setVisible(false);
+	}
+
 	// Sliders
 
 	m_emu_settings->EnhanceSlider(ui->resolutionScale, emu_settings_type::ResolutionScale);


### PR DESCRIPTION
- Hide legacy shader mode interpreter_only unless it is selected or the debug mode is active
- Fix some warning in main.cpp

Follow up to #16805