### PR TITLE
vk: Filter out re-bar usage from memory pressure watchdog

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -1010,6 +1010,8 @@ namespace vk
 				.heap = memory_properties.memoryHeaps[i],
 				.types = {}
 			});
+
+			result.heaps.push_back({ i, memory_properties.memoryHeaps[i].flags, memory_properties.memoryHeaps[i].size });
 		}
 
 		for (u32 i = 0; i < memory_properties.memoryTypeCount; i++)

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -30,6 +30,8 @@ namespace vk
 
 	struct memory_type_mapping
 	{
+		std::vector<memory_heap_info> heaps;
+
 		memory_type_info host_visible_coherent;
 		memory_type_info device_local;
 		memory_type_info device_bar;

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
@@ -200,6 +200,23 @@ namespace vk
 
 		// Allow fastest possible allocation on start
 		set_fastest_allocation_flags();
+
+		// Determine the rebar heap. We will exclude it from stats
+		const auto& memory_map = dev.get_memory_mapping();
+		if (memory_map.device_bar_total_bytes !=
+			memory_map.device_local_total_bytes)
+		{
+			for (u32 i = 0; i < ::size32(memory_map.heaps); ++i)
+			{
+				const auto& heap = memory_map.heaps[i];
+				if ((heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) &&
+					heap.size == memory_map.device_bar_total_bytes)
+				{
+					m_rebar_heap_idx = i;
+					break;
+				}
+			}
+		}
 	}
 
 	void mem_allocator_vma::destroy()
@@ -312,6 +329,12 @@ namespace vk
 	f32 mem_allocator_vma::get_memory_usage()
 	{
 		vmaGetHeapBudgets(m_allocator, stats.data());
+
+		// Filter out the Re-BAR heap
+		if (::size32(stats) > m_rebar_heap_idx)
+		{
+			stats[m_rebar_heap_idx].budget = 0;
+		}
 
 		float max_usage = 0.f;
 		for (const auto& info : stats)

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -59,6 +59,13 @@ namespace vk
 		void rebalance();
 	};
 
+	struct memory_heap_info
+	{
+		u32 index;
+		u32 flags;
+		u64 size;
+	};
+
 	class mem_allocator_base
 	{
 	public:
@@ -113,6 +120,7 @@ namespace vk
 	private:
 		VmaAllocator m_allocator;
 		std::array<VmaBudget, VK_MAX_MEMORY_HEAPS> stats;
+		u32 m_rebar_heap_idx = UINT32_MAX;
 	};
 
 


### PR DESCRIPTION
This should keep users from getting crashes related to low memory when resizable bar is disabled in BIOS.