### PR TITLE
Fix infinite loop in fmt::replace_all if "from" is empty

### DIFF
--- a/3rdparty/version_check.sh
+++ b/3rdparty/version_check.sh
@@ -1,0 +1,115 @@
+#!/bin/sh -ex
+
+verbose=0
+git_verbose=0
+
+if [ "$1" = "-v" ]; then
+    verbose=1
+elif [ "$1" = "-vv" ]; then
+    verbose=1
+    git_verbose=1
+fi
+
+max_dir_length=0
+result_dirs=()
+result_msgs=()
+
+git_call()
+{
+    if [ "$git_verbose" -eq 1 ]; then
+        eval "git $@"
+    elif [[ "$1" == "fetch" ]]; then
+        eval "git $@ >/dev/null 2>&1"
+    else
+        eval "git $@ 2>/dev/null"
+    fi
+}
+
+check_tags()
+{
+    path=$(echo "$1" | sed 's:/*$::')
+
+    echo "Checking $path"
+
+    git_call fetch --prune --all
+
+    # Get the latest tag (by commit date, not tag name)
+    tag_list=$(git_call rev-list --tags --max-count=1)
+    latest_tag=$(git_call describe --tags "$tag_list")
+
+    if [ -n "$latest_tag" ]; then
+
+        # Get the current tag
+        current_tag=$(git_call describe --tags --abbrev=0)
+
+        if [ -n "$current_tag" ]; then
+
+            if [ "$verbose" -eq 1 ]; then
+                echo "$path -> latest: $latest_tag, current: $current_tag"
+            fi
+
+            ts1=$(git_call log -1 --format=%ct $latest_tag)
+            ts2=$(git_call log -1 --format=%ct $current_tag)
+
+            if (( ts1 > ts2 )); then
+                if [ "$verbose" -eq 1 ]; then
+                    echo -e "\t $path: latest is newer"
+                elif [ "$verbose" -eq 0 ]; then
+                    echo "$path -> latest: $latest_tag, current: $current_tag"
+                fi
+
+                path_length=${#path}
+                if (( $path_length > $max_dir_length )); then
+                    max_dir_length=$path_length
+                fi
+                result_dirs+=("$path")
+                result_msgs+=("latest: $latest_tag, current: $current_tag")
+            fi
+
+        elif [ "$verbose" -eq 1 ]; then
+            echo "$path -> latest: $latest_tag"
+        fi
+    elif [ "$verbose" -eq 1 ]; then
+
+        if [ -n "$current_tag" ]; then
+            echo "$path -> current: $current_tag"
+        else
+            echo "$path -> no tags found"
+        fi
+    fi
+}
+
+for submoduledir in */ ;
+do
+    cd "$submoduledir" || continue
+
+    if [ -e ".git" ]; then
+        check_tags "$submoduledir"
+    else
+        # find */ -mindepth 1 -maxdepth 1 -type d | while read -r sub;
+        for sub in */ ;
+        do
+            if [ -e "$sub/.git" ]; then
+                cd "$sub" || continue
+                check_tags "$submoduledir$sub"
+                cd .. || exit
+            fi
+        done
+    fi
+
+    cd .. || exit
+done
+
+echo -e "\n\nResult:\n"
+i=0
+for result_dir in "${result_dirs[@]}"; do
+    msg=""
+    diff=$(($max_dir_length - ${#result_dir}))
+    if (( $diff > 0 )); then
+        msg+=$(printf "%${diff}s" "")
+    fi
+    msg+="$result_dir"
+    echo "$msg -> ${result_msgs[$i]}"
+    ((i++))
+done
+echo ""

--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -748,6 +748,12 @@ void fmt::raw_append(std::string& out, const char* fmt, const fmt_type_info* sup
 
 std::string fmt::replace_all(std::string_view src, std::string_view from, std::string_view to, usz count)
 {
+	if (src.empty())
+		return {};
+
+	if (from.empty() || count == 0)
+		return std::string(src);
+
 	std::string target;
 	target.reserve(src.size() + to.size());
 

--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -875,45 +875,6 @@ std::string fmt::truncate(std::string_view src, usz length)
 	return std::string(src.begin(), src.begin() + std::min(src.size(), length));
 }
 
-bool fmt::match(const std::string& source, const std::string& mask)
-{
-	usz source_position = 0, mask_position = 0;
-
-	for (; source_position < source.size() && mask_position < mask.size(); ++mask_position, ++source_position)
-	{
-		switch (mask[mask_position])
-		{
-		case '?': break;
-
-		case '*':
-			for (usz test_source_position = source_position; test_source_position < source.size(); ++test_source_position)
-			{
-				if (match(source.substr(test_source_position), mask.substr(mask_position + 1)))
-				{
-					return true;
-				}
-			}
-			return false;
-
-		default:
-			if (source[source_position] != mask[mask_position])
-			{
-				return false;
-			}
-
-			break;
-		}
-	}
-
-	if (source_position != source.size())
-		return false;
-
-	if (mask_position != mask.size())
-		return false;
-
-	return true;
-}
-
 std::string get_file_extension(const std::string& file_path)
 {
 	if (usz dotpos = file_path.find_last_of('.'); dotpos != std::string::npos && dotpos + 1 < file_path.size())

--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -201,8 +201,6 @@ namespace fmt
 	// Returns the string shortened to length
 	std::string truncate(std::string_view src, usz length);
 
-	bool match(const std::string& source, const std::string& mask);
-
 	struct buf_to_hexstring
 	{
 		buf_to_hexstring(const u8* buf, usz len, usz line_length = 16, bool with_prefix = false)

--- a/Utilities/StrUtil.h
+++ b/Utilities/StrUtil.h
@@ -39,11 +39,15 @@ std::string get_file_extension(const std::string& file_path);
 
 namespace fmt
 {
-	std::string replace_all(std::string_view src, std::string_view from, std::string_view to, usz count = -1);
+	// Replaces all occurrences of 'from' with 'to' until 'count' substrings were replaced.
+	std::string replace_all(std::string_view src, std::string_view from, std::string_view to, usz count = umax);
 
 	template <usz list_size>
 	std::string replace_all(std::string src, const std::pair<std::string_view, std::string> (&list)[list_size])
 	{
+		if constexpr (list_size == 0)
+			return src;
+
 		for (usz pos = 0; pos < src.length(); ++pos)
 		{
 			for (usz i = 0; i < list_size; ++i)
@@ -71,6 +75,9 @@ namespace fmt
 	template <usz list_size>
 	std::string replace_all(std::string src, const std::pair<std::string_view, std::function<std::string()>> (&list)[list_size])
 	{
+		if constexpr (list_size == 0)
+			return src;
+
 		for (usz pos = 0; pos < src.length(); ++pos)
 		{
 			for (usz i = 0; i < list_size; ++i)
@@ -99,6 +106,9 @@ namespace fmt
 	static inline
 	std::string replace_all(std::string src, const std::vector<std::pair<std::string, std::string>>& list)
 	{
+		if (list.empty())
+			return src;
+
 		for (usz pos = 0; pos < src.length(); ++pos)
 		{
 			for (usz i = 0; i < list.size(); ++i)
@@ -123,9 +133,16 @@ namespace fmt
 		return src;
 	}
 
+	// Splits the string into a vector of strings using the separators. The vector may contain empty strings unless is_skip_empty is true.
 	std::vector<std::string> split(std::string_view source, std::initializer_list<std::string_view> separators, bool is_skip_empty = true);
+
+	// Removes all preceding and trailing characters specified by 'values' from 'source'.
 	std::string trim(const std::string& source, std::string_view values = " \t");
+
+	// Removes all preceding characters specified by 'values' from 'source'.
 	std::string trim_front(const std::string& source, std::string_view values = " \t");
+
+	// Removes all trailing characters specified by 'values' from 'source'.
 	void trim_back(std::string& source, std::string_view values = " \t");
 
 	template <typename T>
@@ -175,9 +192,13 @@ namespace fmt
 		return result;
 	}
 
+	// Returns the string transformed to uppercase
 	std::string to_upper(std::string_view string);
+
+	// Returns the string transformed to lowercase
 	std::string to_lower(std::string_view string);
 
+	// Returns the string shortened to length
 	std::string truncate(std::string_view src, usz length);
 
 	bool match(const std::string& source, const std::string& mask);

--- a/rpcs3/tests/test_fmt.cpp
+++ b/rpcs3/tests/test_fmt.cpp
@@ -340,6 +340,79 @@ namespace fmt
 		EXPECT_EQ(vec({"This", "is", "test!"}), fmt::split(" This is a test! ", {"a", " ", "b"}, true));
 	}
 
+	TEST(StrUtil, test_merge)
+	{
+		using vec = std::vector<std::string>;
+		using lst = std::initializer_list<std::vector<std::string>>;
+
+		// Vector of strings
+		EXPECT_EQ(""s, fmt::merge(vec{}, ""));
+		EXPECT_EQ(""s, fmt::merge(vec{}, " "));
+		EXPECT_EQ(""s, fmt::merge(vec{}, "-"));
+		EXPECT_EQ(""s, fmt::merge(vec{}, " *-* "));
+
+		EXPECT_EQ(""s, fmt::merge(vec{""}, ""));
+		EXPECT_EQ(""s, fmt::merge(vec{""}, " "));
+		EXPECT_EQ(""s, fmt::merge(vec{""}, "-"));
+		EXPECT_EQ(""s, fmt::merge(vec{""}, " *-* "));
+
+		EXPECT_EQ("a"s, fmt::merge(vec{"a"}, ""));
+		EXPECT_EQ("a"s, fmt::merge(vec{"a"}, " "));
+		EXPECT_EQ("a"s, fmt::merge(vec{"a"}, "-"));
+		EXPECT_EQ("a"s, fmt::merge(vec{"a"}, " *-* "));
+
+		EXPECT_EQ("ab"s, fmt::merge(vec{"a", "b"}, ""));
+		EXPECT_EQ("a b"s, fmt::merge(vec{"a", "b"}, " "));
+		EXPECT_EQ("a-b"s, fmt::merge(vec{"a", "b"}, "-"));
+		EXPECT_EQ("a *-* b"s, fmt::merge(vec{"a", "b"}, " *-* "));
+
+		EXPECT_EQ("abc"s, fmt::merge(vec{"a", "b", "c"}, ""));
+		EXPECT_EQ("a b c"s, fmt::merge(vec{"a", "b", "c"}, " "));
+		EXPECT_EQ("a-b-c"s, fmt::merge(vec{"a", "b", "c"}, "-"));
+		EXPECT_EQ("a *-* b *-* c"s, fmt::merge(vec{"a", "b", "c"}, " *-* "));
+
+		// Initializer list of vector of strings
+		EXPECT_EQ(""s, fmt::merge(lst{}, ""));
+		EXPECT_EQ(""s, fmt::merge(lst{}, " "));
+		EXPECT_EQ(""s, fmt::merge(lst{}, "-"));
+		EXPECT_EQ(""s, fmt::merge(lst{}, " *-* "));
+
+		EXPECT_EQ(""s, fmt::merge(lst{vec{}}, ""));
+		EXPECT_EQ(""s, fmt::merge(lst{vec{}}, " "));
+		EXPECT_EQ(""s, fmt::merge(lst{vec{}}, "-"));
+		EXPECT_EQ(""s, fmt::merge(lst{vec{}}, " *-* "));
+
+		EXPECT_EQ("a"s, fmt::merge(lst{vec{"a"}}, ""));
+		EXPECT_EQ("a"s, fmt::merge(lst{vec{"a"}}, " "));
+		EXPECT_EQ("a"s, fmt::merge(lst{vec{"a"}}, "-"));
+		EXPECT_EQ("a"s, fmt::merge(lst{vec{"a"}}, " *-* "));
+
+		EXPECT_EQ("ab"s, fmt::merge(lst{vec{"a", "b"}}, ""));
+		EXPECT_EQ("a b"s, fmt::merge(lst{vec{"a", "b"}}, " "));
+		EXPECT_EQ("a-b"s, fmt::merge(lst{vec{"a", "b"}}, "-"));
+		EXPECT_EQ("a *-* b"s, fmt::merge(lst{vec{"a", "b"}}, " *-* "));
+
+		EXPECT_EQ("abc"s, fmt::merge(lst{vec{"a", "b", "c"}}, ""));
+		EXPECT_EQ("a b c"s, fmt::merge(lst{vec{"a", "b", "c"}}, " "));
+		EXPECT_EQ("a-b-c"s, fmt::merge(lst{vec{"a", "b", "c"}}, "-"));
+		EXPECT_EQ("a *-* b *-* c"s, fmt::merge(lst{vec{"a", "b", "c"}}, " *-* "));
+
+		EXPECT_EQ("ab"s, fmt::merge(lst{vec{"a"}, vec{"b"}}, ""));
+		EXPECT_EQ("a b"s, fmt::merge(lst{vec{"a"}, vec{"b"}}, " "));
+		EXPECT_EQ("a-b"s, fmt::merge(lst{vec{"a"}, vec{"b"}}, "-"));
+		EXPECT_EQ("a *-* b"s, fmt::merge(lst{vec{"a"}, vec{"b"}}, " *-* "));
+
+		EXPECT_EQ("abc"s, fmt::merge(lst{vec{"a"}, vec{"b"}, vec{"c"}}, ""));
+		EXPECT_EQ("a b c"s, fmt::merge(lst{vec{"a"}, vec{"b"}, vec{"c"}}, " "));
+		EXPECT_EQ("a-b-c"s, fmt::merge(lst{vec{"a"}, vec{"b"}, vec{"c"}}, "-"));
+		EXPECT_EQ("a *-* b *-* c"s, fmt::merge(lst{vec{"a"}, vec{"b"}, vec{"c"}}, " *-* "));
+
+		EXPECT_EQ("a1b2"s, fmt::merge(lst{vec{"a", "1"}, vec{"b", "2"}}, ""));
+		EXPECT_EQ("a 1 b 2"s, fmt::merge(lst{vec{"a", "1"}, vec{"b", "2"}}, " "));
+		EXPECT_EQ("a-1-b-2"s, fmt::merge(lst{vec{"a", "1"}, vec{"b", "2"}}, "-"));
+		EXPECT_EQ("a *-* 1 *-* b *-* 2"s, fmt::merge(lst{vec{"a", "1"}, vec{"b", "2"}}, " *-* "));
+	}
+
 	TEST(StrUtil, test_get_file_extension)
 	{
 		EXPECT_EQ(""s, get_file_extension(""));

--- a/rpcs3/tests/test_fmt.cpp
+++ b/rpcs3/tests/test_fmt.cpp
@@ -145,6 +145,201 @@ namespace fmt
 		EXPECT_EQ(str, fmt::truncate(str, str.size() + 1));
 	}
 
+	TEST(StrUtil, test_replace_all)
+	{
+		EXPECT_EQ(""s, fmt::replace_all("", "", ""));
+		EXPECT_EQ(""s, fmt::replace_all("", "", " "));
+		EXPECT_EQ(""s, fmt::replace_all("", "", "word"));
+		EXPECT_EQ(""s, fmt::replace_all("", " ", ""));
+		EXPECT_EQ(""s, fmt::replace_all("", "word", ""));
+		EXPECT_EQ(""s, fmt::replace_all("", "word", "drow"));
+
+		EXPECT_EQ("  "s, fmt::replace_all("  ", "", ""));
+		EXPECT_EQ("  "s, fmt::replace_all("  ", "", " "));
+		EXPECT_EQ("  "s, fmt::replace_all("  ", "", "word"));
+		EXPECT_EQ(""s, fmt::replace_all("  ", " ", ""));
+		EXPECT_EQ("  "s, fmt::replace_all("  ", "word", ""));
+		EXPECT_EQ("  "s, fmt::replace_all("  ", "word", "drow"));
+
+		EXPECT_EQ("word"s, fmt::replace_all("word", "", ""));
+		EXPECT_EQ("word"s, fmt::replace_all("word", "", " "));
+		EXPECT_EQ("word"s, fmt::replace_all("word", "", "word"));
+		EXPECT_EQ("word"s, fmt::replace_all("word", " ", ""));
+		EXPECT_EQ(""s, fmt::replace_all("word", "word", ""));
+		EXPECT_EQ("drow"s, fmt::replace_all("word", "word", "drow"));
+
+		EXPECT_EQ(" word "s, fmt::replace_all(" word ", "", ""));
+		EXPECT_EQ(" word "s, fmt::replace_all(" word ", "", " "));
+		EXPECT_EQ(" word "s, fmt::replace_all(" word ", "", "word"));
+		EXPECT_EQ("word"s, fmt::replace_all(" word ", " ", ""));
+		EXPECT_EQ("  "s, fmt::replace_all(" word ", "word", ""));
+		EXPECT_EQ(" drow "s, fmt::replace_all(" word ", "word", "drow"));
+
+		EXPECT_EQ("word word"s, fmt::replace_all("word word", "", ""));
+		EXPECT_EQ("word word"s, fmt::replace_all("word word", "", " "));
+		EXPECT_EQ("word word"s, fmt::replace_all("word word", "", "word"));
+		EXPECT_EQ("wordword"s, fmt::replace_all("word word", " ", ""));
+		EXPECT_EQ(" "s, fmt::replace_all("word word", "word", ""));
+		EXPECT_EQ("drow drow"s, fmt::replace_all("word word", "word", "drow"));
+
+		// Test count
+		EXPECT_EQ("word word word"s, fmt::replace_all("word word word", "word", "drow", 0));
+		EXPECT_EQ("drow word word"s, fmt::replace_all("word word word", "word", "drow", 1));
+		EXPECT_EQ("drow drow word"s, fmt::replace_all("word word word", "word", "drow", 2));
+		EXPECT_EQ("drow drow drow"s, fmt::replace_all("word word word", "word", "drow", 3));
+		EXPECT_EQ("drow drow drow"s, fmt::replace_all("word word word", "word", "drow", umax));
+		EXPECT_EQ("drow drow drow"s, fmt::replace_all("word word word", "word", "drow", -1));
+	}
+
+	TEST(StrUtil, test_split)
+	{
+		using vec = std::vector<std::string>;
+
+		EXPECT_EQ(vec{""}, fmt::split("", {}, false));
+		EXPECT_EQ(vec{""}, fmt::split("", {""}, false));
+		EXPECT_EQ(vec{""}, fmt::split("", {" "}, false));
+		EXPECT_EQ(vec{""}, fmt::split("", {"a"}, false));
+		EXPECT_EQ(vec{""}, fmt::split("", {"a "}, false));
+		EXPECT_EQ(vec{""}, fmt::split("", {"a b"}, false));
+		EXPECT_EQ(vec{""}, fmt::split("", {"a", " "}, false));
+		EXPECT_EQ(vec{""}, fmt::split("", {"a", " ", "b"}, false));
+
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {}, false));
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {""}, false));
+		EXPECT_EQ(vec{""}, fmt::split(" ", {" "}, false));
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {"a"}, false));
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {"a "}, false));
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {"a b"}, false));
+		EXPECT_EQ(vec{""}, fmt::split(" ", {"a", " "}, false));
+		EXPECT_EQ(vec{""}, fmt::split(" ", {"a", " ", "b"}, false));
+
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {}, false));
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {""}, false));
+		EXPECT_EQ(vec({"", ""}), fmt::split("  ", {" "}, false));
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {"a"}, false));
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {"a "}, false));
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {"a b"}, false));
+		EXPECT_EQ(vec({"", ""}), fmt::split("  ", {"a", " "}, false));
+		EXPECT_EQ(vec({"", ""}), fmt::split("  ", {"a", " ", "b"}, false));
+
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {}, false));
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {""}, false));
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {" "}, false));
+		EXPECT_EQ(vec{""}, fmt::split("a", {"a"}, false));
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {"a "}, false));
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {"a b"}, false));
+		EXPECT_EQ(vec{""}, fmt::split("a", {"a", " "}, false));
+		EXPECT_EQ(vec{""}, fmt::split("a", {"a", " ", "b"}, false));
+
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {}, false));
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {""}, false));
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {" "}, false));
+		EXPECT_EQ(vec({"", ""}), fmt::split("aa", {"a"}, false));
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {"a "}, false));
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {"a b"}, false));
+		EXPECT_EQ(vec({"", ""}), fmt::split("aa", {"a", " "}, false));
+		EXPECT_EQ(vec({"", ""}), fmt::split("aa", {"a", " ", "b"}, false));
+
+		EXPECT_EQ(vec{"a b"}, fmt::split("a b", {}, false));
+		EXPECT_EQ(vec{"a b"}, fmt::split("a b", {""}, false));
+		EXPECT_EQ(vec({"a", "b"}), fmt::split("a b", {" "}, false));
+		EXPECT_EQ(vec({"", " b"}), fmt::split("a b", {"a"}, false));
+		EXPECT_EQ(vec({"", "b"}), fmt::split("a b", {"a "}, false));
+		EXPECT_EQ(vec{""}, fmt::split("a b", {"a b"}, false));
+		EXPECT_EQ(vec({"", "", "b"}), fmt::split("a b", {"a", " "}, false));
+		EXPECT_EQ(vec({"", "", ""}), fmt::split("a b", {"a", " ", "b"}, false));
+
+		EXPECT_EQ(vec{"a b c c b a"}, fmt::split("a b c c b a", {}, false));
+		EXPECT_EQ(vec{"a b c c b a"}, fmt::split("a b c c b a", {""}, false));
+		EXPECT_EQ(vec({"a", "b", "c", "c", "b", "a"}), fmt::split("a b c c b a", {" "}, false));
+		EXPECT_EQ(vec({"", " b c c b "}), fmt::split("a b c c b a", {"a"}, false));
+		EXPECT_EQ(vec({"", "b c c b a"}), fmt::split("a b c c b a", {"a "}, false));
+		EXPECT_EQ(vec({"", " c c b a"}), fmt::split("a b c c b a", {"a b"}, false));
+		EXPECT_EQ(vec({"", "", "b", "c", "c", "b", ""}), fmt::split("a b c c b a", {"a", " "}, false));
+		EXPECT_EQ(vec({"", "", "", "", "c", "c", "", "", ""}), fmt::split("a b c c b a", {"a", " ", "b"}, false));
+
+		EXPECT_EQ(vec{" This is a test! "}, fmt::split(" This is a test! ", {}, false));
+		EXPECT_EQ(vec{" This is a test! "}, fmt::split(" This is a test! ", {""}, false));
+		EXPECT_EQ(vec({"", "This", "is", "a", "test!"}), fmt::split(" This is a test! ", {" "}, false));
+		EXPECT_EQ(vec({" This is ", " test! "}), fmt::split(" This is a test! ", {"a"}, false));
+		EXPECT_EQ(vec({" This is ", "test! "}), fmt::split(" This is a test! ", {"a "}, false));
+		EXPECT_EQ(vec{" This is a test! "}, fmt::split(" This is a test! ", {"a b"}, false));
+		EXPECT_EQ(vec({"", "This", "is", "", "", "test!"}), fmt::split(" This is a test! ", {"a", " "}, false));
+		EXPECT_EQ(vec({"", "This", "is", "", "", "test!"}), fmt::split(" This is a test! ", {"a", " ", "b"}, false));
+
+		EXPECT_EQ(vec{}, fmt::split("", {}, true));
+		EXPECT_EQ(vec{}, fmt::split("", {""}, true));
+		EXPECT_EQ(vec{}, fmt::split("", {" "}, true));
+		EXPECT_EQ(vec{}, fmt::split("", {"a"}, true));
+		EXPECT_EQ(vec{}, fmt::split("", {"a "}, true));
+		EXPECT_EQ(vec{}, fmt::split("", {"a b"}, true));
+		EXPECT_EQ(vec{}, fmt::split("", {"a", " "}, true));
+		EXPECT_EQ(vec{}, fmt::split("", {"a", " ", "b"}, true));
+
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {}, true));
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {""}, true));
+		EXPECT_EQ(vec{}, fmt::split(" ", {" "}, true));
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {"a"}, true));
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {"a "}, true));
+		EXPECT_EQ(vec{" "}, fmt::split(" ", {"a b"}, true));
+		EXPECT_EQ(vec{}, fmt::split(" ", {"a", " "}, true));
+		EXPECT_EQ(vec{}, fmt::split(" ", {"a", " ", "b"}, true));
+
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {}, true));
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {""}, true));
+		EXPECT_EQ(vec{}, fmt::split("  ", {" "}, true));
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {"a"}, true));
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {"a "}, true));
+		EXPECT_EQ(vec{"  "}, fmt::split("  ", {"a b"}, true));
+		EXPECT_EQ(vec{}, fmt::split("  ", {"a", " "}, true));
+		EXPECT_EQ(vec{}, fmt::split("  ", {"a", " ", "b"}, true));
+
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {}, true));
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {""}, true));
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {" "}, true));
+		EXPECT_EQ(vec{}, fmt::split("a", {"a"}, true));
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {"a "}, true));
+		EXPECT_EQ(vec{"a"}, fmt::split("a", {"a b"}, true));
+		EXPECT_EQ(vec{}, fmt::split("a", {"a", " "}, true));
+		EXPECT_EQ(vec{}, fmt::split("a", {"a", " ", "b"}, true));
+
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {}, true));
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {""}, true));
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {" "}, true));
+		EXPECT_EQ(vec{}, fmt::split("aa", {"a"}, true));
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {"a "}, true));
+		EXPECT_EQ(vec{"aa"}, fmt::split("aa", {"a b"}, true));
+		EXPECT_EQ(vec{}, fmt::split("aa", {"a", " "}, true));
+		EXPECT_EQ(vec{}, fmt::split("aa", {"a", " ", "b"}, true));
+
+		EXPECT_EQ(vec{"a b"}, fmt::split("a b", {}, true));
+		EXPECT_EQ(vec{"a b"}, fmt::split("a b", {""}, true));
+		EXPECT_EQ(vec({"a", "b"}), fmt::split("a b", {" "}, true));
+		EXPECT_EQ(vec{" b"}, fmt::split("a b", {"a"}, true));
+		EXPECT_EQ(vec{"b"}, fmt::split("a b", {"a "}, true));
+		EXPECT_EQ(vec{}, fmt::split("a b", {"a b"}, true));
+		EXPECT_EQ(vec{"b"}, fmt::split("a b", {"a", " "}, true));
+		EXPECT_EQ(vec{}, fmt::split("a b", {"a", " ", "b"}, true));
+
+		EXPECT_EQ(vec{"a b c c b a"}, fmt::split("a b c c b a", {}, true));
+		EXPECT_EQ(vec{"a b c c b a"}, fmt::split("a b c c b a", {""}, true));
+		EXPECT_EQ(vec({"a", "b", "c", "c", "b", "a"}), fmt::split("a b c c b a", {" "}, true));
+		EXPECT_EQ(vec{" b c c b "}, fmt::split("a b c c b a", {"a"}, true));
+		EXPECT_EQ(vec{"b c c b a"}, fmt::split("a b c c b a", {"a "}, true));
+		EXPECT_EQ(vec{" c c b a"}, fmt::split("a b c c b a", {"a b"}, true));
+		EXPECT_EQ(vec({"b", "c", "c", "b"}), fmt::split("a b c c b a", {"a", " "}, true));
+		EXPECT_EQ(vec({"c", "c"}), fmt::split("a b c c b a", {"a", " ", "b"}, true));
+
+		EXPECT_EQ(vec{" This is a test! "}, fmt::split(" This is a test! ", {}, true));
+		EXPECT_EQ(vec{" This is a test! "}, fmt::split(" This is a test! ", {""}, true));
+		EXPECT_EQ(vec({"This", "is", "a", "test!"}), fmt::split(" This is a test! ", {" "}, true));
+		EXPECT_EQ(vec({" This is ", " test! "}), fmt::split(" This is a test! ", {"a"}, true));
+		EXPECT_EQ(vec({" This is ", "test! "}), fmt::split(" This is a test! ", {"a "}, true));
+		EXPECT_EQ(vec{" This is a test! "}, fmt::split(" This is a test! ", {"a b"}, true));
+		EXPECT_EQ(vec({"This", "is", "test!"}), fmt::split(" This is a test! ", {"a", " "}, true));
+		EXPECT_EQ(vec({"This", "is", "test!"}), fmt::split(" This is a test! ", {"a", " ", "b"}, true));
+	}
+
 	TEST(StrUtil, test_get_file_extension)
 	{
 		EXPECT_EQ(""s, get_file_extension(""));


### PR DESCRIPTION
- Fixes an infinite loop if the "from" parameter in fmt::replace_all is empty
- Adds some unit tests for fmt::replace_all and fmt::split and fmt::merge
- Removes unused fmt::merge function
- Updates libpng to [1.6.48](https://github.com/pnggroup/libpng/blob/libpng16/CHANGES#L6254)
- Adds version_check.sh script to 3rdparty. I use this script to check if any submodule has a new version.