### PR TITLE
Qt: fix visibility check of table widget items

### DIFF
--- a/rpcs3/rpcs3qt/game_list_delegate.cpp
+++ b/rpcs3/rpcs3qt/game_list_delegate.cpp
@@ -22,7 +22,7 @@ void game_list_delegate::paint(QPainter* painter, const QStyleOptionViewItem& op
 			visible_region.translate(-table->verticalHeader()->width(), -table->horizontalHeader()->height());
 
 			if (const QTableWidgetItem* current_item = table->item(index.row(), index.column());
-				current_item && visible_region.intersects(table->visualItemRect(current_item)))
+				current_item && visible_region.boundingRect().intersects(table->visualItemRect(current_item)))
 			{
 				if (movie_item* item = static_cast<movie_item*>(table->item(index.row(), static_cast<int>(gui::game_list_columns::icon))))
 				{


### PR DESCRIPTION
- Fix visibility check of table widget items
- Fixes icon loading in some game tables in certain styles

In certain styles, only the top and bottom icons were being loaded, e.g. in the save manager game list.
The intersection check of the visible region did not work for some reason.
There's a bug on Qt side that creates a set of smaller rects that don't really fill the entire region.
So let's just use the bounding rect of the region instead.