### PR TITLE
Qt: fix game list image reset after a movie was stopped

### DIFF
--- a/rpcs3/rpcs3qt/qt_video_source.cpp
+++ b/rpcs3/rpcs3qt/qt_video_source.cpp
@@ -30,6 +30,7 @@ void qt_video_source::set_active(bool active)
 	else
 	{
 		stop_movie();
+		image_change_callback();
 	}
 }
 


### PR DESCRIPTION
- Fix game list image reset after a movie was stopped
- Update icon when stopping the movie from the game list
- This fixes a regression that appeared after updating to Qt 6.9.0.
They seem to have removed a signal that was conveniently sent before whenever a movie stopped.