### PR TITLE
[Build] Explicit Triple with LLVM 21.1.0

### DIFF
--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -658,7 +658,7 @@ jit_compiler::jit_compiler(const std::unordered_map<std::string, u64>& _link, co
 	std::string result;
 
 	auto null_mod = std::make_unique<llvm::Module> ("null_", *m_context);
-	null_mod->setTargetTriple(jit_compiler::triple1());
+	null_mod->setTargetTriple(llvm::Triple(jit_compiler::triple1()));
 
 	std::unique_ptr<llvm::RTDyldMemoryManager> mem;
 
@@ -672,7 +672,7 @@ jit_compiler::jit_compiler(const std::unordered_map<std::string, u64>& _link, co
 		else
 		{
 			mem = std::make_unique<MemoryManager2>(std::move(symbols_cement));
-			null_mod->setTargetTriple(jit_compiler::triple2());
+			null_mod->setTargetTriple(llvm::Triple(jit_compiler::triple2()));
 		}
 	}
 	else

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5751,7 +5751,7 @@ static void ppu_initialize2(jit_compiler& jit, const ppu_module<lv2_obj>& module
 	std::unique_ptr<Module> _module = std::make_unique<Module>(obj_name, jit.get_context());
 
 	// Initialize target
-	_module->setTargetTriple(jit_compiler::triple1());
+	_module->setTargetTriple(Triple(jit_compiler::triple1()));
 	_module->setDataLayout(jit.get_engine().getTargetMachine()->createDataLayout());
 
 	// Initialize translator

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1601,7 +1601,7 @@ public:
 
 		// Create LLVM module
 		std::unique_ptr<Module> _module = std::make_unique<Module>(m_hash + ".obj", m_context);
-		_module->setTargetTriple(jit_compiler::triple2());
+		_module->setTargetTriple(Triple(jit_compiler::triple2()));
 		_module->setDataLayout(m_jit.get_engine().getTargetMachine()->createDataLayout());
 		m_module = _module.get();
 
@@ -2876,7 +2876,7 @@ public:
 
 		// Create LLVM module
 		std::unique_ptr<Module> _module = std::make_unique<Module>("spu_interpreter.obj", m_context);
-		_module->setTargetTriple(jit_compiler::triple2());
+		_module->setTargetTriple(Triple(jit_compiler::triple2()));
 		_module->setDataLayout(m_jit.get_engine().getTargetMachine()->createDataLayout());
 		m_module = _module.get();
 


### PR DESCRIPTION
Fix build error, the Triple  constructor is not implicit anymore.

https://github.com/llvm/llvm-project/commit/fff720d6419b92be068ac4f3ac7e8333a781ee20#diff-5008de5706b85963c456532be4d2e8c5b478959be9d315f77c338946bd1fc586R353-R354

[marin@pc-linux ~]$ clang++ --version
clang version 22.0.0git (https://github.com/llvm/llvm-project.git 1669bd3ae9af0cac4414479d8f1e53e329fa3efb)
