### PR TITLE
Fix USE_SYSTEM_OPENAL to use system headers

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -11,7 +11,7 @@
 #include <cmath>
 
 #ifndef WITHOUT_OPENAL
-#include "3rdparty/OpenAL/openal-soft/include/AL/alext.h"
+#include <AL/alext.h>
 #endif
 
 LOG_CHANNEL(cellMic);

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "Utilities/Thread.h"
-#include "3rdparty/OpenAL/openal-soft/include/AL/alc.h"
 #include "Utilities/mutex.h"
+
+#include <AL/alc.h>
 
 // Error Codes
 enum CellMicInError : u32

--- a/rpcs3/rpcs3qt/microphone_creator.cpp
+++ b/rpcs3/rpcs3qt/microphone_creator.cpp
@@ -3,8 +3,8 @@
 
 #include "Utilities/StrUtil.h"
 
-#include "3rdparty/OpenAL/openal-soft/include/AL/al.h"
-#include "3rdparty/OpenAL/openal-soft/include/AL/alc.h"
+#include <AL/al.h>
+#include <AL/alc.h>
 
 LOG_CHANNEL(cfg_log, "CFG");
 


### PR DESCRIPTION
Even when USE_SYSTEM_OPENAL was enabled, the code directly included the bundled OpenAL headers, bypassing the system headers.