### PR TITLE
rsx: Clean up aligned realloc implementation and add UTs

### DIFF
--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -24,12 +24,12 @@ namespace rsx
 		template <size_t Align>
 		void* realloc(void* prev_ptr, [[maybe_unused]] size_t prev_size, size_t new_size)
 		{
-			ensure(reinterpret_cast<usz>(prev_ptr) % Align == 0,
-       			"Pointer not aligned to Align");
-			if (prev_size >= ((new_size + Align - 1) & (0 - Align))) 
+			if (prev_size >= new_size)
 			{
-			    return prev_ptr;
+				return prev_ptr;
 			}
+
+			ensure(reinterpret_cast<usz>(prev_ptr) % Align == 0, "Pointer not aligned to Align");
 #ifdef _WIN32
 			return _aligned_realloc(prev_ptr, new_size, Align);
 #else

--- a/rpcs3/tests/test_simple_array.cpp
+++ b/rpcs3/tests/test_simple_array.cpp
@@ -323,4 +323,35 @@ namespace rsx
 		EXPECT_EQ(*arr.find_if(FN(x == 8)), 8);
 		EXPECT_EQ(arr.find_if(FN(x == 99)), nullptr);
 	}
+
+	TEST(AlignedAllocator, Alloc)
+	{
+		auto ptr = rsx::aligned_allocator::malloc<256>(16);
+		const auto ptr_value = reinterpret_cast<uintptr_t>(ptr);
+		rsx::aligned_allocator::free(ptr);
+
+		EXPECT_NE(ptr_value, 0);
+		EXPECT_EQ(ptr_value % 256, 0);
+	}
+
+	TEST(AlignedAllocator, Realloc)
+	{
+		auto ptr = rsx::aligned_allocator::malloc<256>(16);
+		auto ptr2 = rsx::aligned_allocator::realloc<256>(ptr, 16, 32);
+		const auto ptr_value = reinterpret_cast<uintptr_t>(ptr2);
+		rsx::aligned_allocator::free(ptr2);
+
+		EXPECT_NE(ptr, ptr2);
+		EXPECT_NE(ptr_value, 0);
+		EXPECT_EQ(ptr_value % 256, 0);
+	}
+
+	TEST(AlignedAllocator, Realloc_ReturnsPreviousPointerIfFits)
+	{
+		auto ptr = rsx::aligned_allocator::malloc<256>(16);
+		auto ptr2 = rsx::aligned_allocator::realloc<256>(ptr, 16, 8);
+		rsx::aligned_allocator::free(ptr2);
+
+		EXPECT_EQ(ptr, ptr2);
+	}
 }


### PR DESCRIPTION
You cannot assume the bounds of a pointer returned by aligned_alloc or aligned_malloc because multiples of the alignment will also match the alignment test. Only trust the information that is guaranteed to be correct.
Also adds some generic unit tests.