### PR TITLE
Logitech G27 cleanup

### DIFF
--- a/rpcs3/Emu/Io/LogitechG27.h
+++ b/rpcs3/Emu/Io/LogitechG27.h
@@ -16,72 +16,72 @@
 #include <vector>
 #include <thread>
 
-enum logitech_g27_ffb_state
+enum class logitech_g27_ffb_state
 {
-	G27_FFB_INACTIVE,
-	G27_FFB_DOWNLOADED,
-	G27_FFB_PLAYING
+	inactive,
+	downloaded,
+	playing
 };
 
 struct logitech_g27_ffb_slot
 {
-	logitech_g27_ffb_state state;
-	uint64_t last_update;
-	SDL_HapticEffect last_effect;
-	int effect_id;
+	logitech_g27_ffb_state state = logitech_g27_ffb_state::inactive;
+	u64 last_update = 0;
+	SDL_HapticEffect last_effect {};
+	s32 effect_id = -1;
 };
 
 struct sdl_mapping
 {
-	uint32_t device_type_id; // (vendor_id << 16) | product_id
-	sdl_mapping_type type;
-	uint64_t id;
-	hat_component hat;
-	bool reverse;
-	bool positive_axis;
+	u32 device_type_id = 0; // (vendor_id << 16) | product_id
+	sdl_mapping_type type = sdl_mapping_type::button;
+	u64 id = 0;
+	hat_component hat = hat_component::none;
+	bool reverse = false;
+	bool positive_axis = false;
 };
 
 struct logitech_g27_sdl_mapping
 {
-	sdl_mapping steering;
-	sdl_mapping throttle;
-	sdl_mapping brake;
-	sdl_mapping clutch;
-	sdl_mapping shift_up;
-	sdl_mapping shift_down;
+	sdl_mapping steering {};
+	sdl_mapping throttle {};
+	sdl_mapping brake {};
+	sdl_mapping clutch {};
+	sdl_mapping shift_up {};
+	sdl_mapping shift_down {};
 
-	sdl_mapping up;
-	sdl_mapping down;
-	sdl_mapping left;
-	sdl_mapping right;
+	sdl_mapping up {};
+	sdl_mapping down {};
+	sdl_mapping left {};
+	sdl_mapping right {};
 
-	sdl_mapping triangle;
-	sdl_mapping cross;
-	sdl_mapping square;
-	sdl_mapping circle;
+	sdl_mapping triangle {};
+	sdl_mapping cross {};
+	sdl_mapping square {};
+	sdl_mapping circle {};
 
 	// mappings based on g27 compat mode on g29
-	sdl_mapping l2;
-	sdl_mapping l3;
-	sdl_mapping r2;
-	sdl_mapping r3;
+	sdl_mapping l2 {};
+	sdl_mapping l3 {};
+	sdl_mapping r2 {};
+	sdl_mapping r3 {};
 
-	sdl_mapping plus;
-	sdl_mapping minus;
+	sdl_mapping plus {};
+	sdl_mapping minus {};
 
-	sdl_mapping dial_clockwise;
-	sdl_mapping dial_anticlockwise;
+	sdl_mapping dial_clockwise {};
+	sdl_mapping dial_anticlockwise {};
 
-	sdl_mapping select;
-	sdl_mapping pause;
+	sdl_mapping select {};
+	sdl_mapping pause {};
 
-	sdl_mapping shifter_1;
-	sdl_mapping shifter_2;
-	sdl_mapping shifter_3;
-	sdl_mapping shifter_4;
-	sdl_mapping shifter_5;
-	sdl_mapping shifter_6;
-	sdl_mapping shifter_r;
+	sdl_mapping shifter_1 {};
+	sdl_mapping shifter_2 {};
+	sdl_mapping shifter_3 {};
+	sdl_mapping shifter_4 {};
+	sdl_mapping shifter_5 {};
+	sdl_mapping shifter_6 {};
+	sdl_mapping shifter_r {};
 };
 
 class usb_device_logitech_g27 : public usb_device_emulated
@@ -98,26 +98,25 @@ public:
 	bool open_device() override;
 
 private:
-	u32 m_controller_index;
+	void sdl_refresh();
 
-	logitech_g27_sdl_mapping m_mapping;
-	bool m_reverse_effects;
+	u32 m_controller_index = 0;
+
+	logitech_g27_sdl_mapping m_mapping {};
+	bool m_reverse_effects = false;
 
 	std::mutex m_sdl_handles_mutex;
 	SDL_Joystick* m_led_joystick_handle = nullptr;
 	SDL_Haptic* m_haptic_handle = nullptr;
-	std::map<uint32_t, std::vector<SDL_Joystick*>> m_joysticks;
+	std::map<u32, std::vector<SDL_Joystick*>> m_joysticks;
 	bool m_fixed_loop = false;
-	uint16_t m_wheel_range = 200;
-	logitech_g27_ffb_slot m_effect_slots[4];
-	SDL_HapticEffect m_default_spring_effect = {0};
-	int m_default_spring_effect_id = -1;
+	u16 m_wheel_range = 200;
+	std::array<logitech_g27_ffb_slot, 4> m_effect_slots {};
+	SDL_HapticEffect m_default_spring_effect {};
+	s32 m_default_spring_effect_id = -1;
 
 	bool m_enabled = false;
 
 	std::thread m_house_keeping_thread;
-	std::mutex m_thread_control_mutex;
-	bool m_stop_thread;
-
-	void sdl_refresh();
+	atomic_t<bool> m_stop_thread { false };
 };

--- a/rpcs3/Emu/Io/LogitechG27Config.cpp
+++ b/rpcs3/Emu/Io/LogitechG27Config.cpp
@@ -5,18 +5,52 @@
 #include "Utilities/File.h"
 #include "LogitechG27Config.h"
 
+template <>
+void fmt_class_string<sdl_mapping_type>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](sdl_mapping_type value)
+	{
+		switch (value)
+		{
+		case sdl_mapping_type::button: return "button";
+		case sdl_mapping_type::hat: return "hat";
+		case sdl_mapping_type::axis: return "axis";
+		}
+
+		return unknown;
+	});
+}
+
+template <>
+void fmt_class_string<hat_component>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](hat_component value)
+	{
+		switch (value)
+		{
+		case hat_component::up: return "up";
+		case hat_component::down: return "down";
+		case hat_component::left: return "left";
+		case hat_component::right: return "right";
+		case hat_component::none: return "";
+		}
+
+		return unknown;
+	});
+}
+
 emulated_logitech_g27_config g_cfg_logitech_g27;
 
 LOG_CHANNEL(cfg_log, "CFG");
 
 emulated_logitech_g27_config::emulated_logitech_g27_config()
-	: m_path(fmt::format("%s%s.yml", fs::get_config_dir(true), "LogitechG27"))
+	: m_path(fs::get_config_dir(true) + "LogitechG27.yml")
 {
 }
 
 void emulated_logitech_g27_config::reset()
 {
-	const std::lock_guard<std::mutex> lock(m_mutex);
+	const std::lock_guard lock(m_mutex);
 	cfg::node::from_default();
 }
 

--- a/rpcs3/Emu/Io/LogitechG27Config.h
+++ b/rpcs3/Emu/Io/LogitechG27Config.h
@@ -4,31 +4,31 @@
 
 #include <mutex>
 
-enum sdl_mapping_type
+enum class sdl_mapping_type
 {
-	MAPPING_BUTTON = 0,
-	MAPPING_HAT,
-	MAPPING_AXIS,
+	button = 0,
+	hat,
+	axis,
 };
 
