### PR TITLE
Logs: use thread_local

### DIFF
--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -397,8 +397,8 @@ void logs::message::broadcast(const char* fmt, const fmt_type_info* sup, ...) co
 	g_tls_log_control(fmt, 0);
 
 	// Get text, extract va_args
-	/*constinit thread_local*/ std::string text;
-	/*constinit thread_local*/ std::vector<u64> args;
+	thread_local std::string text;
+	thread_local std::vector<u64> args;
 
 	static constexpr fmt_type_info empty_sup{};
 
@@ -406,7 +406,7 @@ void logs::message::broadcast(const char* fmt, const fmt_type_info* sup, ...) co
 	for (auto v = sup; v && v->fmt_string; v++)
 		args_count++;
 
-	text.reserve(50000);
+	text.clear();
 	args.resize(args_count);
 
 	va_list c_args;


### PR DESCRIPTION
Constinit can't be used on std::string or std::vector.
So let's just use thread_local. maybe it helps...

closes #16287