### PR TITLE
unpkg: Restore support for PSP/Vita packages

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -528,7 +528,7 @@ bool package_reader::read_entries(std::vector<PKGEntry>& entries)
 	entries.clear();
 	entries.resize(m_header.file_count + BUF_PADDING / sizeof(PKGEntry) + 1);
 
-	const usz read_size = decrypt(0, m_header.file_count * sizeof(PKGEntry), m_dec_key.data(), entries.data());
+	const usz read_size = decrypt(0, m_header.file_count * sizeof(PKGEntry), m_header.pkg_platform == PKG_PLATFORM_TYPE_PSP_PSVITA ? PKG_AES_KEY2 : m_dec_key.data(), entries.data());
 
 	if (read_size < m_header.file_count * sizeof(PKGEntry))
 	{


### PR DESCRIPTION
#16739 Removed the ability to install PSP and Vita packages because it stopped using the PSP PKG key for getting the file entries. This just restores the line to the way it was before that PR, but shouldn't break IDU packages.