### PR TITLE
Qt: Hex validator for address/instruction inputs

### DIFF
--- a/rpcs3/rpcs3qt/debugger_frame.cpp
+++ b/rpcs3/rpcs3qt/debugger_frame.cpp
@@ -10,6 +10,7 @@
 #include "call_stack_list.h"
 #include "input_dialog.h"
 #include "qt_utils.h"
+#include "hex_validator.h"
 
 #include "Emu/System.h"
 #include "Emu/IdManager.h"
@@ -1408,11 +1409,11 @@ void debugger_frame::ShowGotoAddressDialog()
 
 	if (const auto thread = get_cpu(); !thread || thread->get_class() != thread_class::spu)
 	{
-		expression_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,8}$"), this));
+		expression_input->setValidator(new HexValidator(8, expression_input));
 	}
 	else
 	{
-		expression_input->setValidator(new QRegularExpressionValidator(QRegularExpression("^(0[xX])?0*[a-fA-F0-9]{0,5}$"), this));
+		expression_input->setValidator(new HexValidator(5, expression_input));
 	}
 
 	// Ok/Cancel
@@ -1451,7 +1452,7 @@ void debugger_frame::ShowGotoAddressDialog()
 		// This also works if no thread is selected and has been selected before
 		if (result == QDialog::Accepted && cpu == get_cpu() && cpu == cpu_check())
 		{
-			PerformGoToRequest(expression_input->text());
+			PerformGoToRequest(normalizeHexQString(expression_input->text()));
 		}
 
 		m_goto_dialog = nullptr;

--- a/rpcs3/rpcs3qt/hex_validator.h
+++ b/rpcs3/rpcs3qt/hex_validator.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QValidator>
+#include <QRegularExpression>
+
+class HexValidator : public QValidator
+{
+public:
+    explicit HexValidator(int maxNibbles, QObject *parent = nullptr)
+      : QValidator(parent)
+      , m_maxNibbles(maxNibbles)
+    {}
+
+    State validate(QString &input, int &pos) const override
+    {
+        Q_UNUSED(pos);
+
+        QString stripped = input;
+        stripped.remove(' ');
+
+        if (stripped.startsWith("0x", Qt::CaseInsensitive)) 
+            stripped = stripped.mid(2);
+
+        if (stripped.isEmpty())
+            return QValidator::Intermediate;
+
+        static const QRegularExpression hexRe("^[0-9A-Fa-f]*$");
+        if (!hexRe.match(stripped).hasMatch())
+            return QValidator::Invalid;
+
+        if (stripped.length() > m_maxNibbles)
+            return QValidator::Invalid;
+
+        return QValidator::Acceptable;
+    }
+
+private:
+    const int m_maxNibbles;
+};
+
+inline QString normalizeHexQString(const QString &input) {
+    QString s = input;
+    s.remove(' ');
+    if (s.startsWith("0x"))
+        s = s.mid(2);
+    return s;
+}

--- a/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
+++ b/rpcs3/rpcs3qt/instruction_editor_dialog.cpp
@@ -1,4 +1,5 @@
 #include "instruction_editor_dialog.h"
+#include "hex_validator.h"
 
 #include "Emu/Cell/SPUThread.h"
 #include "Emu/CPU/CPUThread.h"
@@ -44,8 +45,8 @@ instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, C
 
 	m_instr = new QLineEdit(this);
 	m_instr->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
-	m_instr->setMaxLength(8);
-	m_instr->setMaximumWidth(65);
+	m_instr->setValidator(new HexValidator(8, m_instr));
+	m_instr->setMaximumWidth(130);
 
 	m_disasm->change_mode(cpu_disasm_mode::normal);
 	m_disasm->disasm(m_pc);
@@ -109,7 +110,7 @@ instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, C
 		}
 
 		bool ok;
