### PR TITLE
config: Revert default shader compiler to async with draw-skip

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -130,7 +130,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<frame_limit_type> frame_limit{ this, "Frame limit", frame_limit_type::_auto, true };
 		cfg::_float<0, 1000> second_frame_limit{ this, "Second Frame Limit", 0, true }; // 0 disables its effect
 		cfg::_enum<msaa_level> antialiasing_level{ this, "MSAA", msaa_level::_auto };
-		cfg::_enum<shader_mode> shadermode{ this, "Shader Mode", shader_mode::async_with_interpreter };
+		cfg::_enum<shader_mode> shadermode{ this, "Shader Mode", shader_mode::async_recompiler };
 		cfg::_enum<gpu_preset_level> shader_precision{ this, "Shader Precision", gpu_preset_level::high };
 
 		cfg::_bool write_color_buffers{ this, "Write Color Buffers" };


### PR DESCRIPTION
We need to get some more work in before the interpreter can be the default.

Closes https://github.com/RPCS3/rpcs3/issues/16844
Relates to https://github.com/RPCS3/rpcs3/issues/5186