### PR TITLE
vk: Minor fixes and improvements

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -836,7 +836,7 @@ void VKGSRender::emit_geometry(u32 sub_index)
 			if (m_vertex_layout_storage &&
 				m_vertex_layout_storage->info.buffer != m_vertex_layout_ring_info.heap->value)
 			{
-				vk::get_gc()->dispose(m_vertex_layout_storage);
+				vk::get_resource_manager()->dispose(m_vertex_layout_storage);
 			}
 
 			vk::clear_status_interrupt(vk::heap_changed);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2187,15 +2187,10 @@ void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_
 	if (!m_vertex_layout_storage || !m_vertex_layout_storage->in_range(offset32, range32, base_offset))
 	{
 		ensure(m_texbuffer_view_size >= m_vertex_layout_stream_info.range);
-
-		if (m_vertex_layout_storage)
-		{
-			vk::get_gc()->dispose(m_vertex_layout_storage);
-		}
+		vk::get_resource_manager()->dispose(m_vertex_layout_storage);
 
 		const usz alloc_addr = m_vertex_layout_stream_info.offset;
 		const usz view_size = (alloc_addr + m_texbuffer_view_size) > m_vertex_layout_ring_info.size() ? m_vertex_layout_ring_info.size() - alloc_addr : m_texbuffer_view_size;
-		vk::get_resource_manager()->dispose(m_vertex_layout_storage);
 		m_vertex_layout_storage = std::make_unique<vk::buffer_view>(*m_device, m_vertex_layout_ring_info.heap->value, VK_FORMAT_R32G32_UINT, alloc_addr, view_size);
 		base_offset = 0;
 	}

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2195,6 +2195,7 @@ void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_
 
 		const usz alloc_addr = m_vertex_layout_stream_info.offset;
 		const usz view_size = (alloc_addr + m_texbuffer_view_size) > m_vertex_layout_ring_info.size() ? m_vertex_layout_ring_info.size() - alloc_addr : m_texbuffer_view_size;
+		vk::get_resource_manager()->dispose(m_vertex_layout_storage);
 		m_vertex_layout_storage = std::make_unique<vk::buffer_view>(*m_device, m_vertex_layout_ring_info.heap->value, VK_FORMAT_R32G32_UINT, alloc_addr, view_size);
 		base_offset = 0;
 	}

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -345,6 +345,7 @@ vk::vertex_upload_info VKGSRender::upload_vertex_data()
 
 			//View 64M blocks at a time (different drivers will only allow a fixed viewable heap size, 64M should be safe)
 			const usz view_size = (persistent_range_base + m_texbuffer_view_size) > m_attrib_ring_info.size() ? m_attrib_ring_info.size() - persistent_range_base : m_texbuffer_view_size;
+			vk::get_resource_manager()->dispose(m_persistent_attribute_storage);
 			m_persistent_attribute_storage = std::make_unique<vk::buffer_view>(*m_device, m_attrib_ring_info.heap->value, VK_FORMAT_R8_UINT, persistent_range_base, view_size);
 			persistent_range_base = 0;
 		}
@@ -362,6 +363,7 @@ vk::vertex_upload_info VKGSRender::upload_vertex_data()
 			}
 
 			const usz view_size = (volatile_range_base + m_texbuffer_view_size) > m_attrib_ring_info.size() ? m_attrib_ring_info.size() - volatile_range_base : m_texbuffer_view_size;
