### PR TITLE
Qt: Use localized game icons and titles

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -1382,9 +1382,11 @@ error_code sceNpTrophyGetGameIcon(u32 context, u32 handle, vm::ptr<void> buffer,
 		return SCE_NP_TROPHY_ERROR_INVALID_ARGUMENT;
 	}
 
-	fs::file icon_file(vfs::get("/dev_hdd0/home/" + Emu.GetUsr() + "/trophy/" + ctxt->trp_name + "/ICON0.PNG"));
+	// Try to get icon in current language first
+	const std::string trophy_path = fmt::format("/dev_hdd0/home/%s/trophy/%s/", Emu.GetUsr(), ctxt->trp_name);
+	fs::file icon_file(vfs::get(fmt::format("%s/ICON0_%02d.PNG", trophy_path, static_cast<s32>(g_cfg.sys.language))));
 
-	if (!icon_file)
+	if (!icon_file && !icon_file.open(vfs::get(fmt::format("%s/ICON0.PNG", trophy_path))))
 	{
 		return SCE_NP_TROPHY_ERROR_UNKNOWN_FILE;
 	}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -141,6 +141,7 @@ class Emulator final
 	std::string m_path_original;
 	std::string m_title_id;
 	std::string m_title;
+	std::string m_localized_title;
 	std::string m_app_version;
 	std::string m_hash;
 	std::string m_cat;
@@ -277,6 +278,11 @@ public:
 	const std::string& GetTitle() const
 	{
 		return m_title;
+	}
+
+	const std::string& GetLocalizedTitle() const
+	{
+		return m_localized_title;
 	}
 
 	const std::string GetTitleAndTitleID() const

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -321,7 +321,7 @@ compat::package_info game_compatibility::GetPkgInfo(const QString& pkg_path, gam
 				{
 					if (const std::string localized_title = package.get_title(title_key); !localized_title.empty())
 					{
-						info.title= qstr(localized_title);
+						info.title = qstr(localized_title);
 					}
 
 					if (const std::string localized_changelog = package.get_changelog(changelog_key); !localized_changelog.empty())

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -69,6 +69,8 @@ public:
 	/** Call this method before calling app.exec */
 	bool Init() override;
 
+	static s32 get_language_id();
+
 	std::unique_ptr<gs_frame> get_gs_frame();
 
 	main_window* m_main_window = nullptr;
@@ -90,6 +92,8 @@ private:
 	void UpdatePlaytime();
 	void StopPlaytime();
 
+	void set_language_code(QString language_code);
+
 	class native_event_filter : public QAbstractNativeEventFilter
 	{
 	public:
@@ -99,6 +103,7 @@ private:
 
 	QTranslator m_translator;
 	QString m_language_code;
+	static s32 m_language_id;
 
 	QTimer m_timer;
 	QElapsedTimer m_timer_playtime;

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2413,9 +2413,9 @@ void main_window::RepaintGui()
 	Q_EMIT RequestDialogRepaint();
 }
 
-void main_window::RetranslateUI(const QStringList& language_codes, const QString& language)
+void main_window::RetranslateUI(const QStringList& language_codes, const QString& language_code)
 {
-	UpdateLanguageActions(language_codes, language);
+	UpdateLanguageActions(language_codes, language_code);
 
 	ui->retranslateUi(this);
 

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -111,7 +111,7 @@ public Q_SLOTS:
 	void OnAddBreakpoint(u32 addr) const;
 
 	void RepaintGui();
-	void RetranslateUI(const QStringList& language_codes, const QString& language);
+	void RetranslateUI(const QStringList& language_codes, const QString& language_code);
 
 private Q_SLOTS:
 	void OnPlayOrPause();

--- a/rpcs3/rpcs3qt/save_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/save_manager_dialog.cpp
@@ -2,6 +2,7 @@
 
 #include "custom_table_widget_item.h"
 #include "qt_utils.h"
+#include "gui_application.h"
 #include "gui_settings.h"
 #include "persistent_settings.h"
 #include "game_list_delegate.h"
@@ -405,11 +406,14 @@ void save_manager_dialog::UpdateIcons()
 	m_list->resizeRowsToContents();
 	m_list->resizeColumnToContents(SaveColumns::Icon);
 
+	const s32 language_index = gui_application::get_language_id();
+	const std::string localized_icon = fmt::format("ICON0_%02d.PNG", language_index);
+
 	for (int i = 0; i < m_list->rowCount(); ++i)
 	{
 		if (movie_item* icon_item = static_cast<movie_item*>(m_list->item(i, SaveColumns::Icon)))
 		{
-			icon_item->set_icon_load_func([this, cancel = icon_item->icon_loading_aborted(), dpr](int index)
+			icon_item->set_icon_load_func([this, cancel = icon_item->icon_loading_aborted(), dpr, localized_icon](int index)
 			{
 				if (cancel && cancel->load())
 				{
@@ -428,7 +432,8 @@ void save_manager_dialog::UpdateIcons()
 							const int idx_real = user_item->data(Qt::UserRole).toInt();
 							const SaveDataEntry& entry = ::at32(m_save_entries, idx_real);
 
-							if (!icon.load(QString::fromStdString(m_dir + entry.dirName + "/ICON0.PNG")))
+							if (!icon.load(QString::fromStdString(m_dir + entry.dirName + "/" + localized_icon)) &&
+								!icon.load(QString::fromStdString(m_dir + entry.dirName + "/ICON0.PNG")))
 							{
 								gui_log.warning("Loading icon for save %s failed", entry.dirName);
 								icon = QPixmap(320, 176);


### PR DESCRIPTION
- Uses game icons in shader compile dialog based on current config language
- Uses game title in game window based on current config language
- Uses game icons in GUI dialogs based on current UI language
- Uses game titles in GUI dialogs based on current UI language

fixes #16865