### PR TITLE
fix evedev button remapping

### DIFF
--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -536,6 +536,12 @@ void pad_settings_dialog::InitButtons()
 				continue;
 			}
 
+			// Wait for ui update to happen, or events may get lost.
+			{
+				std::lock_guard lock(m_input_mutex);
+				if (m_input_callback_data.has_new_data) continue;
+			}
+
 			std::lock_guard lock(m_handler_mutex);
 
 			const std::vector<std::string> buttons =


### PR DESCRIPTION
Evdev updates happens faster than the timer which updates the UI. When that happens, m_input_callback_data gets overwritten, and events are lost, making button remapping only work some of the time. This fixes that by waiting for the timer to run before getting more events.
