### PR TITLE
Gui: simplify LogitechG27 settings dialog

### DIFF
--- a/rpcs3/Emu/Io/LogitechG27Config.h
+++ b/rpcs3/Emu/Io/LogitechG27Config.h
@@ -69,48 +69,48 @@ public:
 	// TODO these defaults are for a shifter-less G29 + a xbox controller for shifter testing, perhaps find a new default
 	// TODO, when a new default is found, use the new device type id style
 
-	emulated_logitech_g27_mapping steering{this, "steering", 0x046dc24f, sdl_mapping_type::axis, 0, hat_component::none, false};
-	emulated_logitech_g27_mapping throttle{this, "throttle", 0x046dc24f, sdl_mapping_type::axis, 2, hat_component::none, false};
-	emulated_logitech_g27_mapping brake{this, "brake", 0x046dc24f, sdl_mapping_type::axis, 3, hat_component::none, false};
-	emulated_logitech_g27_mapping clutch{this, "clutch", 0x046dc24f, sdl_mapping_type::axis, 1, hat_component::none, false};
-	emulated_logitech_g27_mapping shift_up{this, "shift_up", 0x046dc24f, sdl_mapping_type::button, 4, hat_component::none, false};
-	emulated_logitech_g27_mapping shift_down{this, "shift_down", 0x046dc24f, sdl_mapping_type::button, 5, hat_component::none, false};
+	emulated_logitech_g27_mapping steering{this, "steering", 0, sdl_mapping_type::axis, 0, hat_component::none, false};
+	emulated_logitech_g27_mapping throttle{this, "throttle", 0, sdl_mapping_type::axis, 2, hat_component::none, false};
+	emulated_logitech_g27_mapping brake{this, "brake", 0, sdl_mapping_type::axis, 3, hat_component::none, false};
+	emulated_logitech_g27_mapping clutch{this, "clutch", 0, sdl_mapping_type::axis, 1, hat_component::none, false};
+	emulated_logitech_g27_mapping shift_up{this, "shift_up", 0, sdl_mapping_type::button, 4, hat_component::none, false};
+	emulated_logitech_g27_mapping shift_down{this, "shift_down", 0, sdl_mapping_type::button, 5, hat_component::none, false};
 
-	emulated_logitech_g27_mapping up{this, "up", 0x046dc24f, sdl_mapping_type::hat, 0, hat_component::up, false};
-	emulated_logitech_g27_mapping down{this, "down", 0x046dc24f, sdl_mapping_type::hat, 0, hat_component::down, false};
-	emulated_logitech_g27_mapping left{this, "left", 0x046dc24f, sdl_mapping_type::hat, 0, hat_component::left, false};
-	emulated_logitech_g27_mapping right{this, "right", 0x046dc24f, sdl_mapping_type::hat, 0, hat_component::right, false};
+	emulated_logitech_g27_mapping up{this, "up", 0, sdl_mapping_type::hat, 0, hat_component::up, false};
+	emulated_logitech_g27_mapping down{this, "down", 0, sdl_mapping_type::hat, 0, hat_component::down, false};
+	emulated_logitech_g27_mapping left{this, "left", 0, sdl_mapping_type::hat, 0, hat_component::left, false};
+	emulated_logitech_g27_mapping right{this, "right", 0, sdl_mapping_type::hat, 0, hat_component::right, false};
 
-	emulated_logitech_g27_mapping triangle{this, "triangle", 0x046dc24f, sdl_mapping_type::button, 3, hat_component::none, false};
-	emulated_logitech_g27_mapping cross{this, "cross", 0x046dc24f, sdl_mapping_type::button, 0, hat_component::none, false};
-	emulated_logitech_g27_mapping square{this, "square", 0x046dc24f, sdl_mapping_type::button, 1, hat_component::none, false};
-	emulated_logitech_g27_mapping circle{this, "circle", 0x046dc24f, sdl_mapping_type::button, 2, hat_component::none, false};
+	emulated_logitech_g27_mapping triangle{this, "triangle", 0, sdl_mapping_type::button, 3, hat_component::none, false};
+	emulated_logitech_g27_mapping cross{this, "cross", 0, sdl_mapping_type::button, 0, hat_component::none, false};
+	emulated_logitech_g27_mapping square{this, "square", 0, sdl_mapping_type::button, 1, hat_component::none, false};
+	emulated_logitech_g27_mapping circle{this, "circle", 0, sdl_mapping_type::button, 2, hat_component::none, false};
 
