### PR TITLE
overlays: hide friends list in home menu if rpcn is not configured

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/FriendsList/overlay_friends_list_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/FriendsList/overlay_friends_list_dialog.cpp
@@ -684,5 +684,12 @@ namespace rsx
 
 			return CELL_OK;
 		}
+
+		bool friends_list_dialog::rpcn_configured()
+		{
+			cfg_rpcn cfg;
+			cfg.load();
+			return !cfg.get_npid().empty() && !cfg.get_password().empty();
+		}
 	} // namespace overlays
 } // namespace RSX

--- a/rpcs3/Emu/RSX/Overlays/FriendsList/overlay_friends_list_dialog.h
+++ b/rpcs3/Emu/RSX/Overlays/FriendsList/overlay_friends_list_dialog.h
@@ -59,6 +59,8 @@ namespace rsx
 			error_code show(bool enable_overlay, std::function<void(s32 status)> on_close);
 
 			void callback_handler(rpcn::NotificationType ntype, const std::string& username, bool status);
+
+			static bool rpcn_configured();
 		};
 	}
 }

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_main_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_main_menu.cpp
@@ -38,26 +38,33 @@ namespace rsx
 
 			add_page(std::make_shared<home_menu_settings>(x, y, width, height, use_separators, this));
 
-			std::unique_ptr<overlay_element> friends = std::make_unique<home_menu_entry>(get_localized_string(localized_string_id::HOME_MENU_FRIENDS));
-			add_item(friends, [](pad_button btn) -> page_navigation
+			if (rsx::overlays::friends_list_dialog::rpcn_configured())
 			{
-				if (btn != pad_button::cross) return page_navigation::stay;
-
-				rsx_log.notice("User selected friends in home menu");
-				Emu.CallFromMainThread([]()
+				std::unique_ptr<overlay_element> friends = std::make_unique<home_menu_entry>(get_localized_string(localized_string_id::HOME_MENU_FRIENDS));
+				add_item(friends, [](pad_button btn) -> page_navigation
 				{
-					if (auto manager = g_fxo->try_get<rsx::overlays::display_manager>())
-					{
-						const error_code result = manager->create<rsx::overlays::friends_list_dialog>()->show(true, [](s32 status)
-						{
-							rsx_log.notice("Closing friends list with status %d", status);
-						});
+					if (btn != pad_button::cross) return page_navigation::stay;
 
-						(result ? rsx_log.error : rsx_log.notice)("Opened friends list with result %d", s32{result});
-					}
+					rsx_log.notice("User selected friends in home menu");
+					Emu.CallFromMainThread([]()
+					{
+						if (auto manager = g_fxo->try_get<rsx::overlays::display_manager>())
+						{
+							const error_code result = manager->create<rsx::overlays::friends_list_dialog>()->show(true, [](s32 status)
+							{
+								rsx_log.notice("Closing friends list with status %d", status);
+							});
+
+							(result ? rsx_log.error : rsx_log.notice)("Opened friends list with result %d", s32{result});
+						}
+					});
+					return page_navigation::stay;
 				});
-				return page_navigation::stay;
-			});
+			}
+			else
+			{
+				rsx_log.notice("Friends list hidden in home menu. RPCN is not configured.");
+			}
 
 			// get current trophy name for trophy list overlay
 			std::string trop_name;


### PR DESCRIPTION
- overlays: hide friends list in home menu if rpcn is not configured

related to #16918