### PR TITLE
sys_fs: Remove PPU sleep hacks

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1036,7 +1036,6 @@ lv2_file::open_result_t lv2_file::open(std::string_view vpath, s32 flags, s32 mo
 error_code sys_fs_open(ppu_thread& ppu, vm::cptr<char> path, s32 flags, vm::ptr<u32> fd, s32 mode, vm::cptr<void> arg, u64 size)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_open(path=%s, flags=%#o, fd=*0x%x, mode=%#o, arg=*0x%x, size=0x%llx)", path, flags, fd, mode, arg, size);
 
@@ -1085,7 +1084,6 @@ error_code sys_fs_open(ppu_thread& ppu, vm::cptr<char> path, s32 flags, vm::ptr<
 error_code sys_fs_read(ppu_thread& ppu, u32 fd, vm::ptr<void> buf, u64 nbytes, vm::ptr<u64> nread)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.trace("sys_fs_read(fd=%d, buf=*0x%x, nbytes=0x%llx, nread=*0x%x)", fd, buf, nbytes, nread);
 
@@ -1122,6 +1120,11 @@ error_code sys_fs_read(ppu_thread& ppu, u32 fd, vm::ptr<void> buf, u64 nbytes, v
 		return CELL_OK;
 	}
 
+	if (nbytes >= 0x100000 && file->type != lv2_file_type::regular)
+	{
+		lv2_obj::sleep(ppu);
+	}
+
 	std::unique_lock lock(file->mp->mutex);
 
 	if (!file->file)
@@ -1154,7 +1157,6 @@ error_code sys_fs_read(ppu_thread& ppu, u32 fd, vm::ptr<void> buf, u64 nbytes, v
 error_code sys_fs_write(ppu_thread& ppu, u32 fd, vm::cptr<void> buf, u64 nbytes, vm::ptr<u64> nwrite)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.trace("sys_fs_write(fd=%d, buf=*0x%x, nbytes=0x%llx, nwrite=*0x%x)", fd, buf, nbytes, nwrite);
 
@@ -1237,7 +1239,6 @@ error_code sys_fs_write(ppu_thread& ppu, u32 fd, vm::cptr<void> buf, u64 nbytes,
 error_code sys_fs_close(ppu_thread& ppu, u32 fd)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	const auto file = idm::get_unlocked<lv2_fs_object, lv2_file>(fd);
 
@@ -1314,7 +1315,6 @@ error_code sys_fs_close(ppu_thread& ppu, u32 fd)
 error_code sys_fs_opendir(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u32> fd)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_opendir(path=%s, fd=*0x%x)", path, fd);
 
@@ -1491,7 +1491,6 @@ error_code sys_fs_readdir(ppu_thread& ppu, u32 fd, vm::ptr<CellFsDirent> dir, vm
 error_code sys_fs_closedir(ppu_thread& ppu, u32 fd)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_closedir(fd=%d)", fd);
 
@@ -1506,7 +1505,6 @@ error_code sys_fs_closedir(ppu_thread& ppu, u32 fd)
 error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat> sb)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_stat(path=%s, sb=*0x%x)", path, sb);
 
@@ -1610,7 +1608,6 @@ error_code sys_fs_stat(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<CellFsStat>
 error_code sys_fs_fstat(ppu_thread& ppu, u32 fd, vm::ptr<CellFsStat> sb)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_fstat(fd=%d, sb=*0x%x)", fd, sb);
 
@@ -1666,7 +1663,6 @@ error_code sys_fs_link(ppu_thread&, vm::cptr<char> from, vm::cptr<char> to)
 error_code sys_fs_mkdir(ppu_thread& ppu, vm::cptr<char> path, s32 mode)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_mkdir(path=%s, mode=%#o)", path, mode);
 
@@ -1728,7 +1724,6 @@ error_code sys_fs_mkdir(ppu_thread& ppu, vm::cptr<char> path, s32 mode)
 error_code sys_fs_rename(ppu_thread& ppu, vm::cptr<char> from, vm::cptr<char> to)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_rename(from=%s, to=%s)", from, to);
 
@@ -1794,7 +1789,6 @@ error_code sys_fs_rename(ppu_thread& ppu, vm::cptr<char> from, vm::cptr<char> to
 error_code sys_fs_rmdir(ppu_thread& ppu, vm::cptr<char> path)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_rmdir(path=%s)", path);
 
@@ -1850,7 +1844,6 @@ error_code sys_fs_rmdir(ppu_thread& ppu, vm::cptr<char> path)
 error_code sys_fs_unlink(ppu_thread& ppu, vm::cptr<char> path)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_unlink(path=%s)", path);
 
@@ -1951,8 +1944,6 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 	case 0x8000000a: // cellFsReadWithOffset
 	case 0x8000000b: // cellFsWriteWithOffset
 	{
-		lv2_obj::sleep(ppu);
-
 		const auto arg = vm::static_ptr_cast<lv2_file_op_rw>(_arg);
 
 		if (_size < arg.size())
@@ -1990,6 +1981,11 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 		if (op == 0x8000000b && file->type != lv2_file_type::regular && arg->size)
 		{
 			sys_fs.error("%s type: Writing %u bytes to FD=%d (path=%s)", file->type, arg->size, file->name.data());
+		}
+
+		if (op == 0x8000000a && file->type != lv2_file_type::regular && arg->size >= 0x100000)
+		{
+			lv2_obj::sleep(ppu);
 		}
 
 		std::unique_lock wlock(file->mp->mutex, std::defer_lock);
@@ -2047,8 +2043,6 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 
 	case 0x80000009: // cellFsSdataOpenByFd
 	{
-		lv2_obj::sleep(ppu);
-
 		const auto arg = vm::static_ptr_cast<lv2_file_op_09>(_arg);
 
 		if (_size < arg.size())
@@ -2102,8 +2096,6 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 
 	case 0xc0000002: // cellFsGetFreeSize (TODO)
 	{
-		lv2_obj::sleep(ppu);
-
 		const auto arg = vm::static_ptr_cast<lv2_file_c0000002>(_arg);
 
 		const auto& mp = g_fxo->get<lv2_fs_mount_info_map>().lookup("/dev_hdd0");
@@ -2418,8 +2410,6 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 
 	case 0xe0000012: // cellFsGetDirectoryEntries
 	{
-		lv2_obj::sleep(ppu);
-
 		const auto arg = vm::static_ptr_cast<lv2_file_op_dir::dir_info>(_arg);
 
 		if (_size < arg.size())
@@ -2433,8 +2423,6 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 		{
 			return CELL_EBADF;
 		}
-
-		ppu.check_state();
 
 		u32 read_count = 0;
 
@@ -2593,7 +2581,6 @@ error_code sys_fs_fcntl(ppu_thread& ppu, u32 fd, u32 op, vm::ptr<void> _arg, u32
 error_code sys_fs_lseek(ppu_thread& ppu, u32 fd, s64 offset, s32 whence, vm::ptr<u64> pos)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.trace("sys_fs_lseek(fd=%d, offset=0x%llx, whence=0x%x, pos=*0x%x)", fd, offset, whence, pos);
 
@@ -2639,7 +2626,6 @@ error_code sys_fs_lseek(ppu_thread& ppu, u32 fd, s64 offset, s32 whence, vm::ptr
 error_code sys_fs_fdatasync(ppu_thread& ppu, u32 fd)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.trace("sys_fs_fdadasync(fd=%d)", fd);
 
@@ -2649,6 +2635,8 @@ error_code sys_fs_fdatasync(ppu_thread& ppu, u32 fd)
 	{
 		return CELL_EBADF;
 	}
+
+	lv2_obj::sleep(ppu);
 
 	std::lock_guard lock(file->mp->mutex);
 
@@ -2664,7 +2652,6 @@ error_code sys_fs_fdatasync(ppu_thread& ppu, u32 fd)
 error_code sys_fs_fsync(ppu_thread& ppu, u32 fd)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.trace("sys_fs_fsync(fd=%d)", fd);
 
@@ -2674,6 +2661,8 @@ error_code sys_fs_fsync(ppu_thread& ppu, u32 fd)
 	{
 		return CELL_EBADF;
 	}
+
+	lv2_obj::sleep(ppu);
 
 	std::lock_guard lock(file->mp->mutex);
 
@@ -2763,7 +2752,6 @@ error_code sys_fs_get_block_size(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u
 error_code sys_fs_truncate(ppu_thread& ppu, vm::cptr<char> path, u64 size)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_truncate(path=%s, size=0x%llx)", path, size);
 
@@ -2815,7 +2803,6 @@ error_code sys_fs_truncate(ppu_thread& ppu, vm::cptr<char> path, u64 size)
 error_code sys_fs_ftruncate(ppu_thread& ppu, u32 fd, u64 size)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_ftruncate(fd=%d, size=0x%llx)", fd, size);
 
@@ -3021,7 +3008,6 @@ error_code sys_fs_disk_free(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u64> t
 error_code sys_fs_utime(ppu_thread& ppu, vm::cptr<char> path, vm::cptr<CellFsUtimbuf> timep)
 {
 	ppu.state += cpu_flag::wait;
-	lv2_obj::sleep(ppu);
 
 	sys_fs.warning("sys_fs_utime(path=%s, timep=*0x%x)", path, timep);
 	sys_fs.warning("** actime=%u, modtime=%u", timep->actime, timep->modtime);


### PR DESCRIPTION
Removes lv2_obj::sleep calls (hack), they were added due to concerns of PPU starvation.
I keep the ones in `sys_fs_fsync`, `sys_fs_fdatasync` and filesystem reads of EDATA/SDATA specifically.
sys_fs_fsync was known to cause frame stutters in God Of War 3 without it, because it waits for days to be flushed to disk.
I keep it for EDATA/SDATA reads as well because they are CPU intensive.
I was wondering if to keep it for writes as well, but, they occur in bulk in disc games installation which is a process kown to have various PPU schedular issues in games. So its removal may fix some issues.