### PR TITLE
Relax SceNpCommunicationId validation

### DIFF
--- a/rpcs3/Emu/NP/np_helpers.cpp
+++ b/rpcs3/Emu/NP/np_helpers.cpp
@@ -24,7 +24,8 @@ namespace np
 
 	std::string communication_id_to_string(const SceNpCommunicationId& communicationId)
 	{
-		return fmt::format("%s_%02d", communicationId.data, communicationId.num);
+		const std::string com_id_data(communicationId.data, communicationId.data + 9);
+		return fmt::format("%s_%02d", com_id_data, communicationId.num);
 	}
 
 	void strings_to_userinfo(std::string_view npid, std::string_view online_name, std::string_view avatar_url, SceNpUserInfo& user_info)

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -2752,7 +2752,7 @@ namespace rpcn
 
 	void rpcn_client::write_communication_id(const SceNpCommunicationId& com_id, std::vector<u8>& data)
 	{
-		ensure(com_id.data[9] == 0 && com_id.num <= 99, "rpcn_client::write_communication_id: Invalid SceNpCommunicationId");
+		ensure(std::all_of(com_id.data, com_id.data + 9, [](char c) { return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z'); }) && com_id.num <= 99, "rpcn_client::write_communication_id: Invalid SceNpCommunicationId");
 		const std::string com_id_str = np::communication_id_to_string(com_id);
 		ensure(com_id_str.size() == 12, "rpcn_client::write_communication_id: Error formatting SceNpCommunicationId");
 		memcpy(data.data(), com_id_str.data(), COMMUNICATION_ID_SIZE);


### PR DESCRIPTION
Relax validation as firmware doesn't actually check com_id.data[9] == 0 and just copies the first 9 chars directly.