### PR TITLE
cellGame: Fix cellHddGameCheck dataVersion parameter

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -464,6 +464,8 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 	{
 		get->isNewData = CELL_HDDGAME_ISNEWDATA_NODIR;
 		get->getParam = {};
+
+		cellGame.warning("cellHddGameCheck(): New data.");
 	}
 	else
 	{
@@ -476,13 +478,22 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 		if (psf.contains("RESOLUTION")) get->getParam.resolution = ::at32(psf, "RESOLUTION").as_integer();
 		if (psf.contains("SOUND_FORMAT")) get->getParam.soundFormat = ::at32(psf, "SOUND_FORMAT").as_integer();
 		if (psf.contains("TITLE")) strcpy_trunc(get->getParam.title, ::at32(psf, "TITLE").as_string());
-		if (psf.contains("APP_VER")) strcpy_trunc(get->getParam.dataVersion, ::at32(psf, "APP_VER").as_string());
-		if (psf.contains("TITLE_ID")) strcpy_trunc(get->getParam.titleId, ::at32(psf, "TITLE_ID").as_string());
+
+		// Old games do not have APP_VER key
+		strcpy_trunc(get->getParam.dataVersion, psf::get_string(psf, "APP_VER", psf::get_string(sfo, "VERSION", "")));
+
+		if (psf.contains("TITLE_ID"))
+		{
+			strcpy_trunc(get->getParam.titleId, ::at32(psf, "TITLE_ID").as_string());
+		}
 
 		for (u32 i = 0; i < CELL_HDDGAME_SYSP_LANGUAGE_NUM; i++)
 		{
 			strcpy_trunc(get->getParam.titleLang[i], psf::get_string(psf, fmt::format("TITLE_%02d", i)));
 		}
+
+		cellGame.warning("cellHddGameCheck(): Data exists:\nATTRIBUTE: 0x%x, RESOLUTION: 0x%x, RESOLUTION: 0x%x, SOUND_FORMAT: 0x%x, dataVersion: %s"
+			, get->getParam.attribute, get->getParam.resolution, get->getParam.soundFormat, get->getParam.soundFormat, std::span<const u8>(reinterpret_cast<const u8*>(get->getParam.dataVersion), 6));
 	}
 
 	// TODO ?

--- a/rpcs3/Emu/Cell/Modules/cellGame.h
+++ b/rpcs3/Emu/Cell/Modules/cellGame.h
@@ -224,8 +224,8 @@ enum
 struct CellGameDataSystemFileParam
 {
 	char title[CELL_GAMEDATA_SYSP_TITLE_SIZE];
-	char titleLang[CELL_GAMEDATA_SYSP_LANGUAGE_NUM][CELL_GAMEDATA_SYSP_TITLE_SIZE];
-	char titleId[CELL_GAMEDATA_SYSP_TITLEID_SIZE];
+	char titleLang[CELL_GAMEDATA_SYSP_LANGUAGE_NUM][CELL_GAMEDATA_SYSP_TITLE_SIZE]; // 0x80
+	char titleId[CELL_GAMEDATA_SYSP_TITLEID_SIZE]; // 0xA80
 	char reserved0[2];
 	char dataVersion[CELL_GAMEDATA_SYSP_VERSION_SIZE];
 	char reserved1[2];
@@ -248,13 +248,13 @@ struct CellGameDataStatGet
 {
 	be_t<s32> hddFreeSizeKB;
 	be_t<u32> isNewData;
-	char contentInfoPath[CELL_GAMEDATA_PATH_MAX];
-	char gameDataPath[CELL_GAMEDATA_PATH_MAX];
-	char reserved0[2];
-	be_t<s64> st_atime_;
-	be_t<s64> st_mtime_;
-	be_t<s64> st_ctime_;
-	CellGameDataSystemFileParam getParam;
+	char contentInfoPath[CELL_GAMEDATA_PATH_MAX]; // 0x8
+	char gameDataPath[CELL_GAMEDATA_PATH_MAX]; // 0x427 
+	char reserved0[2]; // 0x846
+	be_t<s64> st_atime_; // 0x848
+	be_t<s64> st_mtime_; // 0x850
+	be_t<s64> st_ctime_; // 0x858
+	CellGameDataSystemFileParam getParam; // 0x860
 	be_t<s32> sizeKB;
 	be_t<s32> sysSizeKB;
 	char reserved1[68];


### PR DESCRIPTION
Its PARAM.SFO does not have "APP_VER" parameter.
I believe dataVersion member should actually report "VERSION" string always.
Because "VERSION" refers to the version of data files of the game, for which the executable file was not updated and is the function's place to tell the executable that the data is not the initial data the executable was shipped/compiled with. APP_VER is updated when both the data files and executable file are updated so there is little sense in telling the executable about data that was originally compiled/shipped with.
I won't change it in this pull request though.


Fixes #17074

<img width="1427" height="829" alt="image" src="https://github.com/user-attachments/assets/f9b0a9df-19b6-4b42-9b95-d83a92aade4b" />
