### PR TITLE
3rd Party: Update MoltenVK to v1.3.0

### DIFF
--- a/.ci/build-mac-arm64.sh
+++ b/.ci/build-mac-arm64.sh
@@ -49,8 +49,8 @@ brew_arm64_install_packages 0mq aom aribb24 ca-certificates cjson dav1d ffmpeg@5
 "$BREW_ARM64_PATH/bin/brew" link -f ffmpeg@5
 ln -s "/opt/homebrew1/opt/llvm@$LLVM_COMPILER_VER/lib/unwind/libunwind.1.dylib" "/opt/homebrew1/opt/llvm@$LLVM_COMPILER_VER/lib/libunwind.1.dylib"
 
-# moltenvk based on commit for 1.2.11 release
-wget https://raw.githubusercontent.com/Homebrew/homebrew-core/6bfc8950c696d1f952425e8af2a6248603dc0df9/Formula/m/molten-vk.rb
+# moltenvk based on commit for 1.3.0 release
+wget https://raw.githubusercontent.com/Homebrew/homebrew-core/7255441cbcafabaa8950f67c7ec55ff499dbb2d3/Formula/m/molten-vk.rb
 /usr/local/bin/brew install -f --overwrite ./molten-vk.rb
 export CXX=clang++
 export CC=clang

--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -16,8 +16,8 @@ arch -x86_64 /usr/local/bin/brew reinstall -f --build-from-source gnutls freetyp
 arch -x86_64 /usr/local/bin/brew install llvm@$LLVM_COMPILER_VER glew cmake sdl3 vulkan-headers coreutils
 arch -x86_64 /usr/local/bin/brew link -f llvm@$LLVM_COMPILER_VER ffmpeg@5
 
-# moltenvk based on commit for 1.2.11 release
-wget https://raw.githubusercontent.com/Homebrew/homebrew-core/6bfc8950c696d1f952425e8af2a6248603dc0df9/Formula/m/molten-vk.rb
+# moltenvk based on commit for 1.3.0 release
+wget https://raw.githubusercontent.com/Homebrew/homebrew-core/7255441cbcafabaa8950f67c7ec55ff499dbb2d3/Formula/m/molten-vk.rb
 arch -x86_64 /usr/local/bin/brew install -f --overwrite ./molten-vk.rb
 export CXX=clang++
 export CC=clang

--- a/3rdparty/MoltenVK/CMakeLists.txt
+++ b/3rdparty/MoltenVK/CMakeLists.txt
@@ -3,7 +3,7 @@ include(ExternalProject)
 
 ExternalProject_Add(moltenvk
 	GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK.git
-	GIT_TAG 81541f6
+	GIT_TAG 49b97f2
 	BUILD_IN_SOURCE 1
 	SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK
 	CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/MoltenVK/fetchDependencies" --macos


### PR DESCRIPTION
Bumps MoltenVK to v1.3.0

This includes full support for Vulkan 1.3 and adds the following extensions: 
  -  VK_KHR_index_type_uint8
  -  VK_KHR_load_store_op_none
  -  VK_KHR_maintenance4
  -  VK_KHR_maintenance6
  -  VK_KHR_maintenance7
  -  VK_KHR_shader_expect_assume
  -  VK_KHR_shader_subgroup_rotate
  -  VK_KHR_shader_terminate_invocation
  -  VK_KHR_vulkan_memory_model
  -  VK_KHR_zero_initialize_workgroup_memory
  -  VK_EXT_depth_clip_control
  -  VK_EXT_external_memory_metal.
  -  VK_EXT_image_2d_view_of_3d
  -  VK_EXT_index_type_uint8
  -  VK_EXT_load_store_op_none
  -  VK_EXT_pipeline_robustness
  -  VK_EXT_tooling_info

Full changelog is available [here](https://github.com/KhronosGroup/MoltenVK/releases/tag/v1.3.0) 