### PR TITLE
initialize sdl haptic, log haptic device open errors

### DIFF
--- a/rpcs3/Emu/Io/LogitechG27.cpp
+++ b/rpcs3/Emu/Io/LogitechG27.cpp
@@ -266,7 +266,7 @@ void usb_device_logitech_g27::sdl_refresh()
 				SDL_Haptic* cur_haptic = SDL_OpenHapticFromJoystick(cur_joystick);
 				if (cur_haptic == nullptr)
 				{
-					logitech_g27_log.error("Failed opening haptic device from selected ffb device %04x:%04x", cur_vendor_id, cur_product_id);
+					logitech_g27_log.error("Failed opening haptic device from selected ffb device %04x:%04x, %s", cur_vendor_id, cur_product_id, SDL_GetError());
 				}
 				else
 				{

--- a/rpcs3/Input/sdl_instance.cpp
+++ b/rpcs3/Input/sdl_instance.cpp
@@ -69,7 +69,7 @@ bool sdl_instance::initialize()
 	set_hint(SDL_HINT_JOYSTICK_HIDAPI_PS3, "1");
 #endif
 
-	if (!SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD))
+	if (!SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD | SDL_INIT_HAPTIC))
 	{
 		sdl_log.error("Could not initialize! SDL Error: %s", SDL_GetError());
 		return false;


### PR DESCRIPTION
Apologies, I had the wrong assumption that SDL_INIT_HAPTIC came with SDL_INIT_JOYSTICK, in reality SDL_OpenHapticFromJoystick just happened to work on linux without.

