### PR TITLE
Update SDL to 3.2.12

### DIFF
--- a/3rdparty/libsdl-org/SDL.vcxproj
+++ b/3rdparty/libsdl-org/SDL.vcxproj
@@ -532,8 +532,6 @@
       <AdditionalIncludeDirectories>SDL\include;SDL\include\build_config;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ProgramDatabase</DebugInformationFormat>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">SDL_HIDAPI_DISABLED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">SDL_HIDAPI_DISABLED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
- Updates SDL to [3.2.12](https://github.com/libsdl-org/SDL/releases/tag/release-3.2.12)

This contains a commit that fixes statically linked SDL in tandem with hidapi on windows.
This means that we can enable SDL_HIDAPI again, which fixes the switch pro controller issues on my end.

fixes #16862
maybe fixes #16948
maybe fixes #17003