### PR TITLE
Qt: Fix gamelist icons vanishing after stopping a movie

### DIFF
--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -91,19 +91,19 @@ void game_list_grid::populate(
 			if (const QPixmap pixmap = item->get_movie_image(frame); item->get_active() && !pixmap.isNull())
 			{
 				item->set_icon(gui::utils::get_centered_pixmap(pixmap, m_icon_size, 0, 0, 1.0, Qt::FastTransformation));
+				return;
 			}
-			else
-			{
-				std::lock_guard lock(item->pixmap_mutex);
 
+			std::lock_guard lock(item->pixmap_mutex);
+
+			if (!game->pxmap.isNull())
+			{
 				item->set_icon(game->pxmap);
 
 				if (!game->has_hover_gif && !game->has_hover_pam)
 				{
 					game->pxmap = {};
 				}
-
-				item->stop_movie();
 			}
 		});
 

--- a/rpcs3/rpcs3qt/game_list_table.cpp
+++ b/rpcs3/rpcs3qt/game_list_table.cpp
@@ -252,19 +252,19 @@ void game_list_table::populate(
 			if (const QPixmap pixmap = icon_item->get_movie_image(frame); icon_item->get_active() && !pixmap.isNull())
 			{
 				icon_item->setData(Qt::DecorationRole, pixmap.scaled(m_icon_size, Qt::KeepAspectRatio));
+				return;
 			}
-			else
-			{
-				std::lock_guard lock(icon_item->pixmap_mutex);
 
+			std::lock_guard lock(icon_item->pixmap_mutex);
+
+			if (!game->pxmap.isNull())
+			{
 				icon_item->setData(Qt::DecorationRole, game->pxmap);
 
 				if (!game->has_hover_gif && !game->has_hover_pam)
 				{
 					game->pxmap = {};
 				}
-
-				icon_item->stop_movie();
 			}
 		});
 

--- a/rpcs3/rpcs3qt/qt_video_source.cpp
+++ b/rpcs3/rpcs3qt/qt_video_source.cpp
@@ -65,7 +65,7 @@ void qt_video_source::init_movie()
 
 	if (lower.endsWith(".gif"))
 	{
-		m_movie.reset(new QMovie(m_video_path));
+		m_movie = std::make_unique<QMovie>(m_video_path);
 		m_video_path.clear();
 
 		if (!m_movie->isValid())
@@ -98,18 +98,18 @@ void qt_video_source::init_movie()
 			return;
 		}
 
-		m_video_buffer.reset(new QBuffer(&m_video_data));
+		m_video_buffer = std::make_unique<QBuffer>(&m_video_data);
 		m_video_buffer->open(QIODevice::ReadOnly);
 	}
 
-	m_video_sink.reset(new QVideoSink());
+	m_video_sink = std::make_unique<QVideoSink>();
 	QObject::connect(m_video_sink.get(), &QVideoSink::videoFrameChanged, m_video_sink.get(), [this](const QVideoFrame& frame)
 	{
 		m_image_change_callback(frame);
 		m_has_new = true;
 	});
 
-	m_media_player.reset(new QMediaPlayer());
+	m_media_player = std::make_unique<QMediaPlayer>();
 	m_media_player->setVideoSink(m_video_sink.get());
 	m_media_player->setLoops(QMediaPlayer::Infinite);
 

--- a/rpcs3/rpcs3qt/qt_video_source.cpp
+++ b/rpcs3/rpcs3qt/qt_video_source.cpp
@@ -34,11 +34,11 @@ void qt_video_source::set_active(bool active)
 	}
 }
 
-void qt_video_source::image_change_callback() const
+void qt_video_source::image_change_callback(const QVideoFrame& frame) const
 {
 	if (m_image_change_callback)
 	{
-		m_image_change_callback({});
+		m_image_change_callback(frame);
 	}
 }
 
@@ -76,7 +76,7 @@ void qt_video_source::init_movie()
 
 		QObject::connect(m_movie.get(), &QMovie::frameChanged, m_movie.get(), [this](int)
 		{
-			m_image_change_callback({});
+			image_change_callback();
 			m_has_new = true;
 		});
 		return;
@@ -105,7 +105,7 @@ void qt_video_source::init_movie()
 	m_video_sink = std::make_unique<QVideoSink>();
 	QObject::connect(m_video_sink.get(), &QVideoSink::videoFrameChanged, m_video_sink.get(), [this](const QVideoFrame& frame)
 	{
-		m_image_change_callback(frame);
+		image_change_callback(frame);
 		m_has_new = true;
 	});
 

--- a/rpcs3/rpcs3qt/qt_video_source.h
+++ b/rpcs3/rpcs3qt/qt_video_source.h
@@ -31,7 +31,7 @@ public:
 
 	QPixmap get_movie_image(const QVideoFrame& frame) const;
 
-	void image_change_callback() const;
+	void image_change_callback(const QVideoFrame& frame = {}) const;
 	void set_image_change_callback(const std::function<void(const QVideoFrame&)>& func);
 
 protected:

--- a/rpcs3/rpcs3qt/qt_video_source.h
+++ b/rpcs3/rpcs3qt/qt_video_source.h
@@ -49,8 +49,8 @@ protected:
 
 	std::unique_ptr<QBuffer> m_video_buffer;
 	std::unique_ptr<QMediaPlayer> m_media_player;
-	std::shared_ptr<QVideoSink> m_video_sink;
-	std::shared_ptr<QMovie> m_movie;
+	std::unique_ptr<QVideoSink> m_video_sink;
+	std::unique_ptr<QMovie> m_movie;
 
 	std::function<void(const QVideoFrame&)> m_image_change_callback = nullptr;
 


### PR DESCRIPTION
- Do not set an icon if it's null. This happens because we save memory by clearing the pixmap of non-movie items.
Also don't stop the movie here, as it should be stopped already anyway.
- Use unique_ptr in qt_video_source
- Use image_change_callback function to ensure the member is valid

fixes #17053