### PR TITLE
CI: Disable LTO for Windows Clang builds

### DIFF
--- a/.ci/build-windows-clang.sh
+++ b/.ci/build-windows-clang.sh
@@ -27,6 +27,7 @@ cmake ..                                               \
     -DCMAKE_INSTALL_PREFIX=/usr                        \
     -DUSE_NATIVE_INSTRUCTIONS=OFF                      \
     -DUSE_PRECOMPILED_HEADERS=OFF                      \
+    -DUSE_LTO=OFF                                      \
     -DCMAKE_C_FLAGS="$CFLAGS"                          \
     -DCMAKE_CXX_FLAGS="$CFLAGS"                        \
     -DCMAKE_EXE_LINKER_FLAGS="${LINKER_FLAG}"          \


### PR DESCRIPTION
The Windows Clang CI has been failing due to LTO incompatibility with thread-local storage, causing undefined symbol errors during linking: 'undefined symbol: thread-local initialization routine for perf_stat'

This issue is already acknowledged in rpcs3/Emu/perf_meter.hpp:79 with the comment 'Windows clang LTO doesn't seem to like this template'

This is a temporary workaround until the underlying Clang/LTO issue is resolved.