-enum hat_component
+enum class hat_component
 {
-	HAT_NONE = 0,
-	HAT_UP,
-	HAT_DOWN,
-	HAT_LEFT,
-	HAT_RIGHT
+	none = 0,
+	up,
+	down,
+	left,
+	right
 };
 
 struct emulated_logitech_g27_mapping : cfg::node
 {
 	cfg::uint<0, 0xFFFFFFFF> device_type_id;
-	cfg::uint<0, 0xFFFFFFFF> type;
+	cfg::_enum<sdl_mapping_type> type;
 	cfg::uint<0, 0xFFFFFFFFFFFFFFFF> id;
-	cfg::uint<0, 0xFFFFFFFF> hat;
+	cfg::_enum<hat_component> hat;
 	cfg::_bool reverse;
 
-	emulated_logitech_g27_mapping(cfg::node* owner, std::string name, uint32_t device_type_id_def, sdl_mapping_type type_def, uint64_t id_def, hat_component hat_def, bool reverse_def)
+	emulated_logitech_g27_mapping(cfg::node* owner, std::string name, u32 device_type_id_def, sdl_mapping_type type_def, uint64_t id_def, hat_component hat_def, bool reverse_def)
 		: cfg::node(owner, std::move(name)),
 		  device_type_id(this, "device_type_id", device_type_id_def),
 		  type(this, "type", type_def),
@@ -46,44 +46,44 @@ public:
 
 	// TODO these defaults are for a shifter-less G29 + a xbox controller for shifter testing, perhaps find a new default
 
-	emulated_logitech_g27_mapping steering{this, "steering", 0x046dc24f, MAPPING_AXIS, 0, HAT_NONE, false};
-	emulated_logitech_g27_mapping throttle{this, "throttle", 0x046dc24f, MAPPING_AXIS, 2, HAT_NONE, false};
-	emulated_logitech_g27_mapping brake{this, "brake", 0x046dc24f, MAPPING_AXIS, 3, HAT_NONE, false};
-	emulated_logitech_g27_mapping clutch{this, "clutch", 0x046dc24f, MAPPING_AXIS, 1, HAT_NONE, false};
-	emulated_logitech_g27_mapping shift_up{this, "shift_up", 0x046dc24f, MAPPING_BUTTON, 4, HAT_NONE, false};
-	emulated_logitech_g27_mapping shift_down{this, "shift_down", 0x046dc24f, MAPPING_BUTTON, 5, HAT_NONE, false};
+	emulated_logitech_g27_mapping steering{this, "steering", 0x046dc24f, sdl_mapping_type::axis, 0, hat_component::none, false};
+	emulated_logitech_g27_mapping throttle{this, "throttle", 0x046dc24f, sdl_mapping_type::axis, 2, hat_component::none, false};
+	emulated_logitech_g27_mapping brake{this, "brake", 0x046dc24f, sdl_mapping_type::axis, 3, hat_component::none, false};
+	emulated_logitech_g27_mapping clutch{this, "clutch", 0x046dc24f, sdl_mapping_type::axis, 1, hat_component::none, false};
+	emulated_logitech_g27_mapping shift_up{this, "shift_up", 0x046dc24f, sdl_mapping_type::button, 4, hat_component::none, false};
+	emulated_logitech_g27_mapping shift_down{this, "shift_down", 0x046dc24f, sdl_mapping_type::button, 5, hat_component::none, false};
 
-	emulated_logitech_g27_mapping up{this, "up", 0x046dc24f, MAPPING_HAT, 0, HAT_UP, false};
-	emulated_logitech_g27_mapping down{this, "down", 0x046dc24f, MAPPING_HAT, 0, HAT_DOWN, false};
-	emulated_logitech_g27_mapping left{this, "left", 0x046dc24f, MAPPING_HAT, 0, HAT_LEFT, false};
-	emulated_logitech_g27_mapping right{this, "right", 0x046dc24f, MAPPING_HAT, 0, HAT_RIGHT, false};
+	emulated_logitech_g27_mapping up{this, "up", 0x046dc24f, sdl_mapping_type::hat, 0, hat_component::up, false};
+	emulated_logitech_g27_mapping down{this, "down", 0x046dc24f, sdl_mapping_type::hat, 0, hat_component::down, false};
+	emulated_logitech_g27_mapping left{this, "left", 0x046dc24f, sdl_mapping_type::hat, 0, hat_component::left, false};
+	emulated_logitech_g27_mapping right{this, "right", 0x046dc24f, sdl_mapping_type::hat, 0, hat_component::right, false};
 
-	emulated_logitech_g27_mapping triangle{this, "triangle", 0x046dc24f, MAPPING_BUTTON, 3, HAT_NONE, false};
-	emulated_logitech_g27_mapping cross{this, "cross", 0x046dc24f, MAPPING_BUTTON, 0, HAT_NONE, false};
-	emulated_logitech_g27_mapping square{this, "square", 0x046dc24f, MAPPING_BUTTON, 1, HAT_NONE, false};
-	emulated_logitech_g27_mapping circle{this, "circle", 0x046dc24f, MAPPING_BUTTON, 2, HAT_NONE, false};
+	emulated_logitech_g27_mapping triangle{this, "triangle", 0x046dc24f, sdl_mapping_type::button, 3, hat_component::none, false};
+	emulated_logitech_g27_mapping cross{this, "cross", 0x046dc24f, sdl_mapping_type::button, 0, hat_component::none, false};
+	emulated_logitech_g27_mapping square{this, "square", 0x046dc24f, sdl_mapping_type::button, 1, hat_component::none, false};
+	emulated_logitech_g27_mapping circle{this, "circle", 0x046dc24f, sdl_mapping_type::button, 2, hat_component::none, false};
 
-	emulated_logitech_g27_mapping l2{this, "l2", 0x046dc24f, MAPPING_BUTTON, 7, HAT_NONE, false};
-	emulated_logitech_g27_mapping l3{this, "l3", 0x046dc24f, MAPPING_BUTTON, 11, HAT_NONE, false};
-	emulated_logitech_g27_mapping r2{this, "r2", 0x046dc24f, MAPPING_BUTTON, 6, HAT_NONE, false};
-	emulated_logitech_g27_mapping r3{this, "r3", 0x046dc24f, MAPPING_BUTTON, 10, HAT_NONE, false};
+	emulated_logitech_g27_mapping l2{this, "l2", 0x046dc24f, sdl_mapping_type::button, 7, hat_component::none, false};
+	emulated_logitech_g27_mapping l3{this, "l3", 0x046dc24f, sdl_mapping_type::button, 11, hat_component::none, false};
+	emulated_logitech_g27_mapping r2{this, "r2", 0x046dc24f, sdl_mapping_type::button, 6, hat_component::none, false};
+	emulated_logitech_g27_mapping r3{this, "r3", 0x046dc24f, sdl_mapping_type::button, 10, hat_component::none, false};
 
-	emulated_logitech_g27_mapping plus{this, "plus", 0x046dc24f, MAPPING_BUTTON, 19, HAT_NONE, false};
-	emulated_logitech_g27_mapping minus{this, "minus", 0x046dc24f, MAPPING_BUTTON, 20, HAT_NONE, false};
+	emulated_logitech_g27_mapping plus{this, "plus", 0x046dc24f, sdl_mapping_type::button, 19, hat_component::none, false};
+	emulated_logitech_g27_mapping minus{this, "minus", 0x046dc24f, sdl_mapping_type::button, 20, hat_component::none, false};
 
-	emulated_logitech_g27_mapping dial_clockwise{this, "dial_clockwise", 0x046dc24f, MAPPING_BUTTON, 21, HAT_NONE, false};
-	emulated_logitech_g27_mapping dial_anticlockwise{this, "dial_anticlockwise", 0x046dc24f, MAPPING_BUTTON, 22, HAT_NONE, false};
+	emulated_logitech_g27_mapping dial_clockwise{this, "dial_clockwise", 0x046dc24f, sdl_mapping_type::button, 21, hat_component::none, false};
+	emulated_logitech_g27_mapping dial_anticlockwise{this, "dial_anticlockwise", 0x046dc24f, sdl_mapping_type::button, 22, hat_component::none, false};
 
-	emulated_logitech_g27_mapping select{this, "select", 0x046dc24f, MAPPING_BUTTON, 8, HAT_NONE, false};
-	emulated_logitech_g27_mapping pause{this, "pause", 0x046dc24f, MAPPING_BUTTON, 9, HAT_NONE, false};
+	emulated_logitech_g27_mapping select{this, "select", 0x046dc24f, sdl_mapping_type::button, 8, hat_component::none, false};
+	emulated_logitech_g27_mapping pause{this, "pause", 0x046dc24f, sdl_mapping_type::button, 9, hat_component::none, false};
 
-	emulated_logitech_g27_mapping shifter_1{this, "shifter_1", 0x045e028e, MAPPING_BUTTON, 3, HAT_NONE, false};
-	emulated_logitech_g27_mapping shifter_2{this, "shifter_2", 0x045e028e, MAPPING_BUTTON, 0, HAT_NONE, false};
-	emulated_logitech_g27_mapping shifter_3{this, "shifter_3", 0x045e028e, MAPPING_BUTTON, 2, HAT_NONE, false};
-	emulated_logitech_g27_mapping shifter_4{this, "shifter_4", 0x045e028e, MAPPING_BUTTON, 1, HAT_NONE, false};
-	emulated_logitech_g27_mapping shifter_5{this, "shifter_5", 0x045e028e, MAPPING_HAT, 0, HAT_UP, false};
-	emulated_logitech_g27_mapping shifter_6{this, "shifter_6", 0x045e028e, MAPPING_HAT, 0, HAT_DOWN, false};
-	emulated_logitech_g27_mapping shifter_r{this, "shifter_r", 0x045e028e, MAPPING_HAT, 0, HAT_LEFT, false};
+	emulated_logitech_g27_mapping shifter_1{this, "shifter_1", 0x045e028e, sdl_mapping_type::button, 3, hat_component::none, false};
+	emulated_logitech_g27_mapping shifter_2{this, "shifter_2", 0x045e028e, sdl_mapping_type::button, 0, hat_component::none, false};
+	emulated_logitech_g27_mapping shifter_3{this, "shifter_3", 0x045e028e, sdl_mapping_type::button, 2, hat_component::none, false};
+	emulated_logitech_g27_mapping shifter_4{this, "shifter_4", 0x045e028e, sdl_mapping_type::button, 1, hat_component::none, false};
+	emulated_logitech_g27_mapping shifter_5{this, "shifter_5", 0x045e028e, sdl_mapping_type::hat, 0, hat_component::up, false};
+	emulated_logitech_g27_mapping shifter_6{this, "shifter_6", 0x045e028e, sdl_mapping_type::hat, 0, hat_component::down, false};
+	emulated_logitech_g27_mapping shifter_r{this, "shifter_r", 0x045e028e, sdl_mapping_type::hat, 0, hat_component::left, false};
 
 	cfg::_bool reverse_effects{this, "reverse_effects", true};
 	cfg::uint<0, 0xFFFFFFFF> ffb_device_type_id{this, "ffb_device_type_id", 0x046dc24f};

--- a/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
@@ -19,128 +19,133 @@
 
 LOG_CHANNEL(logitech_g27_cfg_log, "LOGIG27");
 
-static constexpr const char* DEFAULT_STATUS = " ";
+static const QString DEFAULT_STATUS = " ";
 
-enum mapping_device_choice
+enum class mapping_device_choice
 {
-	CHOICE_NONE = -1,
-	CHOICE_STEERING = 0,
-	CHOICE_THROTTLE,
-	CHOICE_BRAKE,
-	CHOICE_CLUTCH,
-	CHOICE_SHIFT_UP,
-	CHOICE_SHIFT_DOWN,
+	NONE = -1,
+	STEERING = 0,
+	THROTTLE,
+	BRAKE,
+	CLUTCH,
+	SHIFT_UP,
+	SHIFT_DOWN,
 
-	CHOICE_UP,
-	CHOICE_DOWN,
-	CHOICE_LEFT,
-	CHOICE_RIGHT,
+	UP,
+	DOWN,
+	LEFT,
+	RIGHT,
 
-	CHOICE_TRIANGLE,
-	CHOICE_CROSS,
-	CHOICE_SQUARE,
-	CHOICE_CIRCLE,
+	TRIANGLE,
+	CROSS,
+	SQUARE,
+	CIRCLE,
 
-	CHOICE_L2,
-	CHOICE_L3,
-	CHOICE_R2,
-	CHOICE_R3,
+	L2,
+	L3,
+	R2,
+	R3,
 
-	CHOICE_PLUS,
-	CHOICE_MINUS,
+	PLUS,
+	MINUS,
 
-	CHOICE_DIAL_CLOCKWISE,
-	CHOICE_DIAL_ANTICLOCKWISE,
+	DIAL_CLOCKWISE,
+	DIAL_ANTICLOCKWISE,
 
-	CHOICE_SELECT,
-	CHOICE_PAUSE,
+	SELECT,
+	PAUSE,
 
-	CHOICE_SHIFTER_1,
-	CHOICE_SHIFTER_2,
-	CHOICE_SHIFTER_3,
-	CHOICE_SHIFTER_4,
-	CHOICE_SHIFTER_5,
-	CHOICE_SHIFTER_6,
-	CHOICE_SHIFTER_R
+	SHIFTER_1,
+	SHIFTER_2,
+	SHIFTER_3,
+	SHIFTER_4,
+	SHIFTER_5,
+	SHIFTER_6,
+	SHIFTER_R
 };
 
 class DeviceChoice : public QWidget
 {
 public:
-	DeviceChoice(QWidget* parent, const char* name)
+	DeviceChoice(QWidget* parent, const QString& name)
 		: QWidget(parent)
 	{
 		auto layout = new QHBoxLayout(this);
 		setLayout(layout);
 
 		QLabel* label = new QLabel(this);
-		label->setText(QString(name));
+		label->setText(name);
 		label->setMinimumWidth(400);
 		layout->addWidget(label);
 
 		m_dropdown = new QComboBox(this);
 		layout->addWidget(m_dropdown);
 
-		m_disable_button = new QPushButton(QString("DISABLE"), this);
+		m_disable_button = new QPushButton(tr("DISABLE"), this);
 		layout->addWidget(m_disable_button);
 
-		connect(m_dropdown, &QComboBox::currentIndexChanged, this, [this]()
-			{
-				m_device_choice = static_cast<mapping_device_choice>(this->m_dropdown->currentIndex());
-				update_display();
-			});
+		connect(m_dropdown, &QComboBox::currentIndexChanged, this, [this](int index)
+		{
+			if (index < 0) return;
+
+			const QVariant var = m_dropdown->currentData();
+			if (!var.canConvert<int>()) return;
+
+			m_device_choice = static_cast<mapping_device_choice>(var.toInt());
+			update_display();
+		});
 
 		connect(m_disable_button, &QPushButton::clicked, this, [this]()
-			{
-				m_device_choice = CHOICE_NONE;
-				update_display();
-			});
+		{
+			m_device_choice = mapping_device_choice::NONE;
+			update_display();
+		});
 
-		m_dropdown->setPlaceholderText(QString("-- Disabled --"));
+		m_dropdown->setPlaceholderText(tr("-- Disabled --"));
 
-		m_dropdown->addItem(QString("Steering"), QVariant(CHOICE_STEERING));
-		m_dropdown->addItem(QString("Throttle"), QVariant(CHOICE_THROTTLE));
-		m_dropdown->addItem(QString("Brake"), QVariant(CHOICE_BRAKE));
-		m_dropdown->addItem(QString("Clutch"), QVariant(CHOICE_CLUTCH));
-		m_dropdown->addItem(QString("Shift up"), QVariant(CHOICE_SHIFT_UP));
-		m_dropdown->addItem(QString("Shift down"), QVariant(CHOICE_SHIFT_DOWN));
+		m_dropdown->addItem(tr("Steering"), static_cast<int>(mapping_device_choice::STEERING));
+		m_dropdown->addItem(tr("Throttle"), static_cast<int>(mapping_device_choice::THROTTLE));
+		m_dropdown->addItem(tr("Brake"), static_cast<int>(mapping_device_choice::BRAKE));
+		m_dropdown->addItem(tr("Clutch"), static_cast<int>(mapping_device_choice::CLUTCH));
+		m_dropdown->addItem(tr("Shift up"), static_cast<int>(mapping_device_choice::SHIFT_UP));
+		m_dropdown->addItem(tr("Shift down"), static_cast<int>(mapping_device_choice::SHIFT_DOWN));
 
-		m_dropdown->addItem(QString("Up"), QVariant(CHOICE_UP));
-		m_dropdown->addItem(QString("Down"), QVariant(CHOICE_DOWN));
-		m_dropdown->addItem(QString("Left"), QVariant(CHOICE_LEFT));
-		m_dropdown->addItem(QString("Right"), QVariant(CHOICE_RIGHT));
+		m_dropdown->addItem(tr("Up"), static_cast<int>(mapping_device_choice::UP));
+		m_dropdown->addItem(tr("Down"), static_cast<int>(mapping_device_choice::DOWN));
+		m_dropdown->addItem(tr("Left"), static_cast<int>(mapping_device_choice::LEFT));
+		m_dropdown->addItem(tr("Right"), static_cast<int>(mapping_device_choice::RIGHT));
 
-		m_dropdown->addItem(QString("Triangle"), QVariant(CHOICE_TRIANGLE));
-		m_dropdown->addItem(QString("Cross"), QVariant(CHOICE_CROSS));
-		m_dropdown->addItem(QString("Square"), QVariant(CHOICE_SQUARE));
-		m_dropdown->addItem(QString("Circle"), QVariant(CHOICE_CIRCLE));
+		m_dropdown->addItem(tr("Triangle"), static_cast<int>(mapping_device_choice::TRIANGLE));
+		m_dropdown->addItem(tr("Cross"), static_cast<int>(mapping_device_choice::CROSS));
+		m_dropdown->addItem(tr("Square"), static_cast<int>(mapping_device_choice::SQUARE));
+		m_dropdown->addItem(tr("Circle"), static_cast<int>(mapping_device_choice::CIRCLE));
 
-		m_dropdown->addItem(QString("L2"), QVariant(CHOICE_L2));
-		m_dropdown->addItem(QString("L3"), QVariant(CHOICE_L3));
-		m_dropdown->addItem(QString("R2"), QVariant(CHOICE_R2));
-		m_dropdown->addItem(QString("R3"), QVariant(CHOICE_R3));
+		m_dropdown->addItem(tr("L2"), static_cast<int>(mapping_device_choice::L2));
+		m_dropdown->addItem(tr("L3"), static_cast<int>(mapping_device_choice::L3));
+		m_dropdown->addItem(tr("R2"), static_cast<int>(mapping_device_choice::R2));
+		m_dropdown->addItem(tr("R3"), static_cast<int>(mapping_device_choice::R3));
 
-		m_dropdown->addItem(QString("L4"), QVariant(CHOICE_PLUS));
-		m_dropdown->addItem(QString("L5"), QVariant(CHOICE_MINUS));
+		m_dropdown->addItem(tr("L4"), static_cast<int>(mapping_device_choice::PLUS));
+		m_dropdown->addItem(tr("L5"), static_cast<int>(mapping_device_choice::MINUS));
 
-		m_dropdown->addItem(QString("R4"), QVariant(CHOICE_DIAL_CLOCKWISE));
-		m_dropdown->addItem(QString("R5"), QVariant(CHOICE_DIAL_ANTICLOCKWISE));
+		m_dropdown->addItem(tr("R4"), static_cast<int>(mapping_device_choice::DIAL_CLOCKWISE));
+		m_dropdown->addItem(tr("R5"), static_cast<int>(mapping_device_choice::DIAL_ANTICLOCKWISE));
 
-		m_dropdown->addItem(QString("Select"), QVariant(CHOICE_SELECT));
-		m_dropdown->addItem(QString("Pause"), QVariant(CHOICE_PAUSE));
+		m_dropdown->addItem(tr("Select"), static_cast<int>(mapping_device_choice::SELECT));
+		m_dropdown->addItem(tr("Pause"), static_cast<int>(mapping_device_choice::PAUSE));
 
-		m_dropdown->addItem(QString("Gear 1"), QVariant(CHOICE_SHIFTER_1));
-		m_dropdown->addItem(QString("Gear 2"), QVariant(CHOICE_SHIFTER_2));
-		m_dropdown->addItem(QString("Gear 3"), QVariant(CHOICE_SHIFTER_3));
-		m_dropdown->addItem(QString("Gear 4"), QVariant(CHOICE_SHIFTER_4));
-		m_dropdown->addItem(QString("Gear 5"), QVariant(CHOICE_SHIFTER_5));
-		m_dropdown->addItem(QString("Gear 6"), QVariant(CHOICE_SHIFTER_6));
-		m_dropdown->addItem(QString("Gear r"), QVariant(CHOICE_SHIFTER_R));
+		m_dropdown->addItem(tr("Gear 1"), static_cast<int>(mapping_device_choice::SHIFTER_1));
+		m_dropdown->addItem(tr("Gear 2"), static_cast<int>(mapping_device_choice::SHIFTER_2));
+		m_dropdown->addItem(tr("Gear 3"), static_cast<int>(mapping_device_choice::SHIFTER_3));
+		m_dropdown->addItem(tr("Gear 4"), static_cast<int>(mapping_device_choice::SHIFTER_4));
+		m_dropdown->addItem(tr("Gear 5"), static_cast<int>(mapping_device_choice::SHIFTER_5));
+		m_dropdown->addItem(tr("Gear 6"), static_cast<int>(mapping_device_choice::SHIFTER_6));
+		m_dropdown->addItem(tr("Gear r"), static_cast<int>(mapping_device_choice::SHIFTER_R));
 
 		update_display();
 	}
 
-	mapping_device_choice get_device_choice()
+	mapping_device_choice get_device_choice() const
 	{
 		return m_device_choice;
 	}
@@ -158,20 +163,20 @@ public:
 	}
 
 private:
