### PR TITLE
Fix raw mouse handler keypress logic

### DIFF
--- a/rpcs3/Input/raw_mouse_handler.cpp
+++ b/rpcs3/Input/raw_mouse_handler.cpp
@@ -268,7 +268,7 @@ void raw_mouse::update_values(s32 scan_code, bool pressed)
 	// Get mouse buttons
 	for (const auto& [button, btn] : m_buttons)
 	{
-		if (!btn.is_key || btn.scan_code != scan_code) return;
+		if (!btn.is_key || btn.scan_code != scan_code) continue;
 
 		m_handler->Button(m_index, button, pressed);
 	}


### PR DESCRIPTION
Fixes keypresses assigned as mouse buttons being "ignored" in-game for the raw mouse handler & functionality that relies on it e.g. the emulated PS Move handler.