### PR TITLE
CI: Add windows unit tests

### DIFF
--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -132,6 +132,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v2
+
+      - name: Restore NuGet packages
+        run: nuget restore rpcs3.sln
+
       - name: Setup env
         shell: pwsh
         run: |
@@ -171,7 +177,11 @@ jobs:
 
       - name: Compile RPCS3
         shell: pwsh
-        run: msbuild rpcs3.sln /p:Configuration=Release /v:minimal /p:Platform=x64 /p:CLToolPath=${{ env.CCACHE_BIN_DIR }} /p:UseMultiToolTask=true /p:CustomAfterMicrosoftCommonTargets="${{ github.workspace }}\buildfiles\msvc\ci_only.targets"
+        run: msbuild rpcs3.sln /p:Configuration=Release /v:minimal /p:Platform=x64 /p:PreferredToolArchitecture=x64 /p:CLToolPath=${{ env.CCACHE_BIN_DIR }} /p:UseMultiToolTask=true /p:CustomAfterMicrosoftCommonTargets="${{ github.workspace }}\buildfiles\msvc\ci_only.targets"
+
+      - name: Run Unit Tests
+        shell: pwsh
+        run: build\lib\Release-x64\rpcs3_test.exe
 
       - name: Pack up build artifacts
         run: |

--- a/rpcs3/tests/rpcs3_test.vcxproj
+++ b/rpcs3/tests/rpcs3_test.vcxproj
@@ -10,6 +10,9 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <PropertyGroup>
+    <BuildInSolution Condition="'$(GTestInstalled)' != 'true'">false</BuildInSolution>
+  </PropertyGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{d1cbf84e-07f8-4acb-9cd2-bd205fdeee1e}</ProjectGuid>
     <ConfigurationType>Application</ConfigurationType>
@@ -77,10 +80,10 @@
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(GTestInstalled)' == 'true'">
+  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup Condition="'$(GTestInstalled)' == 'true'">
+  <ItemGroup>
     <ClCompile Include="test.cpp" />
     <ClCompile Include="test_fmt.cpp" />
   </ItemGroup>


### PR DESCRIPTION
- Fixes NuGet package install in the solution
- Ignores build in solution if the package is not installed without touching the source file units
- Install and cache NuGet packages in CI
- Set PreferredToolArchitecture to x64 to fix heap space error in CI
- Run unit test in CI