-	emulated_logitech_g27_mapping l2{this, "l2", 0x046dc24f, sdl_mapping_type::button, 7, hat_component::none, false};
-	emulated_logitech_g27_mapping l3{this, "l3", 0x046dc24f, sdl_mapping_type::button, 11, hat_component::none, false};
-	emulated_logitech_g27_mapping r2{this, "r2", 0x046dc24f, sdl_mapping_type::button, 6, hat_component::none, false};
-	emulated_logitech_g27_mapping r3{this, "r3", 0x046dc24f, sdl_mapping_type::button, 10, hat_component::none, false};
+	emulated_logitech_g27_mapping l2{this, "l2", 0, sdl_mapping_type::button, 7, hat_component::none, false};
+	emulated_logitech_g27_mapping l3{this, "l3", 0, sdl_mapping_type::button, 11, hat_component::none, false};
+	emulated_logitech_g27_mapping r2{this, "r2", 0, sdl_mapping_type::button, 6, hat_component::none, false};
+	emulated_logitech_g27_mapping r3{this, "r3", 0, sdl_mapping_type::button, 10, hat_component::none, false};
 
-	emulated_logitech_g27_mapping plus{this, "plus", 0x046dc24f, sdl_mapping_type::button, 19, hat_component::none, false};
-	emulated_logitech_g27_mapping minus{this, "minus", 0x046dc24f, sdl_mapping_type::button, 20, hat_component::none, false};
+	emulated_logitech_g27_mapping plus{this, "plus", 0, sdl_mapping_type::button, 19, hat_component::none, false};
+	emulated_logitech_g27_mapping minus{this, "minus", 0, sdl_mapping_type::button, 20, hat_component::none, false};
 
-	emulated_logitech_g27_mapping dial_clockwise{this, "dial_clockwise", 0x046dc24f, sdl_mapping_type::button, 21, hat_component::none, false};
-	emulated_logitech_g27_mapping dial_anticlockwise{this, "dial_anticlockwise", 0x046dc24f, sdl_mapping_type::button, 22, hat_component::none, false};
+	emulated_logitech_g27_mapping dial_clockwise{this, "dial_clockwise", 0, sdl_mapping_type::button, 21, hat_component::none, false};
+	emulated_logitech_g27_mapping dial_anticlockwise{this, "dial_anticlockwise", 0, sdl_mapping_type::button, 22, hat_component::none, false};
 
-	emulated_logitech_g27_mapping select{this, "select", 0x046dc24f, sdl_mapping_type::button, 8, hat_component::none, false};
-	emulated_logitech_g27_mapping pause{this, "pause", 0x046dc24f, sdl_mapping_type::button, 9, hat_component::none, false};
+	emulated_logitech_g27_mapping select{this, "select", 0, sdl_mapping_type::button, 8, hat_component::none, false};
+	emulated_logitech_g27_mapping pause{this, "pause", 0, sdl_mapping_type::button, 9, hat_component::none, false};
 
