### PR TITLE
linux: Do not bundle unused Qt6 libraries, reduce AppImage size

### DIFF
--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -25,6 +25,10 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     # Remove libvulkan because it causes issues with gamescope
     rm -f ./AppDir/usr/lib/libvulkan.so*
 
+    # Remove unused Qt6 libraries
+    rm -f ./AppDir/usr/lib/libQt6Qml*.so*
+    rm -f ./AppDir/usr/lib/libQt6Quick.so*
+
     # Remove git directory containing local commit history file
     rm -rf ./AppDir/usr/share/rpcs3/git
 

--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -28,6 +28,8 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     # Remove unused Qt6 libraries
     rm -f ./AppDir/usr/lib/libQt6Qml*.so*
     rm -f ./AppDir/usr/lib/libQt6Quick.so*
+    rm -f ./AppDir/usr/lib/libQt6VirtualKeyboard.so*
+    rm -f ./AppDir/usr/plugins/platforminputcontexts/libqtvirtualkeyboardplugin.so*
 
     # Remove git directory containing local commit history file
     rm -rf ./AppDir/usr/share/rpcs3/git

--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -26,6 +26,7 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     rm -f ./AppDir/usr/lib/libvulkan.so*
 
     # Remove unused Qt6 libraries
+    rm -f ./AppDir/usr/lib/libQt6OpenGL.so*
     rm -f ./AppDir/usr/lib/libQt6Qml*.so*
     rm -f ./AppDir/usr/lib/libQt6Quick.so*
     rm -f ./AppDir/usr/lib/libQt6VirtualKeyboard.so*


### PR DESCRIPTION
AppImage size savings:
- **x86-64:** 106.5 MiB -> 100.6 MiB
- **aarch64:** 88.6 MiB -> 82.6 MiB