### PR TITLE
System: expose date format and time format as settings

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysutil.cpp
@@ -426,11 +426,11 @@ error_code cellSysutilGetSystemParamInt(CellSysutilParamId id, vm::ptr<s32> valu
 		break;
 
 	case CELL_SYSUTIL_SYSTEMPARAM_ID_DATE_FORMAT:
-		*value = CELL_SYSUTIL_DATE_FMT_DDMMYYYY;
+		*value = static_cast<s32>(g_cfg.sys.date_fmt.get());
 		break;
 
 	case CELL_SYSUTIL_SYSTEMPARAM_ID_TIME_FORMAT:
-		*value = CELL_SYSUTIL_TIME_FMT_CLOCK24;
+		*value = static_cast<s32>(g_cfg.sys.time_fmt.get());
 		break;
 
 	case CELL_SYSUTIL_SYSTEMPARAM_ID_TIMEZONE:

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -301,6 +301,8 @@ struct cfg_root : cfg::node
 		cfg::_enum<CellSysutilLang> language{ this, "Language", CellSysutilLang{1} }; // CELL_SYSUTIL_LANG_ENGLISH_US
 		cfg::_enum<CellKbMappingType> keyboard_type{ this, "Keyboard Type", CellKbMappingType{0} }; // CELL_KB_MAPPING_101 = US
 		cfg::_enum<enter_button_assign> enter_button_assignment{ this, "Enter button assignment", enter_button_assign::cross };
+		cfg::_enum<date_format> date_fmt{ this, "Date Format", date_format::ddmmyyyy };
+		cfg::_enum<time_format> time_fmt{ this, "Time Format", time_format::clock24 };
 		cfg::_int<-60*60*24*365*100LL, 60*60*24*365*100LL> console_time_offset{ this, "Console time offset (s)", 0 }; // console time offset, limited to +/-100years
 		cfg::string system_name{this, "System Name", get_random_system_name()};
 		cfg::uint<0, umax> console_psid_high{this, "PSID high"};

--- a/rpcs3/Emu/system_config_types.cpp
+++ b/rpcs3/Emu/system_config_types.cpp
@@ -716,3 +716,34 @@ void fmt_class_string<xfloat_accuracy>::format(std::string& out, u64 arg)
 		return unknown;
 	});
 }
+
+template <>
+void fmt_class_string<date_format>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](date_format value)
+	{
+		switch (value)
+		{
+		case date_format::yyyymmdd: return "yyyymmdd";
+		case date_format::ddmmyyyy: return "ddmmyyyy";
+		case date_format::mmddyyyy: return "mmddyyyy";
+		}
+
+		return unknown;
+	});
+}
+
+template <>
+void fmt_class_string<time_format>::format(std::string& out, u64 arg)
+{
+	format_enum(out, arg, [](time_format value)
+	{
+		switch (value)
+		{
+		case time_format::clock12: return "clock12";
+		case time_format::clock24: return "clock24";
+		}
+
+		return unknown;
+	});
+}

--- a/rpcs3/Emu/system_config_types.h
+++ b/rpcs3/Emu/system_config_types.h
@@ -261,6 +261,19 @@ enum class enter_button_assign
 	cross   // CELL_SYSUTIL_ENTER_BUTTON_ASSIGN_CROSS
 };
 
