### PR TITLE
vk: Resource binding model rewrites [part 2 of 2]

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "io_buffer.h"
+#include "simple_array.hpp"
 #include "../color_utils.h"
 #include "../RSXTexture.h"
 
-#include <stack>
 #include <vector>
 
 namespace rsx
@@ -140,7 +140,7 @@ namespace rsx
 #pragma pack(pop)
 
 		// Texure matrix stack
-		std::stack<texcoord_xform_t> m_texcoord_xform_stack;
+		rsx::simple_array<texcoord_xform_t> m_texcoord_xform_stack;
 
 	public:
 		virtual ~sampled_image_descriptor_base() = default;
@@ -148,14 +148,14 @@ namespace rsx
 
 		void push_texcoord_xform()
 		{
-			m_texcoord_xform_stack.push(texcoord_xform);
+			m_texcoord_xform_stack.push_back(texcoord_xform);
 		}
 
 		void pop_texcoord_xform()
 		{
 			ensure(!m_texcoord_xform_stack.empty());
-			std::memcpy(&texcoord_xform, &m_texcoord_xform_stack.top(), sizeof(texcoord_xform_t));
-			m_texcoord_xform_stack.pop();
+			std::memcpy(&texcoord_xform, &m_texcoord_xform_stack.back(), sizeof(texcoord_xform_t));
+			m_texcoord_xform_stack.pop_back();
 		}
 
 		texture_upload_context upload_context = texture_upload_context::shader_read;

--- a/rpcs3/Emu/RSX/Common/reverse_ptr.hpp
+++ b/rpcs3/Emu/RSX/Common/reverse_ptr.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <util/types.hpp>
+
+namespace rsx
+{
+	// Generic reverse pointer primitive type for fast reverse iterators
+	template <typename Ty>
+	class reverse_pointer
+	{
+		Ty* ptr = nullptr;
+
+	public:
+		reverse_pointer() = default;
+		reverse_pointer(Ty* val)
+			: ptr(val)
+		{}
+
+		reverse_pointer& operator++() { ptr--; return *this; }
+		reverse_pointer operator++(int) { return reverse_pointer(ptr--); }
+		reverse_pointer& operator--() { ptr++; return *this; }
+		reverse_pointer operator--(int) { reverse_pointer(ptr++); }
+
+		bool operator == (const reverse_pointer& other) const { return ptr == other.ptr; }
+
+		Ty* operator -> () const { return ptr; }
+		Ty& operator * () const { return *ptr; }
+	};
+}

--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -4,6 +4,8 @@
 #include <functional>
 #include <algorithm>
 
