### PR TITLE
[CI] FreeBSD use quarterly pkg repo

### DIFF
--- a/.ci/install-freebsd.sh
+++ b/.ci/install-freebsd.sh
@@ -3,7 +3,7 @@
 # shellcheck shell=sh disable=SC2096
 
 # RPCS3 often needs recent Qt and Vulkan-Headers
-sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
+# sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
 
 export ASSUME_ALWAYS_YES=true
 pkg info # debug


### PR DESCRIPTION
Fixes https://github.com/RPCS3/rpcs3/issues/17614

Use `quarterly` repo unless `latest` needed for Qt / Vulkan Headers.