### PR TITLE
Qt: Play ICON1.PAM in save data manager when hovering over the icon

### DIFF
--- a/rpcs3/rpcs3qt/game_list.cpp
+++ b/rpcs3/rpcs3qt/game_list.cpp
@@ -139,6 +139,8 @@ void game_list::mouseMoveEvent(QMouseEvent* event)
 	}
 
 	m_last_hover_item = new_item;
+
+	QTableWidget::mouseMoveEvent(event);
 }
 
 void game_list::mouseDoubleClickEvent(QMouseEvent* ev)
@@ -169,13 +171,15 @@ void game_list::keyPressEvent(QKeyEvent* event)
 	QTableWidget::keyPressEvent(event);
 }
 
-void game_list::leaveEvent(QEvent* /*event*/)
+void game_list::leaveEvent(QEvent* event)
 {
 	if (m_last_hover_item)
 	{
 		m_last_hover_item->set_active(false);
 		m_last_hover_item = nullptr;
 	}
+
+	QTableWidget::leaveEvent(event);
 }
 
 void game_list::FocusAndSelectFirstEntryIfNoneIs()

--- a/rpcs3/rpcs3qt/game_list.cpp
+++ b/rpcs3/rpcs3qt/game_list.cpp
@@ -8,9 +8,9 @@
 
 game_list::game_list() : QTableWidget(), game_list_base()
 {
-	m_icon_ready_callback = [this](const game_info& game)
+	m_icon_ready_callback = [this](const movie_item_base* item)
 	{
-		Q_EMIT IconReady(game);
+		Q_EMIT IconReady(item);
 	};
 }
 

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -36,7 +36,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
 	void FocusToSearchBar();
-	void IconReady(const game_info& game);
+	void IconReady(const movie_item_base* item);
 
 protected:
 	movie_item* m_last_hover_item = nullptr;

--- a/rpcs3/rpcs3qt/game_list_base.cpp
+++ b/rpcs3/rpcs3qt/game_list_base.cpp
@@ -79,7 +79,7 @@ void game_list_base::IconLoadFunction(game_info game, qreal device_pixel_ratio, 
 	if (!cancel || !cancel->load())
 	{
 		if (m_icon_ready_callback)
-			m_icon_ready_callback(game);
+			m_icon_ready_callback(game->item);
 	}
 }
 

--- a/rpcs3/rpcs3qt/game_list_base.h
+++ b/rpcs3/rpcs3qt/game_list_base.h
@@ -32,7 +32,7 @@ protected:
 	QPixmap PaintedPixmap(const QPixmap& icon, qreal device_pixel_ratio, bool paint_config_icon = false, bool paint_pad_config_icon = false, const QColor& compatibility_color = {}) const;
 	QColor GetGridCompatibilityColor(const QString& string) const;
 
-	std::function<void(const game_info&)> m_icon_ready_callback{};
+	std::function<void(const movie_item_base*)> m_icon_ready_callback{};
 	bool m_draw_compat_status_to_grid{};
 	bool m_is_list_layout{};
 	QSize m_icon_size{};

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -14,15 +14,14 @@ game_list_grid::game_list_grid()
 	setObjectName("game_list_grid");
 	setContextMenuPolicy(Qt::CustomContextMenu);
 
-	m_icon_ready_callback = [this](const game_info& game)
+	m_icon_ready_callback = [this](const movie_item_base* item)
 	{
-		Q_EMIT IconReady(game);
+		Q_EMIT IconReady(item);
 	};
 
-	connect(this, &game_list_grid::IconReady, this, [this](const game_info& game)
+	connect(this, &game_list_grid::IconReady, this, [this](const movie_item_base* item)
 	{
-		if (!game || !game->item) return;
-		game->item->call_icon_func();
+		if (item) item->call_icon_func();
 	}, Qt::QueuedConnection); // The default 'AutoConnection' doesn't seem to work in this specific case...
 
 	connect(this, &flow_widget::ItemSelectionChanged, this, [this](int index)

--- a/rpcs3/rpcs3qt/game_list_grid.h
+++ b/rpcs3/rpcs3qt/game_list_grid.h
@@ -33,5 +33,5 @@ Q_SIGNALS:
 	void FocusToSearchBar();
 	void ItemDoubleClicked(const game_info& game);
 	void ItemSelectionChanged(const game_info& game);
-	void IconReady(const game_info& game);
+	void IconReady(const movie_item_base* item);
 };

--- a/rpcs3/rpcs3qt/game_list_table.cpp
+++ b/rpcs3/rpcs3qt/game_list_table.cpp
@@ -52,10 +52,9 @@ game_list_table::game_list_table(game_list_frame* frame, std::shared_ptr<persist
 		}
 	});
 
-	connect(this, &game_list::IconReady, this, [this](const game_info& game)
+	connect(this, &game_list::IconReady, this, [this](const movie_item_base* item)
 	{
-		if (!game || !game->item) return;
-		game->item->call_icon_func();
+		if (item) item->call_icon_func();
 	});
 }
 

--- a/rpcs3/rpcs3qt/save_manager_dialog.h
+++ b/rpcs3/rpcs3qt/save_manager_dialog.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "game_list.h"
 #include "Emu/Cell/Modules/cellSaveData.h"
 
 #include <QDialog>
@@ -46,7 +47,7 @@ private:
 
 	std::vector<SaveDataEntry> GetSaveEntries(const std::string& base_dir);
 
-	QTableWidget* m_list = nullptr;
+	game_list* m_list = nullptr;
 	std::string m_dir;
 	std::vector<SaveDataEntry> m_save_entries;
 

--- a/rpcs3/rpcs3qt/savestate_manager_dialog.h
+++ b/rpcs3/rpcs3qt/savestate_manager_dialog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "game_list_base.h"
+#include "gui_game_info.h"
 
 #include <QWidget>
 #include <QComboBox>


### PR DESCRIPTION
- Play ICON1.PAM in the save data manager when hovering over the icon

NOTE: I'll probably implement playing the video in the big icon in the details in a follow up PR 

![pam](https://github.com/user-attachments/assets/4d99b6d9-e646-418a-910b-bff9a8147a8b)