-	emulated_logitech_g27_mapping shifter_1{this, "shifter_1", 0x045e028e, sdl_mapping_type::button, 3, hat_component::none, false};
-	emulated_logitech_g27_mapping shifter_2{this, "shifter_2", 0x045e028e, sdl_mapping_type::button, 0, hat_component::none, false};
-	emulated_logitech_g27_mapping shifter_3{this, "shifter_3", 0x045e028e, sdl_mapping_type::button, 2, hat_component::none, false};
-	emulated_logitech_g27_mapping shifter_4{this, "shifter_4", 0x045e028e, sdl_mapping_type::button, 1, hat_component::none, false};
-	emulated_logitech_g27_mapping shifter_5{this, "shifter_5", 0x045e028e, sdl_mapping_type::hat, 0, hat_component::up, false};
-	emulated_logitech_g27_mapping shifter_6{this, "shifter_6", 0x045e028e, sdl_mapping_type::hat, 0, hat_component::down, false};
-	emulated_logitech_g27_mapping shifter_r{this, "shifter_r", 0x045e028e, sdl_mapping_type::hat, 0, hat_component::left, false};
+	emulated_logitech_g27_mapping shifter_1{this, "shifter_1", 0, sdl_mapping_type::button, 3, hat_component::none, false};
+	emulated_logitech_g27_mapping shifter_2{this, "shifter_2", 0, sdl_mapping_type::button, 0, hat_component::none, false};
+	emulated_logitech_g27_mapping shifter_3{this, "shifter_3", 0, sdl_mapping_type::button, 2, hat_component::none, false};
+	emulated_logitech_g27_mapping shifter_4{this, "shifter_4", 0, sdl_mapping_type::button, 1, hat_component::none, false};
+	emulated_logitech_g27_mapping shifter_5{this, "shifter_5", 0, sdl_mapping_type::hat, 0, hat_component::up, false};
+	emulated_logitech_g27_mapping shifter_6{this, "shifter_6", 0, sdl_mapping_type::hat, 0, hat_component::down, false};
+	emulated_logitech_g27_mapping shifter_r{this, "shifter_r", 0, sdl_mapping_type::hat, 0, hat_component::left, false};
 
-	cfg::_bool reverse_effects{this, "reverse_effects", true};
-	cfg::uint<0, 0xFFFFFFFFFFFFFFFF> ffb_device_type_id{this, "ffb_device_type_id", 0x046dc24f};
-	cfg::uint<0, 0xFFFFFFFFFFFFFFFF> led_device_type_id{this, "led_device_type_id", 0x046dc24f};
+	cfg::_bool reverse_effects{this, "reverse_effects", false};
+	cfg::uint<0, 0xFFFFFFFFFFFFFFFF> ffb_device_type_id{this, "ffb_device_type_id", 0};
+	cfg::uint<0, 0xFFFFFFFFFFFFFFFF> led_device_type_id{this, "led_device_type_id", 0};
 
 	cfg::_bool enabled{this, "enabled", false};
 

--- a/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
@@ -274,13 +274,15 @@ public:
 
 		update_display();
 
-		horizontal_layout->addWidget(label);
-		horizontal_layout->addWidget(m_display_box);
+		horizontal_layout->addWidget(label, 1);
+		horizontal_layout->addWidget(m_display_box, 2);
 		if (m_button_status)
-			horizontal_layout->addWidget(m_button_status);
-		horizontal_layout->addWidget(m_map_button);
-		horizontal_layout->addWidget(m_unmap_button);
-		horizontal_layout->addWidget(m_reverse_checkbox);
+			horizontal_layout->addWidget(m_button_status, 1);
+		else
+			horizontal_layout->addStretch(1); // For a more consistent layout
+		horizontal_layout->addWidget(m_map_button, 1);
+		horizontal_layout->addWidget(m_unmap_button, 1);
+		horizontal_layout->addWidget(m_reverse_checkbox, 1);
 
 		if (m_axis_status)
 			layout->addWidget(m_axis_status);

