### PR TITLE
Add selection on firmware libraries panel by double-clicking

### DIFF
--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1787,12 +1787,28 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		}
 	});
 
+	connect(ui->lleList, &QListWidget::itemDoubleClicked, this, [](QListWidgetItem* item)
+	{
+		if (!item)
+			return;
+
+		item->setCheckState(item->checkState() ? Qt::CheckState::Unchecked : Qt::CheckState::Checked);
+	});
+
 	connect(ui->hleList, &QListWidget::itemChanged, [this](QListWidgetItem* item)
 	{
 		for (auto cb : ui->hleList->selectedItems())
 		{
 			cb->setCheckState(item->checkState());
 		}
+	});
+
+	connect(ui->hleList, &QListWidget::itemDoubleClicked, this, [](QListWidgetItem* item)
+	{
+		if (!item)
+			return;
+
+		item->setCheckState(item->checkState() ? Qt::CheckState::Unchecked : Qt::CheckState::Checked);
 	});
 
 	connect(this, &settings_dialog::signal_restore_dependant_defaults, this, reset_library_lists);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1792,7 +1792,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		if (!item)
 			return;
 
-		item->setCheckState(item->checkState() ? Qt::CheckState::Unchecked : Qt::CheckState::Checked);
+		item->setCheckState(item->checkState() != Qt::CheckState::Unchecked ? Qt::CheckState::Unchecked : Qt::CheckState::Checked);
 	});
 
 	connect(ui->hleList, &QListWidget::itemChanged, [this](QListWidgetItem* item)

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1808,7 +1808,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 		if (!item)
 			return;
 
-		item->setCheckState(item->checkState() ? Qt::CheckState::Unchecked : Qt::CheckState::Checked);
+		item->setCheckState(item->checkState() != Qt::CheckState::Unchecked ? Qt::CheckState::Unchecked : Qt::CheckState::Checked);
 	});
 
 	connect(this, &settings_dialog::signal_restore_dependant_defaults, this, reset_library_lists);


### PR DESCRIPTION
I minor, and last, follow up of #17459 and #17442 allowing to check/uncheck an entry in the firmware libraries panel by double-clicking.
For that panel, a solution based on single-clicking was preferrable but it seems it was conflicting with the existing itemChanged (single click was triggered twice so producing no state change).
IMO, better than nothing.