### PR TITLE
Qt: Fix savestate table selection style

### DIFF
--- a/rpcs3/rpcs3qt/savestate_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/savestate_manager_dialog.cpp
@@ -82,7 +82,7 @@ savestate_manager_dialog::savestate_manager_dialog(std::shared_ptr<gui_settings>
 	m_savestate_table->verticalScrollBar()->installEventFilter(this);
 	m_savestate_table->verticalScrollBar()->setSingleStep(20);
 	m_savestate_table->horizontalScrollBar()->setSingleStep(20);
-	m_savestate_table->setItemDelegate(new game_list_delegate(m_savestate_table));
+	m_savestate_table->setItemDelegate(new table_item_delegate(m_savestate_table, false));
 	m_savestate_table->setSelectionBehavior(QAbstractItemView::SelectRows);
 	m_savestate_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
 	m_savestate_table->setColumnCount(static_cast<int>(gui::savestate_list_columns::count));


### PR DESCRIPTION
Should fix this:

<img width="504" height="245" alt="image" src="https://github.com/user-attachments/assets/19ad95bc-295b-4046-ad48-f1f22b8a6e1c" />
