### PR TITLE
use recently fixed SDL_UpdateJoysticks from non main thread

### DIFF
--- a/rpcs3/Input/sdl_instance.cpp
+++ b/rpcs3/Input/sdl_instance.cpp
@@ -46,12 +46,9 @@ void sdl_instance::pump_events()
 			return;
 		}
 
-		Emu.CallFromMainThread([this]()
-		{
-			if (!m_initialized) return;
-			SDL_PumpEvents();
-			m_last_pump_us = get_system_time();
-		}, nullptr, false);
+		SDL_UpdateJoysticks();
+
+		m_last_pump_us = get_system_time();
 	}
 }
 


### PR DESCRIPTION
Follow up of https://github.com/libsdl-org/SDL/issues/14033 related to discussion in https://discourse.libsdl.org/t/does-sdl-pumpevents-on-a-new-thread-need-sdl-init-to-be-reinitialized/62557 originated by a bug fix/workaround on RPCS3 recently provided in build 0.0.37-18149 (#17519).
The issue on SDL was a bug, reported as present on `Windows`, fixed in SDL build 3.2.24 integrated in latest rpcs3 builds.
SDL developers also suggested to replace `SDL_PumpEvents` with `SDL_UpdateJoysticks` (due to we only use joypad module) certified to work also from a non main thread, although even `SDL_PumpEvents` is now properly working from a non main thread.
Furthermore, in case that sort of rate controller introduced in #17519 was intended only to not overload the main thread, it could eventually be removed on this PR. Simply let me know if it can be removed.
