### PR TITLE
Qt/Input: Hotkey fixes

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -68,8 +68,6 @@ gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon,
 	, m_start_games_fullscreen(force_fullscreen)
 	, m_renderer(g_cfg.video.renderer)
 {
-	load_gui_settings();
-
 	m_window_title = Emu.GetFormattedTitle(0);
 
 	if (!g_cfg_recording.load())
@@ -121,8 +119,7 @@ gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon,
 		create();
 	}
 
-	m_shortcut_handler = new shortcut_handler(gui::shortcuts::shortcut_handler_id::game_window, this, m_gui_settings);
-	connect(m_shortcut_handler, &shortcut_handler::shortcut_activated, this, &gs_frame::handle_shortcut);
+	load_gui_settings();
 
 	// Change cursor when in fullscreen.
 	connect(this, &QWindow::visibilityChanged, this, [this](QWindow::Visibility visibility)
@@ -174,6 +171,20 @@ void gs_frame::load_gui_settings()
 	m_lock_mouse_in_fullscreen  = m_gui_settings->GetValue(gui::gs_lockMouseFs).toBool();
 	m_hide_mouse_after_idletime = m_gui_settings->GetValue(gui::gs_hideMouseIdle).toBool();
 	m_hide_mouse_idletime = m_gui_settings->GetValue(gui::gs_hideMouseIdleTime).toUInt();
+
+	if (m_disable_kb_hotkeys)
+	{
+		if (m_shortcut_handler)
+		{
+			m_shortcut_handler->deleteLater();
+			m_shortcut_handler = nullptr;
+		}
+	}
+	else if (!m_shortcut_handler)
+	{
+		m_shortcut_handler = new shortcut_handler(gui::shortcuts::shortcut_handler_id::game_window, this, m_gui_settings);
+		connect(m_shortcut_handler, &shortcut_handler::shortcut_activated, this, &gs_frame::handle_shortcut);
+	}
 }
 
 void gs_frame::update_shortcuts()
@@ -1101,7 +1112,7 @@ void gs_frame::handle_cursor(QWindow::Visibility visibility, bool visibility_cha
 
 void gs_frame::mouse_hide_timeout()
 {
-	// Our idle timeout occured, so we update the cursor
+	// Our idle timeout occurred, so we update the cursor
 	if (m_hide_mouse_after_idletime && m_show_mouse)
 	{
 		handle_cursor(visibility(), false, false, false);

--- a/rpcs3/rpcs3qt/shortcut_settings.cpp
+++ b/rpcs3/rpcs3qt/shortcut_settings.cpp
@@ -76,9 +76,9 @@ shortcut_settings::shortcut_settings()
 		{ shortcut::gw_frame_limit, shortcut_info{ "game_window_frame_limit", tr("Toggle Framelimit"), "Ctrl+F10", shortcut_handler_id::game_window, false } },
 		{ shortcut::gw_toggle_mouse_and_keyboard, shortcut_info{ "game_window_toggle_mouse_and_keyboard", tr("Toggle Keyboard"), "Ctrl+F11", shortcut_handler_id::game_window, false } },
 		{ shortcut::gw_home_menu, shortcut_info{ "gw_home_menu", tr("Open Home Menu"), "Shift+F10", shortcut_handler_id::game_window, false } },
-		{ shortcut::gw_mute_unmute, shortcut_info{ "gw_mute_unmute", tr("Mute/Unmute Audio"), "Shift+M", shortcut_handler_id::game_window, false } },
-		{ shortcut::gw_volume_up, shortcut_info{ "gw_volume_up", tr("Volume Up"), "Shift++", shortcut_handler_id::game_window, true } },
-		{ shortcut::gw_volume_down, shortcut_info{ "gw_volume_down", tr("Volume Down"), "Shift+-", shortcut_handler_id::game_window, true } },
+		{ shortcut::gw_mute_unmute, shortcut_info{ "gw_mute_unmute", tr("Mute/Unmute Audio"), "Ctrl+Shift+M", shortcut_handler_id::game_window, false } },
+		{ shortcut::gw_volume_up, shortcut_info{ "gw_volume_up", tr("Volume Up"), "Ctrl+Shift++", shortcut_handler_id::game_window, true } },
+		{ shortcut::gw_volume_down, shortcut_info{ "gw_volume_down", tr("Volume Down"), "Ctrl+Shift+-", shortcut_handler_id::game_window, true } },
 	})
 {
 }


### PR DESCRIPTION
- Disable shortcuts completely if "disable keyboard hotkeys" is enabled
- Add Ctrl+ to audio hotkey defaults (so it's now Ctrl + Shift + M/+/-)
- Update discord-rpc for CMake 4.0

Note: QShortcuts basically prevent the event propagation if activated, so I couldn't find out how to allow both normal input + hotkey input at the same time.

fixes #16969
fixes #16673