### PR TITLE
rsx: fix 3D aspect ratio

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -187,9 +187,9 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 		if (!buffer_pitch)
 			buffer_pitch = buffer_width * avconfig.get_bpp();
 
-		const u32 video_frame_height = (avconfig.stereo_mode == stereo_render_mode_options::disabled ? avconfig.resolution_y : ((avconfig.resolution_y - 30) / 2));
-		buffer_width = std::min(buffer_width, avconfig.resolution_x);
-		buffer_height = std::min(buffer_height, video_frame_height);
+		const size2u video_frame_size = avconfig.video_frame_size();
+		buffer_width = std::min(buffer_width, video_frame_size.width);
+		buffer_height = std::min(buffer_height, video_frame_size.height);
 	}
 	else
 	{

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -457,9 +457,9 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 		if (!buffer_pitch)
 			buffer_pitch = buffer_width * avconfig.get_bpp();
 
-		const u32 video_frame_height = (avconfig.stereo_mode == stereo_render_mode_options::disabled ? avconfig.resolution_y : ((avconfig.resolution_y - 30) / 2));
-		buffer_width = std::min(buffer_width, avconfig.resolution_x);
-		buffer_height = std::min(buffer_height, video_frame_height);
+		const size2u video_frame_size = avconfig.video_frame_size();
+		buffer_width = std::min(buffer_width, video_frame_size.width);
+		buffer_height = std::min(buffer_height, video_frame_size.height);
 	}
 	else
 	{

--- a/rpcs3/Emu/RSX/rsx_utils.cpp
+++ b/rpcs3/Emu/RSX/rsx_utils.cpp
@@ -187,6 +187,16 @@ namespace rsx
 		}
 	}
 
+	size2u avconf::video_frame_size() const
+	{
+		if (state && stereo_mode != stereo_render_mode_options::disabled)
+		{
+			return size2u{ resolution_x, (resolution_y - 30) / 2 };
+		}
+
+		return size2u{ resolution_x, resolution_y };
+	}
+
 	size2u avconf::aspect_convert_dimensions(const size2u& image_dimensions) const
 	{
 		if (image_dimensions.width == 0 || image_dimensions.height == 0)
@@ -210,7 +220,7 @@ namespace rsx
 
 		// Fit the input image into the virtual display 'window'
 		const auto source_aspect = 1. * image_dimensions.width / image_dimensions.height;
-		const auto virtual_output = size2u{ resolution_x, resolution_y };
+		const auto virtual_output = video_frame_size();
 		const auto area1 = convert_aspect_ratio_impl(virtual_output, source_aspect);
 
 		// Fit the virtual display into the physical display

--- a/rpcs3/Emu/RSX/rsx_utils.h
+++ b/rpcs3/Emu/RSX/rsx_utils.h
@@ -172,6 +172,8 @@ namespace rsx
 		u8 get_bpp() const;
 		double get_aspect_ratio() const;
 
+		size2u video_frame_size() const;
+
 		areau aspect_convert_region(const size2u& image_dimensions, const size2u& output_dimensions) const;
 		size2u aspect_convert_dimensions(const size2u& image_dimensions) const;
 	};


### PR DESCRIPTION
It seems we forgot to adjust the vertical resolution in aspect_convert_region when using the 3D option.
Our virtual height during the aspect ratio conversion was more than doubled due to the 3D frame packing.
This resulted in an overadjustment of the resulting output region in order to fit into our frame, manifesting itself as a squished image.

Fixes #17492