### PR TITLE
SPU: Improved GETLLAR spin detection conditions

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCrossController.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCrossController.cpp
@@ -107,13 +107,8 @@ struct cross_controller
 
 	void stop_thread()
 	{
-		if (connection_thread)
-		{
-			auto& thread = *connection_thread;
-			thread = thread_state::aborting;
-			thread();
-			connection_thread.reset();
-		}
+		// Join thread
+		connection_thread.reset();
 	};
 };
 

--- a/rpcs3/Emu/Cell/Modules/cellRec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellRec.cpp
@@ -828,13 +828,8 @@ void rec_info::stop_video_provider(bool flush)
 {
 	cellRec.notice("Stopping video provider.");
 
-	if (video_provider_thread)
-	{
-		auto& thread = *video_provider_thread;
-		thread = thread_state::aborting;
-		thread();
-		video_provider_thread.reset();
-	}
+	// Join thread
+	video_provider_thread.reset();
 
 	// Flush the ringbuffer if necessary.
 	// This should only happen if the video sink is not the encoder itself.

--- a/rpcs3/Emu/Cell/Modules/sceNpUtil.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpUtil.cpp
@@ -59,13 +59,7 @@ struct sce_np_util_manager
 
 	void join_thread()
 	{
-		if (bandwidth_test_thread)
-		{
-			auto& thread = *bandwidth_test_thread;
-			thread = thread_state::aborting;
-			thread();
-			bandwidth_test_thread.reset();
-		}
+		bandwidth_test_thread.reset();
 	}
 };
 

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -802,6 +802,7 @@ public:
 	u32 last_getllar = umax; // LS address of last GETLLAR (if matches current GETLLAR we can let the thread rest)
 	u32 last_getllar_gpr1 = umax;
 	u32 last_getllar_addr = umax;
+	u32 last_getllar_lsa = umax;
 	u32 getllar_spin_count = 0;
 	u32 getllar_busy_waiting_switch = umax; // umax means the test needs evaluation, otherwise it's a boolean
 	u64 getllar_evaluate_time = 0;

--- a/rpcs3/Emu/Io/LogitechG27.cpp
+++ b/rpcs3/Emu/Io/LogitechG27.cpp
@@ -88,14 +88,8 @@ static void clear_sdl_joysticks(std::map<u64, std::vector<SDL_Joystick*>>& joyst
 
 usb_device_logitech_g27::~usb_device_logitech_g27()
 {
-	// wait for the house keeping thread to finish
-	if (m_house_keeping_thread)
-	{
-		auto& thread = *m_house_keeping_thread;
-		thread = thread_state::aborting;
-		thread();
-		m_house_keeping_thread.reset();
-	}
+	// Wait for the house keeping thread to finish
+	m_house_keeping_thread.reset();
 
 	// Close sdl handles
 	{

--- a/rpcs3/Input/gui_pad_thread.cpp
+++ b/rpcs3/Input/gui_pad_thread.cpp
@@ -47,13 +47,8 @@ gui_pad_thread::gui_pad_thread()
 
 gui_pad_thread::~gui_pad_thread()
 {
-	if (m_thread)
-	{
-		auto& thread = *m_thread;
-		thread = thread_state::aborting;
-		thread();
-		m_thread.reset();
-	}
+	// Join thread
+	m_thread.reset();
 
 #ifdef __linux__
 	if (m_uinput_fd != 1)

--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -101,12 +101,8 @@ hid_pad_handler<Device>::hid_pad_handler(pad_handler type, std::vector<id_pair> 
 template <class Device>
 hid_pad_handler<Device>::~hid_pad_handler()
 {
-	if (m_enumeration_thread)
-	{
-		auto& enumeration_thread = *m_enumeration_thread;
-		enumeration_thread = thread_state::aborting;
-		enumeration_thread();
-	}
+	// Join thread
+	m_enumeration_thread.reset();
 
 	for (auto& controller : m_controllers)
 	{

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -309,13 +309,10 @@ void pad_thread::operator()()
 
 		for (auto& thread : threads)
 		{
-			if (thread)
-			{
-				auto& enumeration_thread = *thread;
-				enumeration_thread = thread_state::aborting;
-				enumeration_thread();
-			}
+			// Join thread (ordered explicitly)
+			thread.reset();
 		}
+
 		threads.clear();
 
 		input_log.notice("Pad threads stopped");

--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -277,13 +277,8 @@ void raw_mouse::update_values(s32 scan_code, bool pressed)
 
 raw_mouse_handler::~raw_mouse_handler()
 {
-	if (m_thread)
-	{
-		auto& thread = *m_thread;
-		thread = thread_state::aborting;
-		thread();
-		m_thread.reset();
-	}
+	// Join thread
+	m_thread.reset();
 
 #ifdef _WIN32
 	unregister_raw_input_devices();

--- a/rpcs3/rpcs3qt/pad_motion_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_motion_settings_dialog.cpp
@@ -231,13 +231,9 @@ pad_motion_settings_dialog::pad_motion_settings_dialog(QDialog* parent, std::sha
 
 pad_motion_settings_dialog::~pad_motion_settings_dialog()
 {
-	if (m_input_thread)
-	{
-		m_input_thread_state = input_thread_state::pausing;
-		auto& thread = *m_input_thread;
-		thread = thread_state::aborting;
-		thread();
-	}
+	// Join thread
+	m_input_thread_state = input_thread_state::pausing;
+	m_input_thread.reset();
 }
 
 void pad_motion_settings_dialog::change_device(int index)

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -269,13 +269,8 @@ ps_move_tracker_dialog::~ps_move_tracker_dialog()
 		m_camera_handler->close_camera();
 	}
 
-	if (m_input_thread)
-	{
-		auto& thread = *m_input_thread;
-		thread = thread_state::aborting;
-		thread();
-		m_input_thread.reset();
-	}
+	// Join thread
+	m_input_thread.reset();
 }
 
 void ps_move_tracker_dialog::update_color(bool update_sliders)

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -827,10 +827,7 @@ namespace utils
 				}
 			}
 
-			auto& thread = *m_thread;
-			thread = thread_state::aborting;
-			thread();
-
+			// Join thread
 			m_thread.reset();
 		}
 


### PR DESCRIPTION
* if code position has changed, disable operating system sleep.
* if GETLLAR output buffer address has changed, , disable operating system sleep.
* If GETLLAR output buffer belongs to the stack of a caller function, , disable operating system sleep.

Test #17200 please.