+#include "reverse_ptr.hpp"
+
 namespace rsx
 {
 	template <typename Ty>
@@ -13,6 +15,8 @@ namespace rsx
 	public:
 		using iterator = Ty*;
 		using const_iterator = const Ty*;
+		using reverse_iterator = reverse_pointer<Ty>;
+		using const_reverse_iterator = reverse_pointer<const Ty>;
 		using value_type = Ty;
 
 	private:
@@ -380,6 +384,46 @@ namespace rsx
 		const_iterator end() const
 		{
 			return _data ? _data + _size : nullptr;
+		}
+
+		const_iterator cbegin() const
+		{
+			return _data;
+		}
+
+		const_iterator cend() const
+		{
+			return _data ? _data + _size : nullptr;
+		}
+
+		reverse_iterator rbegin()
+		{
+			return reverse_iterator(end());
+		}
+
+		reverse_iterator rend()
+		{
+			return reverse_iterator(begin());
+		}
+
+		const_reverse_iterator rbegin() const
+		{
+			return const_reverse_iterator(cend());
+		}
+
+		const_reverse_iterator rend() const
+		{
+			return const_reverse_iterator(cbegin());
+		}
+
+		const_reverse_iterator crbegin() const
+		{
+			return const_reverse_iterator(cend());
+		}
+
+		const_reverse_iterator crend() const
+		{
+			return const_reverse_iterator(cbegin());
 		}
 
 		bool any(std::predicate<const Ty&> auto predicate) const

--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -398,32 +398,32 @@ namespace rsx
 
 		reverse_iterator rbegin()
 		{
-			return reverse_iterator(end());
+			return reverse_iterator(end() - 1);
 		}
 
 		reverse_iterator rend()
 		{
-			return reverse_iterator(begin());
+			return reverse_iterator(begin() - 1);
 		}
 
 		const_reverse_iterator rbegin() const
 		{
-			return const_reverse_iterator(cend());
+			return crbegin();
 		}
 
 		const_reverse_iterator rend() const
 		{
-			return const_reverse_iterator(cbegin());
+			return crend();
 		}
 
 		const_reverse_iterator crbegin() const
 		{
-			return const_reverse_iterator(cend());
+			return const_reverse_iterator(cend() - 1);
 		}
 
 		const_reverse_iterator crend() const
 		{
-			return const_reverse_iterator(cbegin());
+			return const_reverse_iterator(cbegin() - 1);
 		}
 
 		bool any(std::predicate<const Ty&> auto predicate) const

--- a/rpcs3/Emu/RSX/Common/surface_store.cpp
+++ b/rpcs3/Emu/RSX/Common/surface_store.cpp
@@ -7,7 +7,7 @@ namespace rsx
 {
 	namespace utility
 	{
-		std::vector<u8> get_rtt_indexes(surface_target color_target)
+		simple_array<u8> get_rtt_indexes(surface_target color_target)
 		{
 			switch (color_target)
 			{

--- a/rpcs3/Emu/RSX/Common/surface_store.cpp
+++ b/rpcs3/Emu/RSX/Common/surface_store.cpp
@@ -7,7 +7,7 @@ namespace rsx
 {
 	namespace utility
 	{
-		simple_array<u8> get_rtt_indexes(surface_target color_target)
+		rsx::simple_array<u8> get_rtt_indexes(surface_target color_target)
 		{
 			switch (color_target)
 			{

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -14,7 +14,7 @@ namespace rsx
 {
 	namespace utility
 	{
-		simple_array<u8> get_rtt_indexes(surface_target color_target);
+		rsx::simple_array<u8> get_rtt_indexes(surface_target color_target);
 		u8 get_mrt_buffers_count(surface_target color_target);
 		usz get_aligned_pitch(surface_color_format format, u32 width);
 		usz get_packed_pitch(surface_color_format format, u32 width);
@@ -314,7 +314,7 @@ namespace rsx
 				}
 			}
 
-			simple_array<std::pair<u32, surface_type>> surface_info;
+			rsx::simple_array<std::pair<u32, surface_type>> surface_info;
 			if (list1.empty())
 			{
 				surface_info = std::move(list2);
@@ -866,10 +866,10 @@ namespace rsx
 				std::forward<Args>(extra_params)...);
 		}
 
-		std::tuple<simple_array<surface_type>, simple_array<surface_type>>
+		std::tuple<rsx::simple_array<surface_type>, rsx::simple_array<surface_type>>
 		find_overlapping_set(const utils::address_range32& range) const
 		{
-			simple_array<surface_type> color_result, depth_result;
+			rsx::simple_array<surface_type> color_result, depth_result;
 			utils::address_range32 result_range;
 
 			if (m_render_targets_memory_range.valid() &&

--- a/rpcs3/Emu/RSX/Common/surface_store.h
+++ b/rpcs3/Emu/RSX/Common/surface_store.h
@@ -14,7 +14,7 @@ namespace rsx
 {
 	namespace utility
 	{
-		std::vector<u8> get_rtt_indexes(surface_target color_target);
+		simple_array<u8> get_rtt_indexes(surface_target color_target);
 		u8 get_mrt_buffers_count(surface_target color_target);
 		usz get_aligned_pitch(surface_color_format format, u32 width);
 		usz get_packed_pitch(surface_color_format format, u32 width);
@@ -245,9 +245,9 @@ namespace rsx
 		void intersect_surface_region(command_list_type cmd, u32 address, surface_type new_surface, surface_type prev_surface)
 		{
 			auto scan_list = [&new_surface, address](const rsx::address_range32& mem_range,
-				surface_ranged_map& data) -> std::vector<std::pair<u32, surface_type>>
+				surface_ranged_map& data) -> rsx::simple_array<std::pair<u32, surface_type>>
 			{
-				std::vector<std::pair<u32, surface_type>> result;
+				rsx::simple_array<std::pair<u32, surface_type>> result;
 				for (auto it = data.begin_range(mem_range); it != data.end(); ++it)
 				{
 					auto surface = Traits::get(it->second);
@@ -314,7 +314,7 @@ namespace rsx
 				}
 			}
 
-			std::vector<std::pair<u32, surface_type>> surface_info;
+			simple_array<std::pair<u32, surface_type>> surface_info;
 			if (list1.empty())
 			{
 				surface_info = std::move(list2);
@@ -629,7 +629,7 @@ namespace rsx
 			invalidated_resources.push_back(std::move(storage));
 		}
 
-		int remove_duplicates_fast_impl(std::vector<surface_overlap_info>& sections, const rsx::address_range32& range)
+		int remove_duplicates_fast_impl(rsx::simple_array<surface_overlap_info>& sections, const rsx::address_range32& range)
 		{
 			// Range tests to check for gaps
 			std::list<utils::address_range32> m_ranges;
@@ -697,7 +697,7 @@ namespace rsx
 			return removed_count;
 		}
 
-		void remove_duplicates_fallback_impl(std::vector<surface_overlap_info>& sections, const rsx::address_range32& range)
+		void remove_duplicates_fallback_impl(rsx::simple_array<surface_overlap_info>& sections, const rsx::address_range32& range)
 		{
 			// Originally used to debug crashes but this function breaks often enough that I'll leave the checks in for now.
 			// Safe to remove after some time if no asserts are reported.
@@ -866,10 +866,10 @@ namespace rsx
 				std::forward<Args>(extra_params)...);
 		}
 
-		std::tuple<std::vector<surface_type>, std::vector<surface_type>>
+		std::tuple<simple_array<surface_type>, simple_array<surface_type>>
 		find_overlapping_set(const utils::address_range32& range) const
 		{
-			std::vector<surface_type> color_result, depth_result;
+			simple_array<surface_type> color_result, depth_result;
 			utils::address_range32 result_range;
 
 			if (m_render_targets_memory_range.valid() &&
@@ -916,8 +916,8 @@ namespace rsx
 			u64 src_offset, dst_offset, write_length;
 			auto block_length = block_range.length();
 
-			auto all_data = std::move(color_data);
-			all_data.insert(all_data.end(), depth_stencil_data.begin(), depth_stencil_data.end());
+			auto& all_data = color_data;
+			all_data += depth_stencil_data;
 
 			if (all_data.size() > 1)
 			{
@@ -1088,10 +1088,10 @@ namespace rsx
 		}
 
 		template <typename commandbuffer_type>
-		std::vector<surface_overlap_info> get_merged_texture_memory_region(commandbuffer_type& cmd, u32 texaddr, u32 required_width, u32 required_height, u32 required_pitch, u8 required_bpp, rsx::surface_access access)
+		rsx::simple_array<surface_overlap_info> get_merged_texture_memory_region(commandbuffer_type& cmd, u32 texaddr, u32 required_width, u32 required_height, u32 required_pitch, u8 required_bpp, rsx::surface_access access)
 		{
-			std::vector<surface_overlap_info> result;
-			std::vector<std::pair<u32, bool>> dirty;
+			rsx::simple_array<surface_overlap_info> result;
+			rsx::simple_array<std::pair<u32, bool>> dirty;
 
 			const auto surface_internal_pitch = (required_width * required_bpp);
 
@@ -1236,7 +1236,7 @@ namespace rsx
 			return result;
 		}
 
-		void check_for_duplicates(std::vector<surface_overlap_info>& sections)
+		void check_for_duplicates(rsx::simple_array<surface_overlap_info>& sections)
 		{
 			utils::address_range32 test_range;
 			for (const auto& section : sections)

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1187,9 +1187,9 @@ namespace rsx
 		}
 
 		template <bool check_unlocked = false>
-		simple_array<section_storage_type*> find_texture_from_range(const address_range32 &test_range, u32 required_pitch = 0, u32 context_mask = 0xFF)
+		rsx::simple_array<section_storage_type*> find_texture_from_range(const address_range32 &test_range, u32 required_pitch = 0, u32 context_mask = 0xFF)
 		{
-			simple_array<section_storage_type*> results;
+			rsx::simple_array<section_storage_type*> results;
 
 			for (auto It = m_storage.range_begin(test_range, full_range, check_unlocked); It != m_storage.range_end(); It++)
 			{
@@ -1894,8 +1894,8 @@ namespace rsx
 					}
 				}
 
-				simple_array<typename SurfaceStoreType::surface_overlap_info> overlapping_fbos;
-				simple_array<section_storage_type*> overlapping_locals;
+				rsx::simple_array<typename SurfaceStoreType::surface_overlap_info> overlapping_fbos;
+				rsx::simple_array<section_storage_type*> overlapping_locals;
 
 				auto fast_fbo_check = [&]() -> sampled_image_descriptor
 				{

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -143,7 +143,7 @@ namespace rsx
 		struct deferred_subresource : image_section_attributes_t
 		{
 			image_resource_type external_handle = 0;
-			std::vector<copy_region_descriptor> sections_to_copy;
+			rsx::simple_array<copy_region_descriptor> sections_to_copy;
 			texture_channel_remap_t remap;
 			deferred_request_command op = deferred_request_command::nop;
 			u32 external_ref_addr = 0;
@@ -491,10 +491,10 @@ namespace rsx
 		virtual section_storage_type* create_nul_section(commandbuffer_type&, const address_range32 &rsx_range, const image_section_attributes_t& attrs, const GCM_tile_reference& tile, bool memory_load) = 0;
 		virtual void set_component_order(section_storage_type& section, u32 gcm_format, component_order expected) = 0;
 		virtual void insert_texture_barrier(commandbuffer_type&, image_storage_type* tex, bool strong_ordering = true) = 0;
-		virtual image_view_type generate_cubemap_from_images(commandbuffer_type&, u32 gcm_format, u16 size, const std::vector<copy_region_descriptor>& sources, const texture_channel_remap_t& remap_vector) = 0;
-		virtual image_view_type generate_3d_from_2d_images(commandbuffer_type&, u32 gcm_format, u16 width, u16 height, u16 depth, const std::vector<copy_region_descriptor>& sources, const texture_channel_remap_t& remap_vector) = 0;
-		virtual image_view_type generate_atlas_from_images(commandbuffer_type&, u32 gcm_format, u16 width, u16 height, const std::vector<copy_region_descriptor>& sections_to_copy, const texture_channel_remap_t& remap_vector) = 0;
-		virtual image_view_type generate_2d_mipmaps_from_images(commandbuffer_type&, u32 gcm_format, u16 width, u16 height, const std::vector<copy_region_descriptor>& sections_to_copy, const texture_channel_remap_t& remap_vector) = 0;
+		virtual image_view_type generate_cubemap_from_images(commandbuffer_type&, u32 gcm_format, u16 size, const rsx::simple_array<copy_region_descriptor>& sources, const texture_channel_remap_t& remap_vector) = 0;
+		virtual image_view_type generate_3d_from_2d_images(commandbuffer_type&, u32 gcm_format, u16 width, u16 height, u16 depth, const rsx::simple_array<copy_region_descriptor>& sources, const texture_channel_remap_t& remap_vector) = 0;
+		virtual image_view_type generate_atlas_from_images(commandbuffer_type&, u32 gcm_format, u16 width, u16 height, const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const texture_channel_remap_t& remap_vector) = 0;
+		virtual image_view_type generate_2d_mipmaps_from_images(commandbuffer_type&, u32 gcm_format, u16 width, u16 height, const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const texture_channel_remap_t& remap_vector) = 0;
 		virtual void update_image_contents(commandbuffer_type&, image_view_type dst, image_resource_type src, u16 width, u16 height) = 0;
 		virtual bool render_target_format_is_compatible(image_storage_type* tex, u32 gcm_format) = 0;
 		virtual void prepare_for_dma_transfers(commandbuffer_type&) = 0;
@@ -652,7 +652,7 @@ namespace rsx
 			}
 
 			// Resync any exclusions that do not require flushing
-			std::vector<section_storage_type*> surfaces_to_inherit;
+			rsx::simple_array<section_storage_type*> surfaces_to_inherit;
 			for (auto& surface : data.sections_to_exclude)
 			{
 				if (surface->get_context() != texture_upload_context::framebuffer_storage)
@@ -1187,9 +1187,9 @@ namespace rsx
 		}
 
 		template <bool check_unlocked = false>
-		std::vector<section_storage_type*> find_texture_from_range(const address_range32 &test_range, u32 required_pitch = 0, u32 context_mask = 0xFF)
+		simple_array<section_storage_type*> find_texture_from_range(const address_range32 &test_range, u32 required_pitch = 0, u32 context_mask = 0xFF)
 		{
-			std::vector<section_storage_type*> results;
+			simple_array<section_storage_type*> results;
 
 			for (auto It = m_storage.range_begin(test_range, full_range, check_unlocked); It != m_storage.range_end(); It++)
 			{
@@ -1731,7 +1731,7 @@ namespace rsx
 			}
 			case deferred_request_command::cubemap_unwrap:
 			{
-				std::vector<copy_region_descriptor> sections(6);
+				rsx::simple_array<copy_region_descriptor> sections(6);
 				for (u16 n = 0; n < 6; ++n)
 				{
 					sections[n] =
@@ -1761,7 +1761,7 @@ namespace rsx
 			}
 			case deferred_request_command::_3d_unwrap:
 			{
-				std::vector<copy_region_descriptor> sections;
+				rsx::simple_array<copy_region_descriptor> sections;
 				sections.resize(desc.depth);
 				for (u16 n = 0; n < desc.depth; ++n)
 				{
@@ -1894,8 +1894,8 @@ namespace rsx
 					}
 				}
 
-				std::vector<typename SurfaceStoreType::surface_overlap_info> overlapping_fbos;
-				std::vector<section_storage_type*> overlapping_locals;
+				simple_array<typename SurfaceStoreType::surface_overlap_info> overlapping_fbos;
+				simple_array<section_storage_type*> overlapping_locals;
 
 				auto fast_fbo_check = [&]() -> sampled_image_descriptor
 				{
@@ -1966,14 +1966,10 @@ namespace rsx
 				if (!overlapping_locals.empty())
 				{
 					// Remove everything that is not a transfer target
-					overlapping_locals.erase
-					(
-						std::remove_if(overlapping_locals.begin(), overlapping_locals.end(), [](const auto& e)
-						{
-							return e->is_dirty() || (e->get_context() != rsx::texture_upload_context::blit_engine_dst);
-						}),
-						overlapping_locals.end()
-					);
+					overlapping_locals.erase_if([](const auto& e)
+					{
+						return e->is_dirty() || (e->get_context() != rsx::texture_upload_context::blit_engine_dst);
+					});
 				}
 
 				if (!options.prefer_surface_cache)
@@ -2411,7 +2407,7 @@ namespace rsx
 				// 1. Only 2D images will invoke this routine
 				// 2. The image has to have been generated on the GPU (fbo or blit target only)
 
-				std::vector<copy_region_descriptor> sections;
+				rsx::simple_array<copy_region_descriptor> sections;
 				const bool use_upscaling = (result.upload_context == rsx::texture_upload_context::framebuffer_storage && g_cfg.video.resolution_scale_percent != 100);
 
 				if (!helpers::append_mipmap_level(sections, result, attributes, 0, use_upscaling, attributes)) [[unlikely]]

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../rsx_utils.h"
+#include "simple_array.hpp"
 #include "TextureUtils.h"
 
 namespace rsx
@@ -249,9 +250,9 @@ namespace rsx
 		template<typename commandbuffer_type, typename section_storage_type, typename copy_region_type, typename surface_store_list_type>
 		void gather_texture_slices(
 			commandbuffer_type& cmd,
-			std::vector<copy_region_type>& out,
+			rsx::simple_array<copy_region_type>& out,
 			const surface_store_list_type& fbos,
-			const std::vector<section_storage_type*>& local,
+			const rsx::simple_array<section_storage_type*>& local,
 			const image_section_attributes_t& attr,
 			u16 count, bool /*is_depth*/)
 		{
@@ -737,7 +738,7 @@ namespace rsx
 		template <typename sampled_image_descriptor, typename commandbuffer_type, typename surface_store_list_type, typename section_storage_type>
 		sampled_image_descriptor merge_cache_resources(
 			commandbuffer_type& cmd,
-			const surface_store_list_type& fbos, const std::vector<section_storage_type*>& local,
+			const surface_store_list_type& fbos, const rsx::simple_array<section_storage_type*>& local,
 			const image_section_attributes_t& attr,
 			const size3f& scale,
 			texture_dimension_extended extended_dimension,
@@ -852,7 +853,7 @@ namespace rsx
 
 		template<typename sampled_image_descriptor, typename copy_region_descriptor_type>
 		bool append_mipmap_level(
-			std::vector<copy_region_descriptor_type>& sections,   // Destination list
+			rsx::simple_array<copy_region_descriptor_type>& sections,   // Destination list
 			const sampled_image_descriptor& level,                // Descriptor for the image level being checked
 			const image_section_attributes_t& attr,               // Attributes of image level
 			u8 mipmap_level,                                      // Level index

--- a/rpcs3/Emu/RSX/Common/unordered_map.hpp
+++ b/rpcs3/Emu/RSX/Common/unordered_map.hpp
@@ -5,15 +5,29 @@
 
 namespace rsx
 {
-	template<typename T, typename U>
-	using unordered_map = std::unordered_map<T, U>;
+	template<
+		typename _Key,
+		typename _Tp,
+		typename _Hash = std::hash<_Key>,
+		typename _Pred = std::equal_to<_Key>>
+	>
+	using unordered_map = std::unordered_map<
+		_Key, _Tp, _Hash, _Pred
+	>;
 }
 #else
 #include "3rdparty/unordered_dense/include/unordered_dense.h"
 
 namespace rsx
 {
-	template<typename T, typename U>
-	using unordered_map = ankerl::unordered_dense::map<T, U>;
+	template <
+		typename Key,
+		typename T,
+		typename Hash = ankerl::unordered_dense::hash<Key>,
+		typename KeyEqual = std::equal_to<Key>
+	>
+	using unordered_map = ankerl::unordered_dense::map<
+		Key, T, Hash, KeyEqual
+	>;
 }
 #endif

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -186,9 +186,9 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 	"	sampler_info texture_parameters[16];\n"
 	"};\n\n"
 
-	"layout(std140, binding = " << GL_RASTERIZER_STATE_BIND_SLOT << ") uniform RasterizerHeap\n";
-	"{\n";
-	"	uvec4 stipple_pattern[8];\n";
+	"layout(std140, binding = " << GL_RASTERIZER_STATE_BIND_SLOT << ") uniform RasterizerHeap\n"
+	"{\n"
+	"	uvec4 stipple_pattern[8];\n"
 	"};\n\n";
 }
 

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -158,50 +158,38 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 
 	OS << "\n";
 
-	std::string constants_block;
-	for (const ParamType& PT : m_parr.params[PF_PARAM_UNIFORM])
+	if (!properties.constant_offsets.empty())
 	{
-		if (PT.type == "sampler1D" ||
-			PT.type == "sampler2D" ||
-			PT.type == "sampler3D" ||
-			PT.type == "samplerCube")
-			continue;
-
-		for (const ParamItem& PI : PT.items)
-		{
-			constants_block += "	" + PT.type + " " + PI.name + ";\n";
-		}
+		OS <<
+			"layout(std140, binding = " << GL_FRAGMENT_CONSTANT_BUFFERS_BIND_SLOT << ") uniform FragmentConstantsBuffer\n"
+			"{\n"
+			"	vec4 fc[" << properties.constant_offsets.size() << "];\n"
+			"};\n"
+			"#define _fetch_constant(x) fc[x]\n\n";
 	}
 
-	if (!constants_block.empty())
-	{
-		OS << "layout(std140, binding = " << GL_FRAGMENT_CONSTANT_BUFFERS_BIND_SLOT << ") uniform FragmentConstantsBuffer\n";
-		OS << "{\n";
-		OS << constants_block;
-		OS << "};\n\n";
-	}
+	OS <<
+	"layout(std140, binding = " << GL_FRAGMENT_STATE_BIND_SLOT << ") uniform FragmentStateBuffer\n"
+	"{\n"
+	"	float fog_param0;\n"
+	"	float fog_param1;\n"
+	"	uint rop_control;\n"
+	"	float alpha_ref;\n"
+	"	uint reserved;\n"
+	"	uint fog_mode;\n"
+	"	float wpos_scale;\n"
+	"	float wpos_bias;\n"
+	"};\n\n"
 
-	OS << "layout(std140, binding = " << GL_FRAGMENT_STATE_BIND_SLOT << ") uniform FragmentStateBuffer\n";
-	OS << "{\n";
-	OS << "	float fog_param0;\n";
-	OS << "	float fog_param1;\n";
-	OS << "	uint rop_control;\n";
-	OS << "	float alpha_ref;\n";
-	OS << "	uint reserved;\n";
-	OS << "	uint fog_mode;\n";
-	OS << "	float wpos_scale;\n";
-	OS << "	float wpos_bias;\n";
-	OS << "};\n\n";
+	"layout(std140, binding = " << GL_FRAGMENT_TEXTURE_PARAMS_BIND_SLOT << ") uniform TextureParametersBuffer\n"
+	"{\n"
+	"	sampler_info texture_parameters[16];\n"
+	"};\n\n"
 
-	OS << "layout(std140, binding = " << GL_FRAGMENT_TEXTURE_PARAMS_BIND_SLOT << ") uniform TextureParametersBuffer\n";
-	OS << "{\n";
-	OS << "	sampler_info texture_parameters[16];\n";
-	OS << "};\n\n";
-
-	OS << "layout(std140, binding = " << GL_RASTERIZER_STATE_BIND_SLOT << ") uniform RasterizerHeap\n";
-	OS << "{\n";
-	OS << "	uvec4 stipple_pattern[8];\n";
-	OS << "};\n\n";
+	"layout(std140, binding = " << GL_RASTERIZER_STATE_BIND_SLOT << ") uniform RasterizerHeap\n";
+	"{\n";
+	"	uvec4 stipple_pattern[8];\n";
+	"};\n\n";
 }
 
 void GLFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
@@ -373,21 +361,7 @@ void GLFragmentProgram::Decompile(const RSXFragmentProgram& prog)
 
 	decompiler.Task();
 
-	for (const ParamType& PT : decompiler.m_parr.params[PF_PARAM_UNIFORM])
-	{
-		for (const ParamItem& PI : PT.items)
-		{
-			if (PT.type == "sampler1D" ||
-				PT.type == "sampler2D" ||
-				PT.type == "sampler3D" ||
-				PT.type == "samplerCube")
-				continue;
-
-			usz offset = atoi(PI.name.c_str() + 2);
-			FragmentConstantOffsetCache.push_back(offset);
-		}
-	}
-
+	constant_offsets = std::move(decompiler.properties.constant_offsets);
 	shader.create(::glsl::program_domain::glsl_fragment_program, source);
 	id = shader.id();
 }

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -189,7 +189,9 @@ void GLFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 	"layout(std140, binding = " << GL_RASTERIZER_STATE_BIND_SLOT << ") uniform RasterizerHeap\n"
 	"{\n"
 	"	uvec4 stipple_pattern[8];\n"
-	"};\n\n";
+	"};\n\n"
+
+	"#define texture_base_index 0\n\n";
 }
 
 void GLFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
@@ -58,7 +58,7 @@ public:
 	ParamArray parr;
 	u32 id;
 	gl::glsl::shader shader;
-	std::vector<usz> FragmentConstantOffsetCache;
+	std::vector<u32> constant_offsets;
 
 	/**
 	 * Decompile a fragment shader located in the PS3's Memory.  This function operates synchronously.

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.cpp
@@ -158,7 +158,7 @@ namespace gl
 
 		if (copy)
 		{
-			std::vector<copy_region_descriptor> region =
+			rsx::simple_array<copy_region_descriptor> region =
 			{{
 				.src = src,
 				.xform = rsx::surface_transform::coordinate_transform,
@@ -183,7 +183,7 @@ namespace gl
 		return dst->get_view(remap);
 	}
 
-	void texture_cache::copy_transfer_regions_impl(gl::command_context& cmd, gl::texture* dst_image, const std::vector<copy_region_descriptor>& sources) const
+	void texture_cache::copy_transfer_regions_impl(gl::command_context& cmd, gl::texture* dst_image, const rsx::simple_array<copy_region_descriptor>& sources) const
 	{
 		const auto dst_bpp = dst_image->pitch() / dst_image->width();
 		const auto dst_aspect = dst_image->aspect();

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -356,7 +356,7 @@ namespace gl
 			baseclass::on_section_resources_destroyed();
 		}
 
-		void sync_surface_memory(const std::vector<cached_texture_section*>& surfaces)
+		void sync_surface_memory(const rsx::simple_array<cached_texture_section*>& surfaces)
 		{
 			auto rtt = gl::as_rtt(vram_texture);
 			rtt->sync_tag();
@@ -480,9 +480,9 @@ namespace gl
 			}
 		}
 
-		void copy_transfer_regions_impl(gl::command_context& cmd, gl::texture* dst_image, const std::vector<copy_region_descriptor>& sources) const;
+		void copy_transfer_regions_impl(gl::command_context& cmd, gl::texture* dst_image, const rsx::simple_array<copy_region_descriptor>& sources) const;
 
-		gl::texture* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const
+		gl::texture* get_template_from_collection_impl(const rsx::simple_array<copy_region_descriptor>& sections_to_transfer) const
 		{
 			if (sections_to_transfer.size() == 1) [[likely]]
 			{
@@ -534,7 +534,7 @@ namespace gl
 					GL_TEXTURE_2D, gcm_format, x, y, w, h, 1, 1, remap_vector, true);
 		}
 
-		gl::texture_view* generate_cubemap_from_images(gl::command_context& cmd, u32 gcm_format, u16 size, const std::vector<copy_region_descriptor>& sources, const rsx::texture_channel_remap_t& remap_vector) override
+		gl::texture_view* generate_cubemap_from_images(gl::command_context& cmd, u32 gcm_format, u16 size, const rsx::simple_array<copy_region_descriptor>& sources, const rsx::texture_channel_remap_t& remap_vector) override
 		{
 			auto _template = get_template_from_collection_impl(sources);
 			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_CUBE_MAP, gcm_format, 0, 0, size, size, 1, 1, remap_vector, false);
@@ -543,7 +543,7 @@ namespace gl
 			return result;
 		}
 
-		gl::texture_view* generate_3d_from_2d_images(gl::command_context& cmd, u32 gcm_format, u16 width, u16 height, u16 depth, const std::vector<copy_region_descriptor>& sources, const rsx::texture_channel_remap_t& remap_vector) override
+		gl::texture_view* generate_3d_from_2d_images(gl::command_context& cmd, u32 gcm_format, u16 width, u16 height, u16 depth, const rsx::simple_array<copy_region_descriptor>& sources, const rsx::texture_channel_remap_t& remap_vector) override
 		{
 			auto _template = get_template_from_collection_impl(sources);
 			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_3D, gcm_format, 0, 0, width, height, depth, 1, remap_vector, false);
@@ -552,7 +552,7 @@ namespace gl
 			return result;
 		}
 
-		gl::texture_view* generate_atlas_from_images(gl::command_context& cmd, u32 gcm_format, u16 width, u16 height, const std::vector<copy_region_descriptor>& sections_to_copy,
+		gl::texture_view* generate_atlas_from_images(gl::command_context& cmd, u32 gcm_format, u16 width, u16 height, const rsx::simple_array<copy_region_descriptor>& sections_to_copy,
 				const rsx::texture_channel_remap_t& remap_vector) override
 		{
 			auto _template = get_template_from_collection_impl(sections_to_copy);
@@ -562,7 +562,7 @@ namespace gl
 			return result;
 		}
 
-		gl::texture_view* generate_2d_mipmaps_from_images(gl::command_context& cmd, u32 gcm_format, u16 width, u16 height, const std::vector<copy_region_descriptor>& sections_to_copy,
+		gl::texture_view* generate_2d_mipmaps_from_images(gl::command_context& cmd, u32 gcm_format, u16 width, u16 height, const rsx::simple_array<copy_region_descriptor>& sections_to_copy,
 			const rsx::texture_channel_remap_t& remap_vector) override
 		{
 			const auto mipmaps = ::narrow<u8>(sections_to_copy.size());
@@ -587,7 +587,7 @@ namespace gl
 
 		void update_image_contents(gl::command_context& cmd, gl::texture_view* dst, gl::texture* src, u16 width, u16 height) override
 		{
-			std::vector<copy_region_descriptor> region =
+			rsx::simple_array<copy_region_descriptor> region =
 			{{
 				.src = src,
 				.xform = rsx::surface_transform::identity,

--- a/rpcs3/Emu/RSX/NV47/FW/draw_call.cpp
+++ b/rpcs3/Emu/RSX/NV47/FW/draw_call.cpp
@@ -138,7 +138,7 @@ namespace rsx
 		is_disjoint_primitive = is_primitive_disjointed(primitive);
 	}
 
-	const simple_array<draw_range_t>& draw_clause::get_subranges() const
+	const rsx::simple_array<draw_range_t>& draw_clause::get_subranges() const
 	{
 		ensure(!is_single_draw());
 

--- a/rpcs3/Emu/RSX/NV47/FW/draw_call.hpp
+++ b/rpcs3/Emu/RSX/NV47/FW/draw_call.hpp
@@ -18,10 +18,10 @@ namespace rsx
 	class draw_clause
 	{
 		// Stores the first and count argument from draw/draw indexed parameters between begin/end clauses.
-		simple_array<draw_range_t> draw_command_ranges{};
+		rsx::simple_array<draw_range_t> draw_command_ranges{};
 
 		// Stores rasterization barriers for primitive types sensitive to adjacency
-		simple_array<barrier_t> draw_command_barriers{};
+		rsx::simple_array<barrier_t> draw_command_barriers{};
 
 		// Counter used to parse the commands in order
 		u32 current_range_index{};
@@ -33,7 +33,7 @@ namespace rsx
 		u32 draw_command_barrier_mask = 0;
 
 		// Draw-time iterator to the draw_command_barriers struct
-		mutable simple_array<barrier_t>::iterator current_barrier_it;
+		mutable rsx::simple_array<barrier_t>::iterator current_barrier_it;
 
 		// Subranges memory cache
 		mutable rsx::simple_array<draw_range_t> subranges_store;
@@ -77,7 +77,7 @@ namespace rsx
 		bool is_rendering{};               // Set while we're actually pushing the draw calls to host GPU
 		bool is_trivial_instanced_draw{};  // Set if the draw call can be executed on the host GPU as a single instanced draw.
 
-		simple_array<u32> inline_vertex_array{};
+		rsx::simple_array<u32> inline_vertex_array{};
 
 		void operator()(utils::serial& ar);
 
@@ -307,6 +307,6 @@ namespace rsx
 		 * Returns a compiled list of all subdraws.
 		 * NOTE: This is a non-trivial operation as it takes disjoint primitive boundaries into account.
 		 */
-		const simple_array<draw_range_t>& get_subranges() const;
+		const rsx::simple_array<draw_range_t>& get_subranges() const;
 	};
 }

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
@@ -232,12 +232,29 @@ std::string FragmentProgramDecompiler::AddCond()
 
 std::string FragmentProgramDecompiler::AddConst()
 {
+	const u32 constant_id = m_size + (4 * sizeof(u32));
+	int index = -1, ctr = 0;
+
+	// Have we seen this constant before?
+	for (auto it = properties.constant_offsets.rbegin(); it != properties.constant_offsets.rend(); ++it, ++ctr)
+	{
+		if (*it == constant_id)
+		{
+			index = ctr;
+			break;
+		}
+	}
+
+	if (index == -1)
+	{
+		index = static_cast<int>(properties.constant_offsets.size());
+		properties.constant_offsets.push_back(constant_id);
+	}
+
 	// Skip next instruction, its just a literal
 	m_offset = 2 * 4 * sizeof(u32);
 
 	// Return the next offset index
-	const u32 index = ::size32(properties.constant_offsets);
-	properties.constant_offsets.push_back(m_size + 4 * 4);
 	return "_fetch_constant(" + std::to_string(index) + ")";
 }
 

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
@@ -189,6 +189,9 @@ public:
 		bool has_tex2D = false;
 		bool has_tex3D = false;
 		bool has_texShadowProj = false;
+
+		// Literal offsets
+		std::vector<u32> constant_offsets;
 	}
 	properties;
 

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
@@ -4,6 +4,7 @@
 #include "RSXFragmentProgram.h"
 
 #include <sstream>
+#include <unordered_map>
 
 /**
  * This class is used to translate RSX Fragment program to GLSL/HLSL code
@@ -43,13 +44,13 @@ class FragmentProgramDecompiler
 	u32 m_const_index = 0;
 	u32 m_offset;
 	u32 m_location = 0;
+	bool m_is_valid_ucode = true;
 
 	u32 m_loop_count;
 	int m_code_level;
 	std::vector<u32> m_end_offsets;
 	std::vector<u32> m_else_offsets;
-
-	bool m_is_valid_ucode = true;
+	std::unordered_map<u32, u32> m_constant_offsets;
 
 	std::array<rsx::MixedPrecisionRegister, 64> temp_registers;
 

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -177,13 +177,6 @@ namespace glsl
 			enabled_options.push_back("_ENABLE_LIT_EMULATION");
 		}
 
-		OS << "#define _select mix\n";
-		OS << "#define _saturate(x) clamp(x, 0., 1.)\n";
-		OS << "#define _get_bits(x, off, count) bitfieldExtract(x, off, count)\n";
-		OS << "#define _set_bits(x, y, off, count) bitfieldInsert(x, y, off, count)\n";
-		OS << "#define _test_bit(x, y) (_get_bits(x, y, 1) != 0)\n";
-		OS << "#define _rand(seed) fract(sin(dot(seed.xy, vec2(12.9898f, 78.233f))) * 43758.5453f)\n\n";
-
 		if (props.require_clip_functions)
 		{
 			OS <<

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -184,6 +184,13 @@ namespace glsl
 		OS << "#define _test_bit(x, y) (_get_bits(x, y, 1) != 0)\n";
 		OS << "#define _rand(seed) fract(sin(dot(seed.xy, vec2(12.9898f, 78.233f))) * 43758.5453f)\n\n";
 
+		if (props.require_clip_functions)
+		{
+			OS <<
+				"#define CLIP_PLANE_DISABLED 1\n"
+				"#define is_user_clip_enabled(idx) (_get_bits(get_user_clip_config(), idx * 2, 2) == CLIP_PLANE_DISABLED)\n"
+				"#define user_clip_factor(idx) float(_get_bits(get_user_clip_config(), idx * 2, 2) - 1)\n\n";
+		}
 
 		if (props.domain == glsl::program_domain::glsl_fragment_program)
 		{

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -366,19 +366,19 @@ vec4 _texture(in vec4 coord, float bias)
 	switch (type)
 	{
 	case RSX_SAMPLE_TEXTURE_1D:
-		coord.x = _texcoord_xform(coord.x, texture_parameters[ur0]);
+		coord.x = _texcoord_xform(coord.x, texture_parameters[ur0 + texture_base_index]);
 		vr0 = texture(SAMPLER1D(ur0), coord.x, bias);
 		break;
 	case RSX_SAMPLE_TEXTURE_2D:
-		coord.xy = _texcoord_xform(coord.xy, texture_parameters[ur0]);
+		coord.xy = _texcoord_xform(coord.xy, texture_parameters[ur0 + texture_base_index]);
 		vr0 = texture(SAMPLER2D(ur0), coord.xy, bias);
 		break;
 	case RSX_SAMPLE_TEXTURE_CUBE:
-		coord.xyz = _texcoord_xform(coord.xyz, texture_parameters[ur0]);
+		coord.xyz = _texcoord_xform(coord.xyz, texture_parameters[ur0 + texture_base_index]);
 		vr0 = texture(SAMPLERCUBE(ur0), coord.xyz, bias);
 		break;
 	case RSX_SAMPLE_TEXTURE_3D:
-		coord.xyz = _texcoord_xform(coord.xyz, texture_parameters[ur0]);
+		coord.xyz = _texcoord_xform(coord.xyz, texture_parameters[ur0 + texture_base_index]);
 		vr0 = texture(SAMPLER3D(ur0), coord.xyz, bias);
 		break;
 	}
@@ -405,19 +405,19 @@ vec4 _textureLod(in vec4 coord, float lod)
 	switch (type)
 	{
 	case RSX_SAMPLE_TEXTURE_1D:
-		coord.x = _texcoord_xform(coord.x, texture_parameters[ur0]);
+		coord.x = _texcoord_xform(coord.x, texture_parameters[ur0 + texture_base_index]);
 		vr0 = textureLod(SAMPLER1D(ur0), coord.x, lod);
 		break;
 	case RSX_SAMPLE_TEXTURE_2D:
-		coord.xy = _texcoord_xform(coord.xy, texture_parameters[ur0]);
+		coord.xy = _texcoord_xform(coord.xy, texture_parameters[ur0 + texture_base_index]);
 		vr0 = textureLod(SAMPLER2D(ur0), coord.xy, lod);
 		break;
 	case RSX_SAMPLE_TEXTURE_CUBE:
-		coord.xyz = _texcoord_xform(coord.xyz, texture_parameters[ur0]);
+		coord.xyz = _texcoord_xform(coord.xyz, texture_parameters[ur0 + texture_base_index]);
 		vr0 = textureLod(SAMPLERCUBE(ur0), coord.xyz, lod);
 		break;
 	case RSX_SAMPLE_TEXTURE_3D:
-		coord.xyz = _texcoord_xform(coord.xyz, texture_parameters[ur0]);
+		coord.xyz = _texcoord_xform(coord.xyz, texture_parameters[ur0 + texture_base_index]);
 		vr0 = textureLod(SAMPLER3D(ur0), coord.xyz, lod);
 		break;
 	}

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -552,6 +552,9 @@ void main()
 	ur1 = ur0 & 31u;                               // address % 32 -> fetch bit offset
 	ur1 = (1u << ur1);                             // address mask
 	uvr0.x = (ur0 >> 7u);                          // address to uvec4 row (each row has 32x4 bits)
+#ifdef VULKAN
+	uvr0.x += fs_stipple_pattern_array_offset;     // Address base offset. Only applies to vulkan.
+#endif
 	ur0 = (ur0 >> 5u) & 3u;                        // address to uvec4 word (address / 32) % 4
 
 	if ((stipple_pattern[uvr0.x][ur0] & ur1) == 0u)

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
@@ -32,6 +32,8 @@ struct draw_parameters_t
 	uint fs_constants_offset;
 	uint fs_context_offset;
 	uint fs_texture_base_index;
+	uint fs_stipple_pattern_offset;
+	uint reserved;
 	uvec2 attrib_data[16];
 };
 

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
@@ -31,4 +31,16 @@ struct vertex_layout_t
 	uvec2 attrib_data[16];
 };
 
+struct fragment_context_t
+{
+	float fog_param0;
+	float fog_param1;
+	uint rop_control;
+	float alpha_ref;
+	uint reserved;
+	uint fog_mode;
+	float wpos_scale;
+	float wpos_bias;
+};
+
 )"

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
@@ -11,4 +11,15 @@ struct sampler_info
 	uint flags;                       // 48
 };
 
+struct vertex_context_t
+{
+	mat4 scale_offset_mat;
+	uint user_clip_configuration_bits;
+	uint transform_branch_bits;
+	float point_size;
+	float z_near;
+	float z_far;
+	// float reserved[3];
+};
+
 )"

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
@@ -19,7 +19,16 @@ struct vertex_context_t
 	float point_size;
 	float z_near;
 	float z_far;
-	// float reserved[3];
+	float reserved[3];
+};
+
+struct vertex_layout_t
+{
+	uint vertex_base_index;
+	uint vertex_index_offset;
+	uint draw_id;
+	uint reserved;
+	uvec2 attrib_data[16];
 };
 
 )"

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXDefines2.glsl
@@ -22,12 +22,16 @@ struct vertex_context_t
 	float reserved[3];
 };
 
-struct vertex_layout_t
+struct draw_parameters_t
 {
 	uint vertex_base_index;
 	uint vertex_index_offset;
 	uint draw_id;
-	uint reserved;
+	uint xform_constants_offset;
+	uint vs_context_offset;
+	uint fs_constants_offset;
+	uint fs_context_offset;
+	uint fs_texture_base_index;
 	uvec2 attrib_data[16];
 };
 

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureDepthConversion.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureDepthConversion.glsl
@@ -1,8 +1,8 @@
 R"(
 #define ZS_READ(index, coord) vec2(texture(TEX_NAME(index), coord).r, float(texture(TEX_NAME_STENCIL(index), coord).x))
-#define TEX1D_Z24X8_RGBA8(index, coord1) _process_texel(convert_z24x8_to_rgba8(ZS_READ(index, COORD_SCALE1(index, coord1)), texture_parameters[index].remap, TEX_FLAGS(index)), TEX_FLAGS(index))
-#define TEX2D_Z24X8_RGBA8(index, coord2) _process_texel(convert_z24x8_to_rgba8(ZS_READ(index, COORD_SCALE2(index, coord2)), texture_parameters[index].remap, TEX_FLAGS(index)), TEX_FLAGS(index))
-#define TEX3D_Z24X8_RGBA8(index, coord3) _process_texel(convert_z24x8_to_rgba8(ZS_READ(index, COORD_SCALE3(index, coord3)), texture_parameters[index].remap, TEX_FLAGS(index)), TEX_FLAGS(index))
+#define TEX1D_Z24X8_RGBA8(index, coord1) _process_texel(convert_z24x8_to_rgba8(ZS_READ(index, COORD_SCALE1(index, coord1)), texture_parameters[index + texture_base_index].remap, TEX_FLAGS(index)), TEX_FLAGS(index))
+#define TEX2D_Z24X8_RGBA8(index, coord2) _process_texel(convert_z24x8_to_rgba8(ZS_READ(index, COORD_SCALE2(index, coord2)), texture_parameters[index + texture_base_index].remap, TEX_FLAGS(index)), TEX_FLAGS(index))
+#define TEX3D_Z24X8_RGBA8(index, coord3) _process_texel(convert_z24x8_to_rgba8(ZS_READ(index, COORD_SCALE3(index, coord3)), texture_parameters[index + texture_base_index].remap, TEX_FLAGS(index)), TEX_FLAGS(index))
 
 // NOTE: Memory layout is fetched as byteswapped BGRA [GBAR] (GOW collection, DS2, DeS)
 // The A component (Z) is useless (should contain stencil8 or just 1)

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOps.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOps.glsl
@@ -4,7 +4,7 @@ R"(
 #define TEX2D_MS(index, coord2) _process_texel(sampleTexture2DMS(TEX_NAME(index), coord2, index), TEX_FLAGS(index))
 #define TEX2D_SHADOW_MS(index, coord3) vec4(comparison_passes(sampleTexture2DMS(TEX_NAME(index), coord3.xy, index).x, coord3.z, ZCOMPARE_FUNC(index)))
 #define TEX2D_SHADOWPROJ_MS(index, coord4) TEX2D_SHADOW_MS(index, (coord4.xyz / coord4.w))
-#define TEX2D_Z24X8_RGBA8_MS(index, coord2) _process_texel(convert_z24x8_to_rgba8(ZS_READ_MS(index, coord2), texture_parameters[index].remap, TEX_FLAGS(index)), TEX_FLAGS(index))
+#define TEX2D_Z24X8_RGBA8_MS(index, coord2) _process_texel(convert_z24x8_to_rgba8(ZS_READ_MS(index, coord2), texture_parameters[index + texture_base_index].remap, TEX_FLAGS(index)), TEX_FLAGS(index))
 
 vec3 compute2x2DownsampleWeights(const in float coord, const in float uv_step, const in float actual_step)
 {

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureOps.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureOps.glsl
@@ -24,17 +24,17 @@ R"(
 	uint _texture_flag_override = 0;
 	#define _enable_texture_expand() _texture_flag_override = SIGN_EXPAND_MASK
 	#define _disable_texture_expand() _texture_flag_override = 0
-	#define TEX_FLAGS(index) (texture_parameters[index].flags | _texture_flag_override)
+	#define TEX_FLAGS(index) (texture_parameters[index + texture_base_index].flags | _texture_flag_override)
 #else
-	#define TEX_FLAGS(index) texture_parameters[index].flags
+	#define TEX_FLAGS(index) texture_parameters[index + texture_base_index].flags
 #endif
 
 #define TEX_NAME(index) tex##index
 #define TEX_NAME_STENCIL(index) tex##index##_stencil
 
-#define COORD_SCALE1(index, coord1) _texcoord_xform(coord1, texture_parameters[index])
-#define COORD_SCALE2(index, coord2) _texcoord_xform(coord2, texture_parameters[index])
-#define COORD_SCALE3(index, coord3) _texcoord_xform(coord3, texture_parameters[index])
+#define COORD_SCALE1(index, coord1) _texcoord_xform(coord1, texture_parameters[index + texture_base_index])
+#define COORD_SCALE2(index, coord2) _texcoord_xform(coord2, texture_parameters[index + texture_base_index])
+#define COORD_SCALE3(index, coord3) _texcoord_xform(coord3, texture_parameters[index + texture_base_index])
 #define COORD_PROJ1(index, coord2) COORD_SCALE1(index, coord2.x / coord2.y)
 #define COORD_PROJ2(index, coord3) COORD_SCALE2(index, coord3.xy / coord3.z)
 #define COORD_PROJ3(index, coord4) COORD_SCALE3(index, coord4.xyz / coord4.w)
@@ -57,9 +57,9 @@ R"(
 
 #ifdef _ENABLE_SHADOW
 #ifdef _EMULATED_TEXSHADOW
-	#define SHADOW_COORD(index, coord3) _texcoord_xform_shadow(coord3, texture_parameters[index])
-	#define SHADOW_COORD4(index, coord4) _texcoord_xform_shadow(coord4, texture_parameters[index])
-	#define SHADOW_COORD_PROJ(index, coord4) _texcoord_xform_shadow(coord4.xyz / coord4.w, texture_parameters[index])
+	#define SHADOW_COORD(index, coord3) _texcoord_xform_shadow(coord3, texture_parameters[index + texture_base_index])
+	#define SHADOW_COORD4(index, coord4) _texcoord_xform_shadow(coord4, texture_parameters[index + texture_base_index])
+	#define SHADOW_COORD_PROJ(index, coord4) _texcoord_xform_shadow(coord4.xyz / coord4.w, texture_parameters[index + texture_base_index])
 
 	#define TEX2D_SHADOW(index, coord3) texture(TEX_NAME(index), SHADOW_COORD(index, coord3))
 	#define TEX3D_SHADOW(index, coord4) texture(TEX_NAME(index), SHADOW_COORD4(index, coord4))

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPPrologue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXROPPrologue.glsl
@@ -7,7 +7,12 @@ R"(
 		const uvec2 stipple_coord = uvec2(gl_FragCoord.xy) % uvec2(32, 32);
 		const uint address = stipple_coord.y * 32u + stipple_coord.x;
 		const uint bit_offset = (address & 31u);
+	#ifdef VULKAN
+		// In vulkan we have a unified array with a dynamic offset
+		const uint word_index = _get_bits(address, 7, 3) + fs_stipple_pattern_array_offset;
+	#else
 		const uint word_index = _get_bits(address, 7, 3);
+	#endif
 		const uint sub_index = _get_bits(address, 5, 2);
 
 		if (!_test_bit(stipple_pattern[word_index][sub_index], int(bit_offset)))

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXVertexFetch.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXVertexFetch.glsl
@@ -156,7 +156,7 @@ attribute_desc fetch_desc(const in int location)
 
 #ifdef VULKAN
 	// Fetch parameters streamed separately from draw parameters
-	uvec2 attrib = texelFetch(vertex_layout_stream, location + int(layout_ptr_offset)).xy;
+	uvec2 attrib = vertex_layouts[vs_attrib_layout_offset].attrib_data[location];
 #else
 	// Data is packed into a ubo
 	const int block = (location >> 1);
@@ -177,6 +177,11 @@ attribute_desc fetch_desc(const in int location)
 	result.modulo = _test_bit(attrib.y, 31);
 	return result;
 }
+
+#ifdef VULKAN
+#define vertex_index_offset vertex_layouts[vs_attrib_layout_offset].vertex_index_offset
+#define vertex_base_index vertex_layouts[vs_attrib_layout_offset].vertex_base_index
+#endif
 
 vec4 read_location(const in int location)
 {

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXVertexFetch.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXVertexFetch.glsl
@@ -156,7 +156,7 @@ attribute_desc fetch_desc(const in int location)
 
 #ifdef VULKAN
 	// Fetch parameters streamed separately from draw parameters
-	uvec2 attrib = vertex_layouts[vs_attrib_layout_offset].attrib_data[location];
+	uvec2 attrib = get_draw_params().attrib_data[location];
 #else
 	// Data is packed into a ubo
 	const int block = (location >> 1);
@@ -179,8 +179,8 @@ attribute_desc fetch_desc(const in int location)
 }
 
 #ifdef VULKAN
-#define vertex_index_offset vertex_layouts[vs_attrib_layout_offset].vertex_index_offset
-#define vertex_base_index vertex_layouts[vs_attrib_layout_offset].vertex_base_index
+#define vertex_index_offset get_draw_params().vertex_index_offset
+#define vertex_base_index get_draw_params().vertex_base_index
 #endif
 
 vec4 read_location(const in int location)

--- a/rpcs3/Emu/RSX/Program/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Program/GLSLTypes.h
@@ -26,6 +26,7 @@ namespace glsl
 		bool require_lit_emulation : 1;
 		bool require_explicit_invariance : 1;
 		bool require_instanced_render : 1;
+		bool require_clip_functions : 1;
 		bool emulate_zclip_transform : 1;
 		bool emulate_depth_clip_only : 1;
 

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.cpp
@@ -782,10 +782,10 @@ bool fragment_program_compare::compare_properties(const RSXFragmentProgram& bina
 namespace rsx
 {
 #if defined(ARCH_X64) || defined(ARCH_ARM64)
-	static inline void write_fragment_constants_to_buffer_sse2(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize)
+	static inline void write_fragment_constants_to_buffer_sse2(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<u32>& offsets_cache, bool sanitize)
 	{
 		f32* dst = buffer.data();
-		for (usz offset_in_fragment_program : offsets_cache)
+		for (u32 offset_in_fragment_program : offsets_cache)
 		{
 			const char* data = static_cast<const char*>(rsx_prog.get_data()) + offset_in_fragment_program;
 
@@ -809,7 +809,7 @@ namespace rsx
 		}
 	}
 #else
-	static inline void write_fragment_constants_to_buffer_fallback(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize)
+	static inline void write_fragment_constants_to_buffer_fallback(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<u32>& offsets_cache, bool sanitize)
 	{
 		f32* dst = buffer.data();
 
@@ -837,7 +837,7 @@ namespace rsx
 	}
 #endif
 
-	void write_fragment_constants_to_buffer(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize)
+	void write_fragment_constants_to_buffer(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<u32>& offsets_cache, bool sanitize)
 	{
 #if defined(ARCH_X64) || defined(ARCH_ARM64)
 		write_fragment_constants_to_buffer_sse2(buffer, rsx_prog, offsets_cache, sanitize);

--- a/rpcs3/Emu/RSX/Program/ProgramStateCache.h
+++ b/rpcs3/Emu/RSX/Program/ProgramStateCache.h
@@ -137,7 +137,7 @@ namespace rsx
 		RSXVertexProgram m_cached_vp_properties;
 	};
 
-	void write_fragment_constants_to_buffer(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<usz>& offsets_cache, bool sanitize = true);
+	void write_fragment_constants_to_buffer(const std::span<f32>& buffer, const RSXFragmentProgram& rsx_prog, const std::vector<u32>& offsets_cache, bool sanitize = true);
 }
 
 
@@ -447,14 +447,14 @@ public:
 
 	void fill_fragment_constants_buffer(std::span<f32> dst_buffer, const fragment_program_type& fragment_program, const RSXFragmentProgram& rsx_prog, bool sanitize = false) const
 	{
-		if (dst_buffer.size_bytes() < (fragment_program.FragmentConstantOffsetCache.size() * 16))
+		if (dst_buffer.size_bytes() < (fragment_program.constant_offsets.size() * 16))
 		{
 			// This can happen if CELL alters the shader after it has been loaded by RSX.
 			rsx_log.error("Insufficient constants buffer size passed to fragment program! Corrupt shader?");
 			return;
 		}
 
-		rsx::write_fragment_constants_to_buffer(dst_buffer, rsx_prog, fragment_program.FragmentConstantOffsetCache, sanitize);
+		rsx::write_fragment_constants_to_buffer(dst_buffer, rsx_prog, fragment_program.constant_offsets, sanitize);
 	}
 
 	void clear()

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -820,30 +820,17 @@ void VKGSRender::emit_geometry(u32 sub_index)
 		update_descriptors = true;
 
 		// Allocate stream layout memory for this batch
-		m_vertex_layout_stream_info.range = rsx::method_registers.current_draw_clause.pass_count() * 128;
-		m_vertex_layout_stream_info.offset = m_vertex_layout_ring_info.alloc<256>(m_vertex_layout_stream_info.range);
-
-		if (vk::test_status_interrupt(vk::heap_changed))
-		{
-			if (m_vertex_layout_storage &&
-				m_vertex_layout_storage->info.buffer != m_vertex_layout_ring_info.heap->value)
-			{
-				vk::get_resource_manager()->dispose(m_vertex_layout_storage);
-			}
-
-			vk::clear_status_interrupt(vk::heap_changed);
-		}
+		const u64 alloc_size = rsx::method_registers.current_draw_clause.pass_count() * 144;
+		m_vertex_layout_dynamic_offset = m_vertex_layout_ring_info.alloc<16>(alloc_size);
 	}
 
 	// Update vertex fetch parameters
 	update_vertex_env(sub_index, upload_info);
 
-	ensure(m_vertex_layout_storage);
 	if (update_descriptors)
 	{
 		m_program->bind_uniform(persistent_buffer, vk::glsl::binding_set_index_vertex, m_vs_binding_table->vertex_buffers_location);
 		m_program->bind_uniform(volatile_buffer, vk::glsl::binding_set_index_vertex, m_vs_binding_table->vertex_buffers_location + 1);
-		m_program->bind_uniform(m_vertex_layout_storage->value, vk::glsl::binding_set_index_vertex, m_vs_binding_table->vertex_buffers_location + 2);
 	}
 
 	bool reload_state = (!m_current_draw.subdraw_id++);

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -820,8 +820,8 @@ void VKGSRender::emit_geometry(u32 sub_index)
 		update_descriptors = true;
 
 		// Allocate stream layout memory for this batch
-		const u64 alloc_size = rsx::method_registers.current_draw_clause.pass_count() * 160;
-		m_vertex_layout_dynamic_offset = m_vertex_layout_ring_info.alloc<16>(alloc_size);
+		const u64 alloc_size = rsx::method_registers.current_draw_clause.pass_count() * 168;
+		m_vertex_layout_dynamic_offset = m_vertex_layout_ring_info.alloc<8>(alloc_size);
 	}
 
 	// Update vertex fetch parameters

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -820,7 +820,7 @@ void VKGSRender::emit_geometry(u32 sub_index)
 		update_descriptors = true;
 
 		// Allocate stream layout memory for this batch
-		const u64 alloc_size = rsx::method_registers.current_draw_clause.pass_count() * 144;
+		const u64 alloc_size = rsx::method_registers.current_draw_clause.pass_count() * 160;
 		m_vertex_layout_dynamic_offset = m_vertex_layout_ring_info.alloc<16>(alloc_size);
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -339,9 +339,9 @@ void VKFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	if (m_shader_props.require_fog_read)
 	{
 		OS <<
-			"const float fog_param0 = fs_contexts[fs_context_offset].fog_param0;\n"
-			"const float fog_param1 = fs_contexts[fs_context_offset].fog_param1;\n"
-			"const uint fog_mode = fs_contexts[fs_context_offset].fog_mode;\n\n";
+			"#define fog_param0 fs_contexts[fs_context_offset].fog_param0\n"
+			"#define fog_param1 fs_contexts[fs_context_offset].fog_param1\n"
+			"#define fog_mode fs_contexts[fs_context_offset].fog_mode\n\n";
 	}
 
 	if (m_shader_props.require_wpos)

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -346,8 +346,8 @@ void VKFragmentDecompilerThread::insertGlobalFunctions(std::stringstream &OS)
 	if (m_shader_props.require_wpos)
 	{
 		OS <<
-			"const float wpos_scale fs_contexts[fs_context_offset].wpos_scale;\n"
-			"const float wpos_bias fs_contexts[fs_context_offset].wpos_bias;\n\n";
+			"#define wpos_scale fs_contexts[fs_context_offset].wpos_scale\n"
+			"#define wpos_bias fs_contexts[fs_context_offset].wpos_bias\n\n";
 	}
 
 	OS << "#define texture_base_index fs_texture_base_index\n\n";

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -286,7 +286,7 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 	OS <<
 		"layout(push_constant) uniform push_constants_block\n"
 		"{\n"
-		"	uint fs_constants_offset;\n"
+		"	layout(offset=12) uint fs_constants_offset;\n"
 		"};\n\n";
 
 	const vk::glsl::program_input push_constants

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -235,7 +235,8 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 		"#define get_draw_params() draw_parameters[draw_parameters_offset]\n"
 		"#define fs_constants_offset get_draw_params().fs_constants_offset\n"
 		"#define fs_context_offset get_draw_params().fs_context_offset\n"
-		"#define fs_texture_base_index get_draw_params().fs_texture_base_index\n\n";
+		"#define fs_texture_base_index get_draw_params().fs_texture_base_index\n"
+		"#define fs_stipple_pattern_array_offset get_draw_params().fs_stipple_pattern_offset\n\n";
 
 	if (!properties.constant_offsets.empty())
 	{
@@ -257,9 +258,9 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 	OS << "	sampler_info texture_parameters[];\n";
 	OS << "};\n\n";
 
-	OS << "layout(std140, set=1, binding=" << vk_prog->binding_table.polygon_stipple_params_location << ") uniform RasterizerHeap\n";
+	OS << "layout(std430, set=1, binding=" << vk_prog->binding_table.polygon_stipple_params_location << ") readonly buffer RasterizerHeap\n";
 	OS << "{\n";
-	OS << "	uvec4 stipple_pattern[8];\n";
+	OS << "	uvec4 stipple_pattern[];\n";
 	OS << "};\n\n";
 
 	vk::glsl::program_input in
@@ -287,7 +288,7 @@ void VKFragmentDecompilerThread::insertConstants(std::stringstream & OS)
 	inputs.push_back(in);
 
 	in.location = vk_prog->binding_table.polygon_stipple_params_location;
-	in.type = vk::glsl::input_type_uniform_buffer;
+	in.type = vk::glsl::input_type_storage_buffer;
 	in.name = "RasterizerHeap";
 	inputs.push_back(in);
 

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
@@ -62,7 +62,7 @@ public:
 	VkShaderModule handle = nullptr;
 	u32 id;
 	vk::glsl::shader shader;
-	std::vector<usz> FragmentConstantOffsetCache;
+	std::vector<u32> constant_offsets;
 
 	std::array<u32, 4> output_color_masks{ {} };
 	std::vector<vk::glsl::program_input> uniforms;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -1941,8 +1941,8 @@ void VKGSRender::load_program_env()
 	if (update_vertex_env)
 	{
 		// Vertex state
-		const auto mem = m_vertex_env_ring_info.static_alloc<256>();
-		auto buf = static_cast<u8*>(m_vertex_env_ring_info.map(mem, 148));
+		const auto mem = m_vertex_env_ring_info.static_alloc<128>();
+		auto buf = static_cast<u8*>(m_vertex_env_ring_info.map(mem, 84));
 
 		m_draw_processor.fill_scale_offset_data(buf, false);
 		m_draw_processor.fill_user_clip_data(buf + 64);
@@ -1952,7 +1952,7 @@ void VKGSRender::load_program_env()
 		*(reinterpret_cast<f32*>(buf + 80)) = ctx->clip_max();
 
 		m_vertex_env_ring_info.unmap();
-		m_vertex_env_buffer_info = { m_vertex_env_ring_info.heap->value, mem, 144 };
+		m_vertex_env_buffer_info = { m_vertex_env_ring_info.heap->value, mem, 128 };
 	}
 
 	if (update_instancing_data)

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -512,7 +512,7 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	m_attrib_ring_info.create(VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, VK_ATTRIB_RING_BUFFER_SIZE_M * 0x100000, "attrib buffer", 0x400000, VK_TRUE);
 	m_fragment_env_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "fragment env buffer");
 	m_vertex_env_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "vertex env buffer");
-	m_fragment_texture_params_ring_info.create(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "fragment texture params buffer");
+	m_fragment_texture_params_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "fragment texture params buffer");
 	m_vertex_layout_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "vertex layout buffer", 0x10000, VK_TRUE);
 	m_fragment_constants_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "fragment constants buffer");
 	m_transform_constants_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_TRANSFORM_CONSTANTS_BUFFER_SIZE_M * 0x100000, "transform constants buffer");
@@ -554,7 +554,7 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	m_vertex_env_buffer_info = { m_vertex_env_ring_info.heap->value, 0, VK_WHOLE_SIZE };
 	m_vertex_constants_buffer_info = { m_transform_constants_ring_info.heap->value, 0, VK_WHOLE_SIZE };
 	m_fragment_env_buffer_info = { m_fragment_env_ring_info.heap->value, 0, VK_WHOLE_SIZE };
-	m_fragment_texture_params_buffer_info = { m_fragment_texture_params_ring_info.heap->value, 0, 16 };
+	m_fragment_texture_params_buffer_info = { m_fragment_texture_params_ring_info.heap->value, 0, VK_WHOLE_SIZE };
 	m_raster_env_buffer_info = { m_raster_env_ring_info.heap->value, 0, 128 };
 	m_vertex_layout_stream_info = { m_vertex_layout_ring_info.heap->value, 0, VK_WHOLE_SIZE };
 	m_fragment_constants_buffer_info = { m_fragment_constants_ring_info.heap->value, 0, VK_WHOLE_SIZE };
@@ -2029,12 +2029,11 @@ void VKGSRender::load_program_env()
 
 	if (update_fragment_texture_env)
 	{
-		auto mem = m_fragment_texture_params_ring_info.static_alloc<256, 768>();
-		auto buf = m_fragment_texture_params_ring_info.map(mem, 768);
+		m_texture_parameters_dynamic_offset = m_fragment_texture_params_ring_info.static_alloc<16, 768>();
+		auto buf = m_fragment_texture_params_ring_info.map(m_texture_parameters_dynamic_offset, 768);
 
 		current_fragment_program.texture_params.write_to(buf, current_fp_metadata.referenced_textures_mask);
 		m_fragment_texture_params_ring_info.unmap();
-		m_fragment_texture_params_buffer_info = { m_fragment_texture_params_ring_info.heap->value, mem, 768 };
 	}
 
 	if (update_raster_env)
@@ -2196,6 +2195,7 @@ void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_
 	{
 		u32 fs_constants_offset;
 		u32 fs_context_offset;
+		u32 fs_texture_base_index;
 	};
 
 	struct rsx_prog_vertex_layout_entry_t
@@ -2214,6 +2214,7 @@ void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_
 	const u32 vertex_layout_offset = static_cast<u32>(m_vertex_layout_dynamic_offset) / 144u;
 	const u32 fs_constant_id_offset = static_cast<u32>(m_fragment_constants_dynamic_offset) / 16u;
 	const u32 fs_context_offset = static_cast<u32>(m_fragment_env_dynamic_offset) / 32u;
+	const u32 fs_texture_base_index = static_cast<u32>(m_texture_parameters_dynamic_offset) / 48u;
 
 	// Pack
 	rsx_vs_prog_push_constants_block_t vs_push_constants;
@@ -2224,6 +2225,7 @@ void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_
 	rsx_fs_prog_push_constants_block_t fs_push_constants;
 	fs_push_constants.fs_constants_offset = fs_constant_id_offset;
 	fs_push_constants.fs_context_offset = fs_context_offset;
+	fs_push_constants.fs_texture_base_index = fs_texture_base_index;
 
 	vkCmdPushConstants(
 		*m_current_command_buffer,

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2185,6 +2185,7 @@ void VKGSRender::upload_transform_constants(const rsx::io_buffer& buffer)
 
 void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_info)
 {
+#pragma pack(push, 1)
 	struct rsx_vs_prog_push_constants_block_t
 	{
 		u32 xform_constants_offset;
@@ -2205,6 +2206,7 @@ void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_
 		u32 reserved;
 		s32 attrib_data[1];
 	};
+#pragma pack(pop)
 
 	// Actual allocation must have been done previously
 	const u32 vs_constant_id_offset = static_cast<u32>(m_xform_constants_dynamic_offset) / 16u;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -2210,7 +2210,7 @@ void VKGSRender::update_vertex_env(u32 id, const vk::vertex_upload_info& vertex_
 
 	// Actual allocation must have been done previously
 	const u32 vs_constant_id_offset = static_cast<u32>(m_xform_constants_dynamic_offset) / 16u;
-	const u32 vertex_context_offset = static_cast<u32>(m_vertex_env_dynamic_offset) / 128u;
+	const u32 vertex_context_offset = static_cast<u32>(m_vertex_env_dynamic_offset) / 96u;
 	const u32 vertex_layout_offset = static_cast<u32>(m_vertex_layout_dynamic_offset) / 144u;
 	const u32 fs_constant_id_offset = static_cast<u32>(m_fragment_constants_dynamic_offset) / 16u;
 

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -518,7 +518,7 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	m_transform_constants_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_TRANSFORM_CONSTANTS_BUFFER_SIZE_M * 0x100000, "transform constants buffer");
 	m_index_buffer_ring_info.create(VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_INDEX_RING_BUFFER_SIZE_M * 0x100000, "index buffer");
 	m_texture_upload_buffer_ring_info.create(VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_TEXTURE_UPLOAD_RING_BUFFER_SIZE_M * 0x100000, "texture upload buffer", 32 * 0x100000);
-	m_raster_env_ring_info.create(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "raster env buffer");
+	m_raster_env_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_UBO_RING_BUFFER_SIZE_M * 0x100000, "raster env buffer");
 	m_instancing_buffer_ring_info.create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_TRANSFORM_CONSTANTS_BUFFER_SIZE_M * 0x100000, "instancing data buffer");
 
 	vk::data_heap_manager::register_ring_buffers

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -155,6 +155,7 @@ private:
 	u64 m_vertex_layout_dynamic_offset = 0;
 	u64 m_fragment_constants_dynamic_offset = 0;
 	u64 m_fragment_env_dynamic_offset = 0;
+	u64 m_texture_parameters_dynamic_offset = 0;
 
 	std::array<vk::frame_context_t, VK_MAX_ASYNC_FRAMES> frame_context_storage;
 	//Temp frame context to use if the real frame queue is overburdened. Only used for storage

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -152,6 +152,7 @@ private:
 
 	rsx::simple_array<u8> m_multidraw_parameters_buffer;
 	u64 m_xform_constants_dynamic_offset = 0;          // We manage transform_constants dynamic offset manually to alleviate performance penalty of doing a hot-patch of constants.
+	u64 m_vertex_env_dynamic_offset = 0;
 
 	std::array<vk::frame_context_t, VK_MAX_ASYNC_FRAMES> frame_context_storage;
 	//Temp frame context to use if the real frame queue is overburdened. Only used for storage

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -79,7 +79,6 @@ private:
 
 	std::unique_ptr<vk::buffer_view> m_persistent_attribute_storage;
 	std::unique_ptr<vk::buffer_view> m_volatile_attribute_storage;
-	std::unique_ptr<vk::buffer_view> m_vertex_layout_storage;
 
 	VkDependencyInfoKHR m_async_compute_dependency_info {};
 	VkMemoryBarrier2KHR m_async_compute_memory_barrier {};
@@ -153,6 +152,7 @@ private:
 	rsx::simple_array<u8> m_multidraw_parameters_buffer;
 	u64 m_xform_constants_dynamic_offset = 0;          // We manage transform_constants dynamic offset manually to alleviate performance penalty of doing a hot-patch of constants.
 	u64 m_vertex_env_dynamic_offset = 0;
+	u64 m_vertex_layout_dynamic_offset = 0;
 
 	std::array<vk::frame_context_t, VK_MAX_ASYNC_FRAMES> frame_context_storage;
 	//Temp frame context to use if the real frame queue is overburdened. Only used for storage

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -153,6 +153,7 @@ private:
 	u64 m_xform_constants_dynamic_offset = 0;          // We manage transform_constants dynamic offset manually to alleviate performance penalty of doing a hot-patch of constants.
 	u64 m_vertex_env_dynamic_offset = 0;
 	u64 m_vertex_layout_dynamic_offset = 0;
+	u64 m_fragment_constants_dynamic_offset = 0;
 
 	std::array<vk::frame_context_t, VK_MAX_ASYNC_FRAMES> frame_context_storage;
 	//Temp frame context to use if the real frame queue is overburdened. Only used for storage

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -156,6 +156,7 @@ private:
 	u64 m_fragment_constants_dynamic_offset = 0;
 	u64 m_fragment_env_dynamic_offset = 0;
 	u64 m_texture_parameters_dynamic_offset = 0;
+	u64 m_stipple_array_dynamic_offset = 0;
 
 	std::array<vk::frame_context_t, VK_MAX_ASYNC_FRAMES> frame_context_storage;
 	//Temp frame context to use if the real frame queue is overburdened. Only used for storage

--- a/rpcs3/Emu/RSX/VK/VKGSRender.h
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.h
@@ -154,6 +154,7 @@ private:
 	u64 m_vertex_env_dynamic_offset = 0;
 	u64 m_vertex_layout_dynamic_offset = 0;
 	u64 m_fragment_constants_dynamic_offset = 0;
+	u64 m_fragment_env_dynamic_offset = 0;
 
 	std::array<vk::frame_context_t, VK_MAX_ASYNC_FRAMES> frame_context_storage;
 	//Temp frame context to use if the real frame queue is overburdened. Only used for storage

--- a/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRenderTypes.hpp
@@ -74,7 +74,7 @@ namespace vk
 			}
 
 			++reset_id;
-			CHECK_RESULT(vkResetCommandBuffer(commands, 0));
+			vk::command_buffer::reset();
 		}
 
 		bool poke()

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -414,8 +414,8 @@ namespace vk
 				bind_sets[count++] = set.commit();   // Commit variable changes and return handle to the new set
 			}
 
-			vkCmdBindPipeline(cmd, bind_point, m_pipeline);
-			vkCmdBindDescriptorSets(cmd, bind_point, m_pipeline_layout, 0, count, bind_sets, 0, nullptr);
+			cmd.bind_pipeline(m_pipeline, bind_point);
+			cmd.bind_descriptor_sets({ bind_sets, count }, bind_point, m_pipeline_layout);
 			return *this;
 		}
 

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -651,7 +651,7 @@ namespace vk
 						.binding = input.location,
 						.descriptorType = type,
 						.descriptorCount = descriptor_count(input.name),
-						.stageFlags = to_shader_stage_flags(input.domain)
+						.stageFlags = to_shader_stage_flags(input.domain) | input.ex_stages
 					};
 					bindings.push_back(binding);
 

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
@@ -130,6 +130,9 @@ namespace vk
 			rsx::simple_array<VkDescriptorPoolSize> m_descriptor_pool_sizes;
 			rsx::simple_array<VkDescriptorType> m_descriptor_types;
 
+			u32 m_descriptor_template_typemask = 0u;
+			rsx::simple_array<VkWriteDescriptorSet> m_descriptor_template;
+
 			std::vector<descriptor_slot_t> m_descriptor_slots;
 			std::vector<bool> m_descriptors_dirty;
 			bool m_any_descriptors_dirty = false;

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
@@ -60,6 +60,8 @@ namespace vk
 			u32 location = umax;
 			std::string name = "undefined";
 
+			VkFlags ex_stages = 0;
+
 			inline bound_buffer& as_buffer() { return *std::get_if<bound_buffer>(&bound_data); }
 			inline bound_sampler& as_sampler() { return *std::get_if<bound_sampler>(&bound_data); }
 			inline push_constant_ref& as_push_constant() { return *std::get_if<push_constant_ref>(&bound_data); }

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
@@ -134,6 +134,7 @@ namespace vk
 
 			u32 m_descriptor_template_typemask = 0u;
 			rsx::simple_array<VkWriteDescriptorSet> m_descriptor_template;
+			u64 m_descriptor_template_cache_id = umax;
 
 			std::vector<descriptor_slot_t> m_descriptor_slots;
 			std::vector<bool> m_descriptors_dirty;
@@ -148,6 +149,8 @@ namespace vk
 
 			void create_descriptor_set_layout();
 			void create_descriptor_pool();
+			void create_descriptor_template();
+			void update_descriptor_template();
 
 			VkDescriptorSet allocate_descriptor_set();
 			VkDescriptorSet commit();

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -302,7 +302,7 @@ namespace vk
 			{
 				dma_sync(true);
 
-				std::vector<VkBufferCopy> copy;
+				rsx::simple_array<VkBufferCopy> copy;
 				copy.reserve(transfer_height);
 
 				u32 dst_offset = dma_mapping.first;
@@ -398,7 +398,7 @@ namespace vk
 		m_cached_memory_size = 0;
 	}
 
-	void texture_cache::copy_transfer_regions_impl(vk::command_buffer& cmd, vk::image* dst, const std::vector<copy_region_descriptor>& sections_to_transfer) const
+	void texture_cache::copy_transfer_regions_impl(vk::command_buffer& cmd, vk::image* dst, const rsx::simple_array<copy_region_descriptor>& sections_to_transfer) const
 	{
 		const auto dst_aspect = dst->aspect();
 		const auto dst_bpp = vk::get_format_texel_width(dst->format());
@@ -585,7 +585,7 @@ namespace vk
 		return mapping;
 	}
 
-	vk::image* texture_cache::get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const
+	vk::image* texture_cache::get_template_from_collection_impl(const rsx::simple_array<copy_region_descriptor>& sections_to_transfer) const
 	{
 		if (sections_to_transfer.size() == 1) [[likely]]
 		{
@@ -714,7 +714,7 @@ namespace vk
 
 		if (copy)
 		{
-			std::vector<copy_region_descriptor> region =
+			rsx::simple_array<copy_region_descriptor> region =
 			{ {
 				.src = source,
 				.xform = rsx::surface_transform::coordinate_transform,
@@ -750,7 +750,7 @@ namespace vk
 	}
 
 	vk::image_view* texture_cache::generate_cubemap_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 size,
-		const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
+		const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
 	{
 		auto _template = get_template_from_collection_impl(sections_to_copy);
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
@@ -785,7 +785,7 @@ namespace vk
 	}
 
 	vk::image_view* texture_cache::generate_3d_from_2d_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height, u16 depth,
-		const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
+		const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
 	{
 		auto _template = get_template_from_collection_impl(sections_to_copy);
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_3D,
@@ -820,7 +820,7 @@ namespace vk
 	}
 
 	vk::image_view* texture_cache::generate_atlas_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
-		const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
+		const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
 	{
 		auto _template = get_template_from_collection_impl(sections_to_copy);
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
@@ -858,7 +858,7 @@ namespace vk
 	}
 
 	vk::image_view* texture_cache::generate_2d_mipmaps_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
-		const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
+		const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
 	{
 		const auto mipmaps = ::narrow<u8>(sections_to_copy.size());
 		auto _template = get_template_from_collection_impl(sections_to_copy);
@@ -905,7 +905,7 @@ namespace vk
 
 	void texture_cache::update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, vk::image* src, u16 width, u16 height)
 	{
-		std::vector<copy_region_descriptor> region =
+		rsx::simple_array<copy_region_descriptor> region =
 		{ {
 			.src = src,
 			.xform = rsx::surface_transform::identity,

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -1339,7 +1339,7 @@ namespace vk
 			cmd.submit(submit_info, VK_TRUE);
 			vk::wait_for_fence(&submit_fence, GENERAL_WAIT_TIMEOUT);
 
-			CHECK_RESULT(vkResetCommandBuffer(cmd, 0));
+			cmd.reset();
 			cmd.begin();
 		}
 		else

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -301,7 +301,7 @@ namespace vk
 			if (const auto tiled_region = rsx::get_current_renderer()->get_tiled_memory_region(range))
 			{
 				auto real_data = vm::get_super_ptr<u8>(range.start);
-				auto out_data = std::vector<u8>(tiled_region.tile->size);
+				auto out_data = rsx::simple_array<u8>(tiled_region.tile->size);
 				rsx::tile_texel_data<u32>(
 					out_data.data(),
 					real_data,
@@ -325,7 +325,7 @@ namespace vk
 
 				// Read-modify-write to avoid corrupting already resident memory outside texture region
 				void* data = get_ptr(range.start);
-				std::vector<u8> tmp_data(rsx_pitch * height);
+				rsx::simple_array<u8> tmp_data(rsx_pitch * height);
 				std::memcpy(tmp_data.data(), data, tmp_data.size());
 
 				switch (gcm_format)
@@ -366,7 +366,7 @@ namespace vk
 			rsx_pitch = pitch;
 		}
 
-		void sync_surface_memory(const std::vector<cached_texture_section*>& surfaces)
+		void sync_surface_memory(const rsx::simple_array<cached_texture_section*>& surfaces)
 		{
 			auto rtt = vk::as_rtt(vram_texture);
 			rtt->sync_tag();
@@ -445,9 +445,9 @@ namespace vk
 
 		VkComponentMapping apply_component_mapping_flags(u32 gcm_format, rsx::component_order flags, const rsx::texture_channel_remap_t& remap_vector) const;
 
-		void copy_transfer_regions_impl(vk::command_buffer& cmd, vk::image* dst, const std::vector<copy_region_descriptor>& sections_to_transfer) const;
+		void copy_transfer_regions_impl(vk::command_buffer& cmd, vk::image* dst, const rsx::simple_array<copy_region_descriptor>& sections_to_transfer) const;
 
-		vk::image* get_template_from_collection_impl(const std::vector<copy_region_descriptor>& sections_to_transfer) const;
+		vk::image* get_template_from_collection_impl(const rsx::simple_array<copy_region_descriptor>& sections_to_transfer) const;
 
 		std::unique_ptr<vk::viewable_image> find_cached_image(VkFormat format, u16 w, u16 h, u16 d, u16 mipmaps, VkImageType type, VkImageCreateFlags create_flags, VkImageUsageFlags usage, VkSharingMode sharing);
 
@@ -462,16 +462,16 @@ namespace vk
 			u16 x, u16 y, u16 w, u16 h, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* generate_cubemap_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 size,
-			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
+			const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* generate_3d_from_2d_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height, u16 depth,
-			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
+			const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* generate_atlas_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
-			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
+			const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		vk::image_view* generate_2d_mipmaps_from_images(vk::command_buffer& cmd, u32 gcm_format, u16 width, u16 height,
-			const std::vector<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
+			const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector) override;
 
 		void release_temporary_subresource(vk::image_view* view) override;
 

--- a/rpcs3/Emu/RSX/VK/vkutils/commands.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/commands.h
@@ -75,7 +75,9 @@ namespace vk
 
 		// State cache
 		mutable std::array<VkDescriptorSet, 2> m_bound_descriptor_sets {{ VK_NULL_HANDLE }};
-		mutable VkPipeline m_bound_pipeline = VK_NULL_HANDLE;
+		mutable std::array<VkPipeline, 2> m_bound_pipelines{{ VK_NULL_HANDLE }};
+
+		void clear_state_cache();
 
 	public:
 		enum access_type_hint

--- a/rpcs3/Emu/RSX/VK/vkutils/commands.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/commands.h
@@ -4,6 +4,8 @@
 #include "device.h"
 #include "sync.h"
 
+#include <span>
+
 namespace vk
 {
 	class command_pool

--- a/rpcs3/Emu/RSX/VK/vkutils/commands.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/commands.h
@@ -71,6 +71,10 @@ namespace vk
 		command_pool* pool = nullptr;
 		VkCommandBuffer commands = nullptr;
 
+		// State cache
+		mutable std::array<VkDescriptorSet, 2> m_bound_descriptor_sets {{ VK_NULL_HANDLE }};
+		mutable VkPipeline m_bound_pipeline = VK_NULL_HANDLE;
+
 	public:
 		enum access_type_hint
 		{
@@ -97,40 +101,28 @@ namespace vk
 
 		void create(command_pool& cmd_pool);
 		void destroy();
+		void reset();
 
 		void begin();
 		void end();
 		void submit(queue_submit_t& submit_info, VkBool32 flush = VK_FALSE);
 
+		// Abstractions with caching
+		void bind_pipeline(VkPipeline pipeline, VkPipelineBindPoint bind_point) const;
+		void bind_descriptor_sets(const std::span<VkDescriptorSet>& sets, VkPipelineBindPoint bind_point, VkPipelineLayout pipe_layout) const;
+		void bind_descriptor_sets(const std::span<VkDescriptorSet>& sets, const std::span<u32>& dynamic_offsets, VkPipelineBindPoint bind_point, VkPipelineLayout pipe_layout) const;
+
 		// Properties
-		command_pool& get_command_pool() const
-		{
-			return *pool;
-		}
+		command_pool& get_command_pool() const { return *pool; }
+		u32 get_queue_family() const { return pool->get_queue_family(); }
+		bool is_recording() const { return is_open; }
 
-		u32 get_queue_family() const
-		{
-			return pool->get_queue_family();
-		}
-
-		void clear_flags()
-		{
-			flags = 0;
-		}
-
-		void set_flag(command_buffer_data_flag flag)
-		{
-			flags |= flag;
-		}
+		void clear_flags() { flags = 0; }
+		void set_flag(command_buffer_data_flag flag) { flags |= flag; }
 
 		operator VkCommandBuffer() const
 		{
 			return commands;
-		}
-
-		bool is_recording() const
-		{
-			return is_open;
 		}
 	};
 }

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -468,6 +468,7 @@ namespace vk
 		const auto num_copies = ::size32(m_pending_copies);
 		vkUpdateDescriptorSets(*g_render_device, num_writes, m_pending_writes.data(), num_copies, m_pending_copies.data());
 
+		m_storage_cache_id++;
 		m_push_type_mask = 0;
 		m_pending_writes.clear();
 		m_pending_copies.clear();

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -453,7 +453,8 @@ namespace vk
 		// Notify
 		on_bind();
 
-		vkCmdBindDescriptorSets(cmd, bind_point, layout, 0, 1, &m_handle, ::size32(m_dynamic_offsets), m_dynamic_offsets.data());
+		VkDescriptorSet sets[1] = { m_handle };
+		cmd.bind_descriptor_sets(sets, m_dynamic_offsets, bind_point, layout);
 	}
 
 	void descriptor_set::flush()

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -404,30 +404,15 @@ namespace vk
 		vkUpdateDescriptorSets(*g_render_device, 1, &writer, 0, nullptr);
 	}
 
-	void descriptor_set::push(rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask)
+	void descriptor_set::push(const rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask)
 	{
 		m_push_type_mask |= type_mask;
-
-		if (m_pending_copies.empty()) [[likely]]
-		{
-			m_pending_copies = std::move(copy_cmd);
-			return;
-		}
-
 		m_pending_copies += copy_cmd;
 	}
 
-	void descriptor_set::push(rsx::simple_array<VkWriteDescriptorSet>& write_cmds, u32 type_mask)
+	void descriptor_set::push(const rsx::simple_array<VkWriteDescriptorSet>& write_cmds, u32 type_mask)
 	{
 		m_push_type_mask |= type_mask;
-
-#if !defined(__clang__) || (__clang_major__ >= 16)
-		if (m_pending_writes.empty()) [[unlikely]]
-		{
-			m_pending_writes = std::move(write_cmds);
-			return;
-		}
-#endif
 		m_pending_writes += write_cmds;
 	}
 

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -85,43 +85,6 @@ namespace vk
 		void init(VkDescriptorSet new_set);
 
 	public:
-		descriptor_set(VkDescriptorSet set);
-		descriptor_set() = default;
-		~descriptor_set();
-
-		descriptor_set(const descriptor_set&) = delete;
-
-		void swap(descriptor_set& other);
-		descriptor_set& operator = (VkDescriptorSet set);
-
-		VkDescriptorSet value() const { return m_handle; }
-		operator bool() const { return m_handle != VK_NULL_HANDLE; }
-
-		VkDescriptorSet* ptr();
-		void push(const VkBufferView& buffer_view, VkDescriptorType type, u32 binding);
-		void push(const VkDescriptorBufferInfo& buffer_info, VkDescriptorType type, u32 binding);
-		void push(const VkDescriptorImageInfo& image_info, VkDescriptorType type, u32 binding);
-		void push(const VkDescriptorImageInfo* image_info, u32 count, VkDescriptorType type, u32 binding);
-		void push(const rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask = umax);
-		void push(const rsx::simple_array<VkWriteDescriptorSet>& write_cmds, u32 type_mask = umax);
-		void push(const descriptor_set_dynamic_offset_t& offset);
-
-		void on_bind();
-		void bind(const vk::command_buffer& cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout);
-
-		void flush();
-
-	private:
-		VkDescriptorSet m_handle = VK_NULL_HANDLE;
-		u64 m_update_after_bind_mask = 0;
-		u64 m_push_type_mask = 0;
-		bool m_in_use = false;
-
-		rsx::simple_array<VkBufferView> m_buffer_view_pool;
-		rsx::simple_array<VkDescriptorBufferInfo> m_buffer_info_pool;
-		rsx::simple_array<VkDescriptorImageInfo> m_image_info_pool;
-		rsx::simple_array<u32> m_dynamic_offsets;
-
 #if defined(__clang__) && (__clang_major__ < 16)
 		// Clang (pre 16.x) does not support LWG 2089, std::construct_at for POD types
 		struct WriteDescriptorSetT : public VkWriteDescriptorSet
@@ -153,6 +116,67 @@ namespace vk
 #else
 		using WriteDescriptorSetT = VkWriteDescriptorSet;
 #endif
+
+	public:
+		descriptor_set(VkDescriptorSet set);
+		descriptor_set() = default;
+		~descriptor_set();
+
+		descriptor_set(const descriptor_set&) = delete;
+
+		void swap(descriptor_set& other);
+		descriptor_set& operator = (VkDescriptorSet set);
+
+		VkDescriptorSet value() const { return m_handle; }
+		operator bool() const { return m_handle != VK_NULL_HANDLE; }
+
+		VkDescriptorSet* ptr();
+		void push(const VkBufferView& buffer_view, VkDescriptorType type, u32 binding);
+		void push(const VkDescriptorBufferInfo& buffer_info, VkDescriptorType type, u32 binding);
+		void push(const VkDescriptorImageInfo& image_info, VkDescriptorType type, u32 binding);
+		void push(const VkDescriptorImageInfo* image_info, u32 count, VkDescriptorType type, u32 binding);
+		void push(const rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask = umax);
+		void push(const rsx::simple_array<VkWriteDescriptorSet>& write_cmds, u32 type_mask = umax);
+		void push(const descriptor_set_dynamic_offset_t& offset);
+
+		// Event handlers
+		void on_bind();
+		void bind(const vk::command_buffer& cmd, VkPipelineBindPoint bind_point, VkPipelineLayout layout);
+
+		void flush();
+
+		// Typed temporary storage access. Should be inline, the overhead is significant
+		FORCE_INLINE VkBufferView* store(const VkBufferView& buffer_view)
+		{
+			m_buffer_view_pool.push_back(buffer_view);
+			return &m_buffer_view_pool.back();
+		}
+
+		FORCE_INLINE VkDescriptorBufferInfo* store(const VkDescriptorBufferInfo& buffer_info)
+		{
+			m_buffer_info_pool.push_back(buffer_info);
+			return &m_buffer_info_pool.back();
+		}
+
+		FORCE_INLINE VkDescriptorImageInfo* store(const VkDescriptorImageInfo& image_info)
+		{
+			m_image_info_pool.push_back(image_info);
+			return &m_image_info_pool.back();
+		}
+
+		// Temporary storage accessor
+		const rsx::simple_array<WriteDescriptorSetT> peek() const { return m_pending_writes; }
+
+	private:
+		VkDescriptorSet m_handle = VK_NULL_HANDLE;
+		u64 m_update_after_bind_mask = 0;
+		u64 m_push_type_mask = 0;
+		bool m_in_use = false;
+
+		rsx::simple_array<VkBufferView> m_buffer_view_pool;
+		rsx::simple_array<VkDescriptorBufferInfo> m_buffer_info_pool;
+		rsx::simple_array<VkDescriptorImageInfo> m_image_info_pool;
+		rsx::simple_array<u32> m_dynamic_offsets;
 
 		rsx::simple_array<WriteDescriptorSetT> m_pending_writes;
 		rsx::simple_array<VkCopyDescriptorSet> m_pending_copies;

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -102,8 +102,8 @@ namespace vk
 		void push(const VkDescriptorBufferInfo& buffer_info, VkDescriptorType type, u32 binding);
 		void push(const VkDescriptorImageInfo& image_info, VkDescriptorType type, u32 binding);
 		void push(const VkDescriptorImageInfo* image_info, u32 count, VkDescriptorType type, u32 binding);
-		void push(rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask = umax);
-		void push(rsx::simple_array<VkWriteDescriptorSet>& write_cmds, u32 type_mask = umax);
+		void push(const rsx::simple_array<VkCopyDescriptorSet>& copy_cmd, u32 type_mask = umax);
+		void push(const rsx::simple_array<VkWriteDescriptorSet>& write_cmds, u32 type_mask = umax);
 		void push(const descriptor_set_dynamic_offset_t& offset);
 
 		void on_bind();

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.h
@@ -164,13 +164,15 @@ namespace vk
 			return &m_image_info_pool.back();
 		}
 
-		// Temporary storage accessor
+		// Temporary storage accessors
 		const rsx::simple_array<WriteDescriptorSetT> peek() const { return m_pending_writes; }
+		u64 cache_id() const { return m_storage_cache_id; }
 
 	private:
 		VkDescriptorSet m_handle = VK_NULL_HANDLE;
 		u64 m_update_after_bind_mask = 0;
 		u64 m_push_type_mask = 0;
+		u64 m_storage_cache_id = 0;
 		bool m_in_use = false;
 
 		rsx::simple_array<VkBufferView> m_buffer_view_pool;

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -640,6 +640,7 @@
     <ClInclude Include="Emu\RSX\color_utils.h" />
     <ClInclude Include="Emu\RSX\Common\bitfield.hpp" />
     <ClInclude Include="Emu\RSX\Common\buffer_stream.hpp" />
+    <ClInclude Include="Emu\RSX\Common\reverse_ptr.hpp" />
     <ClInclude Include="Emu\RSX\Common\tiled_dma_copy.hpp" />
     <ClInclude Include="Emu\RSX\Common\expected.hpp" />
     <ClInclude Include="Emu\RSX\Common\io_buffer.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -2746,6 +2746,9 @@
     <ClInclude Include="Emu\Io\evdev_gun_handler.h">
       <Filter>Emu\Io</Filter>
     </ClInclude>
+    <ClInclude Include="Emu\RSX\Common\reverse_ptr.hpp">
+      <Filter>Emu\GPU\RSX\Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Emu\RSX\Program\GLSLSnippets\GPUDeswizzle.glsl">

--- a/rpcs3/tests/test_simple_array.cpp
+++ b/rpcs3/tests/test_simple_array.cpp
@@ -229,5 +229,15 @@ namespace rsx
 		}
 
 		EXPECT_EQ(sum, 15);
+
+		rindex = 0;
+		sum = 0;
+		for (auto it = arr.crbegin(); it != arr.crend(); ++it, ++rindex)
+		{
+			EXPECT_EQ(*it, arr2[rindex]);
+			sum += *it;
+		}
+
+		EXPECT_EQ(sum, 15);
 	}
 }

--- a/rpcs3/tests/test_simple_array.cpp
+++ b/rpcs3/tests/test_simple_array.cpp
@@ -214,4 +214,20 @@ namespace rsx
 			EXPECT_EQ(arr[i], i + 1);
 		}
 	}
+
+	TEST(SimpleArray, ReverseIterator)
+	{
+		rsx::simple_array<int> arr{ 1, 2, 3, 4, 5 };
+		rsx::simple_array<int> arr2{ 5, 4, 3, 2, 1 };
+
+		int rindex = 0;
+		int sum = 0;
+		for (auto it = arr.rbegin(); it != arr.rend(); ++it, ++rindex)
+		{
+			EXPECT_EQ(*it, arr2[rindex]);
+			sum += *it;
+		}
+
+		EXPECT_EQ(sum, 15);
+	}
 }


### PR DESCRIPTION
Relates to https://github.com/RPCS3/rpcs3/issues/17277

### Changes
- Remove all per-draw UBO objects and replace with SSBO array-of-structs model. This removes a lot of descriptor bind operations completely.
- Avoid using more than a few bytes of data in push constants. Instead, we write a per-draw config and push a pointer offset to the next one. Restricting push constants memory to 4 bytes per draw has decent gains.
- Replace std::vector with rsx::simple_array for trivial storage. The latter has small-vector optimizations that drastically reduce the number of memory allocations done on the fly and gives a decent perf bump to both Vulkan and OpenGL.
- Other minor optimizations related to resource bindings.

Overall, a 10-20% boost is observed depending on the game. MESA drivers benefit the most here since they doesn't keep a state cache like the properietary ones so state changes are more expensive on those drivers.