### PR TITLE
vk: Fix typo in NVIDIA-specific stencil unresolve path

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKResolveHelper.h
+++ b/rpcs3/Emu/RSX/VK/VKResolveHelper.h
@@ -277,7 +277,7 @@ namespace vk
 
 			static_parameters_width = 3;
 
-			build(false, true, false);
+			build(false, true, true);
 		}
 
 		void get_dynamic_state_entries(std::vector<VkDynamicState>& state_descriptors) override


### PR DESCRIPTION
Issue discovered by @digant73 (see https://github.com/RPCS3/rpcs3/issues/16916#issuecomment-2794924520)

The issue only occurs on the NVIDIA-specific workaround for stencil export hence the variability in reproducing.
Closes https://github.com/RPCS3/rpcs3/issues/16916