### PR TITLE
vk: Fix invalidated surface_cache resource deletion bug

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -183,7 +183,7 @@ namespace vk
 		});
 
 		const u64 last_finished_frame = vk::get_last_completed_frame_id();
-		invalidated_resources.remove_if([&](std::unique_ptr<vk::render_target>& rtt)
+		for (auto& rtt : invalidated_resources)
 		{
 			ensure(rtt->frame_tag != 0);
 
@@ -191,13 +191,13 @@ namespace vk
 			{
 				// Actively in use, likely for a reading pass.
 				// Call handle_memory_pressure before calling this method.
-				return false;
+				continue;
 			}
 
 			if (rtt->frame_tag >= last_finished_frame)
 			{
 				// RTT itself still in use by the frame.
-				return false;
+				continue;
 			}
 
 			if (!rtt->old_contents.empty())
@@ -212,21 +212,34 @@ namespace vk
 				vk::get_resource_manager()->dispose(rtt->resolve_surface);
 			}
 
+			int threshold = 8;
 			switch (memory_pressure)
 			{
 			case rsx::problem_severity::low:
-				return (rtt->unused_check_count() >= 2);
+				threshold = 2;
+				break;
 			case rsx::problem_severity::moderate:
-				return (rtt->unused_check_count() >= 1);
+				threshold = 1;
+				break;
 			case rsx::problem_severity::severe:
 			case rsx::problem_severity::fatal:
 				// We're almost dead anyway. Remove forcefully.
-				vk::get_resource_manager()->dispose(rtt);
-				return true;
+				threshold = -1;
+				break;
 			default:
 				fmt::throw_exception("Unreachable");
 			}
-		});
+
+			if (threshold < 0 || (rtt->unused_check_count() >= threshold))
+			{
+				vk::get_resource_manager()->dispose(rtt);
+				ensure(!rtt);
+			}
+		}
+
+		invalidated_resources.remove_if(
+			[](auto& rtt) { return !rtt; }
+		);
 	}
 
 	bool surface_cache::is_overallocated()


### PR DESCRIPTION
Turns out calling invalidate then returning true to remove the pointer led to some (~~broken optimization maybe?~~ GC was just never called for some severity levels) issue where the pointer was deleted before the call to GC. Likely fixes some obscure device lost issues in some titles.
Discovered while debugging the descriptors rewrite work.