### PR TITLE
vk: Stop using internal defines to structure platform-specific code

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -193,9 +193,6 @@ if(USE_VULKAN)
 			if (WAYLAND_FOUND)
 				target_include_directories(3rdparty_vulkan
 					INTERFACE ${WAYLAND_INCLUDE_DIR})
-
-				target_compile_definitions(3rdparty_vulkan
-					INTERFACE -DVK_USE_PLATFORM_WAYLAND_KHR)
 			endif()
 		endif()
 

--- a/rpcs3/Emu/RSX/VK/VulkanAPI.h
+++ b/rpcs3/Emu/RSX/VK/VulkanAPI.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// Configure vulkan.h
 #ifdef _WIN32
 #define VK_USE_PLATFORM_WIN32_KHR
 #elif defined(__APPLE__)
@@ -25,6 +26,13 @@
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
+
+// Undefine header configuration variables
+#undef VK_USE_PLATFORM_WIN32_KHR
+#undef VK_USE_PLATFORM_MACOS_MVK
+#undef VK_USE_PLATFORM_ANDROID_KHR
+#undef VK_USE_PLATFORM_XLIB_KHR
+#undef VK_USE_PLATFORM_WAYLAND_KHR
 
 #include <util/types.hpp>
 

--- a/rpcs3/Emu/RSX/VK/VulkanAPI.h
+++ b/rpcs3/Emu/RSX/VK/VulkanAPI.h
@@ -6,8 +6,13 @@
 #define VK_USE_PLATFORM_MACOS_MVK
 #elif defined(ANDROID)
 #define VK_USE_PLATFORM_ANDROID_KHR
-#elif HAVE_X11
-#define VK_USE_PLATFORM_XLIB_KHR
+#else
+#if defined(HAVE_X11)
+ #define VK_USE_PLATFORM_XLIB_KHR
+#endif
+#if defined(HAVE_WAYLAND)
+ #define VK_USE_PLATFORM_WAYLAND_KHR
+#endif
 #endif
 
 #ifdef _MSC_VER

--- a/rpcs3/Emu/RSX/VK/vkutils/instance.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/instance.cpp
@@ -174,14 +174,14 @@ namespace vk
 				found_surface_ext = true;
 			}
 #endif
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#ifdef HAVE_WAYLAND
 			if (support.is_supported(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME))
 			{
 				extensions.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
 				found_surface_ext = true;
 			}
 #endif //(WAYLAND)
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
+#ifdef ANDROID
 			if (support.is_supported(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
 			{
 				extensions.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);

--- a/rpcs3/Emu/RSX/display.h
+++ b/rpcs3/Emu/RSX/display.h
@@ -11,7 +11,7 @@ using Display = struct _XDisplay;
 using Window  = unsigned long;
 #endif
 
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#ifdef HAVE_WAYLAND
 #include <wayland-client.h>
 #endif
 
@@ -22,14 +22,14 @@ using display_handle_t = void*; // NSView
 #else
 #include <variant>
 using display_handle_t = std::variant<
-#if defined(HAVE_X11) && defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#if defined(HAVE_X11) && defined(HAVE_WAYLAND)
 	std::pair<Display*, Window>, std::pair<wl_display*, wl_surface*>
 #elif defined(HAVE_X11)
 	std::pair<Display*, Window>
-#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#elif defined(HAVE_WAYLAND)
 	std::pair<wl_display*, wl_surface*>
 #elif defined(ANDROID)
-	struct ANativeWindow *
+	struct ANativeWindow*
 #endif
 >;
 #endif


### PR DESCRIPTION
VK_USE_xxxx are internal API header initialization flags. They're not meant for switching around generic code, use HAVE_X11 and HAVE_WAYLAND instead.