### PR TITLE
Qt: Fix multi package install dialog on Linux

### DIFF
--- a/rpcs3/rpcs3qt/richtext_item_delegate.h
+++ b/rpcs3/rpcs3qt/richtext_item_delegate.h
@@ -38,12 +38,7 @@ public:
 
 		// Adjust our painter parameters with some magic that looks good.
 		// This is necessary so that we don't draw on top of the optional widget.
-		// If you're not happy with this code don't hesitate to contact Megamouse
-#ifdef __linux__
-		static constexpr int margin_adjustement = 12;
-#else
 		static constexpr int margin_adjustement = 4;
-#endif
 
 		const int margin = (option.rect.height() - opt.fontMetrics.height() - margin_adjustement);
 		QRect text_rect  = style->subElementRect(QStyle::SE_ItemViewItemText, &opt, nullptr);
@@ -56,10 +51,7 @@ public:
 		text_rect.setTop(text_rect.top() + margin);
 
 		painter->translate(text_rect.topLeft());
-
-#ifndef __linux__
 		painter->setClipRect(text_rect.translated(-text_rect.topLeft()));
-#endif
 
 		// Create a context for our painter
 		QAbstractTextDocumentLayout::PaintContext context;


### PR DESCRIPTION
Fixes #16895 by undoing the workaround in #12692 which actually introduces this issue

I don't think this workaround is required anymore. We used Qt 5.15.2 back then, and now we're on Qt 6.8.3. Testing locally on both local build and AppImage allows the entries to display properly.

AppImage
![Screenshot_20250408_052938](https://github.com/user-attachments/assets/4cb5970d-dc19-45c5-b562-8b6292357df7)

Local
![Screenshot_20250408_050206](https://github.com/user-attachments/assets/b03291ff-7062-4b9a-8817-150f31418385)

@RipleyTom to verify if it still displays fine without the workaround

Tested on KDE Plasma 6.3.3.