### PR TITLE
SPU LLVM: Preserve sign on inf to NaN conversion in spu_re_acc with vfixupimmps

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -6835,7 +6835,7 @@ public:
 
 				const auto div_result = the_one / div;
 
-				return vfixupimmps(bitcast<f32[4]>(splat<u32[4]>(0xFFFFFFFFu)), div_result, splat<u32[4]>(0x11001188u), 0, 0xff);
+				return vfixupimmps(div_result, div_result, splat<u32[4]>(0x00220088u), 0, 0xff);
 			});	
 		}
 		else


### PR DESCRIPTION
Fixes broken graphics in god of war ascension when AVX-512 was enabled.
![image](https://github.com/user-attachments/assets/1f8e9da2-2dba-4131-a814-5831c8a1c2f3)

Fixes: https://github.com/RPCS3/rpcs3/issues/16770