### PR TITLE
Missed arrowlake-S and lunarlake

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -136,7 +136,9 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 		cpu == "znver1" ||
 		cpu == "znver2" ||
 		cpu == "znver3" ||
-		cpu == "arrowlake")
+		cpu == "arrowlake" ||
+		cpu == "arrowlake-s" ||
+		cpu == "lunarlake")
 	{
 		m_use_fma = true;
 		m_use_avx = true;
@@ -159,7 +161,9 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 		cpu == "alderlake" ||
 		cpu == "raptorlake" ||
 		cpu == "meteorlake" ||
-		cpu == "arrowlake")
+		cpu == "arrowlake" ||
+		cpu == "arrowlake-s" ||
+		cpu == "lunarlake")
 	{
 		m_use_vnni = true;
 	}
@@ -170,7 +174,9 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 		cpu == "alderlake" ||
 		cpu == "raptorlake" ||
 		cpu == "meteorlake" ||
-		cpu == "arrowlake")
+		cpu == "arrowlake" ||
+		cpu == "arrowlake-s" ||
+		cpu == "lunarlake")
 	{
 		m_use_gfni = true;
 	}


### PR DESCRIPTION
Apparently this gen there's an `arrowlake` AND `arrowlake-s` target cause arrowlake mobile has lowpower e-cores