### PR TITLE
Fix invalid comparator in savedata_op sorting

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -862,11 +862,11 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			{
 				if (order == CELL_SAVEDATA_SORTORDER_DESCENT && type == CELL_SAVEDATA_SORTTYPE_MODIFIEDTIME)
 				{
-					return entry1.mtime >= entry2.mtime;
+					return entry1.mtime > entry2.mtime;
 				}
 				if (order == CELL_SAVEDATA_SORTORDER_DESCENT && type == CELL_SAVEDATA_SORTTYPE_SUBTITLE)
 				{
-					return entry1.subtitle >= entry2.subtitle;
+					return entry1.subtitle > entry2.subtitle;
 				}
 				if (order == CELL_SAVEDATA_SORTORDER_ASCENT && type == CELL_SAVEDATA_SORTTYPE_MODIFIEDTIME)
 				{


### PR DESCRIPTION
According to the C++ standard, comparison functions used in sorting algorithms such as std::sort must establish a strict weak ordering. Specifically, the comparator must be irreflexive: for all values x, comp(x, x) must be false.

The original comparator used >= for descending order, which violates this requirement in the case of equal values (i.e., when a == b, both comp(a, b) and comp(b, a) would return true). This can result in undefined behavior in sorting algorithms, including potential segmentation faults due to invalid iterator manipulation.

This change replaces >= with > to ensure irreflexivity and compliance with the standard's requirement for a strict weak ordering.