### PR TITLE
Generate random OpenPSID upon config initalisation

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -206,12 +206,11 @@ error_code sys_ss_get_console_id(vm::ptr<u8> buf)
 	return sys_ss_appliance_info_manager(0x19003, buf);
 }
 
-error_code sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid)
+error_code sys_ss_get_open_psid(vm::ptr<u128> psid)
 {
 	sys_ss.notice("sys_ss_get_open_psid(psid=*0x%x)", psid);
 
-	psid->high = g_cfg.sys.console_psid_high;
-	psid->low = g_cfg.sys.console_psid_low;
+	*psid = g_cfg.sys.console_psid.get();
 
 	return CELL_OK;
 }
@@ -259,8 +258,8 @@ error_code sys_ss_appliance_info_manager(u32 code, vm::ptr<u8> buffer)
 	case 0x19005:
 	{
 		// AIM_get_open_ps_id
-		be_t<u64> psid[2] = { +g_cfg.sys.console_psid_high, +g_cfg.sys.console_psid_low };
-		std::memcpy(buffer.get_ptr(), psid, 16);
+		const be_t<u128> psid = g_cfg.sys.console_psid.get();
+		std::memcpy(buffer.get_ptr(), &psid, 16);
 		break;
 	}
 	case 0x19006:

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -206,11 +206,14 @@ error_code sys_ss_get_console_id(vm::ptr<u8> buf)
 	return sys_ss_appliance_info_manager(0x19003, buf);
 }
 
-error_code sys_ss_get_open_psid(vm::ptr<u128> psid)
+error_code sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid)
 {
 	sys_ss.notice("sys_ss_get_open_psid(psid=*0x%x)", psid);
 
-	*psid = g_cfg.sys.console_psid.get();
+	const u128 configured_psid = g_cfg.sys.console_psid.get();
+
+	psid->high = static_cast<u64>(configured_psid >> 64);
+	psid->low = static_cast<u64>(configured_psid);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_ss.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.h
@@ -13,16 +13,10 @@ enum sys_ss_rng_error : u32
 	SYS_SS_RTC_ERROR_UNK = 0x8001050f,
 };
 
-struct CellSsOpenPSID
-{
-	be_t<u64> high;
-	be_t<u64> low;
-};
-
 error_code sys_ss_random_number_generator(u64 pkg_id, vm::ptr<void> buf, u64 size);
 error_code sys_ss_access_control_engine(u64 pkg_id, u64 a2, u64 a3);
 error_code sys_ss_get_console_id(vm::ptr<u8> buf);
-error_code sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid);
+error_code sys_ss_get_open_psid(vm::ptr<u128> psid);
 error_code sys_ss_appliance_info_manager(u32 code, vm::ptr<u8> buffer);
 error_code sys_ss_get_cache_of_product_mode(vm::ptr<u8> ptr);
 error_code sys_ss_secure_rtc(u64 cmd, u64 a2, u64 a3, u64 a4);

--- a/rpcs3/Emu/Cell/lv2/sys_ss.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.h
@@ -13,10 +13,16 @@ enum sys_ss_rng_error : u32
 	SYS_SS_RTC_ERROR_UNK = 0x8001050f,
 };
 
+struct CellSsOpenPSID
+{
+	be_t<u64> high;
+	be_t<u64> low;
+};
+
 error_code sys_ss_random_number_generator(u64 pkg_id, vm::ptr<void> buf, u64 size);
 error_code sys_ss_access_control_engine(u64 pkg_id, u64 a2, u64 a3);
 error_code sys_ss_get_console_id(vm::ptr<u8> buf);
-error_code sys_ss_get_open_psid(vm::ptr<u128> psid);
+error_code sys_ss_get_open_psid(vm::ptr<CellSsOpenPSID> psid);
 error_code sys_ss_appliance_info_manager(u32 code, vm::ptr<u8> buffer);
 error_code sys_ss_get_cache_of_product_mode(vm::ptr<u8> ptr);
 error_code sys_ss_secure_rtc(u64 cmd, u64 a2, u64 a3, u64 a4);