-	mapping_device_choice m_device_choice = CHOICE_NONE;
-	QComboBox* m_dropdown = nullptr;
-	QPushButton* m_disable_button = nullptr;
-
 	void update_display()
 	{
 		m_dropdown->setCurrentIndex(static_cast<int>(m_device_choice));
 	}
+
+	mapping_device_choice m_device_choice = mapping_device_choice::NONE;
+	QComboBox* m_dropdown = nullptr;
+	QPushButton* m_disable_button = nullptr;
 };
 
 class Mapping : public QGroupBox
 {
 public:
-	Mapping(QWidget* parent, emulated_logitech_g27_settings_dialog* dialog, bool is_axis, const char* name, bool flip_axis_display)
+	Mapping(QWidget* parent, emulated_logitech_g27_settings_dialog* dialog, bool is_axis, const QString& name, bool flip_axis_display)
 		: QGroupBox(parent), m_setting_dialog(dialog), m_is_axis(is_axis), m_name(name), m_flip_axis_display(flip_axis_display)
 	{
 		QVBoxLayout* layout = new QVBoxLayout(this);
@@ -184,7 +189,7 @@ public:
 		layout->addWidget(horizontal_container);
 
 		QLabel* label = new QLabel(horizontal_container);
-		label->setText(QString(name));
+		label->setText(name);
 
 		m_display_box = new QLabel(horizontal_container);
 		m_display_box->setTextFormat(Qt::RichText);
@@ -192,19 +197,17 @@ public:
 		m_display_box->setFrameStyle(QFrame::Box);
 		m_display_box->setMinimumWidth(150);
 
-		m_map_button = new QPushButton(QString("MAP"), horizontal_container);
-		m_unmap_button = new QPushButton(QString("UNMAP"), horizontal_container);
-		m_reverse_checkbox = new QCheckBox(QString("Reverse"), horizontal_container);
+		m_map_button = new QPushButton(tr("MAP"), horizontal_container);
+		m_unmap_button = new QPushButton(tr("UNMAP"), horizontal_container);
+		m_reverse_checkbox = new QCheckBox(tr("Reverse"), horizontal_container);
 
-		if (!this->m_is_axis)
+		if (!m_is_axis)
 		{
-			m_axis_status = nullptr;
-			m_button_status = new QCheckBox(QString("Pressed"), horizontal_container);
+			m_button_status = new QCheckBox(tr("Pressed"), horizontal_container);
 			m_button_status->setDisabled(true);
 		}
 		else
 		{
-			m_button_status = nullptr;
 			m_axis_status = new QSlider(Qt::Horizontal, this);
 			m_axis_status->setDisabled(true);
 			m_axis_status->setMinimum(-0x8000);
@@ -216,134 +219,130 @@ public:
 
 		horizontal_layout->addWidget(label);
 		horizontal_layout->addWidget(m_display_box);
-		if (!this->m_is_axis)
+		if (m_button_status)
 			horizontal_layout->addWidget(m_button_status);
 		horizontal_layout->addWidget(m_map_button);
 		horizontal_layout->addWidget(m_unmap_button);
 		horizontal_layout->addWidget(m_reverse_checkbox);
 
-		if (this->m_is_axis)
+		if (m_axis_status)
 			layout->addWidget(m_axis_status);
 
 		connect(m_map_button, &QPushButton::clicked, this, [this]()
-			{
-				this->m_mapping_in_progress = true;
-				this->m_timeout_msec = 5500;
-				this->m_setting_dialog->set_enable(false);
-				this->m_last_joystick_states = this->m_setting_dialog->get_joystick_states();
-			});
+		{
+			m_mapping_in_progress = true;
+			m_timeout_msec = 5500;
+			m_setting_dialog->set_enable(false);
+			m_last_joystick_states = m_setting_dialog->get_joystick_states();
+		});
 
 		connect(m_unmap_button, &QPushButton::clicked, this, [this]()
-			{
-				this->m_mapping.device_type_id = 0;
-				update_display();
-			});
+		{
+			m_mapping.device_type_id = 0;
+			update_display();
+		});
 
 		connect(m_reverse_checkbox, &QCheckBox::clicked, this, [this]()
-			{
-				this->m_mapping.reverse = this->m_reverse_checkbox->isChecked();
-			});
+		{
+			m_mapping.reverse = m_reverse_checkbox->isChecked();
+		});
 
 		m_tick_timer = new QTimer(this);
 		connect(m_tick_timer, &QTimer::timeout, this, [this]()
+		{
+			if (m_mapping_in_progress)
 			{
-				if (this->m_mapping_in_progress)
+				const int timeout_sec = m_timeout_msec / 1000;
+				const std::map<u32, joystick_state>& new_joystick_states = m_setting_dialog->get_joystick_states();
+
+				m_setting_dialog->set_state_text(tr("Input %0 for %1, timeout in %2 %3").arg(m_is_axis ? tr("axis") : tr("button/hat")).arg(m_name).arg(timeout_sec).arg(timeout_sec >= 2 ? tr("seconds") : tr("second")));
+
+				for (auto& [device_type_id, new_joystick_state] : new_joystick_states)
 				{
-					char text_buf[128];
-
-					int timeout_sec = this->m_timeout_msec / 1000;
-
-					const std::map<uint32_t, joystick_state>& new_joystick_states = this->m_setting_dialog->get_joystick_states();
-
-					sprintf(text_buf, "Input %s for %s, timeout in %d %s", this->m_is_axis ? "axis" : "button/hat", this->m_name.c_str(), timeout_sec, timeout_sec >= 2 ? "seconds" : "second");
-					this->m_setting_dialog->set_state_text(text_buf);
-
-					for (auto new_joystick_state : new_joystick_states)
+					const auto last_joystick_state = m_last_joystick_states.find(device_type_id);
+					if (last_joystick_state == m_last_joystick_states.cend())
 					{
-						auto last_joystick_state = this->m_last_joystick_states.find(new_joystick_state.first);
-						if (last_joystick_state == this->m_last_joystick_states.end())
+						continue;
+					}
+
+					if (m_is_axis)
+					{
+						constexpr s16 axis_change_threshold = 0x7FFF / 5;
+						if (last_joystick_state->second.axes.size() != new_joystick_state.axes.size())
 						{
+							logitech_g27_cfg_log.error("During input state change diff, number of axes on %04x:%04x changed", device_type_id >> 16, device_type_id & 0xFFFF);
 							continue;
 						}
-
-						if (this->m_is_axis)
+						for (usz i = 0; i < new_joystick_state.axes.size(); i++)
 						{
-							const static int16_t axis_change_threshold = 0x7FFF / 5;
-							if (last_joystick_state->second.axes.size() != new_joystick_state.second.axes.size())
+							const s32 diff = std::abs(last_joystick_state->second.axes[i] - new_joystick_state.axes[i]);
+							if (diff > axis_change_threshold)
 							{
-								logitech_g27_cfg_log.error("during input state change diff, number of axes on %04x:%04x changed", new_joystick_state.first >> 16, new_joystick_state.first & 0xFFFF);
-								continue;
-							}
-							for (std::vector<int16_t>::size_type i = 0; i < new_joystick_state.second.axes.size(); i++)
-							{
-								int32_t diff = std::abs(last_joystick_state->second.axes[i] - new_joystick_state.second.axes[i]);
-								if (diff > axis_change_threshold)
-								{
-									this->m_mapping_in_progress = false;
-									this->m_setting_dialog->set_state_text(DEFAULT_STATUS);
-									this->m_setting_dialog->set_enable(true);
-									this->m_mapping.device_type_id = new_joystick_state.first;
-									this->m_mapping.type = MAPPING_AXIS;
-									this->m_mapping.id = i;
-									this->m_mapping.hat = HAT_NONE;
-									break;
-								}
-							}
-						}
-						else
-						{
-							if (last_joystick_state->second.buttons.size() != new_joystick_state.second.buttons.size())
-							{
-								logitech_g27_cfg_log.error("during input state change diff, number of buttons on %04x:%04x changed", new_joystick_state.first >> 16, new_joystick_state.first & 0xFFFF);
-								continue;
-							}
-							if (last_joystick_state->second.hats.size() != new_joystick_state.second.hats.size())
-							{
-								logitech_g27_cfg_log.error("during input state change diff, number of hats on %04x:%04x changed", new_joystick_state.first >> 16, new_joystick_state.first & 0xFFFF);
-								continue;
-							}
-							for (std::vector<int16_t>::size_type i = 0; i < new_joystick_state.second.buttons.size(); i++)
-							{
-								if (last_joystick_state->second.buttons[i] != new_joystick_state.second.buttons[i])
-								{
-									this->m_mapping_in_progress = false;
-									this->m_setting_dialog->set_state_text(DEFAULT_STATUS);
-									this->m_setting_dialog->set_enable(true);
-									this->m_mapping.device_type_id = new_joystick_state.first;
-									this->m_mapping.type = MAPPING_BUTTON;
-									this->m_mapping.id = i;
-									this->m_mapping.hat = HAT_NONE;
-									break;
-								}
-							}
-							for (std::vector<int16_t>::size_type i = 0; i < new_joystick_state.second.hats.size(); i++)
-							{
-								if (last_joystick_state->second.hats[i] != new_joystick_state.second.hats[i] && new_joystick_state.second.hats[i] != HAT_NONE)
-								{
-									this->m_mapping_in_progress = false;
-									this->m_setting_dialog->set_state_text(DEFAULT_STATUS);
-									this->m_setting_dialog->set_enable(true);
-									this->m_mapping.device_type_id = new_joystick_state.first;
-									this->m_mapping.type = MAPPING_HAT;
-									this->m_mapping.id = i;
-									this->m_mapping.hat = new_joystick_state.second.hats[i];
-									break;
-								}
+								m_mapping_in_progress = false;
+								m_setting_dialog->set_state_text(DEFAULT_STATUS);
+								m_setting_dialog->set_enable(true);
+								m_mapping.device_type_id = device_type_id;
+								m_mapping.type = sdl_mapping_type::axis;
+								m_mapping.id = i;
+								m_mapping.hat = hat_component::none;
+								break;
 							}
 						}
 					}
-
-					this->m_timeout_msec = this->m_timeout_msec - 25;
-					if (this->m_timeout_msec <= 0)
+					else
 					{
-						this->m_mapping_in_progress = false;
-						this->m_setting_dialog->set_state_text(DEFAULT_STATUS);
-						this->m_setting_dialog->set_enable(true);
+						if (last_joystick_state->second.buttons.size() != new_joystick_state.buttons.size())
+						{
+							logitech_g27_cfg_log.error("during input state change diff, number of buttons on %04x:%04x changed", device_type_id >> 16, device_type_id & 0xFFFF);
+							continue;
+						}
+						if (last_joystick_state->second.hats.size() != new_joystick_state.hats.size())
+						{
+							logitech_g27_cfg_log.error("during input state change diff, number of hats on %04x:%04x changed", device_type_id >> 16, device_type_id & 0xFFFF);
+							continue;
+						}
+						for (usz i = 0; i < new_joystick_state.buttons.size(); i++)
+						{
+							if (last_joystick_state->second.buttons[i] != new_joystick_state.buttons[i])
+							{
+								m_mapping_in_progress = false;
+								m_setting_dialog->set_state_text(DEFAULT_STATUS);
+								m_setting_dialog->set_enable(true);
+								m_mapping.device_type_id = device_type_id;
+								m_mapping.type = sdl_mapping_type::button;
+								m_mapping.id = i;
+								m_mapping.hat = hat_component::none;
+								break;
+							}
+						}
+						for (usz i = 0; i < new_joystick_state.hats.size(); i++)
+						{
+							if (last_joystick_state->second.hats[i] != new_joystick_state.hats[i] && new_joystick_state.hats[i] != hat_component::none)
+							{
+								m_mapping_in_progress = false;
+								m_setting_dialog->set_state_text(DEFAULT_STATUS);
+								m_setting_dialog->set_enable(true);
+								m_mapping.device_type_id = device_type_id;
+								m_mapping.type = sdl_mapping_type::hat;
+								m_mapping.id = i;
+								m_mapping.hat = new_joystick_state.hats[i];
+								break;
+							}
+						}
 					}
 				}
 
-				update_display();
-			});
+				m_timeout_msec -= 25;
+				if (m_timeout_msec <= 0)
+				{
+					m_mapping_in_progress = false;
+					m_setting_dialog->set_state_text(DEFAULT_STATUS);
+					m_setting_dialog->set_enable(true);
+				}
+			}
+
+			update_display();
+		});
 		m_tick_timer->start(25);
 	}
 
