### PR TITLE
CI: upgrade FreeBSD to 13.5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,7 @@ freebsd_task:
   matrix:
     - name: Cirrus FreeBSD
       freebsd_instance:
-        image_family: freebsd-13-4
+        image_family: freebsd-13-5
         cpu: 8
         memory: 8G
   env:


### PR DESCRIPTION
Followup to #16701 and prevent CI breakage in ~3 months.

```
$ c++ --version
FreeBSD clang version 19.1.7 (https://github.com/llvm/llvm-project.git llvmorg-19.1.7-0-gcd708029e0b2)
Target: x86_64-unknown-freebsd13.5
Thread model: posix
InstalledDir: /usr/bin
```
