### PR TITLE
Patch manager:  Fix configurable value dropdown visibility

### DIFF
--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -549,7 +549,7 @@ void patch_manager_dialog::filter_patches(const QString& term)
 	m_expand_current_match = false;
 }
 
-void patch_manager_dialog::update_patch_info(const patch_manager_dialog::gui_patch_info& info) const
+void patch_manager_dialog::update_patch_info(const patch_manager_dialog::gui_patch_info& info, bool force_update) const
 {
 	ui->label_hash->setText(info.hash);
 	ui->label_author->setText(info.author);
@@ -577,7 +577,7 @@ void patch_manager_dialog::update_patch_info(const patch_manager_dialog::gui_pat
 		return;
 	}
 
-	if (key == info.config_value_key)
+	if (!force_update && key == info.config_value_key)
 	{
 		// Don't update widget if the config key did not change
 		return;
@@ -641,7 +641,7 @@ void patch_manager_dialog::handle_item_selected(QTreeWidgetItem* current, QTreeW
 	if (!current)
 	{
 		// Clear patch info if no item is selected
-		update_patch_info({});
+		update_patch_info({}, true);
 		return;
 	}
 
@@ -719,7 +719,7 @@ void patch_manager_dialog::handle_item_selected(QTreeWidgetItem* current, QTreeW
 	}
 	}
 
-	update_patch_info(info);
+	update_patch_info(info, current != previous);
 
 	const QString key = ui->configurable_selector->currentIndex() < 0 ? "" : ui->configurable_selector->currentData().toString();
 	current->setData(0, config_key_role, key);

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -735,41 +735,48 @@ void patch_manager_dialog::handle_item_changed(QTreeWidgetItem* item, int /*colu
 	// Get checkstate of the item
 	const bool enabled = item->checkState(0) == Qt::CheckState::Checked;
 
-	// Get patch identifiers stored in item data
-	const node_level level = static_cast<node_level>(item->data(0, node_level_role).toInt());
-	const std::string hash = item->data(0, hash_role).toString().toStdString();
-	const std::string title = item->data(0, title_role).toString().toStdString();
-	const std::string serial = item->data(0, serial_role).toString().toStdString();
-	const std::string app_version = item->data(0, app_version_role).toString().toStdString();
-	const std::string description = item->data(0, description_role).toString().toStdString();
-	const std::string patch_group = item->data(0, patch_group_role).toString().toStdString();
-
 	// Uncheck other patches with the same patch_group if this patch was enabled
-	if (const auto node = item->parent(); node && enabled && !patch_group.empty() && level == node_level::patch_level)
+	if (const auto node = item->parent(); node && enabled)
 	{
-		for (int i = 0; i < node->childCount(); i++)
-		{
-			if (const auto other = node->child(i); other && other != item)
-			{
-				const std::string other_patch_group = other->data(0, patch_group_role).toString().toStdString();
+		const node_level level = static_cast<node_level>(item->data(0, node_level_role).toInt());
+		const std::string patch_group = item->data(0, patch_group_role).toString().toStdString();
 
-				if (other_patch_group == patch_group)
+		if (!patch_group.empty() && level == node_level::patch_level)
+		{
+			for (int i = 0; i < node->childCount(); i++)
+			{
+				if (const auto other = node->child(i); other && other != item)
 				{
-					other->setCheckState(0, Qt::CheckState::Unchecked);
+					const std::string other_patch_group = other->data(0, patch_group_role).toString().toStdString();
+
+					if (other_patch_group == patch_group)
+					{
+						other->setCheckState(0, Qt::CheckState::Unchecked);
+					}
 				}
 			}
 		}
 	}
 
 	// Enable/disable the patch for this item and show its metadata
+	const std::string hash = item->data(0, hash_role).toString().toStdString();
 	if (m_map.contains(hash))
 	{
 		auto& info = m_map[hash].patch_info_map;
+		const std::string description = item->data(0, description_role).toString().toStdString();
 
 		if (info.contains(description))
 		{
+			const std::string title = item->data(0, title_role).toString().toStdString();
+			const std::string serial = item->data(0, serial_role).toString().toStdString();
+			const std::string app_version = item->data(0, app_version_role).toString().toStdString();
+
 			info[description].titles[title][serial][app_version].enabled = enabled;
-			handle_item_selected(item, item);
+
+			if (item->isSelected())
+			{
+				handle_item_selected(item, item);
+			}
 		}
 	}
 }

--- a/rpcs3/rpcs3qt/patch_manager_dialog.h
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.h
@@ -58,7 +58,7 @@ private:
 	void load_patches(bool show_error);
 	void populate_tree();
 	void save_config() const;
-	void update_patch_info(const gui_patch_info& info) const;
+	void update_patch_info(const gui_patch_info& info, bool force_update) const;
 	static bool is_valid_file(const QMimeData& md, QStringList* drop_paths = nullptr);
 	void download_update(bool automatic, bool auto_accept);
 	bool handle_json(const QByteArray& data);


### PR DESCRIPTION
- Fix configurable value dropdown visibility in the patch manager (it stayed hidden after selecting a differen patch)
- Optimize patch_manager_dialog::handle_item_changed. This was always running a lot of code for every single item regardless of the content