### PR TITLE
Update MacOS build to LLVM 20 to fix build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,7 +149,7 @@ jobs:
     ARTDIR: $(Build.ArtifactStagingDirectory)
     QT_VER: '6.7.3'
     QT_VER_MAIN: '6'
-    LLVM_COMPILER_VER: '19'
+    LLVM_COMPILER_VER: '20'
 
   pool:
     vmImage: "macOS-14"
@@ -210,7 +210,7 @@ jobs:
     ARTDIR: $(Build.ArtifactStagingDirectory)
     QT_VER: '6.7.3'
     QT_VER_MAIN: '6'
-    LLVM_COMPILER_VER: '19'
+    LLVM_COMPILER_VER: '20'
 
   pool:
     vmImage: "macOS-14"


### PR DESCRIPTION
This is an attempt to fix this MacOS build error:
```
In file included from /usr/local/opt/llvm@19/bin/../include/c++/v1/__thread/support.h:112:
/usr/local/opt/llvm@19/bin/../include/c++/v1/__thread/support/pthread.h:18:10: error: 'pthread.h' file not found with <angled> include; use "quotes" instead
/usr/local/opt/llvm@19/bin/../include/c++/v1/__thread/support/pthread.h:19:10: fatal error: 'sched.h' file not found
[9/1735] Building CXX object 3rdparty/glslang/glslang/glslang/OSDependent/Unix/CMakeFiles/OSDependent.dir/ossource.cpp.o
[10/1735] Building CXX object 3rdparty/glslang/glslang/OGLCompilersDLL/CMakeFiles/OGLCompiler.dir/InitializeDll.cpp.o
[11/1735] Generating scripts/sym.out
[12/1735] Building CXX object 3rdparty/glslang/glslang/glslang/CMakeFiles/GenericCodeGen.dir/GenericCodeGen/CodeGen.cpp.o
[13/1735] Building CXX object 3rdparty/glslang/glslang/glslang/CMakeFiles/GenericCodeGen.dir/GenericCodeGen/Link.cpp.o
```