### PR TITLE
Fix game termination (again)

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -6160,7 +6160,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 				{
 					if (utils::has_waitpkg())
 					{
-						__tpause(std::min<u32>(eventstat_spin_count, 10) * 500, 0x1);
+						__tpause(std::min<u64>(eventstat_spin_count, 10) * 500, 0x1);
 					}
 					else
 					{
@@ -6173,7 +6173,7 @@ s64 spu_thread::get_ch_value(u32 ch)
 						};
 
 						// Provide the first X64 cache line of the reservation to be tracked
-						__mwaitx<check_wait_t>(std::min<u32>(eventstat_spin_count, 17) * 500, 0xf0, std::addressof(*resrv_mem), +rtime, vm::reservation_acquire(raddr));
+						__mwaitx<check_wait_t>(std::min<u64>(eventstat_spin_count, 17) * 500, 0xf0, std::addressof(*resrv_mem), +rtime, vm::reservation_acquire(raddr));
 					}
 				}
 				else

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -2987,7 +2987,7 @@ void Emulator::GracefulShutdown(bool allow_autoexit, bool async_op, bool savesta
 				});
 			}
 
-			if (static_cast<u64>(info) != m_stop_ctr || Emu.IsStopped())
+			if (static_cast<u64>(info) != m_stop_ctr || Emu.IsStopped(true))
 			{
 				return true;
 			}


### PR DESCRIPTION
We wait for the emu to stop, so it doesn't make sense to return the loop when we are "stopping".