### PR TITLE
rsx: Minor improvements

### DIFF
--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -390,14 +390,22 @@ namespace rsx
 			}
 
 			bool ret = false;
-			for (auto ptr = _data, last = _data + _size - 1; ptr < last; ptr++)
+			for (auto ptr = _data, last = _data + _size - 1; ptr <= last; ptr++)
 			{
 				if (predicate(*ptr))
 				{
+					ret = true;
+
+					if (ptr == last)
+					{
+						// Popping the last entry from list. Just set the new size and exit
+						_size--;
+						break;
+					}
+
 					// Move item to the end of the list and shrink by 1
 					std::memcpy(ptr, last, sizeof(Ty));
 					last = _data + (--_size);
-					ret = true;
 				}
 			}
 

--- a/rpcs3/Emu/RSX/Core/RSXDrawCommands.cpp
+++ b/rpcs3/Emu/RSX/Core/RSXDrawCommands.cpp
@@ -4,7 +4,6 @@
 #include "Emu/RSX/Common/BufferUtils.h"
 #include "Emu/RSX/Common/buffer_stream.hpp"
 #include "Emu/RSX/Common/io_buffer.h"
-#include "Emu/RSX/Common/simple_array.hpp"
 #include "Emu/RSX/NV47/HW/context_accessors.define.h"
 #include "Emu/RSX/Program/GLSLCommon.h"
 #include "Emu/RSX/rsx_methods.h"
@@ -759,7 +758,8 @@ namespace rsx
 		ensure(draw_call.is_trivial_instanced_draw);
 
 		// Temp indirection table. Used to track "running" updates.
-		rsx::simple_array<u32> instancing_indirection_table;
+		auto& instancing_indirection_table = m_scratch_buffers.u32buf;
+
 		// indirection table size
 		const auto full_reupload = !prog || prog->has_indexed_constants;
 		const auto reloc_table = full_reupload ? decltype(prog->constant_ids){} : prog->constant_ids;
@@ -767,7 +767,8 @@ namespace rsx
 		instancing_indirection_table.resize(redirection_table_size);
 
 		// Temp constants data
-		rsx::simple_array<u128> constants_data;
+		auto& constants_data = m_scratch_buffers.u128buf;
+		constants_data.clear();
 		constants_data.reserve(redirection_table_size * draw_call.pass_count());
 
 		// Allocate indirection buffer on GPU stream

--- a/rpcs3/Emu/RSX/Core/RSXDrawCommands.h
+++ b/rpcs3/Emu/RSX/Core/RSXDrawCommands.h
@@ -2,6 +2,7 @@
 
 #include <util/types.hpp>
 
+#include "Emu/RSX/Common/simple_array.hpp"
 #include "Emu/RSX/Core/RSXVertexTypes.h"
 #include "Emu/RSX/NV47/FW/draw_call.hpp"
 #include "Emu/RSX/Program/ProgramStateCache.h"
@@ -27,6 +28,12 @@ namespace rsx
 
 		std::array<push_buffer_vertex_info, 16> m_vertex_push_buffers;
 		rsx::simple_array<u32> m_element_push_buffer;
+
+		struct
+		{
+			rsx::simple_array<u32> u32buf;
+			rsx::simple_array<u128> u128buf;
+		} mutable m_scratch_buffers;
 
 	public:
 		draw_command_processor() = default;


### PR DESCRIPTION
1. Fix simple_array<T>::erase_if. Not used much but fixes a broken optimization check in the texture cache when performing blit operations.
2. Make instancing data preparation less punishing by reusing scratch buffers