### PR TITLE
sys_usbd: Fix null pointer deref on destruction

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -591,7 +591,8 @@ usb_handler_thread::~usb_handler_thread()
 	}
 
 #if LIBUSB_API_VERSION >= 0x01000102
-	libusb_hotplug_deregister_callback(ctx, callback_handle);
+	if (ctx && hotplug_supported)
+		libusb_hotplug_deregister_callback(ctx, callback_handle);
 #endif
 
 	if (ctx)


### PR DESCRIPTION
This fixes a crash inside libusb for users who would fail libusb_init* (e.g. running in a mount namespace and not any using USB peripherals, so not giving the container direct USB access).

We also might as well not call deregister if register failed (but doing so wouldn't cause problems in this case).