### PR TITLE
rsx: Don't trigger surface swap-in/swap-out handlers when replacing self

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -435,7 +435,7 @@ namespace rsx
 			memory_tag_samples[0].second = ~memory_tag_samples[0].second;
 		}
 
-		bool test()
+		bool test() const
 		{
 			for (const auto& e : memory_tag_samples)
 			{

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -69,7 +69,10 @@ namespace gl
 		void create(u16 w, u16 h, u16 depth, u16 mipmaps, gl::texture* image, u32 rsx_pitch, bool managed,
 				gl::texture::format gl_format = gl::texture::format::rgba, gl::texture::type gl_type = gl::texture::type::ubyte, bool swap_bytes = false)
 		{
-			if (vram_texture && !managed_texture && get_protection() == utils::protection::no)
+			auto new_texture = static_cast<gl::viewable_image*>(image);
+			ensure(!exists() || !is_managed() || vram_texture == new_texture);
+
+			if (vram_texture != new_texture && !managed_texture && get_protection() == utils::protection::no)
 			{
 				// In-place image swap, still locked. Likely a color buffer that got rebound as depth buffer or vice-versa.
 				gl::as_rtt(vram_texture)->on_swap_out();
@@ -81,8 +84,6 @@ namespace gl
 				}
 			}
 
-			auto new_texture = static_cast<gl::viewable_image*>(image);
-			ensure(!exists() || !is_managed() || vram_texture == new_texture);
 			vram_texture = new_texture;
 
 			if (managed)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -47,7 +47,10 @@ namespace vk
 
 		void create(u16 w, u16 h, u16 depth, u16 mipmaps, vk::image* image, u32 rsx_pitch, bool managed, u32 gcm_format, bool pack_swap_bytes = false)
 		{
-			if (vram_texture && !managed_texture && get_protection() == utils::protection::no)
+			auto new_texture = static_cast<vk::viewable_image*>(image);
+			ensure(!exists() || !is_managed() || vram_texture == new_texture);
+
+			if (vram_texture != new_texture && !managed_texture && get_protection() == utils::protection::no)
 			{
 				// In-place image swap, still locked. Likely a color buffer that got rebound as depth buffer or vice-versa.
 				vk::as_rtt(vram_texture)->on_swap_out();
@@ -59,8 +62,6 @@ namespace vk
 				}
 			}
 
-			auto new_texture = static_cast<vk::viewable_image*>(image);
-			ensure(!exists() || !is_managed() || vram_texture == new_texture);
 			vram_texture = new_texture;
 
 			ensure(rsx_pitch);


### PR DESCRIPTION
Avoid unnecessary swap-out/swap-in pair when replacing a texture with itself. Nothing has changed obviously, so we should not mess with the tags.
Example of corrupted sequence:
```
E RSX: DSV is now locked                                                                      # Locked for WCB/WDB
E RSX: DSV of interest can be written to: tag=0xc6342, mask=true     # Render with write access to the data
E RSX: DSV is now unlocked!                                                                 # False swap-out caused by self-replace. Tags updated. 
E RSX: DSV is now locked                                                                      # False swap-in caused by self-replace. Tags updated again.
E RSX: DSV of interest can be written to: tag=0xc6566, mask=false    # New draw with read access to the data

# Next comes the memory fault. Because of the false swap-out/swap-in pair, the tags are falsely updated causing mismatch...

E RSX: Locked surface at 0x301c0000 has no flushable data! last_use_tag=0xc6342, texture_cache_metadata_tag=0xc6555, test=true
```

Fixes https://github.com/RPCS3/rpcs3/issues/15225