### PR TITLE
input: only copy relevant members to external buttons and sticks

### DIFF
--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -379,20 +379,22 @@ enum special_button_value
 struct Button
 {
 	u32 m_offset = 0;
-	std::set<u32> m_key_codes{};
 	u32 m_outKeyCode = 0;
 	u16 m_value    = 0;
 	bool m_pressed = false;
+
+	std::set<u32> m_key_codes{};
 
 	u16 m_actual_value = 0;              // only used in keyboard_pad_handler
 	bool m_analog      = false;          // only used in keyboard_pad_handler
 	bool m_trigger     = false;          // only used in keyboard_pad_handler
 	std::map<u32, u16> m_pressed_keys{}; // only used in keyboard_pad_handler
 
+	Button(){}
 	Button(u32 offset, std::set<u32> key_codes, u32 outKeyCode)
 		: m_offset(offset)
-		, m_key_codes(std::move(key_codes))
 		, m_outKeyCode(outKeyCode)
+		, m_key_codes(std::move(key_codes))
 	{
 		if (offset == CELL_PAD_BTN_OFFSET_DIGITAL1)
 		{
@@ -419,9 +421,10 @@ struct Button
 struct AnalogStick
 {
 	u32 m_offset = 0;
+	u16 m_value = 128;
+
 	std::set<u32> m_key_codes_min{};
 	std::set<u32> m_key_codes_max{};
-	u16 m_value = 128;
 
 	std::map<u32, u16> m_pressed_keys_min{}; // only used in keyboard_pad_handler
 	std::map<u32, u16> m_pressed_keys_max{}; // only used in keyboard_pad_handler

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -305,8 +305,27 @@ void pad_thread::apply_copilots()
 			continue;
 		}
 
-		pad->m_buttons_external = pad->m_buttons;
-		pad->m_sticks_external = pad->m_sticks;
+		pad->m_buttons_external.resize(pad->m_buttons.size());
+
+		for (usz i = 0; i < pad->m_buttons.size(); i++)
+		{
+			const Button& src = pad->m_buttons[i];
+			Button& dst = pad->m_buttons_external[i];
+
+			dst.m_offset = src.m_offset;
+			dst.m_outKeyCode = src.m_outKeyCode;
+			dst.m_value = src.m_value;
+			dst.m_pressed = src.m_pressed;
+		}
+
+		for (usz i = 0; i < pad->m_sticks.size(); i++)
+		{
+			const AnalogStick& src = pad->m_sticks[i];
+			AnalogStick& dst = pad->m_sticks_external[i];
+
+			dst.m_offset = src.m_offset;
+			dst.m_value = src.m_value;
+		}
 
 		if (pad->copilots.empty() || pad->is_copilot())
 		{


### PR DESCRIPTION
fixes a crash in std::set, which is not thread safe

fixes #17295