### PR TITLE
sceNpTrophyRegisterContext: Send signals asynchronously

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.h
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.h
@@ -135,7 +135,7 @@ struct SceNpTrophyFlagArray
 	be_t<u32> flag_bits[SCE_NP_TROPHY_FLAG_SETSIZE >> SCE_NP_TROPHY_FLAG_BITS_SHIFT];
 };
 
-enum
+enum SceNpTrophyStatus : u32
 {
 	SCE_NP_TROPHY_STATUS_UNKNOWN             = 0,
 	SCE_NP_TROPHY_STATUS_NOT_INSTALLED       = 1,


### PR DESCRIPTION
* Raise callbacks after the PPU has returned from the funtion.
* Make the wait between callbacks manadatory with minimum waiting time, even if the previous callback is handled.
* Add more SCE_NP_TROPHY_STATUS_PROCESSING_FINALIZE steps.

~~- [ ] TODO: Test wait times against real hw.~~

