### PR TITLE
Add unit tests to CI

### DIFF
--- a/.ci/build-linux-aarch64.sh
+++ b/.ci/build-linux-aarch64.sh
@@ -4,6 +4,8 @@ if [ -z "$CIRRUS_CI" ]; then
    cd rpcs3 || exit 1
 fi
 
+shellcheck .ci/*.sh
+
 git config --global --add safe.directory '*'
 
 # Pull all the submodules except llvm, opencv, sdl and curl
@@ -48,8 +50,6 @@ cmake ..                                               \
 ninja; build_status=$?;
 
 cd ..
-
-shellcheck .ci/*.sh
 
 # If it compiled succesfully let's deploy.
 # Azure and Cirrus publish PRs as artifacts only.

--- a/.ci/build-linux-aarch64.sh
+++ b/.ci/build-linux-aarch64.sh
@@ -41,6 +41,8 @@ cmake ..                                               \
     -DOpenGL_GL_PREFERENCE=LEGACY                      \
     -DLLVM_DIR=/opt/llvm/lib/cmake/llvm                \
     -DSTATIC_LINK_LLVM=ON                              \
+    -DBUILD_RPCS3_TESTS=ON                             \
+    -DRUN_RPCS3_TESTS=ON                               \
     -G Ninja
 
 ninja; build_status=$?;

--- a/.ci/build-linux.sh
+++ b/.ci/build-linux.sh
@@ -52,6 +52,8 @@ cmake ..                                               \
     -DOpenGL_GL_PREFERENCE=LEGACY                      \
     -DLLVM_DIR=/opt/llvm/lib/cmake/llvm                \
     -DSTATIC_LINK_LLVM=ON                              \
+    -DBUILD_RPCS3_TESTS=ON                             \
+    -DRUN_RPCS3_TESTS=ON                               \
     -G Ninja
 
 ninja; build_status=$?;

--- a/.ci/build-linux.sh
+++ b/.ci/build-linux.sh
@@ -4,6 +4,8 @@ if [ -z "$CIRRUS_CI" ]; then
    cd rpcs3 || exit 1
 fi
 
+shellcheck .ci/*.sh
+
 git config --global --add safe.directory '*'
 
 # Pull all the submodules except llvm, opencv, sdl and curl
@@ -59,8 +61,6 @@ cmake ..                                               \
 ninja; build_status=$?;
 
 cd ..
-
-shellcheck .ci/*.sh
 
 # If it compiled succesfully let's deploy.
 # Azure and Cirrus publish PRs as artifacts only.

--- a/.ci/build-mac-arm64.sh
+++ b/.ci/build-mac-arm64.sh
@@ -115,6 +115,8 @@ mkdir build && cd build || exit 1
 export MACOSX_DEPLOYMENT_TARGET=14.0
 
 "$BREW_X64_PATH/bin/cmake" .. \
+    -DBUILD_RPCS3_TESTS=OFF \
+    -DRUN_RPCS3_TESTS=OFF \
     -DUSE_SDL=ON \
     -DUSE_DISCORD_RPC=ON \
     -DUSE_VULKAN=ON \

--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -81,6 +81,8 @@ mkdir build && cd build || exit 1
 export MACOSX_DEPLOYMENT_TARGET=14.0
 
 "$BREW_X64_PATH/bin/cmake" .. \
+    -DBUILD_RPCS3_TESTS=OFF \
+    -DRUN_RPCS3_TESTS=OFF \
     -DUSE_SDL=ON \
     -DUSE_DISCORD_RPC=ON \
     -DUSE_VULKAN=ON \

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -193,13 +193,18 @@ if(BUILD_RPCS3_TESTS)
 
     message(STATUS "Building unit tests...")
 
-    add_executable(rpcs3_test
-        tests/test_fmt.cpp
+    add_executable(rpcs3_test)
+
+    target_sources(rpcs3_test
+        PRIVATE
+            tests/test.cpp
+            tests/test_fmt.cpp
     )
 
     target_link_libraries(rpcs3_test
-        rpcs3_lib
-        GTest::gtest_main
+        PRIVATE
+            rpcs3_lib
+            GTest::gtest
     )
 
     target_include_directories(rpcs3_test

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -187,7 +187,9 @@ if (NOT ANDROID)
 endif()
 
 # Unit tests
-if(BUILD_RPCS3_TESTS)
+if(BUILD_RPCS3_TESTS AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    message(STATUS "FIXME: Unit tests are currently not linking with GCC")
+elseif(BUILD_RPCS3_TESTS)
     enable_testing()
     find_package(GTest REQUIRED)
 


### PR DESCRIPTION
- Adds gtest unit tests to the Linux clang CI (gcc doesn't seem to link for some reason)