### PR TITLE
vk: Properly initialize VS inputs

### DIFF
--- a/rpcs3/Emu/RSX/GL/glutils/program.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/program.cpp
@@ -128,6 +128,8 @@ namespace gl
 				case ::glsl::program_domain::glsl_compute_program:
 					base_name = "shaderlog/ComputeProgram";
 					break;
+				default:
+					fmt::throw_exception("Unexpected program type %d", static_cast<int>(type));
 				}
 
 				fs::write_file(fs::get_cache_dir() + base_name + std::to_string(m_id) + ".glsl", fs::rewrite, str, length);

--- a/rpcs3/Emu/RSX/Program/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Program/GLSLTypes.h
@@ -6,7 +6,10 @@ namespace glsl
 	{
 		glsl_vertex_program = 0,
 		glsl_fragment_program = 1,
-		glsl_compute_program = 2
+		glsl_compute_program = 2,
+
+		// Meta
+		glsl_invalid_program = 0xff
 	};
 
 	enum glsl_rules : unsigned char

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
@@ -22,7 +22,9 @@ namespace vk
 			input_type_storage_texture,
 			input_type_push_constant,
 
-			input_type_max_enum
+			// Meta
+			input_type_max_enum,
+			input_type_undefined = umax
 		};
 
 		struct bound_sampler
@@ -48,15 +50,15 @@ namespace vk
 
 		struct program_input
 		{
-			::glsl::program_domain domain;
-			program_input_type type;
+			::glsl::program_domain domain = ::glsl::glsl_invalid_program;
+			program_input_type type = input_type_undefined;
 
 			using bound_data_t = std::variant<bound_buffer, bound_sampler, push_constant_ref>;
 			bound_data_t bound_data;
 
 			u32 set = 0;
 			u32 location = umax;
-			std::string name;
+			std::string name = "undefined";
 
 			inline bound_buffer& as_buffer() { return *std::get_if<bound_buffer>(&bound_data); }
 			inline bound_sampler& as_sampler() { return *std::get_if<bound_sampler>(&bound_data); }


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/17367

During the rewrite, VS inputs remained the same, relying on default state of inputs. Default init for unreliable fields is now set to some invalid enum constants to trigger asserts. That's a lot better than random data.