### PR TITLE
overlays: take screenshot after exiting the home menu

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLPresent.cpp
+++ b/rpcs3/Emu/RSX/GL/GLPresent.cpp
@@ -323,7 +323,9 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 
 	if (image_to_flip)
 	{
-		if (g_user_asked_for_screenshot || (g_recording_mode != recording_mode::stopped && m_frame->can_consume_frame()))
+		const bool user_asked_for_screenshot = g_user_asked_for_screenshot.exchange(false);
+
+		if (user_asked_for_screenshot || (g_recording_mode != recording_mode::stopped && m_frame->can_consume_frame()))
 		{
 			static const gl::pixel_pack_settings pack_settings{};
 
@@ -374,7 +376,7 @@ void GLGSRender::flip(const rsx::display_flip_info_t& info)
 			{
 				screenshot_log.error("Failed to capture image: 0x%x", err);
 			}
-			else if (g_user_asked_for_screenshot.exchange(false))
+			else if (user_asked_for_screenshot)
 			{
 				m_frame->take_screenshot(std::move(sshot_frame), buffer_width, buffer_height, false);
 			}

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu.cpp
@@ -4,6 +4,8 @@
 #include "Emu/system_config.h"
 #include "Utilities/date_time.h"
 
+extern atomic_t<bool> g_user_asked_for_screenshot;
+
 namespace rsx
 {
 	namespace overlays
@@ -94,12 +96,13 @@ namespace rsx
 				break;
 			}
 			case page_navigation::exit:
+			case page_navigation::exit_for_screenshot:
 			{
 				fade_animation.current = color4f(1.f);
 				fade_animation.end = color4f(0.f);
 				fade_animation.active = true;
 
-				fade_animation.on_finish = [this]
+				fade_animation.on_finish = [this, navigation]
 				{
 					close(true, true);
 
@@ -109,6 +112,12 @@ namespace rsx
 						{
 							Emu.Resume();
 						});
+					}
+
+					if (navigation == page_navigation::exit_for_screenshot)
+					{
+						rsx_log.notice("Taking screenshot after exiting home menu");
+						g_user_asked_for_screenshot = true;
 					}
 				};
 				break;

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_components.h
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_components.h
@@ -18,7 +18,8 @@ namespace rsx
 			stay,
 			back,
 			next,
-			exit
+			exit,
+			exit_for_screenshot
 		};
 
 		struct home_menu_entry : horizontal_layout

--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_main_menu.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_main_menu.cpp
@@ -11,7 +11,6 @@
 #include "Emu/Cell/Modules/sceNpTrophy.h"
 
 extern atomic_t<bool> g_user_asked_for_recording;
-extern atomic_t<bool> g_user_asked_for_screenshot;
 
 namespace rsx
 {
@@ -98,8 +97,7 @@ namespace rsx
 				if (btn != pad_button::cross) return page_navigation::stay;
 
 				rsx_log.notice("User selected screenshot in home menu");
-				g_user_asked_for_screenshot = true;
-				return page_navigation::exit;
+				return page_navigation::exit_for_screenshot;
 			});
 
 			std::unique_ptr<overlay_element> recording = std::make_unique<home_menu_entry>(get_localized_string(localized_string_id::HOME_MENU_RECORDING));

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -694,7 +694,9 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 			m_upscaler->scale_output(*m_current_command_buffer, image_to_flip, target_image, target_layout, rgn, UPSCALE_AND_COMMIT | UPSCALE_DEFAULT_VIEW);
 		}
 
-		if (g_user_asked_for_screenshot || (g_recording_mode != recording_mode::stopped && m_frame->can_consume_frame()))
+		const bool user_asked_for_screenshot = g_user_asked_for_screenshot.exchange(false);
+
+		if (user_asked_for_screenshot || (g_recording_mode != recording_mode::stopped && m_frame->can_consume_frame()))
 		{
 			const usz sshot_size = buffer_height * buffer_width * 4;
 
@@ -766,7 +768,7 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 
 			const bool is_bgra = image_to_copy->format() == VK_FORMAT_B8G8R8A8_UNORM;
 
-			if (g_user_asked_for_screenshot.exchange(false))
+			if (user_asked_for_screenshot)
 			{
 				m_frame->take_screenshot(std::move(sshot_frame), buffer_width, buffer_height, is_bgra);
 			}


### PR DESCRIPTION
- Take screenshot after exiting the home menu (if triggered by home menu action)

fixes #17674
