### PR TITLE
restore ffmpeg dependencies on linux

### DIFF
--- a/.ci/deploy-linux.sh
+++ b/.ci/deploy-linux.sh
@@ -26,9 +26,6 @@ if [ "$DEPLOY_APPIMAGE" = "true" ]; then
     rm -f ./AppDir/usr/lib/libvulkan.so*
 
     # Remove unused Qt6 libraries
-    rm -f ./AppDir/usr/lib/libQt6OpenGL.so*
-    rm -f ./AppDir/usr/lib/libQt6Qml*.so*
-    rm -f ./AppDir/usr/lib/libQt6Quick.so*
     rm -f ./AppDir/usr/lib/libQt6VirtualKeyboard.so*
     rm -f ./AppDir/usr/plugins/platforminputcontexts/libqtvirtualkeyboardplugin.so*
 


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/17269

Running `ldd /tmp/.mount_*/usr/plugins/multimedia/libffmpegmediaplugin.so` will list the linked dependencies.
The AppImage will search for system libs if not packaged in the image, and will fail if not a version match.