### PR TITLE
input: disable pad vibration after no new data was sent for 3 seconds

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -752,6 +752,22 @@ void PadHandlerBase::process()
 
 		pad->move_data.orientation_enabled = b_has_orientation && device->config && device->config->orientation_enabled.get();
 
+		// Disable pad vibration if no new data was sent for 3 seconds
+		if (pad->m_last_rumble_time_us > 0)
+		{
+			std::lock_guard lock(pad::g_pad_mutex);
+
+			if ((get_system_time() - pad->m_last_rumble_time_us) > 3'000'000)
+			{
+				for (VibrateMotor& motor : pad->m_vibrateMotors)
+				{
+					motor.m_value = 0;
+				}
+
+				pad->m_last_rumble_time_us = 0;
+			}
+		}
+
 		const connection status = update_connection(device);
 
 		switch (status)

--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -522,6 +522,8 @@ struct Pad
 	s32 m_orientation_reset_button_index{-1}; // Special button index. -1 if not set.
 	bool get_orientation_reset_button_active();
 
+	u64 m_last_rumble_time_us{0};
+
 	// Cable State:   0 - 1  plugged in ?
 	u8 m_cable_state{0};
 

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -236,6 +236,7 @@ void pad_thread::SetRumble(const u32 pad, u8 large_motor, bool small_motor)
 	if (pad >= m_pads.size())
 		return;
 
+	m_pads[pad]->m_last_rumble_time_us = get_system_time();
 	m_pads[pad]->m_vibrateMotors[0].m_value = large_motor;
 	m_pads[pad]->m_vibrateMotors[1].m_value = small_motor ? 255 : 0;
 }


### PR DESCRIPTION
- Disable pad vibration after no new data was sent for 3 seconds. This is supposedly how the lib does it.