+			vk::get_resource_manager()->dispose(m_volatile_attribute_storage);
 			m_volatile_attribute_storage = std::make_unique<vk::buffer_view>(*m_device, m_attrib_ring_info.heap->value, VK_FORMAT_R8_UINT, volatile_range_base, view_size);
 			volatile_range_base = 0;
 		}

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -320,13 +320,13 @@ vk::vertex_upload_info VKGSRender::upload_vertex_data()
 		if (m_persistent_attribute_storage &&
 			m_persistent_attribute_storage->info.buffer != m_attrib_ring_info.heap->value)
 		{
-			vk::get_gc()->dispose(m_persistent_attribute_storage);
+			vk::get_resource_manager()->dispose(m_persistent_attribute_storage);
 		}
 
 		if (m_volatile_attribute_storage &&
 			m_volatile_attribute_storage->info.buffer != m_attrib_ring_info.heap->value)
 		{
-			vk::get_gc()->dispose(m_volatile_attribute_storage);
+			vk::get_resource_manager()->dispose(m_volatile_attribute_storage);
 		}
 
 		vk::clear_status_interrupt(vk::heap_changed);
@@ -337,15 +337,10 @@ vk::vertex_upload_info VKGSRender::upload_vertex_data()
 		if (!m_persistent_attribute_storage || !m_persistent_attribute_storage->in_range(persistent_range_base, required.first, persistent_range_base))
 		{
 			ensure(m_texbuffer_view_size >= required.first); // "Incompatible driver (MacOS?)"
-
-			if (m_persistent_attribute_storage)
-			{
-				vk::get_gc()->dispose(m_persistent_attribute_storage);
-			}
+			vk::get_resource_manager()->dispose(m_persistent_attribute_storage);
 
 			//View 64M blocks at a time (different drivers will only allow a fixed viewable heap size, 64M should be safe)
 			const usz view_size = (persistent_range_base + m_texbuffer_view_size) > m_attrib_ring_info.size() ? m_attrib_ring_info.size() - persistent_range_base : m_texbuffer_view_size;
-			vk::get_resource_manager()->dispose(m_persistent_attribute_storage);
 			m_persistent_attribute_storage = std::make_unique<vk::buffer_view>(*m_device, m_attrib_ring_info.heap->value, VK_FORMAT_R8_UINT, persistent_range_base, view_size);
 			persistent_range_base = 0;
 		}
@@ -356,14 +351,9 @@ vk::vertex_upload_info VKGSRender::upload_vertex_data()
 		if (!m_volatile_attribute_storage || !m_volatile_attribute_storage->in_range(volatile_range_base, required.second, volatile_range_base))
 		{
 			ensure(m_texbuffer_view_size >= required.second); // "Incompatible driver (MacOS?)"
-
-			if (m_volatile_attribute_storage)
-			{
-				vk::get_gc()->dispose(m_persistent_attribute_storage);
-			}
+			vk::get_resource_manager()->dispose(m_volatile_attribute_storage);
 
 			const usz view_size = (volatile_range_base + m_texbuffer_view_size) > m_attrib_ring_info.size() ? m_attrib_ring_info.size() - volatile_range_base : m_texbuffer_view_size;
-			vk::get_resource_manager()->dispose(m_volatile_attribute_storage);
 			m_volatile_attribute_storage = std::make_unique<vk::buffer_view>(*m_device, m_attrib_ring_info.heap->value, VK_FORMAT_R8_UINT, volatile_range_base, view_size);
 			volatile_range_base = 0;
 		}

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -759,6 +759,15 @@ namespace vk
 			device.pNext = &custom_border_color_features;
 		}
 
+		VkPhysicalDeviceMultiDrawFeaturesEXT multidraw_features{};
+		if (pgpu->multidraw_support)
+		{
+			multidraw_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT;
+			multidraw_features.multiDraw = VK_TRUE;
+			multidraw_features.pNext = const_cast<void*>(device.pNext);
+			device.pNext = &multidraw_features;
+		}
+
 		VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT fbo_loop_features{};
 		if (pgpu->optional_features_support.framebuffer_loops)
 		{


### PR DESCRIPTION
1. Proper initialize EXT_multidraw extension for vulkan
2. Fix a bug in the ringbuffer static allocator where the result could point out of bounds
3. Do not delete vertex attribute buffer views when they are full. Always use the GC instead!

Closes https://github.com/RPCS3/rpcs3/issues/17086
Somewhat relates to https://github.com/RPCS3/rpcs3/issues/12585