### PR TITLE
rsx: Flush MM queue before applying nv3089 block transfers

### DIFF
--- a/rpcs3/Emu/RSX/Host/MM.h
+++ b/rpcs3/Emu/RSX/Host/MM.h
@@ -3,6 +3,9 @@
 #include <util/types.hpp>
 #include <util/vm.hpp>
 
+#include "Emu/RSX/Common/simple_array.hpp"
+#include "Utilities/address_range.h"
+
 namespace rsx
 {
 	struct MM_block
@@ -36,5 +39,6 @@ namespace rsx
 	void mm_protect(void* start, u64 length, utils::protection prot);
 	void mm_flush_lazy();
 	void mm_flush(u32 vm_address);
+	void mm_flush(const rsx::simple_array<utils::address_range>& ranges);
 	void mm_flush();
 }

--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -3,6 +3,7 @@
 
 #include "Emu/RSX/RSXThread.h"
 #include "Emu/RSX/Core/RSXReservationLock.hpp"
+#include "Emu/RSX/Host/MM.h"
 
 #include "context_accessors.define.h"
 
@@ -56,6 +57,13 @@ namespace rsx
 			}
 
 			auto res = ::rsx::reservation_lock<true>(write_address, write_length, read_address, read_length);
+
+			rsx::simple_array<utils::address_range> flush_mm_ranges =
+			{
+				utils::address_range::start_length(write_address, write_length).to_page_range(),
+				utils::address_range::start_length(read_address, read_length).to_page_range()
+			};
+			rsx::mm_flush(flush_mm_ranges);
 
 			u8 *dst = vm::_ptr<u8>(write_address);
 			const u8 *src = vm::_ptr<u8>(read_address);


### PR DESCRIPTION
Closes https://github.com/RPCS3/rpcs3/issues/16845
Relates to https://github.com/RPCS3/rpcs3/issues/16800