+enum class date_format
+{
+	yyyymmdd, // CELL_SYSUTIL_DATE_FMT_YYYYMMDD
+	ddmmyyyy, // CELL_SYSUTIL_DATE_FMT_DDMMYYYY
+	mmddyyyy  // CELL_SYSUTIL_DATE_FMT_MMDDYYYY
+};
+
+enum class time_format
+{
+	clock12, // CELL_SYSUTIL_TIME_FMT_CLOCK12
+	clock24  // CELL_SYSUTIL_TIME_FMT_CLOCK24
+};
+
 enum class np_internet_status
 {
 	disabled,

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -1336,6 +1336,21 @@ QString emu_settings::GetLocalizedSetting(const QString& original, emu_settings_
 		case vk_gpu_scheduler_mode::fast: return tr("Fast", "Asynchronous Queue Scheduler");
 		}
 		break;
+	case emu_settings_type::DateFormat:
+		switch (static_cast<date_format>(index))
+		{
+		case date_format::yyyymmdd: return tr("Year/Month/Day", "Date Format");
+		case date_format::ddmmyyyy: return tr("Day/Month/Year", "Date Format");
+		case date_format::mmddyyyy: return tr("Month/Day/Year", "Date Format");
+		}
+		break;
+	case emu_settings_type::TimeFormat:
+		switch (static_cast<time_format>(index))
+		{
+		case time_format::clock12: return tr("12-hour clock", "Time Format");
+		case time_format::clock24: return tr("24-hour clock", "Time Format");
+		}
+		break;
 	case emu_settings_type::Language:
 		switch (static_cast<CellSysutilLang>(index))
 		{

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -203,11 +203,15 @@ enum class emu_settings_type
 	Language,
 	KeyboardType,
 	EnterButtonAssignment,
+	DateFormat,
+	TimeFormat,
+	ConsoleTimeOffset,
+
+	// VFS
 	EnableHostRoot,
 	EmptyHdd0Tmp,
 	LimitCacheSize,
 	MaximumCacheSize,
-	ConsoleTimeOffset,
 };
 
 /** A helper map that keeps track of where a given setting type is located*/
@@ -405,13 +409,16 @@ inline static const std::map<emu_settings_type, cfg_location> settings_location 
 	// System
 	{ emu_settings_type::LicenseArea,           { "System", "License Area"}},
 	{ emu_settings_type::Language,              { "System", "Language"}},
-	{ emu_settings_type::KeyboardType,          { "System", "Keyboard Type"} },
+	{ emu_settings_type::KeyboardType,          { "System", "Keyboard Type"}},
 	{ emu_settings_type::EnterButtonAssignment, { "System", "Enter button assignment"}},
+	{ emu_settings_type::DateFormat,            { "System", "Date Format"}},
+	{ emu_settings_type::TimeFormat,            { "System", "Time Format"}},
+	{ emu_settings_type::ConsoleTimeOffset,     { "System", "Console time offset (s)"}},
+
 	{ emu_settings_type::EnableHostRoot,        { "VFS", "Enable /host_root/"}},
 	{ emu_settings_type::EmptyHdd0Tmp,          { "VFS", "Empty /dev_hdd0/tmp/"}},
 	{ emu_settings_type::LimitCacheSize,        { "VFS", "Limit disk cache size"}},
 	{ emu_settings_type::MaximumCacheSize,      { "VFS", "Disk cache maximum size (MB)"}},
-	{ emu_settings_type::ConsoleTimeOffset,     { "System", "Console time offset (s)"}},
 
 	// Savestates
 	{ emu_settings_type::SuspendEmulationSavestateMode,       { "Savestate", "Suspend Emulation Savestate Mode" }},

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1412,6 +1412,12 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceComboBox(ui->keyboardType, emu_settings_type::KeyboardType, false, false, 0, true);
 	SubscribeTooltip(ui->gb_keyboardType, tooltips.settings.keyboard_type);
 
+	m_emu_settings->EnhanceComboBox(ui->dateFormat, emu_settings_type::DateFormat);
+	SubscribeTooltip(ui->gb_dateFormat, tooltips.settings.date_format);
+
+	m_emu_settings->EnhanceComboBox(ui->timeFormat, emu_settings_type::TimeFormat);
+	SubscribeTooltip(ui->gb_timeFormat, tooltips.settings.time_format);
+
 	// Checkboxes
 
 	m_emu_settings->EnhanceCheckBox(ui->enableHostRoot, emu_settings_type::EnableHostRoot);

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2009,6 +2009,30 @@
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="gb_dateFormat">
+              <property name="title">
+               <string>Date Format</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_dateFormat">
+               <item>
+                <widget class="QComboBox" name="dateFormat"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="gb_timeFormat">
+              <property name="title">
+               <string>Time Format</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_timeFormat">
+               <item>
+                <widget class="QComboBox" name="timeFormat"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <widget class="QGroupBox" name="gb_console_time">
               <property name="title">
                <string>Console Time</string>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -263,6 +263,8 @@ public:
 
 		const QString license_area            = tr("The console region defines the license area of the PS3.\nDepending on the license area, some games may not work.");
 		const QString system_language         = tr("Some games may fail to boot if the system language is not available in the game itself.\nOther games will switch language automatically to what is selected here.\nIt is recommended leaving this on a language supported by the game.");
+		const QString date_format             = tr("Select the PS3's date format.");
+		const QString time_format             = tr("Select the PS3's time format.");
 		const QString keyboard_type           = tr("Sets the used keyboard layout.\nCurrently only US, Japanese and German layouts are fully supported at this moment.");
 		const QString enter_button_assignment = tr("The button used for enter/accept/confirm in system dialogs.\nChange this to use the Circle button instead, which is the default configuration on Japanese systems and in many Japanese games.\nIn these cases having the cross button assigned can often lead to confusion.");
 		const QString enable_host_root        = tr("Required for some Homebrew.\nIf unsure, do not use this option.");


### PR DESCRIPTION
- Expose date format as setting (Year/Month/Day, Month/Day/Year, Day/Month/Year)
- Expose time format as setting (12-hour clock, 24-hour clock)

This may and will only have an impact on games (untested)

<img width="1554" height="1191" alt="image" src="https://github.com/user-attachments/assets/76be1b8f-76ff-4486-a4ef-3e1b6e48827f" />
