### PR TITLE
Minor improvements and cleanup on VFS panel

### DIFF
--- a/rpcs3/rpcs3qt/vfs_dialog_path_widget.cpp
+++ b/rpcs3/rpcs3qt/vfs_dialog_path_widget.cpp
@@ -46,7 +46,6 @@ vfs_dialog_path_widget::vfs_dialog_path_widget(const QString& name, const QStrin
 	vbox->addWidget(m_dir_list);
 	vbox->addLayout(selected_config_layout);
 
-	m_dir_list->setStyleSheet("QListView::item:selected { background: palette(Highlight) }"); // Highlight current row
 	setLayout(vbox);
 
 	connect(m_dir_list->model(), &QAbstractItemModel::dataChanged, this, [this](const QModelIndex&, const QModelIndex&, const QList<int>& roles)


### PR DESCRIPTION
- Minor fixes and code reduction
- Improved user experience:
  - Clicking on the small checkbox area and double clicking on the main checkbox's text area is managed in the same way as recently implemented in the `Patch Manager` panel. That means:
    - A click on the small checkbox area will check/uncheck the item. No impact on row selection
    - A double click on the main checkbox's text area will select the row and also check/uncheck the item
  - `-` button properly enabled/disabled according to the selected row (e.g. disabled for row 1)
  - Removal of a selected row is made consistent. That row will remain the selected row. Current code is broken; on first removal, the selection is moved to the checked row

Below some screenshots.

### At startup (row 3 is the checked, selected and highlighted row):

<img width="1763" height="791" alt="image" src="https://github.com/user-attachments/assets/e42e88a6-bd3b-4b65-add4-b15a26480c24" />


### After selection of row 4 (row 3 remains checked and row 4 is selected and is getting focus):

<img width="1761" height="789" alt="image" src="https://github.com/user-attachments/assets/00a46953-bb4e-4a37-9c45-8deed42f27a0" />


### After removal of row 4 (row 4 is still selected and highlighted (focus is lost due to the `-` button was pressed):

<img width="1759" height="784" alt="image" src="https://github.com/user-attachments/assets/cbc539a3-c590-419f-ac87-cd823cab6a57" />


### After row 2 is checked (row 4 remains selected and is getting focus):

<img width="1755" height="788" alt="image" src="https://github.com/user-attachments/assets/dd25b51f-dc80-44a5-9270-e3eb5f5bcb6a" />

