### PR TITLE
Fix emulator crash when a pad gets disconnected (e.g. due to inactivity)

### DIFF
--- a/rpcs3/Input/hid_pad_handler.cpp
+++ b/rpcs3/Input/hid_pad_handler.cpp
@@ -108,7 +108,7 @@ hid_device* HidDevice::open()
 	}, false);
 #else
 	// Lock before calling "hid_open_path()"
-	std::lock_guard static_lock(g_hid_mutex);
+	std::unique_lock static_lock(g_hid_mutex, std::defer_lock);
 
 	hidDevice = hid_open_path(path.data());
 #endif


### PR DESCRIPTION
Follow up of an old possible regression reported in #14063 related to emulator crash when a pad (DS3, DS4 etc.) got disconnected (e.g. due to inactivity).
It was reported by many users that build 0.0.25-14523 (#13175) (updating lib `hidapi` from 0.12.0 to  0.13.0) was possibly causing the crash of the emulator, since some random time, after the pad got disconnected.
That issue was reported by users on `Windows` and `Linux`. I also verified that since that build I also have the same issue on my env (`Windows 11`).
So, I just applied on current build the old `hidapi` version 0.12.0 (reported as working) and 0.13.0 (possibly broken) and verified that the emulator was crashing with both.
After some testing, I simply verified that the issue is caused by threads concurrent access to some (non multi-thread safe) `hidapi` functions.
I saw in the code that a similar issue was detected and fixed in the past for `MAC` env, so this PR is making something similar for all the other envs (with some minor exceptions for `Android`).

`NOTE:`
- For a DS3 pad, the issue was primarily due to the continuous invocation of `dev->open()` in `ds3_pad_handler::update_connection()` triggered by the disconnection of the pad. Not sure this bombing (a good penetration test to highlight bugs) is the desired behavior, or maybe a connection attempt after a time interval (e.g. 1 second)  makes more sense, Maybe something the main developers can improve in further PRs.

fixes #14063
