### PR TITLE
Add RPCN Account Recovery Option

### DIFF
--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -302,6 +302,7 @@ namespace rpcn
 		ErrorType resend_token(const std::string& npid, const std::string& password);
 		ErrorType send_reset_token(std::string_view npid, std::string_view email);
 		ErrorType reset_password(std::string_view npid, std::string_view token, std::string_view password);
+		ErrorType recover_account(std::string_view email);
 		bool add_friend(const std::string& friend_username);
 		bool remove_friend(const std::string& friend_username);
 

--- a/rpcs3/Emu/NP/rpcn_types.h
+++ b/rpcs3/Emu/NP/rpcn_types.h
@@ -12,6 +12,7 @@ namespace rpcn
 		SendToken,
 		SendResetToken,
 		ResetPassword,
+		RecoverAccount,
 		ResetState,
 		AddFriend,
 		RemoveFriend,


### PR DESCRIPTION
Enables users to recover their RPCN accounts using their email address.
![image](https://github.com/user-attachments/assets/de552a01-17dc-494f-9fd6-55a67ce722e5)
![image](https://github.com/user-attachments/assets/82a12323-9986-4ec9-a7ac-4f9691039d21)


RPCN portion of PR here: https://github.com/RipleyTom/rpcn/pull/107