### PR TITLE
sdl_pad_handler run sdl_instance::get_instance().initialize() outside of main thread

### DIFF
--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -180,12 +180,7 @@ bool sdl_pad_handler::Init()
 	if (m_is_init)
 		return true;
 
-	bool instance_success;
-
-	Emu.BlockingCallFromMainThread([&instance_success]()
-	{
-		instance_success = sdl_instance::get_instance().initialize();
-	});
+	const bool instance_success = sdl_instance::get_instance().initialize();
 
 	if (!instance_success)
 		return false;

--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -180,9 +180,7 @@ bool sdl_pad_handler::Init()
 	if (m_is_init)
 		return true;
 
-	const bool instance_success = sdl_instance::get_instance().initialize();
-
-	if (!instance_success)
+	if (!sdl_instance::get_instance().initialize())
 		return false;
 
 	if (g_cfg.io.load_sdl_mappings)


### PR DESCRIPTION
sdl instance init now has it's own lock, it might be fine to run it outside of main thread

@gdawg can you check if this causes issues on MacOS? https://github.com/RPCS3/rpcs3/pull/16487

addresses https://github.com/RPCS3/rpcs3/issues/17227

```
(lldb) thread list 
Process 8 stopped
* thread #1: tid = 8, 0x00007fcfd94a8a8d libc.so.6`syscall + 29, name = 'rpcs3', stop reason = signal SIGSTOP
  thread #2: tid = 10, 0x00007fcfd94306c2 libc.so.6`__syscall_cancel_arch_end, name = 'Log Writer'
  thread #3: tid = 11, 0x00007fcfd94306c2 libc.so.6`__syscall_cancel_arch_end, name = 'QXcbEventQueue'
  thread #4: tid = 15, 0x00007fcfd94306c2 libc.so.6`__syscall_cancel_arch_end, name = 'QDBusConnection'
  thread #9: tid = 38, 0x00007fcfd94306c2 libc.so.6`__syscall_cancel_arch_end, name = 'libusb_event'
  thread #10: tid = 39, 0x00007fcfd94306c2 libc.so.6`__syscall_cancel_arch_end, name = 'libusb'
  thread #11: tid = 68, 0x00007fcfd94306c2 libc.so.6`__syscall_cancel_arch_end, name = 'QPulseAudioEngi'
  thread #16: tid = 285, 0x00007fcfd94a8a8d libc.so.6`syscall + 29, name = 'Gui Pad Thread'
(lldb) thread select 16
* thread #16, name = 'Gui Pad Thread'
    frame #0: 0x00007fcfd94a8a8d libc.so.6`syscall + 29
libc.so.6`syscall:
->  0x7fcfd94a8a8d <+29>: cmpq   $-0xfff, %rax  ; imm = 0xF001 
    0x7fcfd94a8a93 <+35>: jae    0x7fcfd94a8a96 ; <+38>
    0x7fcfd94a8a95 <+37>: retq   
    0x7fcfd94a8a96 <+38>: movq   0xf634b(%rip), %rcx ; _GLOBAL_OFFSET_TABLE_ + 648
(lldb) bt 
* thread #16, name = 'Gui Pad Thread'
  * frame #0: 0x00007fcfd94a8a8d libc.so.6`syscall + 29
    frame #1: 0x0000000001d12f40 rpcs3`futex(uaddr=0x00007fcedaff72b0, futex_op=128, val=0, timeout=0x0000000000000000, mask=0) at sync.h:78:9
    frame #2: 0x0000000001d12758 rpcs3`atomic_wait_engine::wait(data=0x00007fcedaff72b0, old_value=0, timeout=18446744073709551615, ext=0x0000000000000000) at atomic.cpp:928:7
    frame #3: 0x00000000011661d7 rpcs3`atomic_t<unsigned int, 4ul>::wait(this=0x00007fcedaff72b0, old_value=0, timeout=inf) const requires sizeof (std::remove_cv<T>::type) == 4 at atomic.hpp:1691:3
    frame #4: 0x0000000001c9696d rpcs3`Emulator::BlockingCallFromMainThread(this=0x00000000033bf0c0, func=0x00007fcedaff7438, src_loc=source_location @ 0x00007fcedaff72a8) const at System.cpp:206:11
    frame #5: 0x00000000016247ab rpcs3`sdl_pad_handler::Init(this=0x00007fcde6811840) at sdl_pad_handler.cpp:185:6
    frame #6: 0x000000000158be75 rpcs3`gui_pad_thread::init(this=0x0000000039ff3c50) at gui_pad_thread.cpp:130:20
    frame #7: 0x000000000158de5a rpcs3`gui_pad_thread::run(this=0x0000000039ff3c50) at gui_pad_thread.cpp:258:9
    frame #8: 0x000000000158f898 rpcs3`gui_pad_thread::gui_pad_thread()::$_0::operator()(this=0x0000000035deebc0) const at gui_pad_thread.cpp:45:95
    frame #9: 0x000000000158f875 rpcs3`void std::__invoke_impl<void, gui_pad_thread::gui_pad_thread()::$_0&>((null)=__invoke_other @ 0x00007fcedaff822f, __f=0x0000000035deebc0) at invoke.h:63:14
    frame #10: 0x000000000158f825 rpcs3`std::enable_if<is_invocable_r_v<void, gui_pad_thread::gui_pad_thread()::$_0&>, void>::type std::__invoke_r<void, gui_pad_thread::gui_pad_thread()::$_0&>(__fn=0x0000000035deebc0) at invoke.h:113:2
    frame #11: 0x000000000158f74d rpcs3`std::_Function_handler<void (), gui_pad_thread::gui_pad_thread()::$_0>::_M_invoke(__functor=0x0000000035deebc0) at std_function.h:292:9
    frame #12: 0x0000000000f8198e rpcs3`std::function<void ()>::operator()(this=0x0000000035deebc0) const at std_function.h:593:9
    frame #13: 0x000000000125225a rpcs3`named_thread<std::function<void ()>>::entry_point2(this=0x0000000035deebc0) at Thread.h:488:14
    frame #14: 0x0000000001248bb9 rpcs3`named_thread<std::function<void ()>>::entry_point(_base=0x0000000035deebe0) at Thread.h:469:45
    frame #15: 0x00007fcfc8d6050b
    frame #16: 0x00007fcfd94aacec libc.so.6`__clone3 + 44
```