### PR TITLE
Logitech G27 update shifter input

### DIFF
--- a/rpcs3/Emu/Io/LogitechG27.cpp
+++ b/rpcs3/Emu/Io/LogitechG27.cpp
@@ -763,12 +763,12 @@ void usb_device_logitech_g27::interrupt_transfer(u32 buf_size, u8* buf, u32 endp
 		// rough analog values recorded in https://github.com/RPCS3/rpcs3/pull/17199#issuecomment-2883934412
 		// buf[8] shifter x
 		// buf[9] shifter y
-		static const u8 shifter_coord_center = 0x80;
-		static const u8 shifter_coord_top = 0xb7;
-		static const u8 shifter_coord_bottom = 0x32;
-		static const u8 shifter_coord_left = 0x30;
-		static const u8 shifter_coord_right = 0xb3;
-		static const u8 shifter_coord_right_reverse = 0xaa;
+		constexpr u8 shifter_coord_center = 0x80;
+		constexpr u8 shifter_coord_top = 0xb7;
+		constexpr u8 shifter_coord_bottom = 0x32;
+		constexpr u8 shifter_coord_left = 0x30;
+		constexpr u8 shifter_coord_right = 0xb3;
+		constexpr u8 shifter_coord_right_reverse = 0xaa;
 		if (shifter_1)
 		{
 			buf[8] = shifter_coord_left;

--- a/rpcs3/Emu/Io/LogitechG27.cpp
+++ b/rpcs3/Emu/Io/LogitechG27.cpp
@@ -209,6 +209,7 @@ static inline logitech_g27_sdl_mapping get_runtime_mapping()
 	convert_mapping(cfg.shifter_5, mapping.shifter_5);
 	convert_mapping(cfg.shifter_6, mapping.shifter_6);
 	convert_mapping(cfg.shifter_r, mapping.shifter_r);
+	convert_mapping(cfg.shifter_press, mapping.shifter_press);
 
 	return mapping;
 }
@@ -711,6 +712,7 @@ void usb_device_logitech_g27::interrupt_transfer(u32 buf_size, u8* buf, u32 endp
 		const bool shifter_5 = sdl_to_logitech_g27_button(m_joysticks, m_mapping.shifter_5);
 		const bool shifter_6 = sdl_to_logitech_g27_button(m_joysticks, m_mapping.shifter_6);
 		const bool shifter_r = sdl_to_logitech_g27_button(m_joysticks, m_mapping.shifter_r);
+		const bool shifter_press = sdl_to_logitech_g27_button(m_joysticks, m_mapping.shifter_press);
 		m_sdl_handles_mutex.unlock();
 
 		// populate buffer
@@ -750,7 +752,7 @@ void usb_device_logitech_g27::interrupt_transfer(u32 buf_size, u8* buf, u32 endp
 		// shifter connected
 		set_bit(buf, 83, true);
 		// shifter stick down
-		set_bit(buf, 86, shifter_1 || shifter_2 || shifter_3 || shifter_4 || shifter_5 || shifter_6 || shifter_r);
+		set_bit(buf, 86, shifter_press);
 
 		buf[3] = (steering << 2) | buf[3];
 		buf[4] = steering >> 6;
@@ -758,8 +760,56 @@ void usb_device_logitech_g27::interrupt_transfer(u32 buf_size, u8* buf, u32 endp
 		buf[6] = brake;
 		buf[7] = clutch;
 
-		buf[8] = 0x80; // shifter x, don't own one to test gear/coord mapping
-		buf[9] = 0x80; // shifter y
+		// rough analog values recorded in https://github.com/RPCS3/rpcs3/pull/17199#issuecomment-2883934412
+		// buf[8] shifter x
+		// buf[9] shifter y
+		static const u8 shifter_coord_center = 0x80;
+		static const u8 shifter_coord_top = 0xb7;
+		static const u8 shifter_coord_bottom = 0x32;
+		static const u8 shifter_coord_left = 0x30;
+		static const u8 shifter_coord_right = 0xb3;
+		static const u8 shifter_coord_right_reverse = 0xaa;
+		if (shifter_1)
+		{
+			buf[8] = shifter_coord_left;
+			buf[9] = shifter_coord_top;
+		}
+		else if (shifter_2)
+		{
+			buf[8] = shifter_coord_left;
+			buf[9] = shifter_coord_bottom;
+		}
+		else if (shifter_3)
+		{
+			buf[8] = shifter_coord_center;
+			buf[9] = shifter_coord_top;
+		}
+		else if (shifter_4)
+		{
+			buf[8] = shifter_coord_center;
+			buf[9] = shifter_coord_bottom;
+		}
+		else if (shifter_5)
+		{
+			buf[8] = shifter_coord_right;
+			buf[9] = shifter_coord_top;
+		}
+		else if (shifter_6)
+		{
+			buf[8] = shifter_coord_right;
+			buf[9] = shifter_coord_bottom;
+		}
+		else if (shifter_r)
+		{
+			buf[8] = shifter_coord_right_reverse;
+			buf[9] = shifter_coord_bottom;
+		}
+		else
+		{
+			buf[8] = shifter_coord_center;
+			buf[9] = shifter_coord_center;
+		}
+
 		buf[10] = buf[10] | (m_wheel_range > 360 ? 0x90 : 0x10);
 
 		// logitech_g27_log.error("%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10]);

--- a/rpcs3/Emu/Io/LogitechG27.h
+++ b/rpcs3/Emu/Io/LogitechG27.h
@@ -94,6 +94,7 @@ struct logitech_g27_sdl_mapping
 	sdl_mapping shifter_5 {};
 	sdl_mapping shifter_6 {};
 	sdl_mapping shifter_r {};
+	sdl_mapping shifter_press {};
 };
 
 class usb_device_logitech_g27 : public usb_device_emulated

--- a/rpcs3/Emu/Io/LogitechG27Config.h
+++ b/rpcs3/Emu/Io/LogitechG27Config.h
@@ -107,6 +107,7 @@ public:
 	emulated_logitech_g27_mapping shifter_5{this, "shifter_5", 0, sdl_mapping_type::hat, 0, hat_component::up, false};
 	emulated_logitech_g27_mapping shifter_6{this, "shifter_6", 0, sdl_mapping_type::hat, 0, hat_component::down, false};
 	emulated_logitech_g27_mapping shifter_r{this, "shifter_r", 0, sdl_mapping_type::hat, 0, hat_component::left, false};
+	emulated_logitech_g27_mapping shifter_press{this, "shifter_press", 0, sdl_mapping_type::hat, 0, hat_component::right, false};
 
 	cfg::_bool reverse_effects{this, "reverse_effects", false};
 	cfg::uint<0, 0xFFFFFFFFFFFFFFFF> ffb_device_type_id{this, "ffb_device_type_id", 0};

--- a/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp
@@ -68,6 +68,7 @@ enum class mapping_device
 	SHIFTER_5,
 	SHIFTER_6,
 	SHIFTER_R,
+	SHIFTER_PRESS,
 
 	// Enum count
 	COUNT
@@ -109,6 +110,7 @@ QString device_name(mapping_device dev)
 	case mapping_device::SHIFTER_5: return QObject::tr("Gear 5");
 	case mapping_device::SHIFTER_6: return QObject::tr("Gear 6");
 	case mapping_device::SHIFTER_R: return QObject::tr("Gear R");
+	case mapping_device::SHIFTER_PRESS: return QObject::tr("Shifter press");
 	case mapping_device::COUNT: return "";
 	}
 	return "";
@@ -151,6 +153,7 @@ emulated_logitech_g27_mapping& device_cfg(mapping_device dev)
 	case mapping_device::SHIFTER_5: return cfg.shifter_5;
 	case mapping_device::SHIFTER_6: return cfg.shifter_6;
 	case mapping_device::SHIFTER_R: return cfg.shifter_r;
+	case mapping_device::SHIFTER_PRESS: return cfg.shifter_press;
 	default: fmt::throw_exception("Unexpected mapping_device %d", static_cast<int>(dev));
 	}
 }


### PR DESCRIPTION
Based on the information provided by @Florin9doi
https://github.com/RPCS3/rpcs3/pull/17199#issuecomment-2883934412

Although it seems that (some) Logitech shifters mechanically requires press down to shift into reverse (but not out of), keep press down as a user mapping for flexibility against different hardware and games; if desired, users can map both shifter_r and shifter_press onto the same input.