### PR TITLE
Fix IPv6 support detection

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/network_context.cpp
@@ -18,7 +18,7 @@ bool send_packet_from_p2p_port_ipv4(const std::vector<u8>& data, const sockaddr_
 		{
 			auto& def_port = ::at32(nc.list_p2p_ports, SCE_NP_PORT);
 
-			if (def_port.is_ipv6)
+			if (np::is_ipv6_supported())
 			{
 				const auto addr6 = np::sockaddr_to_sockaddr6(addr);
 
@@ -52,7 +52,7 @@ bool send_packet_from_p2p_port_ipv6(const std::vector<u8>& data, const sockaddr_
 		if (nc.list_p2p_ports.contains(SCE_NP_PORT))
 		{
 			auto& def_port = ::at32(nc.list_p2p_ports, SCE_NP_PORT);
-			ensure(def_port.is_ipv6);
+			ensure(np::is_ipv6_supported());
 
 			if (::sendto(def_port.p2p_socket, reinterpret_cast<const char*>(data.data()), ::size32(data), 0, reinterpret_cast<const sockaddr*>(&addr), sizeof(sockaddr_in6)) == -1)
 			{

--- a/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.h
@@ -48,8 +48,6 @@ struct nt_p2p_port
 	socket_type p2p_socket = 0;
 	u16 port               = 0;
 
-	bool is_ipv6 = false;
-
 	shared_mutex bound_p2p_vports_mutex;
 	// For DGRAM_P2P sockets (vport, sock_ids)
 	std::map<u16, std::set<s32>> bound_p2p_vports{};

--- a/rpcs3/Emu/NP/rpcn_config.cpp
+++ b/rpcs3/Emu/NP/rpcn_config.cpp
@@ -211,3 +211,33 @@ bool cfg_rpcn::del_host(std::string_view del_description, std::string_view del_h
 
 	return false;
 }
+
+std::optional<std::pair<std::string, u16>> parse_rpcn_host(std::string_view host)
+{
+	if (host.empty())
+	{
+		rpcn_log.error("RPCN host is empty!");
+		return std::nullopt;
+	}
+
+	auto splithost = fmt::split(host, {":"});
+	if (splithost.size() != 1 && splithost.size() != 2)
+	{
+		rpcn_log.error("RPCN host is invalid!");
+		return std::nullopt;
+	}
+
+	u16 port = 31313;
+
+	if (splithost.size() == 2)
+	{
+		port = ::narrow<u16>(std::stoul(splithost[1]));
+		if (port == 0)
+		{
+			rpcn_log.error("RPCN port is invalid!");
+			return std::nullopt;
+		}
+	}
+
+	return std::make_pair(std::move(splithost[0]), port);
+}

--- a/rpcs3/Emu/NP/rpcn_config.h
+++ b/rpcs3/Emu/NP/rpcn_config.h
@@ -36,4 +36,6 @@ private:
 	void set_hosts(const std::vector<std::pair<std::string, std::string>>& vec_hosts);
 };
 
+std::optional<std::pair<std::string, u16>> parse_rpcn_host(std::string_view host);
+
 extern cfg_rpcn g_cfg_rpcn;

--- a/rpcs3/rpcs3qt/rpcn_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/rpcn_settings_dialog.cpp
@@ -200,9 +200,8 @@ rpcn_account_dialog::rpcn_account_dialog(QWidget* parent)
 			g_cfg_rpcn.set_host(host.toString().toStdString());
 			g_cfg_rpcn.save();
 
-			// Resets the state in case the support was limited by the RPCN server
-			if (!np::is_ipv6_supported())
-				np::is_ipv6_supported(np::IPV6_SUPPORT::IPV6_UNKNOWN);
+			// Resets the ipv6 support as it depends on availability of the feature on the server
+			np::is_ipv6_supported(np::IPV6_SUPPORT::IPV6_UNKNOWN);
 		});
 
 	connect(btn_add_server, &QAbstractButton::clicked, this, [this]()


### PR DESCRIPTION
Simplify IPv6 detection to be only in one function which removes the need to store if the socket is ipv6 in structures, either it's supported and all p2p sockets are ipv6 or none of them are.

Use g_fxo instead of a singleton so the detection is reset when a game restarts.
Fixes a bug where IPv6 was available but connecting to a RPCN server that only had an IPv4 it got forcefully disabled.