### PR TITLE
rsx: Fix iterating subdraws with mid-range primitive barriers

### DIFF
--- a/rpcs3/Emu/RSX/NV47/FW/draw_call.cpp
+++ b/rpcs3/Emu/RSX/NV47/FW/draw_call.cpp
@@ -138,7 +138,7 @@ namespace rsx
 		is_disjoint_primitive = is_primitive_disjointed(primitive);
 	}
 
-	simple_array<draw_range_t> draw_clause::get_subranges() const
+	const simple_array<draw_range_t>& draw_clause::get_subranges() const
 	{
 		ensure(!is_single_draw());
 
@@ -146,7 +146,8 @@ namespace rsx
 		const auto limit = range.first + range.count;
 		const auto _pass_count = pass_count();
 
-		simple_array<draw_range_t> ret;
+		auto &ret = subranges_store;
+		ret.clear();
 		ret.reserve(_pass_count);
 
 		u32 previous_barrier = range.first;

--- a/rpcs3/Emu/RSX/NV47/FW/draw_call.cpp
+++ b/rpcs3/Emu/RSX/NV47/FW/draw_call.cpp
@@ -183,11 +183,11 @@ namespace rsx
 	u32 draw_clause::execute_pipeline_dependencies(context* ctx, instanced_draw_config_t* instance_config) const
 	{
 		u32 result = 0u;
-		for (;
-			current_barrier_it != draw_command_barriers.end() && current_barrier_it->draw_id == current_range_index;
-			current_barrier_it++)
+		for (auto it = current_barrier_it;
+			it != draw_command_barriers.end() && it->draw_id == current_range_index;
+			it++)
 		{
-			const auto& barrier = *current_barrier_it;
+			const auto& barrier = *it;
 			switch (barrier.type)
 			{
 			case primitive_restart_barrier:

--- a/rpcs3/Emu/RSX/NV47/FW/draw_call.hpp
+++ b/rpcs3/Emu/RSX/NV47/FW/draw_call.hpp
@@ -252,6 +252,12 @@ namespace rsx
 				return false;
 			}
 
+			// Advance barrier iterator so it always points to the current draw
+			for (;
+				current_barrier_it != draw_command_barriers.end() &&
+				current_barrier_it->draw_id < current_range_index;
+				++current_barrier_it);
+
 			if (draw_command_ranges[current_range_index].count == 0)
 			{
 				// Dangling execution barrier

--- a/rpcs3/Emu/RSX/NV47/FW/draw_call.hpp
+++ b/rpcs3/Emu/RSX/NV47/FW/draw_call.hpp
@@ -35,6 +35,9 @@ namespace rsx
 		// Draw-time iterator to the draw_command_barriers struct
 		mutable simple_array<barrier_t>::iterator current_barrier_it;
 
+		// Subranges memory cache
+		mutable rsx::simple_array<draw_range_t> subranges_store;
+
 		// Helper functions
 		// Add a new draw command
 		void append_draw_command(const draw_range_t& range)
@@ -298,6 +301,6 @@ namespace rsx
 		 * Returns a compiled list of all subdraws.
 		 * NOTE: This is a non-trivial operation as it takes disjoint primitive boundaries into account.
 		 */
-		simple_array<draw_range_t> get_subranges() const;
+		const simple_array<draw_range_t>& get_subranges() const;
 	};
 }


### PR DESCRIPTION
Previously execute_pipeline_dependencies was the sole consumer of the barrier iterator and advanced it during processing. This works great but when optimizing other routines that might also need to process barriers we end up reading a stale iterator.
Also applies a minor optimization to get rid of some memory allocations which were being done per-draw-call which is not great for performance.

Closes https://github.com/RPCS3/rpcs3/issues/17079