### PR TITLE
Avoid passing -fuse-ld to non-linking step

### DIFF
--- a/.ci/build-linux-aarch64.sh
+++ b/.ci/build-linux-aarch64.sh
@@ -22,15 +22,16 @@ else
     export CXX="${CLANGXX_BINARY}"
     export LINKER="${LLD_BINARY}"
 fi
-export CFLAGS="$CFLAGS -fuse-ld=${LINKER}"
-export CXXFLAGS="$CXXFLAGS -fuse-ld=${LINKER}"
+
+export LINKER_FLAG="-fuse-ld=${LINKER}"
 
 cmake ..                                               \
     -DCMAKE_INSTALL_PREFIX=/usr                        \
     -DUSE_NATIVE_INSTRUCTIONS=OFF                      \
     -DUSE_PRECOMPILED_HEADERS=OFF                      \
-    -DCMAKE_C_FLAGS="$CFLAGS"                          \
-    -DCMAKE_CXX_FLAGS="$CFLAGS"                        \
+    -DCMAKE_EXE_LINKER_FLAGS="${LINKER_FLAG}"          \
+    -DCMAKE_MODULE_LINKER_FLAGS="${LINKER_FLAG}"       \
+    -DCMAKE_SHARED_LINKER_FLAGS="${LINKER_FLAG}"       \
     -DUSE_SYSTEM_CURL=ON                               \
     -DUSE_SDL=ON                                       \
     -DUSE_SYSTEM_SDL=ON                                \

--- a/.ci/build-linux.sh
+++ b/.ci/build-linux.sh
@@ -30,7 +30,7 @@ else
     export RANLIB=/usr/bin/llvm-ranlib-"$LLVMVER"
 fi
 
-export CFLAGS="$CFLAGS -fuse-ld=${LINKER}"
+export LINKER_FLAG="-fuse-ld=${LINKER}"
 
 cmake ..                                               \
     -DCMAKE_INSTALL_PREFIX=/usr                        \
@@ -38,6 +38,9 @@ cmake ..                                               \
     -DUSE_PRECOMPILED_HEADERS=OFF                      \
     -DCMAKE_C_FLAGS="$CFLAGS"                          \
     -DCMAKE_CXX_FLAGS="$CFLAGS"                        \
+    -DCMAKE_EXE_LINKER_FLAGS="${LINKER_FLAG}"          \
+    -DCMAKE_MODULE_LINKER_FLAGS="${LINKER_FLAG}"       \
+    -DCMAKE_SHARED_LINKER_FLAGS="${LINKER_FLAG}"       \
     -DCMAKE_AR="$AR"                                   \
     -DCMAKE_RANLIB="$RANLIB"                           \
     -DUSE_SYSTEM_CURL=ON                               \

--- a/buildfiles/cmake/ConfigureCompiler.cmake
+++ b/buildfiles/cmake/ConfigureCompiler.cmake
@@ -93,6 +93,9 @@ else()
 		add_compile_options(-Wno-class-memaccess)
 	endif()
 
+	# Note that this refers to binary size optimization during linking, it differs from optimization compiler level
+	add_link_options(-Wl,-O2)
+
 	if(NOT APPLE AND NOT WIN32)
 		# This hides our LLVM from mesa's LLVM, otherwise we get some unresolvable conflicts.
 		add_link_options(-Wl,--exclude-libs,ALL)


### PR DESCRIPTION
Only use -fuse-ld in linking steps, also adds "-Wl,-O2" for all builds.