### PR TITLE
PPU: HasBreakpoint fast path when empty

### DIFF
--- a/rpcs3/rpcs3qt/breakpoint_handler.h
+++ b/rpcs3/rpcs3qt/breakpoint_handler.h
@@ -4,6 +4,7 @@
 #include "Utilities/bit_set.h"
 #include <map>
 #include "Utilities/mutex.h"
+#include <atomic>
 
 enum class breakpoint_types
 {
@@ -46,6 +47,7 @@ private:
 	// TODO : generalize to hold multiple games and handle flags.Probably do : std::map<std::string (gameid), std::set<breakpoint>>.
 	// Although, externally, they'll only be accessed by loc (I think) so a map of maps may also do?
 	shared_mutex mutex_breakpoints;
+	std::atomic<bool> m_empty{true};
 	std::map<u32, bs_t<breakpoint_types>> m_breakpoints; //! Holds all breakpoints.
 	bool m_break_on_bpm = false;
 };


### PR DESCRIPTION
Compiling with `HAS_MEMORY_BREAKPOINTS`  incurs a massive performance penalty while running in PPU interpreter mode. This caused the game I was testing to take 2x to 3x longer to even reach the point where I need to set a breakpoint. This made debugging quite a chore, and I was often switching between builds even when using interpreter mode in both simply because of how long it took. 

This PR speeds up RPCS3 while no breakpoints are set by bypassing the mutex locking in favor of an atomic check.