### PR TITLE
Qt/System: Clear games in games.yml that are inside the old vfs path during game list refresh

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -4139,6 +4139,13 @@ game_boot_result Emulator::AddGameToYml(const std::string& path)
 	return game_boot_result::invalid_file_or_folder;
 }
 
+void Emulator::UpdateGamesPath(const std::string& path, bool save_on_disk)
+{
+	m_games_config.set_save_on_dirty(save_on_disk);
+	[[maybe_unused]] const games_config::result res = m_games_config.update_vfs_path(path);
+	m_games_config.set_save_on_dirty(true);
+}
+
 u32 Emulator::RemoveGames(const std::vector<std::string>& title_id_list, bool save_on_disk)
 {
 	if (title_id_list.empty())

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -454,6 +454,7 @@ public:
 	u32 AddGamesFromDir(const std::string& path);
 	game_boot_result AddGame(const std::string& path);
 	game_boot_result AddGameToYml(const std::string& path);
+	void UpdateGamesPath(const std::string& path, bool save_on_disk = true);
 	u32 RemoveGames(const std::vector<std::string>& title_id_list, bool save_on_disk = true);
 	game_boot_result RemoveGameFromYml(const std::string& title_id);
 

--- a/rpcs3/Emu/games_config.h
+++ b/rpcs3/Emu/games_config.h
@@ -25,12 +25,15 @@ public:
 	result add_game(const std::string& key, const std::string& path);
 	result add_external_hdd_game(const std::string& key, std::string& path);
 	result remove_game(const std::string& key);
+	result update_vfs_path(const std::string& path);
 	bool save();
 
 private:
 	bool save_nl();
 	void load();
 
+	const std::string vfs_path_key = "VFS_PATH";
+	std::string m_vfs_path;
 	std::map<std::string, std::string> m_games;
 	mutable shared_mutex m_mutex;
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -419,6 +419,9 @@ void game_list_frame::Refresh(const bool from_drive, const std::vector<std::stri
 
 		const std::string games_dir = rpcs3::utils::get_games_dir();
 
+		// Update games path. This will remove any game in memory that matches the previous games path (we don't save to "games.yml" yet).
+		Emu.UpdateGamesPath(games_dir, false);
+
 		// List of serials (title id) to remove in "games.yml" file (if any)
 		std::vector<std::string> serials_to_remove = serials_to_remove_from_yml; // Initialize the list with the specified serials (if any)
 


### PR DESCRIPTION
- Clear games in games.yml that are inside the old vfs path during game list refresh
- Since we refresh the game list on startup as well as after changing the VFS config, this should work fine

Fixes #13357 (at least I don't see a pressing reason to keep it open)