@@ -356,11 +355,11 @@ public:
 
 	void set_mapping(const sdl_mapping& mapping)
 	{
-		this->m_mapping = mapping;
+		m_mapping = mapping;
 		update_display();
 	}
 
-	const sdl_mapping& get_mapping()
+	const sdl_mapping& get_mapping() const
 	{
 		return m_mapping;
 	}
@@ -369,9 +368,9 @@ private:
 	emulated_logitech_g27_settings_dialog* m_setting_dialog = nullptr;
 	DeviceChoice* m_ffb_device = nullptr;
 	DeviceChoice* m_led_device = nullptr;
-	sdl_mapping m_mapping = {0};
+	sdl_mapping m_mapping{};
 	bool m_is_axis = false;
-	std::string m_name = "";
+	QString m_name;
 	bool m_flip_axis_display = false;
 
 	QLabel* m_display_box = nullptr;
@@ -382,48 +381,15 @@ private:
 	bool m_mapping_in_progress = false;
 	int m_timeout_msec = 5500;
 	QTimer* m_tick_timer = nullptr;
-	std::map<uint32_t, joystick_state> m_last_joystick_states;
+	std::map<u32, joystick_state> m_last_joystick_states;
 
 	QCheckBox* m_button_status = nullptr;
 	QSlider* m_axis_status = nullptr;
 
 	void update_display()
 	{
-		char text_buf[64];
-		const char* type_string = nullptr;
-		switch (m_mapping.type)
-		{
-		case MAPPING_BUTTON:
-			type_string = "button";
-			break;
-		case MAPPING_HAT:
-			type_string = "hat";
-			break;
-		case MAPPING_AXIS:
-			type_string = "axis";
-			break;
-		}
-		const char* hat_string = nullptr;
-		switch (m_mapping.hat)
-		{
-		case HAT_UP:
-			hat_string = "up";
-			break;
-		case HAT_DOWN:
-			hat_string = "down";
-			break;
-		case HAT_LEFT:
-			hat_string = "left";
-			break;
-		case HAT_RIGHT:
-			hat_string = "right";
-			break;
-		case HAT_NONE:
-			hat_string = "";
-			break;
-		}
-		sprintf(text_buf, "%04x:%04x, %s %u %s", m_mapping.device_type_id >> 16, m_mapping.device_type_id & 0xFFFF, type_string, m_mapping.id, hat_string);
-		m_display_box->setText(QString(text_buf));
+		const std::string text = fmt::format("%04x:%04x, %s %u %s", m_mapping.device_type_id >> 16, m_mapping.device_type_id & 0xFFFF, m_mapping.type, m_mapping.id, m_mapping.hat);
+		m_display_box->setText(QString::fromStdString(text));
 
 		m_reverse_checkbox->setChecked(m_mapping.reverse);
 
@@ -432,26 +398,22 @@ private:
 
 		if (m_axis_status)
 		{
-			int32_t axis_value = (-0x8000);
+			s32 axis_value = -0x8000;
 			if (m_mapping.reverse)
-				axis_value = axis_value * (-1);
+				axis_value *= -1;
 			if (m_flip_axis_display)
-				axis_value = axis_value * (-1);
-			if (axis_value > 0x7FFF)
-				axis_value = 0x7FFF;
-			if (axis_value < (-0x8000))
-				axis_value = (-0x8000);
-			m_axis_status->setValue(axis_value);
+				axis_value *= -1;
+			m_axis_status->setValue(std::clamp(axis_value, -0x8000, 0x7FFF));
 		}
 
-		const std::map<uint32_t, joystick_state>& joystick_states = m_setting_dialog->get_joystick_states();
+		const std::map<u32, joystick_state>& joystick_states = m_setting_dialog->get_joystick_states();
 		auto joystick_state = joystick_states.find(m_mapping.device_type_id);
 
 		if (joystick_state != joystick_states.end())
 		{
 			switch (m_mapping.type)
 			{
-			case MAPPING_BUTTON:
+			case sdl_mapping_type::button:
 			{
 				if (joystick_state->second.buttons.size() <= m_mapping.id)
 					break;
@@ -461,7 +423,7 @@ private:
 				m_button_status->setChecked(value);
 				break;
 			}
-			case MAPPING_HAT:
+			case sdl_mapping_type::hat:
 			{
 				if (joystick_state->second.hats.size() <= m_mapping.id)
 					break;
@@ -471,20 +433,16 @@ private:
 				m_button_status->setChecked(value);
 				break;
 			}
-			case MAPPING_AXIS:
+			case sdl_mapping_type::axis:
 			{
 				if (joystick_state->second.axes.size() <= m_mapping.id)
 					break;
-				int32_t value = joystick_state->second.axes[m_mapping.id];
+				s32 value = joystick_state->second.axes[m_mapping.id];
 				if (m_mapping.reverse)
-					value = value * (-1);
+					value *= -1;
 				if (m_flip_axis_display)
-					value = value * (-1);
-				if (value > 0x7FFF)
-					value = 0x7FFF;
-				else if (value < (-0x8000))
-					value = (-0x8000);
-				m_axis_status->setValue(value);
+					value *= -1;
+				m_axis_status->setValue(std::clamp(value, -0x8000, 0x7FFF));
 				break;
 			}
 			}
@@ -494,74 +452,74 @@ private:
 
 void emulated_logitech_g27_settings_dialog::save_ui_state_to_config()
 {
-#define SAVE_MAPPING(name, device_choice)                                \
-	{                                                                    \
-		const sdl_mapping& m = m_##name->get_mapping();                  \
-		g_cfg_logitech_g27.name.device_type_id.set(m.device_type_id);    \
-		g_cfg_logitech_g27.name.type.set(m.type);                        \
-		g_cfg_logitech_g27.name.id.set(m.id);                            \
-		g_cfg_logitech_g27.name.hat.set(m.hat);                          \
-		g_cfg_logitech_g27.name.reverse.set(m.reverse);                  \
-		if (m_ffb_device->get_device_choice() == device_choice)          \
-		{                                                                \
-			g_cfg_logitech_g27.ffb_device_type_id.set(m.device_type_id); \
-		}                                                                \
-		if (m_led_device->get_device_choice() == device_choice)          \
-		{                                                                \
-			g_cfg_logitech_g27.led_device_type_id.set(m.device_type_id); \
-		}                                                                \
-	}
+	const auto save_mapping = [this](emulated_logitech_g27_mapping& mapping, Mapping* ui_mapping, mapping_device_choice device_choice)
+	{
+		const sdl_mapping& m = ui_mapping->get_mapping();
+		mapping.device_type_id.set(m.device_type_id);
+		mapping.type.set(m.type);
+		mapping.id.set(m.id);
+		mapping.hat.set(m.hat);
+		mapping.reverse.set(m.reverse);
+		if (m_ffb_device->get_device_choice() == device_choice)
+		{
+			g_cfg_logitech_g27.ffb_device_type_id.set(m.device_type_id);
+		}
+		if (m_led_device->get_device_choice() == device_choice)
+		{
+			g_cfg_logitech_g27.led_device_type_id.set(m.device_type_id);
+		}
+	};
 
-	SAVE_MAPPING(steering, CHOICE_STEERING);
-	SAVE_MAPPING(throttle, CHOICE_THROTTLE);
-	SAVE_MAPPING(brake, CHOICE_BRAKE);
-	SAVE_MAPPING(clutch, CHOICE_CLUTCH);
-	SAVE_MAPPING(shift_up, CHOICE_SHIFT_UP);
-	SAVE_MAPPING(shift_down, CHOICE_SHIFT_DOWN);
+	auto& cfg = g_cfg_logitech_g27;
 
-	SAVE_MAPPING(up, CHOICE_UP);
-	SAVE_MAPPING(down, CHOICE_DOWN);
-	SAVE_MAPPING(left, CHOICE_LEFT);
-	SAVE_MAPPING(right, CHOICE_RIGHT);
+	save_mapping(cfg.steering, m_steering, mapping_device_choice::STEERING);
+	save_mapping(cfg.throttle, m_throttle, mapping_device_choice::THROTTLE);
+	save_mapping(cfg.brake, m_brake, mapping_device_choice::BRAKE);
+	save_mapping(cfg.clutch, m_clutch, mapping_device_choice::CLUTCH);
+	save_mapping(cfg.shift_up, m_shift_up, mapping_device_choice::SHIFT_UP);
+	save_mapping(cfg.shift_down, m_shift_down, mapping_device_choice::SHIFT_DOWN);
 
-	SAVE_MAPPING(triangle, CHOICE_TRIANGLE);
-	SAVE_MAPPING(cross, CHOICE_CROSS);
-	SAVE_MAPPING(square, CHOICE_SQUARE);
-	SAVE_MAPPING(circle, CHOICE_CIRCLE);
+	save_mapping(cfg.up, m_up, mapping_device_choice::UP);
+	save_mapping(cfg.down, m_down, mapping_device_choice::DOWN);
+	save_mapping(cfg.left, m_left, mapping_device_choice::LEFT);
+	save_mapping(cfg.right, m_right, mapping_device_choice::RIGHT);
 
-	SAVE_MAPPING(l2, CHOICE_L2);
-	SAVE_MAPPING(l3, CHOICE_L3);
-	SAVE_MAPPING(r2, CHOICE_R2);
-	SAVE_MAPPING(r3, CHOICE_R3);
+	save_mapping(cfg.triangle, m_triangle, mapping_device_choice::TRIANGLE);
+	save_mapping(cfg.cross, m_cross, mapping_device_choice::CROSS);
+	save_mapping(cfg.square, m_square, mapping_device_choice::SQUARE);
+	save_mapping(cfg.circle, m_circle, mapping_device_choice::CIRCLE);
 
-	SAVE_MAPPING(plus, CHOICE_PLUS);
-	SAVE_MAPPING(minus, CHOICE_MINUS);
+	save_mapping(cfg.l2, m_l2, mapping_device_choice::L2);
+	save_mapping(cfg.l3, m_l3, mapping_device_choice::L3);
+	save_mapping(cfg.r2, m_r2, mapping_device_choice::R2);
+	save_mapping(cfg.r3, m_r3, mapping_device_choice::R3);
 
-	SAVE_MAPPING(dial_clockwise, CHOICE_DIAL_CLOCKWISE);
-	SAVE_MAPPING(dial_anticlockwise, CHOICE_DIAL_ANTICLOCKWISE);
+	save_mapping(cfg.plus, m_plus, mapping_device_choice::PLUS);
+	save_mapping(cfg.minus, m_minus, mapping_device_choice::MINUS);
 
-	SAVE_MAPPING(select, CHOICE_SELECT);
-	SAVE_MAPPING(pause, CHOICE_PAUSE);
+	save_mapping(cfg.dial_clockwise, m_dial_clockwise, mapping_device_choice::DIAL_CLOCKWISE);
+	save_mapping(cfg.dial_anticlockwise, m_dial_anticlockwise, mapping_device_choice::DIAL_ANTICLOCKWISE);
 
-	SAVE_MAPPING(shifter_1, CHOICE_SHIFTER_1);
-	SAVE_MAPPING(shifter_2, CHOICE_SHIFTER_2);
-	SAVE_MAPPING(shifter_3, CHOICE_SHIFTER_3);
-	SAVE_MAPPING(shifter_4, CHOICE_SHIFTER_4);
-	SAVE_MAPPING(shifter_5, CHOICE_SHIFTER_5);
-	SAVE_MAPPING(shifter_6, CHOICE_SHIFTER_6);
-	SAVE_MAPPING(shifter_r, CHOICE_SHIFTER_R);
+	save_mapping(cfg.select, m_select, mapping_device_choice::SELECT);
+	save_mapping(cfg.pause, m_pause, mapping_device_choice::PAUSE);
 
-#undef SAVE_MAPPING
+	save_mapping(cfg.shifter_1, m_shifter_1, mapping_device_choice::SHIFTER_1);
+	save_mapping(cfg.shifter_2, m_shifter_2, mapping_device_choice::SHIFTER_2);
+	save_mapping(cfg.shifter_3, m_shifter_3, mapping_device_choice::SHIFTER_3);
+	save_mapping(cfg.shifter_4, m_shifter_4, mapping_device_choice::SHIFTER_4);
+	save_mapping(cfg.shifter_5, m_shifter_5, mapping_device_choice::SHIFTER_5);
+	save_mapping(cfg.shifter_6, m_shifter_6, mapping_device_choice::SHIFTER_6);
+	save_mapping(cfg.shifter_r, m_shifter_r, mapping_device_choice::SHIFTER_R);
 
 	g_cfg_logitech_g27.enabled.set(m_enabled->isChecked());
 	g_cfg_logitech_g27.reverse_effects.set(m_reverse_effects->isChecked());
 
-	if (m_ffb_device->get_device_choice() == CHOICE_NONE)
+	if (m_ffb_device->get_device_choice() == mapping_device_choice::NONE)
 	{
 		g_cfg_logitech_g27.ffb_device_type_id.set(0);
 	}
 
-	if (m_led_device->get_device_choice() == CHOICE_NONE)
+	if (m_led_device->get_device_choice() == mapping_device_choice::NONE)
 	{
 		g_cfg_logitech_g27.led_device_type_id.set(0);
 	}
@@ -569,66 +527,68 @@ void emulated_logitech_g27_settings_dialog::save_ui_state_to_config()
 
 void emulated_logitech_g27_settings_dialog::load_ui_state_from_config()
 {
-#define LOAD_MAPPING(name, device_choice)                                                                                        \
-	{                                                                                                                            \
-		const sdl_mapping m = {                                                                                                  \
-			.device_type_id = static_cast<uint32_t>(g_cfg_logitech_g27.name.device_type_id.get()),                               \
-			.type = static_cast<sdl_mapping_type>(g_cfg_logitech_g27.name.type.get()),                                           \
-			.id = static_cast<uint8_t>(g_cfg_logitech_g27.name.id.get()),                                                        \
-			.hat = static_cast<hat_component>(g_cfg_logitech_g27.name.hat.get()),                                                \
-			.reverse = g_cfg_logitech_g27.name.reverse.get(),                                                                    \
-			.positive_axis = false};                                                                                             \
-		m_##name->set_mapping(m);                                                                                                \
-		if (g_cfg_logitech_g27.ffb_device_type_id.get() == m.device_type_id && m_ffb_device->get_device_choice() == CHOICE_NONE) \
-		{                                                                                                                        \
-			m_ffb_device->set_device_choice(device_choice);                                                                      \
-		}                                                                                                                        \
-		if (g_cfg_logitech_g27.led_device_type_id.get() == m.device_type_id && m_led_device->get_device_choice() == CHOICE_NONE) \
-		{                                                                                                                        \
-			m_led_device->set_device_choice(device_choice);                                                                      \
-		}                                                                                                                        \
-	}
+	const auto load_mapping = [this](const emulated_logitech_g27_mapping& mapping, Mapping* ui_mapping, mapping_device_choice device_choice)
+	{
+		const sdl_mapping m =
+		{
+			.device_type_id = mapping.device_type_id.get(),
+			.type = mapping.type.get(),
+			.id = mapping.id.get(),
+			.hat = mapping.hat.get(),
+			.reverse = mapping.reverse.get(),
+			.positive_axis = false
+		};
+		ui_mapping->set_mapping(m);
+		if (g_cfg_logitech_g27.ffb_device_type_id.get() == m.device_type_id && m_ffb_device->get_device_choice() == mapping_device_choice::NONE)
+		{
+			m_ffb_device->set_device_choice(device_choice);
+		}
+		if (g_cfg_logitech_g27.led_device_type_id.get() == m.device_type_id && m_led_device->get_device_choice() == mapping_device_choice::NONE)
+		{
+			m_led_device->set_device_choice(device_choice);
+		}
+	};
 
-	LOAD_MAPPING(steering, CHOICE_STEERING);
-	LOAD_MAPPING(throttle, CHOICE_THROTTLE);
-	LOAD_MAPPING(brake, CHOICE_BRAKE);
-	LOAD_MAPPING(clutch, CHOICE_CLUTCH);
-	LOAD_MAPPING(shift_up, CHOICE_SHIFT_UP);
-	LOAD_MAPPING(shift_down, CHOICE_SHIFT_DOWN);
+	const auto& cfg = g_cfg_logitech_g27;
 
-	LOAD_MAPPING(up, CHOICE_UP);
-	LOAD_MAPPING(down, CHOICE_DOWN);
-	LOAD_MAPPING(left, CHOICE_LEFT);
-	LOAD_MAPPING(right, CHOICE_RIGHT);
+	load_mapping(cfg.steering, m_steering, mapping_device_choice::STEERING);
+	load_mapping(cfg.throttle, m_throttle, mapping_device_choice::THROTTLE);
+	load_mapping(cfg.brake, m_brake, mapping_device_choice::BRAKE);
+	load_mapping(cfg.clutch, m_clutch, mapping_device_choice::CLUTCH);
+	load_mapping(cfg.shift_up, m_shift_up, mapping_device_choice::SHIFT_UP);
+	load_mapping(cfg.shift_down, m_shift_down, mapping_device_choice::SHIFT_DOWN);
 
-	LOAD_MAPPING(triangle, CHOICE_TRIANGLE);
-	LOAD_MAPPING(cross, CHOICE_CROSS);
-	LOAD_MAPPING(square, CHOICE_SQUARE);
-	LOAD_MAPPING(circle, CHOICE_CIRCLE);
+	load_mapping(cfg.up, m_up, mapping_device_choice::UP);
+	load_mapping(cfg.down, m_down, mapping_device_choice::DOWN);
+	load_mapping(cfg.left, m_left, mapping_device_choice::LEFT);
+	load_mapping(cfg.right, m_right, mapping_device_choice::RIGHT);
 
-	LOAD_MAPPING(l2, CHOICE_L2);
-	LOAD_MAPPING(l3, CHOICE_L3);
-	LOAD_MAPPING(r2, CHOICE_R2);
-	LOAD_MAPPING(r3, CHOICE_R3);
+	load_mapping(cfg.triangle, m_triangle, mapping_device_choice::TRIANGLE);
+	load_mapping(cfg.cross, m_cross, mapping_device_choice::CROSS);
+	load_mapping(cfg.square, m_square, mapping_device_choice::SQUARE);
+	load_mapping(cfg.circle, m_circle, mapping_device_choice::CIRCLE);
 
-	LOAD_MAPPING(plus, CHOICE_PLUS);
-	LOAD_MAPPING(minus, CHOICE_MINUS);
+	load_mapping(cfg.l2, m_l2, mapping_device_choice::L2);
+	load_mapping(cfg.l3, m_l3, mapping_device_choice::L3);
+	load_mapping(cfg.r2, m_r2, mapping_device_choice::R2);
+	load_mapping(cfg.r3, m_r3, mapping_device_choice::R3);
 
-	LOAD_MAPPING(dial_clockwise, CHOICE_DIAL_CLOCKWISE);
-	LOAD_MAPPING(dial_anticlockwise, CHOICE_DIAL_ANTICLOCKWISE);
+	load_mapping(cfg.plus, m_plus, mapping_device_choice::PLUS);
+	load_mapping(cfg.minus, m_minus, mapping_device_choice::MINUS);
 
-	LOAD_MAPPING(select, CHOICE_SELECT);
-	LOAD_MAPPING(pause, CHOICE_PAUSE);
+	load_mapping(cfg.dial_clockwise, m_dial_clockwise, mapping_device_choice::DIAL_CLOCKWISE);
+	load_mapping(cfg.dial_anticlockwise, m_dial_anticlockwise, mapping_device_choice::DIAL_ANTICLOCKWISE);
 
-	LOAD_MAPPING(shifter_1, CHOICE_SHIFTER_1);
-	LOAD_MAPPING(shifter_2, CHOICE_SHIFTER_2);
-	LOAD_MAPPING(shifter_3, CHOICE_SHIFTER_3);
-	LOAD_MAPPING(shifter_4, CHOICE_SHIFTER_4);
-	LOAD_MAPPING(shifter_5, CHOICE_SHIFTER_5);
-	LOAD_MAPPING(shifter_6, CHOICE_SHIFTER_6);
-	LOAD_MAPPING(shifter_r, CHOICE_SHIFTER_R);
+	load_mapping(cfg.select, m_select, mapping_device_choice::SELECT);
+	load_mapping(cfg.pause, m_pause, mapping_device_choice::PAUSE);
 
-#undef LOAD_MAPPING
+	load_mapping(cfg.shifter_1, m_shifter_1, mapping_device_choice::SHIFTER_1);
+	load_mapping(cfg.shifter_2, m_shifter_2, mapping_device_choice::SHIFTER_2);
+	load_mapping(cfg.shifter_3, m_shifter_3, mapping_device_choice::SHIFTER_3);
+	load_mapping(cfg.shifter_4, m_shifter_4, mapping_device_choice::SHIFTER_4);
+	load_mapping(cfg.shifter_5, m_shifter_5, mapping_device_choice::SHIFTER_5);
+	load_mapping(cfg.shifter_6, m_shifter_6, mapping_device_choice::SHIFTER_6);
+	load_mapping(cfg.shifter_r, m_shifter_r, mapping_device_choice::SHIFTER_R);
 
 	m_enabled->setChecked(g_cfg_logitech_g27.enabled.get());
 	m_reverse_effects->setChecked(g_cfg_logitech_g27.reverse_effects.get());
@@ -651,49 +611,49 @@ emulated_logitech_g27_settings_dialog::emulated_logitech_g27_settings_dialog(QWi
 	g_cfg_logitech_g27.load();
 
 	connect(buttons, &QDialogButtonBox::clicked, this, [this, buttons](QAbstractButton* button)
+	{
+		if (button == buttons->button(QDialogButtonBox::Apply))
 		{
-			if (button == buttons->button(QDialogButtonBox::Apply))
-			{
-				save_ui_state_to_config();
-				g_cfg_logitech_g27.save();
-				load_ui_state_from_config();
-			}
-			else if (button == buttons->button(QDialogButtonBox::Save))
-			{
-				save_ui_state_to_config();
-				g_cfg_logitech_g27.save();
-				accept();
-			}
-			else if (button == buttons->button(QDialogButtonBox::RestoreDefaults))
-			{
-				if (QMessageBox::question(this, tr("Confirm Reset"), tr("Reset all?")) != QMessageBox::Yes)
-					return;
-				g_cfg_logitech_g27.reset();
-				load_ui_state_from_config();
-				g_cfg_logitech_g27.save();
-			}
-			else if (button == buttons->button(QDialogButtonBox::Cancel))
-			{
-				reject();
-			}
-		});
+			save_ui_state_to_config();
+			g_cfg_logitech_g27.save();
+			load_ui_state_from_config();
+		}
+		else if (button == buttons->button(QDialogButtonBox::Save))
+		{
+			save_ui_state_to_config();
+			g_cfg_logitech_g27.save();
+			accept();
+		}
+		else if (button == buttons->button(QDialogButtonBox::RestoreDefaults))
+		{
+			if (QMessageBox::question(this, tr("Confirm Reset"), tr("Reset all?")) != QMessageBox::Yes)
+				return;
+			g_cfg_logitech_g27.reset();
+			load_ui_state_from_config();
+			g_cfg_logitech_g27.save();
+		}
+		else if (button == buttons->button(QDialogButtonBox::Cancel))
+		{
+			reject();
+		}
+	});
 
-	QLabel* warning = new QLabel(QString("Warning: Force feedback output were meant for Logitech G27, on stronger wheels please adjust force strength accordingly in your wheel software."), this);
+	QLabel* warning = new QLabel(tr("Warning: Force feedback output were meant for Logitech G27, on stronger wheels please adjust force strength accordingly in your wheel software."), this);
 	warning->setStyleSheet("color: red;");
 	warning->setWordWrap(true);
 	v_layout->addWidget(warning);
 
-	m_enabled = new QCheckBox(QString("Enabled (requires game restart)"), this);
+	m_enabled = new QCheckBox(tr("Enabled (requires game restart)"), this);
 	v_layout->addWidget(m_enabled);
 
-	m_reverse_effects = new QCheckBox(QString("Reverse force feedback effects"), this);
+	m_reverse_effects = new QCheckBox(tr("Reverse force feedback effects"), this);
 	v_layout->addWidget(m_reverse_effects);
 
-	m_state_text = new QLabel(QString(DEFAULT_STATUS), this);
+	m_state_text = new QLabel(DEFAULT_STATUS, this);
 	v_layout->addWidget(m_state_text);
 
-	m_ffb_device = new DeviceChoice(this, "Use the device with the following mapping for force feedback:");
-	m_led_device = new DeviceChoice(this, "Use the device with the following mapping for LED:");
+	m_ffb_device = new DeviceChoice(this, tr("Use the device with the following mapping for force feedback:"));
+	m_led_device = new DeviceChoice(this, tr("Use the device with the following mapping for LED:"));
 
 	m_mapping_scroll_area = new QScrollArea(this);
 	QWidget* mapping_widget = new QWidget(m_mapping_scroll_area);
@@ -707,57 +667,57 @@ emulated_logitech_g27_settings_dialog::emulated_logitech_g27_settings_dialog(QWi
 
 	v_layout->addWidget(m_mapping_scroll_area);
 
-	QLabel* axis_label = new QLabel(QString("Axes:"), mapping_widget);
+	QLabel* axis_label = new QLabel(tr("Axes:"), mapping_widget);
 	mapping_layout->addWidget(axis_label);
 
-	auto add_mapping_setting = [mapping_widget, this, mapping_layout](Mapping*& target, bool is_axis, const char* display_name, bool flip_axis_display)
+	const auto add_mapping_setting = [mapping_widget, this, mapping_layout](Mapping*& target, bool is_axis, const QString& display_name, bool flip_axis_display)
 	{
 		target = new Mapping(mapping_widget, this, is_axis, display_name, flip_axis_display);
 		mapping_layout->addWidget(target);
 	};
 
-	add_mapping_setting(m_steering, true, "Steering", false);
-	add_mapping_setting(m_throttle, true, "Throttle", true);
-	add_mapping_setting(m_brake, true, "Brake", true);
-	add_mapping_setting(m_clutch, true, "Clutch", true);
+	add_mapping_setting(m_steering, true, tr("Steering"), false);
+	add_mapping_setting(m_throttle, true, tr("Throttle"), true);
+	add_mapping_setting(m_brake, true, tr("Brake"), true);
+	add_mapping_setting(m_clutch, true, tr("Clutch"), true);
 
-	QLabel* button_label = new QLabel(QString("Buttons:"), mapping_widget);
+	QLabel* button_label = new QLabel(tr("Buttons:"), mapping_widget);
 	mapping_layout->addWidget(button_label);
 
-	add_mapping_setting(m_shift_up, false, "Shift up", false);
-	add_mapping_setting(m_shift_down, false, "Shift down", false);
+	add_mapping_setting(m_shift_up, false, tr("Shift up"), false);
+	add_mapping_setting(m_shift_down, false, tr("Shift down"), false);
 
-	add_mapping_setting(m_up, false, "Up", false);
-	add_mapping_setting(m_down, false, "Down", false);
-	add_mapping_setting(m_left, false, "Left", false);
-	add_mapping_setting(m_right, false, "Right", false);
+	add_mapping_setting(m_up, false, tr("Up"), false);
+	add_mapping_setting(m_down, false, tr("Down"), false);
+	add_mapping_setting(m_left, false, tr("Left"), false);
+	add_mapping_setting(m_right, false, tr("Right"), false);
 
-	add_mapping_setting(m_triangle, false, "Triangle", false);
-	add_mapping_setting(m_cross, false, "Cross", false);
-	add_mapping_setting(m_square, false, "Square", false);
-	add_mapping_setting(m_circle, false, "Circle", false);
+	add_mapping_setting(m_triangle, false, tr("Triangle"), false);
+	add_mapping_setting(m_cross, false, tr("Cross"), false);
+	add_mapping_setting(m_square, false, tr("Square"), false);
+	add_mapping_setting(m_circle, false, tr("Circle"), false);
 
-	add_mapping_setting(m_l2, false, "L2", false);
-	add_mapping_setting(m_l3, false, "L3", false);
-	add_mapping_setting(m_r2, false, "R2", false);
-	add_mapping_setting(m_r3, false, "R3", false);
+	add_mapping_setting(m_l2, false, tr("L2"), false);
+	add_mapping_setting(m_l3, false, tr("L3"), false);
+	add_mapping_setting(m_r2, false, tr("R2"), false);
+	add_mapping_setting(m_r3, false, tr("R3"), false);
 
-	add_mapping_setting(m_plus, false, "L4", false);
-	add_mapping_setting(m_minus, false, "L5", false);
+	add_mapping_setting(m_plus, false, tr("L4"), false);
+	add_mapping_setting(m_minus, false, tr("L5"), false);
 
-	add_mapping_setting(m_dial_clockwise, false, "R4", false);
-	add_mapping_setting(m_dial_anticlockwise, false, "R5", false);
+	add_mapping_setting(m_dial_clockwise, false, tr("R4"), false);
+	add_mapping_setting(m_dial_anticlockwise, false, tr("R5"), false);
 
-	add_mapping_setting(m_select, false, "Select", false);
-	add_mapping_setting(m_pause, false, "Start", false);
+	add_mapping_setting(m_select, false, tr("Select"), false);
+	add_mapping_setting(m_pause, false, tr("Start"), false);
 
-	add_mapping_setting(m_shifter_1, false, "Gear 1", false);
-	add_mapping_setting(m_shifter_2, false, "Gear 2", false);
-	add_mapping_setting(m_shifter_3, false, "Gear 3", false);
-	add_mapping_setting(m_shifter_4, false, "Gear 4", false);
-	add_mapping_setting(m_shifter_5, false, "Gear 5", false);
-	add_mapping_setting(m_shifter_6, false, "Gear 6", false);
-	add_mapping_setting(m_shifter_r, false, "Gear R", false);
+	add_mapping_setting(m_shifter_1, false, tr("Gear 1"), false);
+	add_mapping_setting(m_shifter_2, false, tr("Gear 2"), false);
+	add_mapping_setting(m_shifter_3, false, tr("Gear 3"), false);
+	add_mapping_setting(m_shifter_4, false, tr("Gear 4"), false);
+	add_mapping_setting(m_shifter_5, false, tr("Gear 5"), false);
+	add_mapping_setting(m_shifter_6, false, tr("Gear 6"), false);
+	add_mapping_setting(m_shifter_r, false, tr("Gear R"), false);
 
 	v_layout->addSpacing(20);
 
@@ -777,83 +737,80 @@ emulated_logitech_g27_settings_dialog::emulated_logitech_g27_settings_dialog(QWi
 
 emulated_logitech_g27_settings_dialog::~emulated_logitech_g27_settings_dialog()
 {
-	for (auto joystick_handle : m_joystick_handles)
+	for (SDL_Joystick* joystick_handle : m_joystick_handles)
 	{
 		if (joystick_handle)
-			SDL_CloseJoystick(reinterpret_cast<SDL_Joystick*>(joystick_handle));
+			SDL_CloseJoystick(joystick_handle);
 	}
 }
 
-static inline hat_component get_sdl_hat_component(uint8_t sdl_hat)
+static inline hat_component get_sdl_hat_component(u8 sdl_hat)
 {
 	if (sdl_hat & SDL_HAT_UP)
 	{
-		return HAT_UP;
+		return hat_component::up;
 	}
 
 	if (sdl_hat & SDL_HAT_DOWN)
 	{
-		return HAT_DOWN;
+		return hat_component::down;
 	}
 
 	if (sdl_hat & SDL_HAT_LEFT)
 	{
-		return HAT_LEFT;
+		return hat_component::left;
 	}
 
 	if (sdl_hat & SDL_HAT_RIGHT)
 	{
-		return HAT_RIGHT;
+		return hat_component::right;
 	}
 
-	return HAT_NONE;
+	return hat_component::none;
 }
 
-const std::map<uint32_t, joystick_state>& emulated_logitech_g27_settings_dialog::get_joystick_states()
+const std::map<u32, joystick_state>& emulated_logitech_g27_settings_dialog::get_joystick_states()
 {
 	if (!m_sdl_initialized)
 	{
 		return m_last_joystick_states;
 	}
 
-	uint64_t now = SDL_GetTicks();
+	const u64 now = SDL_GetTicks();
 
-	if (SDL_GetTicks() - m_last_joystick_states_update < 25)
+	if (now - m_last_joystick_states_update < 25)
 	{
 		return m_last_joystick_states;
 	}
 
 	m_last_joystick_states_update = now;
 
-	std::map<uint32_t, joystick_state> new_joystick_states;
+	std::map<u32, joystick_state> new_joystick_states;
+	std::vector<SDL_Joystick*> new_joystick_handles;
 
 	sdl_instance::get_instance().pump_events();
 
-	int joystick_count;
-	SDL_JoystickID* joystick_ids = SDL_GetJoysticks(&joystick_count);
-
-	std::vector<void*> new_joystick_handles;
-
-	if (joystick_ids != nullptr)
+	int joystick_count = 0;
+	if (SDL_JoystickID* joystick_ids = SDL_GetJoysticks(&joystick_count))
 	{
 		for (int i = 0; i < joystick_count; i++)
 		{
 			SDL_Joystick* cur_joystick = SDL_OpenJoystick(joystick_ids[i]);
-			if (cur_joystick == nullptr)
+			if (!cur_joystick)
 			{
 				continue;
 			}
 			new_joystick_handles.push_back(cur_joystick);
 
-			uint32_t device_type_id = (SDL_GetJoystickVendor(cur_joystick) << 16) | SDL_GetJoystickProduct(cur_joystick);
+			const u32 device_type_id = (SDL_GetJoystickVendor(cur_joystick) << 16) | SDL_GetJoystickProduct(cur_joystick);
 
 			auto cur_state = new_joystick_states.find(device_type_id);
 			if (cur_state == new_joystick_states.end())
 			{
-				joystick_state s;
-				int num_axes = SDL_GetNumJoystickAxes(cur_joystick);
-				int num_buttons = SDL_GetNumJoystickButtons(cur_joystick);
-				int num_hats = SDL_GetNumJoystickHats(cur_joystick);
+				joystick_state s {};
+				const int num_axes = SDL_GetNumJoystickAxes(cur_joystick);
+				const int num_buttons = SDL_GetNumJoystickButtons(cur_joystick);
+				const int num_hats = SDL_GetNumJoystickHats(cur_joystick);
 				for (int j = 0; j < num_axes; j++)
 				{
 					s.axes.push_back(SDL_GetJoystickAxis(cur_joystick, j));
@@ -864,36 +821,36 @@ const std::map<uint32_t, joystick_state>& emulated_logitech_g27_settings_dialog:
 				}
 				for (int j = 0; j < num_hats; j++)
 				{
-					uint8_t sdl_hat = SDL_GetJoystickHat(cur_joystick, j);
+					const u8 sdl_hat = SDL_GetJoystickHat(cur_joystick, j);
 					s.hats.push_back(get_sdl_hat_component(sdl_hat));
 				}
 				new_joystick_states[device_type_id] = s;
 			}
 			else
 			{
-				for (std::vector<int16_t>::size_type j = 0; j < cur_state->second.axes.size(); j++)
+				for (s32 j = 0; j < static_cast<s32>(cur_state->second.axes.size()); j++)
 				{
 					cur_state->second.axes[j] = (cur_state->second.axes[j] + SDL_GetJoystickAxis(cur_joystick, j)) / 2;
 				}
-				for (std::vector<bool>::size_type j = 0; j < cur_state->second.buttons.size(); j++)
+				for (s32 j = 0; j < static_cast<s32>(cur_state->second.buttons.size()); j++)
 				{
 					cur_state->second.buttons[j] = cur_state->second.buttons[j] || SDL_GetJoystickButton(cur_joystick, j);
 				}
-				for (std::vector<hat_component>::size_type j = 0; j < cur_state->second.hats.size(); j++)
+				for (s32 j = 0; j < static_cast<s32>(cur_state->second.hats.size()); j++)
 				{
-					if (cur_state->second.hats[j] != HAT_NONE)
+					if (cur_state->second.hats[j] != hat_component::none)
 						continue;
-					uint8_t sdl_hat = SDL_GetJoystickHat(cur_joystick, j);
+					const u8 sdl_hat = SDL_GetJoystickHat(cur_joystick, j);
 					cur_state->second.hats[j] = get_sdl_hat_component(sdl_hat);
 				}
 			}
 		}
 	}
 
-	for (auto joystick_handle : m_joystick_handles)
+	for (SDL_Joystick* joystick_handle : m_joystick_handles)
 	{
 		if (joystick_handle)
-			SDL_CloseJoystick(reinterpret_cast<SDL_Joystick*>(joystick_handle));
+			SDL_CloseJoystick(joystick_handle);
 	}
 
 	m_joystick_handles = new_joystick_handles;
@@ -902,9 +859,9 @@ const std::map<uint32_t, joystick_state>& emulated_logitech_g27_settings_dialog:
 	return m_last_joystick_states;
 }
 
-void emulated_logitech_g27_settings_dialog::set_state_text(const char* text)
+void emulated_logitech_g27_settings_dialog::set_state_text(const QString& text)
 {
-	m_state_text->setText(QString(text));
+	m_state_text->setText(text);
 }
 
 void emulated_logitech_g27_settings_dialog::set_enable(bool enable)
@@ -959,14 +916,5 @@ void emulated_logitech_g27_settings_dialog::set_enable(bool enable)
 	m_mapping_scroll_area->verticalScrollBar()->setEnabled(enable);
 	m_mapping_scroll_area->verticalScrollBar()->setSliderPosition(slider_position);
 }
-
-#else
-
-// minimal symbols for sdl-less builds automoc
-#include "emulated_logitech_g27_settings_dialog.h"
-
-emulated_logitech_g27_settings_dialog::emulated_logitech_g27_settings_dialog(QWidget* parent)
-	: QDialog(parent) {}
-emulated_logitech_g27_settings_dialog::~emulated_logitech_g27_settings_dialog() {};
 
 #endif

--- a/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.h
+++ b/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#ifdef HAVE_SDL3
+
 #include <QDialog>
 #include <QLabel>
 #include <QCheckBox>
 #include <QScrollArea>
 
-#ifdef HAVE_SDL3
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
@@ -14,7 +15,6 @@
 #ifndef _MSC_VER
 #pragma GCC diagnostic pop
 #endif
-#endif
 
 #include <map>
 #include <vector>
@@ -22,7 +22,7 @@
 
 struct joystick_state
 {
-	std::vector<int16_t> axes;
+	std::vector<s16> axes;
 	std::vector<bool> buttons;
 	std::vector<hat_component> hats;
 };
@@ -36,15 +36,17 @@ class emulated_logitech_g27_settings_dialog : public QDialog
 
 public:
 	emulated_logitech_g27_settings_dialog(QWidget* parent = nullptr);
-	~emulated_logitech_g27_settings_dialog();
-	void set_state_text(const char*);
-	const std::map<uint32_t, joystick_state>& get_joystick_states();
+	virtual ~emulated_logitech_g27_settings_dialog();
+	void set_state_text(const QString& text);
+	const std::map<u32, joystick_state>& get_joystick_states();
 	void set_enable(bool enable);
 
 private:
-	std::map<uint32_t, joystick_state> m_last_joystick_states;
-	// hack: need a completed dummy class when linking automoc generated with sdl-less build
-	std::vector<void*> m_joystick_handles;
+	void load_ui_state_from_config();
+	void save_ui_state_to_config();
+
+	std::map<u32, joystick_state> m_last_joystick_states;
+	std::vector<SDL_Joystick*> m_joystick_handles;
 	uint64_t m_last_joystick_states_update = 0;
 	bool m_sdl_initialized = false;
 
@@ -97,7 +99,6 @@ private:
 	DeviceChoice* m_led_device = nullptr;
 
 	QScrollArea* m_mapping_scroll_area = nullptr;
-
-	void load_ui_state_from_config();
-	void save_ui_state_to_config();
 };
+
+#endif


### PR DESCRIPTION
Cleanup previous PR:
- code style
- fix warnings
- replace defines with lambdas
- more const correctness
- replace hex_buf with fmt method
- use enum class
- add missing localizations

NOTE:
This will replace numbers with strings in the config file.
So you have to remap the buttons etc.