### PR TITLE
[TEST ONLY] vk: Allow GPUs with only 64k maxTexelBufferElements to run with broken graphics

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -564,7 +564,12 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	const auto& limits = m_device->gpu().get_limits();
 	m_texbuffer_view_size = std::min(limits.maxTexelBufferElements, VK_ATTRIB_RING_BUFFER_SIZE_M * 0x100000u);
 
-	if (m_texbuffer_view_size < 0x800000)
+	if (m_texbuffer_view_size <= 65536)
+	{
+		// Expected on PanVK
+		rsx_log.error("Your GPU does not support enough addressable texels for a buffer view. Graphics will not render correctly.", m_texbuffer_view_size);
+	}
+	else if (m_texbuffer_view_size < 0x800000)
 	{
 		// Warn, only possibly expected on macOS
 		rsx_log.warning("Current driver may crash due to memory limitations (%uk)", m_texbuffer_view_size / 1024);

--- a/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexBuffers.cpp
@@ -344,7 +344,10 @@ vk::vertex_upload_info VKGSRender::upload_vertex_data()
 	{
 		if (!m_persistent_attribute_storage || !m_persistent_attribute_storage->in_range(persistent_range_base, required.first, persistent_range_base))
 		{
-			ensure(m_texbuffer_view_size >= required.first); // "Incompatible driver (MacOS?)"
+			if (m_texbuffer_view_size < required.first) // "Incompatible driver (PanVK)"
+			{
+				rsx_log.error("Not enough texbuffer memory, required.first=%d, available=%d", required.first, m_texbuffer_view_size);
+			}
 			vk::get_resource_manager()->dispose(m_persistent_attribute_storage);
 
 			//View 64M blocks at a time (different drivers will only allow a fixed viewable heap size, 64M should be safe)
@@ -358,7 +361,10 @@ vk::vertex_upload_info VKGSRender::upload_vertex_data()
 	{
 		if (!m_volatile_attribute_storage || !m_volatile_attribute_storage->in_range(volatile_range_base, required.second, volatile_range_base))
 		{
-			ensure(m_texbuffer_view_size >= required.second); // "Incompatible driver (MacOS?)"
+			if (m_texbuffer_view_size < required.second) // "Incompatible driver (PanVK)"
+			{
+				rsx_log.error("Not enough texbuffer memory, required.second=%d, available=%d", required.second, m_texbuffer_view_size);
+			}
 			vk::get_resource_manager()->dispose(m_volatile_attribute_storage);
 
 			const usz view_size = (volatile_range_base + m_texbuffer_view_size) > m_attrib_ring_info.size() ? m_attrib_ring_info.size() - volatile_range_base : m_texbuffer_view_size;


### PR DESCRIPTION
We already allow the render to execute with other kinds of critical lack of features or extensions.

Allows Mali-G610 to run with panvk with broken graphics instead of crashing.