### PR TITLE
Implement sys_spu_image_open_by_fd, fix sys_spu_image_open

### DIFF
--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -1371,7 +1371,10 @@ fs::file decrypt_self(const fs::file& elf_or_self, const u8* klic_key, SelfAddit
 	elf_or_self.seek(0);
 
 	// Check SELF header first. Check for a debug SELF.
-	if (elf_or_self.size() >= 4 && elf_or_self.read<u32>() == "SCE\0"_u32)
+	u32 file_type = umax;
+	elf_or_self.read_at(0, &file_type, sizeof(file_type));
+
+	if (file_type == "SCE\0"_u32)
 	{
 		if (fs::file res = CheckDebugSelf(elf_or_self))
 		{

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -373,7 +373,7 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 
 	uns_func, uns_func, uns_func, uns_func, uns_func,       //255-259  UNS
 
-	NULL_FUNC(sys_spu_image_open_by_fd),                    //260 (0x104)
+	BIND_SYSC(sys_spu_image_open_by_fd),                    //260 (0x104)
 
 	uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, //261-269  UNS
 	uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, uns_func, //270-279  UNS

--- a/rpcs3/Emu/Cell/lv2/sys_spu.h
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.h
@@ -225,7 +225,7 @@ struct sys_spu_image
 		return num_segs;
 	}
 
-	void load(const fs::file& stream);
+	bool load(const fs::file& stream);
 	void free() const;
 	static void deploy(u8* loc, std::span<const sys_spu_segment> segs, bool is_verbose = true);
 };
@@ -354,6 +354,7 @@ class ppu_thread;
 error_code sys_spu_initialize(ppu_thread&, u32 max_usable_spu, u32 max_raw_spu);
 error_code _sys_spu_image_get_information(ppu_thread&, vm::ptr<sys_spu_image> img, vm::ptr<u32> entry_point, vm::ptr<s32> nsegs);
 error_code sys_spu_image_open(ppu_thread&, vm::ptr<sys_spu_image> img, vm::cptr<char> path);
+error_code sys_spu_image_open_by_fd(ppu_thread&, vm::ptr<sys_spu_image> img, s32 fd, s64 offset);
 error_code _sys_spu_image_import(ppu_thread&, vm::ptr<sys_spu_image> img, u32 src, u32 size, u32 arg4);
 error_code _sys_spu_image_close(ppu_thread&, vm::ptr<sys_spu_image> img);
 error_code _sys_spu_image_get_segments(ppu_thread&, vm::ptr<sys_spu_image> img, vm::ptr<sys_spu_segment> segments, s32 nseg);


### PR DESCRIPTION
* Implement sys_spu_image_open_by_fd syscall.
* Use the vm::user64k memory allocations for LV2 SPU image loading type. from reversing it is the same allocation type as PRX.
* Allow unsigned SPU ELF, as  long as the main PPU executable is also unsigned. (I don't allow it regardless due to accuracy reasons)

Fixes spu_alu test from https://github.com/RPCS3/ps3autotests, although I should also fix the test to not use the syscall. Instead, loading the ELF from memory which would allow it be unsigned and run on real PS3 as well.