### PR TITLE
PPU/cellSpurs: MGS4: Fix cellSpursAddUrgentCommand race condition

### DIFF
--- a/rpcs3/Emu/Cell/PPUInterpreter.cpp
+++ b/rpcs3/Emu/Cell/PPUInterpreter.cpp
@@ -484,6 +484,7 @@ auto ppu_feed_data(ppu_thread& ppu, u64 addr)
 		{
 			// Reservation was lost
 			ppu.raddr = 0;
+			ppu.res_cached = 0;
 		}
 	}
 	else
@@ -503,6 +504,7 @@ auto ppu_feed_data(ppu_thread& ppu, u64 addr)
 		if (std::memcmp(buffer + offs, src, size))
 		{
 			ppu.raddr = 0;
+			ppu.res_cached = 0;
 		}
 	}
 

--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -264,6 +264,7 @@ public:
 	u64 rtime{0};
 	alignas(64) std::byte rdata[128]{}; // Reservation data
 	bool use_full_rdata{};
+	u32 res_cached{0}; // Reservation "cached" addresss
 	u32 res_notify{0};
 	u64 res_notify_time{0};
 


### PR DESCRIPTION
cellSpursAddUrgentCommand searches in 4 slots for an empty slot to put the command at.

![image](https://github.com/user-attachments/assets/68b7de88-9638-4c82-9223-71cdf4b0a497)

At first, it seems to do so unordered.


Meanwhile, on SPU side, it expects an order between all the commands because it pops them it in FIFO manner.
Not keeping track of how many commands are queued in total.
This is the SPU function resposible:
![image](https://github.com/user-attachments/assets/ddae9f0f-2e34-4795-ac9d-81d7233f51fc)

[SPU_unqueue.txt](https://github.com/user-attachments/files/19407636/SPU_unqueue.txt.txt)

After second observation of cellSpursAddUrgentCommand, something odd takes places here.
Usually, reservation loops are individual and are expected to be closed without any changes of the previous loop affected by the proceeding one.
But in this case, after a single failure, the entire operation is reset, a loop of 4 reservation operations suddenly is reset completely.

This makes one wonder if it the HW expects something else here, perhaps it caches the reservation internally here?
After some adjustments to LDARX and STDCX to cache the reservation between succeeding loops, Metal Gear Solid 4 no longer freezes!

This commit also disables the MG4 cellSpurs Freeze patch by RPCS3, as it is no longer needed and can hurt performance.

Here is an MGS4 screenshot just for fun:

![image](https://github.com/user-attachments/assets/362f314b-e47c-463a-b8c9-a4573a8de78b)


Now that the function behaves properly, the SPURS urgent command queue size is now 4 which is plenty room for the PPU and it no longer needs to spin on this function, waiting for an empty slot to become available.
I believe the behaviour of the hack is why #16903 affected MGS4 performance so much.

@cipherxof Please test performance on this build too!


Fixes #6514 