-		const ulong opcode = m_instr->text().toULong(&ok, 16);
+		const ulong opcode = normalizeHexQString(m_instr->text()).toULong(&ok, 16);
 		if (!ok || opcode > u32{umax})
 		{
 			QMessageBox::critical(this, tr("Error"), tr("Failed to parse PPU instruction."));
@@ -152,7 +153,7 @@ instruction_editor_dialog::instruction_editor_dialog(QWidget *parent, u32 _pc, C
 void instruction_editor_dialog::updatePreview() const
 {
 	bool ok;
-	const be_t<u32> opcode{static_cast<u32>(m_instr->text().toULong(&ok, 16))};
+	const be_t<u32> opcode{static_cast<u32>(normalizeHexQString(m_instr->text()).toULong(&ok, 16))};
 	m_disasm->change_ptr(reinterpret_cast<const u8*>(&opcode) - std::intptr_t{m_pc});
 
 	if (ok && m_disasm->disasm(m_pc))

--- a/rpcs3/rpcs3qt/memory_viewer_panel.cpp
+++ b/rpcs3/rpcs3qt/memory_viewer_panel.cpp
@@ -2,6 +2,7 @@
 #include "Emu/Memory/vm.h"
 
 #include "memory_viewer_panel.h"
+#include "hex_validator.h"
 
 #include "Emu/Cell/SPUThread.h"
 #include "Emu/CPU/CPUDisAsm.h"
@@ -94,10 +95,9 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, std::shared_ptr<CPUDis
 	m_addr_line = new QLineEdit(this);
 	m_addr_line->setPlaceholderText("00000000");
 	m_addr_line->setFont(mono);
-	m_addr_line->setMaxLength(18);
+	m_addr_line->setValidator(new HexValidator(m_type == thread_class::spu ? 5 : 8, m_addr_line));
 	m_addr_line->setFixedWidth(75);
 	m_addr_line->setFocus();
-	m_addr_line->setValidator(new QRegularExpressionValidator(QRegularExpression(m_type == thread_class::spu ? "^(0[xX])?0*[a-fA-F0-9]{0,5}$" : "^(0[xX])?0*[a-fA-F0-9]{0,8}$"), this));
 	hbox_tools_mem_addr->addWidget(m_addr_line);
 	tools_mem_addr->setLayout(hbox_tools_mem_addr);
 
@@ -287,7 +287,8 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, std::shared_ptr<CPUDis
 	QGroupBox* group_search = new QGroupBox(tr("Memory Search"), this);
 	QPushButton* button_collapse_viewer = new QPushButton(reinterpret_cast<const char*>(u8"Ʌ"), group_search);
 	button_collapse_viewer->setFixedWidth(QLabel(button_collapse_viewer->text()).sizeHint().width() * 3);
-
+	button_collapse_viewer->setAutoDefault(false);
+	
 	m_search_line = new QLineEdit(group_search);
 	m_search_line->setFixedWidth(QLabel(QString("This is the very length of the lineedit due to hidpi reasons.").chopped(4)).sizeHint().width());
 	m_search_line->setPlaceholderText(tr("Search..."));
@@ -424,8 +425,7 @@ memory_viewer_panel::memory_viewer_panel(QWidget* parent, std::shared_ptr<CPUDis
 	connect(m_addr_line, &QLineEdit::returnPressed, [this]()
 	{
 		bool ok = false;
-		const QString text = m_addr_line->text();
-		const u32 addr = (text.startsWith("0x", Qt::CaseInsensitive) ? text.right(text.size() - 2) : text).toULong(&ok, 16);
+		const u32 addr = normalizeHexQString(m_addr_line->text()).toULong(&ok, 16);
 		if (ok) m_addr = addr;
 
 		scroll(0); // Refresh


### PR DESCRIPTION
Allows inputs to accept spaces and hex values prefixed with 0x. It's fairly common to copy and paste addresses or instructions from the memory viewer, cheat engine, ghidra etc... which contain spaces, so his allows you to paste them directly into RPCS3 without using an intermediary text editor. It's probably also cleaner to have a central hex validator that works the same across every input that accepts addresses or instructions instead of hard coding the same regex everywhere.

This also fixes a bug where the collapse button was focused by default and was unable to be unfocused, which caused the memory viewer to collapse every time you pressed enter.