### PR TITLE
Qt: Allow to clear keyboard shortcuts in dialog

### DIFF
--- a/rpcs3/rpcs3qt/shortcut_dialog.cpp
+++ b/rpcs3/rpcs3qt/shortcut_dialog.cpp
@@ -39,6 +39,7 @@ shortcut_dialog::shortcut_dialog(const std::shared_ptr<gui_settings> gui_setting
 		key_sequence_edit->setObjectName(shortcut.name);
 		key_sequence_edit->setMinimumWidth(label->sizeHint().width());
 		key_sequence_edit->setKeySequence(key_sequence);
+		key_sequence_edit->setClearButtonEnabled(true);
 
 		m_values[shortcut.name] = key_sequence.toString();
 

--- a/rpcs3/rpcs3qt/shortcut_handler.h
+++ b/rpcs3/rpcs3qt/shortcut_handler.h
@@ -23,6 +23,7 @@ public Q_SLOTS:
 
 private:
 	void handle_shortcut(gui::shortcuts::shortcut shortcut_key, const QKeySequence& key_sequence);
+	QShortcut* make_shortcut(gui::shortcuts::shortcut key, const shortcut_info& info, const QKeySequence& key_sequence);
 
 	gui::shortcuts::shortcut_handler_id m_handler_id;
 	std::shared_ptr<gui_settings> m_gui_settings;

--- a/rpcs3/rpcs3qt/shortcut_settings.cpp
+++ b/rpcs3/rpcs3qt/shortcut_settings.cpp
@@ -114,13 +114,5 @@ QKeySequence shortcut_settings::get_key_sequence(const shortcut_info& entry, con
 
 	const QString saved_value = gui_settings->GetValue(get_shortcut_gui_save(entry.name)).toString();
 
-	QKeySequence key_sequence = QKeySequence::fromString(saved_value);
-
-	if (key_sequence.isEmpty())
-	{
-		// Use the default shortcut if no shortcut was configured
-		key_sequence = QKeySequence::fromString(entry.key_sequence);
-	}
-
-	return key_sequence;
+	return QKeySequence::fromString(saved_value);
 }


### PR DESCRIPTION
- Adds clear button to keyboard shortcut widgets
- Handle empty shortcuts properly in shortcut_handler

fixes #17577