### PR TITLE
PPU Loader: Consume Executable Memory

### DIFF
--- a/rpcs3/Emu/Cell/PPUModule.cpp
+++ b/rpcs3/Emu/Cell/PPUModule.cpp
@@ -2155,6 +2155,8 @@ bool ppu_load_exec(const ppu_exec_object& elf, bool virtual_load, const std::str
 
 	const auto old_process_info = g_ps3_process_info;
 
+	u32 segs_size = 0;
+
 	// Allocate memory at fixed positions
 	for (const auto& prog : elf.progs)
 	{
@@ -2249,6 +2251,8 @@ bool ppu_load_exec(const ppu_exec_object& elf, bool virtual_load, const std::str
 			{
 				ppu_register_range(addr, size);
 			}
+
+			segs_size += utils::align<u32>(size + (addr % 0x10000), 0x10000);
 		}
 	}
 
@@ -2773,7 +2777,7 @@ bool ppu_load_exec(const ppu_exec_object& elf, bool virtual_load, const std::str
 
 	ppu->gpr[1] -= stack_alloc_size;
 
-	ensure(g_fxo->get<lv2_memory_container>().take(primary_stacksize));
+	ensure(g_fxo->get<lv2_memory_container>().take(primary_stacksize + segs_size));
 
 	ppu->cmd_push({ppu_cmd::initialize, 0});
 


### PR DESCRIPTION
Take into calculations the memory required for the PS3 applicatrion binary to load.
This is the most signficant change from #12747
This will also reduce host RAM usage and savestate size a bit for some games, because they would now use less memory of their own which are based on the memory statistics RPCS3 reports through the syscall: `sys_memory_get_user_memory_size`.
It does not fix Brink (the game in target) because the changeset is not complete, it would instead be commited and tested on HW gradually.
This improves accuracy for all games.