### PR TITLE
Alpha WIP: SPU Anlyzer: Detect RdDec pseudo-reads loops

### DIFF
--- a/rpcs3/Emu/Cell/SPURecompiler.h
+++ b/rpcs3/Emu/Cell/SPURecompiler.h
@@ -193,9 +193,7 @@ public:
 	// Value flags (TODO: only is_const is implemented)
 	enum class vf : u32
 	{
-		is_const,
 		is_mask,
-		is_rel,
 		is_null,
 
 		__bitset_enum_max
@@ -206,8 +204,8 @@ public:
 		bs_t<vf> flag{+vf::is_null};
 		u32 value{};
 		u32 tag = umax;
-		u32 known_ones{};
-		u32 known_zeroes{};
+		u32 value_range = 0;
+		u32 bit_range = umax;
 		u32 origin = SPU_LS_SIZE;
 		bool is_instruction = false;
 


### PR DESCRIPTION
This does not work at all at the moment.
The attemp is to detect constant-iterated loops with constant register output that there only doing is to read the SPU_RdDec channel aimlessly.
Comon in Red Dead Redemption.
I realized that if I commit to it and open a pull request even at this state, it would go fown to the obvilion of history.

Attemts to address #16834