### PR TITLE
Remove roadmap link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ If you want to contribute as a developer, please take a look at the following pa
 
 * [Coding Style](https://github.com/RPCS3/rpcs3/wiki/Coding-Style)
 * [Developer Information](https://github.com/RPCS3/rpcs3/wiki/Developer-Information)
-* [Roadmap](https://rpcs3.net/roadmap)
 
 You should also contact any of the developers in the forums or in the Discord server to learn more about the current state of the emulator.
 


### PR DESCRIPTION
Roadmap was removed from the website as it wasn't updated in years.