--- a/rpcs3/Emu/system_config.cpp
+++ b/rpcs3/Emu/system_config.cpp
@@ -3,6 +3,8 @@
 
 #include "util/sysinfo.hpp"
 
+#include <random>
+
 cfg_root g_cfg{};
 cfg_root g_backup_cfg{};
 
@@ -15,4 +17,14 @@ std::string cfg_root::node_sys::get_random_system_name()
 {
 	std::srand(static_cast<u32>(std::time(nullptr)));
 	return "RPCS3-" + std::to_string(100 + std::rand() % 899);
+}
+
+u128 cfg_root::node_sys::get_random_psid()
+{
+	std::random_device rnd;
+	std::mt19937_64 prng(rnd());
+	std::uniform_int_distribution<u64> uniformDist;
+	u128 result = uniformDist(prng);
+	result += u128{uniformDist(prng)} << 64;
+	return result;
 }

--- a/rpcs3/Emu/system_config.cpp
+++ b/rpcs3/Emu/system_config.cpp
@@ -21,10 +21,15 @@ std::string cfg_root::node_sys::get_random_system_name()
 
 u128 cfg_root::node_sys::get_random_psid()
 {
-	std::random_device rnd;
-	std::mt19937_64 prng(rnd());
-	std::uniform_int_distribution<u64> uniformDist;
-	u128 result = uniformDist(prng);
-	result += u128{uniformDist(prng)} << 64;
+	// Generate seed for each 32-bits for maximum entropy using Standard Library
+	std::uniform_int_distribution<u32> uniform_dist;
+	std::mt19937 prng;
+
+	u128 result{};
+	prng.seed(std::random_device()()), result += u128{uniform_dist(prng)} << 0;
+	prng.seed(std::random_device()()), result += u128{uniform_dist(prng)} << 32;
+	prng.seed(std::random_device()()), result += u128{uniform_dist(prng)} << 64;
+	prng.seed(std::random_device()()), result += u128{uniform_dist(prng)} << 96;
+
 	return result;
 }

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -296,6 +296,7 @@ struct cfg_root : cfg::node
 	struct node_sys : cfg::node
 	{
 		static std::string get_random_system_name();
+		static u128 get_random_psid();
 
 		node_sys(cfg::node* _this) : cfg::node(_this, "System") {}
 
@@ -307,8 +308,7 @@ struct cfg_root : cfg::node
 		cfg::_enum<time_format> time_fmt{ this, "Time Format", time_format::clock24 };
 		cfg::_int<-60*60*24*365*100LL, 60*60*24*365*100LL> console_time_offset{ this, "Console time offset (s)", 0 }; // console time offset, limited to +/-100years
 		cfg::string system_name{this, "System Name", get_random_system_name()};
-		cfg::uint<0, umax> console_psid_high{this, "PSID high"};
-		cfg::uint<0, umax> console_psid_low{this, "PSID low"};
+		cfg::uint128 console_psid{this, "Console PSID", get_random_psid()};
 		cfg::string hdd_model{this, "HDD Model Name", ""};
 		cfg::string hdd_serial{this, "HDD Serial Number", ""};
 		cfg::node_map_entry sup_argv{ this, "Process ARGV" };


### PR DESCRIPTION
As the title suggests, this PR randomises the PSID stored in RPCS3s configuration during startup.

This is required at least for ModNation Racers when playing online, as it uses the consoles PSID to differenciate players in a lobby, and all emulator instances having a PSID of 0 breaks matchmaking.

Tested that the random values are writing to the config. Draft PR whilst I figure out updating existing configs with a PSID of zero.

**I would more than welcome any feedback on how best to approach the above, if theres somewhere in particular its best to slip in a value check :)**

Any constructive critisim or changes please let me know.