### PR TITLE
PPU LLVM: Fix VMAXFP and VMINFP

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1290,7 +1290,7 @@ void PPUTranslator::VMADDFP(ppu_opcode_t op)
 void PPUTranslator::VMAXFP(ppu_opcode_t op)
 {
 	const auto [a, b] = get_vrs<f32[4]>(op.va, op.vb);
-	set_vr(op.vd, vec_handle_result(bitcast<f32[4]>(bitcast<u32[4]>(fmax(a, b)) & bitcast<u32[4]>(fmax(b, a)))));
+	set_vr(op.vd, vec_handle_result(select(fcmp_ord(a < b) | fcmp_uno(b != b), b, a)));
 }
 
 void PPUTranslator::VMAXSB(ppu_opcode_t op)
@@ -1352,7 +1352,7 @@ void PPUTranslator::VMHRADDSHS(ppu_opcode_t op)
 void PPUTranslator::VMINFP(ppu_opcode_t op)
 {
 	const auto [a, b] = get_vrs<f32[4]>(op.va, op.vb);
-	set_vr(op.vd, vec_handle_result(bitcast<f32[4]>(bitcast<u32[4]>(fmin(a, b)) | bitcast<u32[4]>(fmin(b, a)))));
+	set_vr(op.vd, vec_handle_result(select(fcmp_ord(a > b) | fcmp_uno(b != b), b, a)));
 }
 
 void PPUTranslator::VMINSB(ppu_opcode_t op)

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -483,8 +483,6 @@ namespace vm
 			}
 		}
 
-		bool to_prepare_memory = true;
-
 		for (u64 i = 0;; i++)
 		{
 			auto& bits = get_range_lock_bits(true);
@@ -512,22 +510,11 @@ namespace vm
 
 			if (i < 100)
 			{
-				if (to_prepare_memory)
-				{
-					// We have some spare time, prepare cache lines (todo: reservation tests here)
-					utils::prefetch_write(vm::get_super_ptr(addr));
-					utils::prefetch_write(vm::get_super_ptr(addr) + 64);
-					to_prepare_memory = false;
-				}
-
 				busy_wait(200);
 			}
 			else
 			{
 				std::this_thread::yield();
-
-				// Thread may have been switched or the cache clue has been undermined, cache needs to be prapred again
-				to_prepare_memory = true;
 			}
 		}
 
@@ -591,13 +578,6 @@ namespace vm
 					break;
 				}
 
-				if (to_prepare_memory)
-				{
-					utils::prefetch_write(vm::get_super_ptr(addr));
-					utils::prefetch_write(vm::get_super_ptr(addr) + 64);
-					to_prepare_memory = false;
-				}
-
 				utils::pause();
 			}
 
@@ -607,13 +587,6 @@ namespace vm
 				{
 					while (!(ptr->state & cpu_flag::wait))
 					{
-						if (to_prepare_memory)
-						{
-							utils::prefetch_write(vm::get_super_ptr(addr));
-							utils::prefetch_write(vm::get_super_ptr(addr) + 64);
-							to_prepare_memory = false;
-						}
-
 						utils::pause();
 					}
 				}

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -2363,7 +2363,7 @@ void game_list_frame::BatchActionBySerials(progress_dialog* pdlg, const std::set
 
 		connect(future_watcher, &QFutureWatcher<void>::finished, this, [=, this]()
 		{
-			pdlg->setLabelText(progressLabel.arg(*index).arg(serials_size));
+			pdlg->setLabelText(progressLabel.arg(+*index).arg(serials_size));
 			pdlg->setCancelButtonText(tr("OK"));
 			QApplication::beep();
 
@@ -2396,7 +2396,7 @@ void game_list_frame::BatchActionBySerials(progress_dialog* pdlg, const std::set
 			return;
 		}
 
-		pdlg->setLabelText(progressLabel.arg(*index).arg(serials_size));
+		pdlg->setLabelText(progressLabel.arg(+*index).arg(serials_size));
 		pdlg->setCancelButtonText(tr("OK"));
 		connect(pdlg, &progress_dialog::canceled, this, [pdlg](){ pdlg->deleteLater(); });
 		QApplication::beep();


### PR DESCRIPTION
The previous code targets x86's behaviour of `minps` and `maxps` instructions, in which if one of the operands is a NaN, the second argument is returned.
What's is expected on PowerPC (PPU) is that if any of the arguments is NaN, a QNaN would be returned.

The bug was that the codegen of VMAXFP does not return a NaN if only either of its arguments is a NaN.

Fixes https://github.com/RPCS3/rpcs3/issues/16236

PPU LLVM cache needs to be cleared for testing.