### PR TITLE
Logitech G27 fail unknown 0xa1 0x01 control transfer, add more logging

### DIFF
--- a/rpcs3/Emu/Io/LogitechG27.h
+++ b/rpcs3/Emu/Io/LogitechG27.h
@@ -99,6 +99,7 @@ public:
 	void control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer) override;
 	void interrupt_transfer(u32 buf_size, u8* buf, u32 endpoint, UsbTransfer* transfer) override;
 	bool open_device() override;
+	bool set_configuration(u8 cfg_num) override;
 
 private:
 	void sdl_refresh();


### PR DESCRIPTION
There's currently an unknown control transfer with the emulated g27, that doesn't happen in pass through packet capture with G27(emulated by G29) + GT5/GT6

```
sys_usbd: Unhandled control transfer: 0xa1
```

I have yet to figure out the source of this control transfer, why does both working games (GT5/GT6) and non work game(s) (F1 2010 as reported in https://github.com/RPCS3/rpcs3/issues/17191) emit it for the emulated device.

The change does not affect GT5/GT6 at all, those continue to work