### PR TITLE
Free previous pointer after reallocating memory

### DIFF
--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -24,7 +24,9 @@ namespace rsx
 		template <size_t Align>
 		void* realloc(void* prev_ptr, [[maybe_unused]] size_t prev_size, size_t new_size)
 		{
-			if (prev_size >= utils::align<usz>(new_size, Align) && reinterpret_cast<usz>(prev_ptr) % Align == 0)
+			ensure(reinterpret_cast<usz>(prev_ptr) % Align == 0,
+       			"Pointer not aligned to Align");
+			if (prev_size >= ((new_size + Align - 1) & (0 - Align))) 
 			{
 			    return prev_ptr;
 			}
@@ -33,7 +35,7 @@ namespace rsx
 #else
 			void* ret = std::aligned_alloc(Align, new_size);
 			std::memcpy(ret, prev_ptr, std::min(prev_size, new_size));
-			free(prev_ptr);
+			std::free(prev_ptr);
 			return ret;
 #endif
 		}


### PR DESCRIPTION
After realloc in simple_array free the memory referenced by the old pointer.