### PR TITLE
[macOS CI] Fix mvk formulae causing builds to fail

### DIFF
--- a/.ci/build-mac-arm64.sh
+++ b/.ci/build-mac-arm64.sh
@@ -12,8 +12,10 @@ export HOMEBREW_NO_INSTALL_CLEANUP=1
 /opt/homebrew/bin/brew link -f --quiet "llvm@$LLVM_COMPILER_VER" ffmpeg@5
 
 # moltenvk based on commit for 1.3.0 release
+export HOMEBREW_DEVELOPER=1 # Prevents blocking of local formulae
 wget https://raw.githubusercontent.com/Homebrew/homebrew-core/7255441cbcafabaa8950f67c7ec55ff499dbb2d3/Formula/m/molten-vk.rb
 /opt/homebrew/bin/brew install -f --overwrite --formula --quiet ./molten-vk.rb
+export HOMEBREW_DEVELOPER=0
 export CXX=clang++
 export CC=clang
 

--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -16,8 +16,10 @@ arch -x86_64 /usr/local/bin/brew install --quiet "llvm@$LLVM_COMPILER_VER" glew 
 arch -x86_64 /usr/local/bin/brew link -f --quiet "llvm@$LLVM_COMPILER_VER" ffmpeg@5
 
 # moltenvk based on commit for 1.3.0 release
+export HOMEBREW_DEVELOPER=1 # Prevents blocking of local formulae
 wget https://raw.githubusercontent.com/Homebrew/homebrew-core/7255441cbcafabaa8950f67c7ec55ff499dbb2d3/Formula/m/molten-vk.rb
 arch -x86_64 /usr/local/bin/brew install -f --overwrite --formula --quiet ./molten-vk.rb
+export HOMEBREW_DEVELOPER=0
 export CXX=clang++
 export CC=clang
 


### PR DESCRIPTION
As the title states, Homebrew decided to 'kill' (aka hide) support for installing formulae directly from local .rb files. The official solution is some convoluted BS involving taps and whatnot, but simply enabling HOMEBREW_DEVELOPER when installing just MVK then disabling it after works fine enough (and this would be enabled when making a tap anyways).
This fixes the current state of Intel Mac builds failing and preempts the Apple Silicon builds possibly failing in the future too, should GH update the Actions image with a newer Homebrew version.