### PR TITLE
SPU: Skip PUTLLUC writes of the same data

### DIFF
--- a/rpcs3/Emu/Memory/vm_reservation.h
+++ b/rpcs3/Emu/Memory/vm_reservation.h
@@ -35,6 +35,7 @@ namespace vm
 
 	// Update reservation status
 	void reservation_update(u32 addr);
+	std::pair<bool, u64> try_reservation_update(u32 addr);
 
 	struct reservation_waiter_t
 	{


### PR DESCRIPTION
Avoid halting PPUs for writes which can be ignored because they do not change data. Simply update reservation timestamp and leave.