### PR TITLE
Logitech G27 unset unverfied shifter connected bit 83

### DIFF
--- a/rpcs3/Emu/Io/LogitechG27.cpp
+++ b/rpcs3/Emu/Io/LogitechG27.cpp
@@ -119,12 +119,14 @@ u16 usb_device_logitech_g27::get_num_emu_devices()
 
 void usb_device_logitech_g27::control_transfer(u8 bmRequestType, u8 bRequest, u16 wValue, u16 wIndex, u16 wLength, u32 buf_size, u8* buf, UsbTransfer* transfer)
 {
+	// log these explicitly for now
+	logitech_g27_log.todo("control transfer bmRequestType %02x, bRequest %02x, wValue %04x, wIndex %04x, wLength %04x, %s", bmRequestType, bRequest, wValue, wIndex, wLength, fmt::buf_to_hexstring(buf, buf_size));
+
 	transfer->fake = true;
 	transfer->expected_count = buf_size;
 	transfer->expected_result = HC_CC_NOERR;
 	transfer->expected_time = get_timestamp() + 100;
 
-	// Log these for now, might not need to implement anything
 	usb_device_emulated::control_transfer(bmRequestType, bRequest, wValue, wIndex, wLength, buf_size, buf, transfer);
 }
 
@@ -746,8 +748,8 @@ void usb_device_logitech_g27::interrupt_transfer(u32 buf_size, u8* buf, u32 endp
 
 		// calibrated, unsure
 		set_bit(buf, 82, true);
-		// shifter connected
-		set_bit(buf, 83, true);
+		// shifter connected, 0 for now until it can be verified
+		set_bit(buf, 83, false);
 		// shifter stick down
 		set_bit(buf, 86, shifter_1 || shifter_2 || shifter_3 || shifter_4 || shifter_5 || shifter_6 || shifter_r);
 


### PR DESCRIPTION
Not having a shifter on my usb dump setup is making it a bit hard to get the protocol right

It would be very helpful if someone can provide with shifter G27 dumps from various games, to help sort this out

Apparently, the unknown control transfer mentioned over at https://github.com/RPCS3/rpcs3/pull/17198 only happens when input buffer bit 83 is set to true, but I'm not able to capture that on my G29 emulated G27 since I do not own the shifter addon for G29

```
sys_usbd: Unhandled control transfer: 0xa1
```

I'm unsure if the mentioned control transfer would return non error result if a shifter is connected to the wheel.

This PR carries a version of the emulated wheel that has bit 83 set to 0 instead of 1, for user feedback

While unsetting "shifter connected" on https://github.com/sonik-br/lgff_wheel_adapter/blob/d97f7823154818e1b3edff6d51498a122c302728/pico_lgff_wheel_adapter/reports.h#L265-L310 seems wrong, it does not affect shifter input in GT5/GT6 at all