### PR TITLE
rsx: Do not interpolate when performing image reconstruction (D24X8 <-> BGRA8)

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -387,6 +387,16 @@ void GLGSRender::load_texture_env()
 					{
 						m_graphics_state |= rsx::fragment_program_state_dirty;
 					}
+
+					if (const auto texture_format = tex.format() & ~(CELL_GCM_TEXTURE_UN | CELL_GCM_TEXTURE_LN);
+						sampler_state->format_class != rsx::classify_format(texture_format) &&
+						(texture_format == CELL_GCM_TEXTURE_A8R8G8B8 || texture_format == CELL_GCM_TEXTURE_D8R8G8B8))
+					{
+						// Depth format redirected to BGRA8 resample stage. Do not filter to avoid bits leaking.
+						// If accurate graphics are desired, force a bitcast to COLOR as a workaround.
+						m_fs_sampler_states[i].set_parameteri(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+						m_fs_sampler_states[i].set_parameteri(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+					}
 				}
 			}
 			else

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -324,6 +324,12 @@ void VKGSRender::load_texture_env()
 					// Most PS3-like formats can be linearly filtered without problem
 					can_sample_linear = true;
 				}
+				else if (sampler_state->format_class != rsx::classify_format(texture_format) &&
+					(texture_format == CELL_GCM_TEXTURE_A8R8G8B8 || texture_format == CELL_GCM_TEXTURE_D8R8G8B8))
+				{
+					// Depth format redirected to BGRA8 resample stage. Do not filter to avoid bits leaking
+					can_sample_linear = false;
+				}
 				else
 				{
 					// Not all GPUs support linear filtering of depth formats


### PR DESCRIPTION
- Interpolation introduces bit leakage

Closes https://github.com/RPCS3/rpcs3/issues/17148