### PR TITLE
Make sure hid_enumerate isn't called simultaneously in different threads

### DIFF
--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -199,7 +199,11 @@ void hid_pad_handler<Device>::enumerate_devices()
 			}
 		}
 	}
-#else
+#endif
+
+	std::lock_guard lock(m_enumeration_mutex);
+
+#ifndef ANDROID
 	for (const auto& [vid, pid] : m_ids)
 	{
 		hid_device_info* dev_info = hid_enumerate(vid, pid);
@@ -230,7 +234,6 @@ void hid_pad_handler<Device>::enumerate_devices()
 #endif
 	hid_log.notice("%s enumeration found %d devices (%f ms)", m_type, device_paths.size(), timer.GetElapsedTimeInMilliSec());
 
-	std::lock_guard lock(m_enumeration_mutex);
 	m_new_enumerated_devices = device_paths;
 	m_enumerated_serials = std::move(serials);
 


### PR DESCRIPTION
Tries to fix https://github.com/RPCS3/rpcs3/issues/11339#issuecomment-2936528036

(currently untested however, am trying to build to see as I see the issue consistently)