--- a/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
@@ -635,7 +635,7 @@ emulated_logitech_g27_settings_dialog::emulated_logitech_g27_settings_dialog(QWi
 	warning->setWordWrap(true);
 	v_layout->addWidget(warning);
 
-	QLabel* mapping_note = new QLabel(tr("Note: Please DO NOT map your wheel onto gamepads, only map it here. If your wheel was mapped onto gamepads, go to gamepad settings and unmap it. If you used vJoy to map your wheel onto a gamepad before for rpcs3, undo that."), this);
+	QLabel* mapping_note = new QLabel(tr("Note: Please DO NOT map your wheel onto gamepads, only map it here. If your wheel was mapped onto gamepads, go to gamepad settings and unmap it. If you used vJoy to map your wheel onto a gamepad before for RPCS3, undo that."), this);
 	mapping_note->setWordWrap(true);
 	v_layout->addWidget(mapping_note);
 

--- a/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
@@ -5,6 +5,7 @@
 #include "emulated_logitech_g27_settings_dialog.h"
 #include "Emu/Io/LogitechG27.h"
 #include "Input/sdl_instance.h"
+#include "qt_utils.h"
 
 #include <QDialogButtonBox>
 #include <QGroupBox>
@@ -633,7 +634,7 @@ emulated_logitech_g27_settings_dialog::emulated_logitech_g27_settings_dialog(QWi
 	});
 
 	QLabel* warning = new QLabel(tr("Warning: Force feedback output were meant for Logitech G27, on stronger wheels please adjust force strength accordingly in your wheel software."), this);
-	warning->setStyleSheet("color: red;");
+	warning->setStyleSheet(QString("color: %0;").arg(gui::utils::get_label_color("emulated_logitech_g27_warning_label", Qt::red, Qt::red).name()));
 	warning->setWordWrap(true);
 	v_layout->addWidget(warning);
 

--- a/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.h
+++ b/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.h
@@ -30,6 +30,8 @@ struct joystick_state
 class Mapping;
 class DeviceChoice;
 
+enum class mapping_device;
+
 class emulated_logitech_g27_settings_dialog : public QDialog
 {
 	Q_OBJECT
@@ -56,44 +58,7 @@ private:
 	QCheckBox* m_enabled = nullptr;
 	QCheckBox* m_reverse_effects = nullptr;
 
-	Mapping* m_steering = nullptr;
-	Mapping* m_throttle = nullptr;
-	Mapping* m_brake = nullptr;
-	Mapping* m_clutch = nullptr;
-	Mapping* m_shift_up = nullptr;
-	Mapping* m_shift_down = nullptr;
-
-	Mapping* m_up = nullptr;
-	Mapping* m_down = nullptr;
-	Mapping* m_left = nullptr;
-	Mapping* m_right = nullptr;
-
-	Mapping* m_triangle = nullptr;
-	Mapping* m_cross = nullptr;
-	Mapping* m_square = nullptr;
-	Mapping* m_circle = nullptr;
-
-	Mapping* m_l2 = nullptr;
-	Mapping* m_l3 = nullptr;
-	Mapping* m_r2 = nullptr;
-	Mapping* m_r3 = nullptr;
-
-	Mapping* m_plus = nullptr;
-	Mapping* m_minus = nullptr;
-
-	Mapping* m_dial_clockwise = nullptr;
-	Mapping* m_dial_anticlockwise = nullptr;
-
-	Mapping* m_select = nullptr;
-	Mapping* m_pause = nullptr;
-
-	Mapping* m_shifter_1 = nullptr;
-	Mapping* m_shifter_2 = nullptr;
-	Mapping* m_shifter_3 = nullptr;
-	Mapping* m_shifter_4 = nullptr;
-	Mapping* m_shifter_5 = nullptr;
-	Mapping* m_shifter_6 = nullptr;
-	Mapping* m_shifter_r = nullptr;
+	std::map<mapping_device, Mapping*> m_mappings;
 
 	DeviceChoice* m_ffb_device = nullptr;
 	DeviceChoice* m_led_device = nullptr;


### PR DESCRIPTION
- Simplify LogitechG27 settings dialog by deduplicating some code
- This removes the necessity to maintain two seperate translations for the mappings (which was already not identical in case of Gear R/r )
- Fixes some style/naming issues
- Improve layout to better align buttons