### PR TITLE
Add multi-selection context menu

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -901,6 +901,22 @@ std::string_view fs::get_parent_dir_view(std::string_view path, u32 parent_level
 	return result;
 }
 
+std::string fs::get_path_if_dir(const std::string& path)
+{
+	if (path.empty() || !fs::is_dir(path))
+	{
+		return {};
+	}
+
+	// If delimiters are already present at the end of the string then nothing else to do
+	if (usz sz = path.find_last_of(delim); sz != umax && (sz + 1) == path.size())
+	{
+		return path;
+	}
+
+	return path + '/';
+}
+
 bool fs::get_stat(const std::string& path, stat_t& info)
 {
 	// Ensure consistent information on failure

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -195,6 +195,9 @@ namespace fs
 		return std::string{get_parent_dir_view(path, parent_level)};
 	}
 
+	// Return "path" plus an ending delimiter (if missing) if "path" is an existing directory. Otherwise, an empty string
+	std::string get_path_if_dir(const std::string& path);
+
 	// Get file information
 	bool get_stat(const std::string& path, stat_t& info);
 

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -149,11 +149,6 @@ namespace rpcs3::utils
 		return emu_dir_.empty() ? fs::get_config_dir() : emu_dir_;
 	}
 
-	std::string get_games_dir()
-	{
-		return g_cfg_vfs.get(g_cfg_vfs.games_dir, get_emu_dir());
-	}
-
 	std::string get_hdd0_dir()
 	{
 		return g_cfg_vfs.get(g_cfg_vfs.dev_hdd0, get_emu_dir());
@@ -184,9 +179,29 @@ namespace rpcs3::utils
 		return g_cfg_vfs.get(g_cfg_vfs.dev_bdvd, get_emu_dir());
 	}
 
+	std::string get_games_dir()
+	{
+		return g_cfg_vfs.get(g_cfg_vfs.games_dir, get_emu_dir());
+	}
+
 	std::string get_hdd0_game_dir()
 	{
 		return get_hdd0_dir() + "game/";
+	}
+
+	std::string get_hdd0_locks_dir()
+	{
+		return get_hdd0_game_dir() + "$locks/";
+	}
+
+	std::string get_hdd1_cache_dir()
+	{
+		return get_hdd1_dir() + "caches/";
+	}
+
+	std::string get_games_shortcuts_dir()
+	{
+		return get_games_dir() + "shortcuts/";
 	}
 
 	u64 get_cache_disk_usage()
@@ -224,6 +239,98 @@ namespace rpcs3::utils
 		}
 
 		return cache_dir;
+	}
+
+	std::string get_data_dir()
+	{
+		return fs::get_config_dir() + "data/";
+	}
+
+	std::string get_icons_dir()
+	{
+		return fs::get_config_dir() + "Icons/game_icons/";
+	}
+
+	std::string get_savestates_dir()
+	{
+		return fs::get_config_dir() + "savestates/";
+	}
+
+	std::string get_captures_dir()
+	{
+		return fs::get_config_dir() + "captures/";
+	}
+
+	std::string get_recordings_dir()
+	{
+		return fs::get_config_dir() + "recordings/";
+	}
+
+	std::string get_screenshots_dir()
+	{
+		return fs::get_config_dir() + "screenshots/";
+	}
+
+	std::string get_cache_dir_by_serial(const std::string& serial)
+	{
+		return get_cache_dir() + (serial == "vsh.self" ? "vsh" : serial);
+	}
+
+	std::string get_data_dir(const std::string& serial)
+	{
+		return get_data_dir() + serial;
+	}
+
+	std::string get_icons_dir(const std::string& serial)
+	{
+		return get_icons_dir() + serial;
+	}
+
+	std::string get_savestates_dir(const std::string& serial)
+	{
+		return get_savestates_dir() + serial;
+	}
+
+	std::string get_recordings_dir(const std::string& serial)
+	{
+		return get_recordings_dir() + serial;
+	}
+
+	std::string get_screenshots_dir(const std::string& serial)
+	{
+		return get_screenshots_dir() + serial;
+	}
+
+	std::set<std::string> get_dir_list(const std::string& base_dir, const std::string& serial)
+	{
+		std::set<std::string> dir_list;
+
+		for (const auto& entry : fs::dir(base_dir))
+		{
+			// Check for sub folder starting with serial (e.g. BCES01118_BCES01118)
+			if (entry.is_directory && entry.name.starts_with(serial))
+			{
+				dir_list.insert(base_dir + entry.name);
+			}
+		}
+
+		return dir_list;
+	}
+
+	std::set<std::string> get_file_list(const std::string& base_dir, const std::string& serial)
+	{
+		std::set<std::string> file_list;
+
+		for (const auto& entry : fs::dir(base_dir))
+		{
+			// Check for files starting with serial (e.g. BCES01118_BCES01118)
+			if (!entry.is_directory && entry.name.starts_with(serial))
+			{
+				file_list.insert(base_dir + entry.name);
+			}
+		}
+
+		return file_list;
 	}
 
 	std::string get_rap_file_path(const std::string_view& rap)

--- a/rpcs3/Emu/system_utils.hpp
+++ b/rpcs3/Emu/system_utils.hpp
@@ -2,6 +2,7 @@
 
 #include "util/types.hpp"
 #include <string>
+#include <set>
 
 enum class game_content_type
 {
@@ -26,20 +27,41 @@ namespace rpcs3::utils
 	// VFS directories and disk usage
 	std::vector<std::pair<std::string, u64>> get_vfs_disk_usage();
 	std::string get_emu_dir();
-	std::string get_games_dir();
 	std::string get_hdd0_dir();
 	std::string get_hdd1_dir();
 	std::string get_flash_dir();
 	std::string get_flash2_dir();
 	std::string get_flash3_dir();
 	std::string get_bdvd_dir();
+	std::string get_games_dir();
 
 	std::string get_hdd0_game_dir();
+	std::string get_hdd0_locks_dir();
+	std::string get_hdd1_cache_dir();
+	std::string get_games_shortcuts_dir();
 
 	// Cache directories and disk usage
 	u64 get_cache_disk_usage();
 	std::string get_cache_dir();
 	std::string get_cache_dir(std::string_view module_path);
+
+	std::string get_data_dir();
+	std::string get_icons_dir();
+	std::string get_savestates_dir();
+	std::string get_captures_dir();
+	std::string get_recordings_dir();
+	std::string get_screenshots_dir();
+
+	// get_cache_dir_by_serial() named in this way to avoid conflict (wrong invocation) with get_cache_dir()
+	std::string get_cache_dir_by_serial(const std::string& serial);
+	std::string get_data_dir(const std::string& serial);
+	std::string get_icons_dir(const std::string& serial);
+	std::string get_savestates_dir(const std::string& serial);
+	std::string get_recordings_dir(const std::string& serial);
+	std::string get_screenshots_dir(const std::string& serial);
+
+	std::set<std::string> get_dir_list(const std::string& base_dir, const std::string& serial);
+	std::set<std::string> get_file_list(const std::string& base_dir, const std::string& serial);
 
 	std::string get_rap_file_path(const std::string_view& rap);
 	bool verify_c00_unlock_edat(const std::string_view& content_id, bool fast = false);

--- a/rpcs3/rpcs3qt/game_list_table.cpp
+++ b/rpcs3/rpcs3qt/game_list_table.cpp
@@ -24,7 +24,7 @@ game_list_table::game_list_table(game_list_frame* frame, std::shared_ptr<persist
 	setItemDelegate(new game_list_delegate(this));
 	setEditTriggers(QAbstractItemView::NoEditTriggers);
 	setSelectionBehavior(QAbstractItemView::SelectRows);
-	setSelectionMode(QAbstractItemView::SingleSelection);
+	setSelectionMode(QAbstractItemView::ExtendedSelection);
 	setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
 	setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
 	verticalScrollBar()->setSingleStep(20);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -221,7 +221,7 @@ bool main_window::Init([[maybe_unused]] bool with_cli_boot)
 
 	if (enable_play_last)
 	{
-		ui->sysPauseAct->setText(tr("&Play last played game"));
+		ui->sysPauseAct->setText(tr("&Play Last Played Game"));
 		ui->sysPauseAct->setIcon(m_icon_play);
 		ui->toolbar_start->setToolTip(start_tooltip);
 	}
@@ -2722,15 +2722,43 @@ void main_window::CreateConnects()
 	});
 	connect(ui->exitAct, &QAction::triggered, this, &QWidget::close);
 
-	connect(ui->batchCreateCPUCachesAct, &QAction::triggered, m_game_list_frame, [list = m_game_list_frame]() { list->BatchCreateCPUCaches(); });
-	connect(ui->batchRemoveCustomConfigurationsAct, &QAction::triggered, m_game_list_frame, &game_list_frame::BatchRemoveCustomConfigurations);
-	connect(ui->batchRemoveCustomPadConfigurationsAct, &QAction::triggered, m_game_list_frame, &game_list_frame::BatchRemoveCustomPadConfigurations);
-	connect(ui->batchRemoveShaderCachesAct, &QAction::triggered, m_game_list_frame, &game_list_frame::BatchRemoveShaderCaches);
-	connect(ui->batchRemovePPUCachesAct, &QAction::triggered, m_game_list_frame, &game_list_frame::BatchRemovePPUCaches);
-	connect(ui->batchRemoveSPUCachesAct, &QAction::triggered, m_game_list_frame, &game_list_frame::BatchRemoveSPUCaches);
-	connect(ui->removeHDD1CachesAct, &QAction::triggered, this, &main_window::RemoveHDD1Caches);
-	connect(ui->removeAllCachesAct, &QAction::triggered, this, &main_window::RemoveAllCaches);
-	connect(ui->removeSavestatesAct, &QAction::triggered, this, &main_window::RemoveSavestates);
+	connect(ui->batchCreateCPUCachesAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->BatchCreateCPUCaches({}, false, true);
+	});
+	connect(ui->batchRemoveCustomConfigurationsAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->BatchRemoveCustomConfigurations({}, true);
+	});
+	connect(ui->batchRemoveCustomPadConfigurationsAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->BatchRemoveCustomPadConfigurations({}, true);
+	});
+	connect(ui->batchRemoveShaderCachesAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->BatchRemoveShaderCaches({}, true);
+	});
+	connect(ui->batchRemovePPUCachesAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->BatchRemovePPUCaches({}, true);
+	});
+	connect(ui->batchRemoveSPUCachesAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->BatchRemoveSPUCaches({}, true);
+	});
+	connect(ui->removeHDD1CachesAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->BatchRemoveHDD1Caches({}, true);
+	});
+	connect(ui->removeAllCachesAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->BatchRemoveAllCaches({}, true);
+	});
+	connect(ui->removeSavestatesAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->SetContentList(game_list_frame::content_type::SAVESTATES, {});
+		m_game_list_frame->BatchRemoveContentLists({}, true);
+	});
 	connect(ui->cleanUpGameListAct, &QAction::triggered, this, &main_window::CleanUpGameList);
 
 	connect(ui->removeFirmwareCacheAct, &QAction::triggered, this, &main_window::RemoveFirmwareCache);
@@ -3657,67 +3685,6 @@ void main_window::SetIconSizeActions(int idx) const
 		ui->setIconSizeMediumAct->setChecked(true);
 	else
 		ui->setIconSizeLargeAct->setChecked(true);
-}
-
-void main_window::RemoveHDD1Caches()
-{
-	if (fs::remove_all(rpcs3::utils::get_hdd1_dir() + "caches", false))
-	{
-		QMessageBox::information(this, tr("HDD1 Caches Removed"), tr("HDD1 caches successfully removed"));
-	}
-	else
-	{
-		QMessageBox::warning(this, tr("Error"), tr("Could not remove HDD1 caches"));
-	}
-}
-
-void main_window::RemoveAllCaches()
-{
-	if (QMessageBox::question(this, tr("Confirm Removal"), tr("Remove all caches?")) != QMessageBox::Yes)
-		return;
-
-	const std::string cache_base_dir = rpcs3::utils::get_cache_dir();
-	u64 caches_count = 0;
-	u64 caches_removed = 0;
-
-	for (const game_info& game : m_game_list_frame->GetGameInfo()) // Loop on detected games
-	{
-		if (game && QString::fromStdString(game->info.category) != cat::cat_ps3_os && fs::exists(cache_base_dir + game->info.serial)) // If not OS category and cache exists
-		{
-			caches_count++;
-
-			if (fs::remove_all(cache_base_dir + game->info.serial))
-			{
-				caches_removed++;
-			}
-		}
-	}
-
-	if (caches_count == caches_removed)
-	{
-		QMessageBox::information(this, tr("Caches Removed"), tr("%0 cache(s) successfully removed").arg(caches_removed));
-	}
-	else
-	{
-		QMessageBox::warning(this, tr("Error"), tr("Could not remove %0 of %1 cache(s)").arg(caches_count - caches_removed).arg(caches_count));
-	}
-
-	RemoveHDD1Caches();
-}
-
-void main_window::RemoveSavestates()
-{
-	if (QMessageBox::question(this, tr("Confirm Removal"), tr("Remove savestates?")) != QMessageBox::Yes)
-		return;
-
-	if (fs::remove_all(fs::get_config_dir() + "savestates", false))
-	{
-		QMessageBox::information(this, tr("Savestates Removed"), tr("Savestates successfully removed"));
-	}
-	else
-	{
-		QMessageBox::warning(this, tr("Error"), tr("Could not remove savestates"));
-	}
 }
 
 void main_window::CleanUpGameList()

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -114,9 +114,6 @@ private Q_SLOTS:
 	void SetIconSizeActions(int idx) const;
 	void ResizeIcons(int index);
 
-	void RemoveHDD1Caches();
-	void RemoveAllCaches();
-	void RemoveSavestates();
 	void CleanUpGameList();
 
 	void RemoveFirmwareCache();

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -1174,7 +1174,7 @@
   </action>
   <action name="batchRemoveCustomPadConfigurationsAct">
    <property name="text">
-    <string>Remove Custom Pad Configurations</string>
+    <string>Remove Custom Gamepad Configurations</string>
    </property>
   </action>
   <action name="batchRemoveShaderCachesAct">


### PR DESCRIPTION
Follow up of #17715 to implement #6008

Added multi-selection context menu. The PR is a follow up of #16038 that re-organized the context menu currently limited to a single game selection.
This PR allows to select multiple games from the game list, by the use of usual `Shift`, `CTRL` keys and mouse click, and so to provide a context menu for the selected games by a mouse right-click.
The multiple selection is currently supported by the game list in `List Mode` (see limitations reported below).

### Current limitations:
- Multi-selection is not supported by `Grid Mode`, This is simply due to the Qt objects currently used for the `Grid Mode`. It could probably be easily supported by few changes made by main developers. This task remained out of scope in this PR
<strike>- The selection of multiple games in `List Mode` is allowed by clicking on the game's icon only (see screenshot). This limitation is probably due to other interfering registered actions that main developers could easily update in further PR to fix this minor limitation</strike> Fixed by #17799

### NOTES:
- Unfortunately the PR could not be split in other smaller PRs without compromising the usability or making the code even more (e.g. without providing shared methods such as `ValidateRemoval()` etc.)
- The existing batch and non-batch removal methods remained perfectly backward compatible. E.g. for batch removal methods, no game list provided means the entire game list is used
- Back-End `GetContentInfo()` method (collecting content info and path size) seems not needing the use of a concurrent thread to collect disk usage as needed in #17715. The method uses disk size info from game list. The scan for disk usage is limited to auxiliary folders such as Savestates, Captures, Recordings, Screenshots not providing huge number of files that could slowdown the GUI. Eventually, the concurrent thread can be added. I simply considered it an overkill

fixes #6008


### Changes log:

- `game_list_frame.cpp`:
  - Action `remove_game` present in single-selection context menu moved to `DialogRemoveGame()` method in order to make it sharable (so reducing code) with the new multi-selection context menu
  - `DialogRemoveGame()` method based on:
    - Back-End:  BE `GetContentInfo()` method collects all the info (info text, data paths etc.) that will be used by new Front-End methods `DialogRemoveGame()`, `DialogGameInfo()` and new BE `RemoveContentList()` method
    - Front-End: It only displays and manages a dialog box according to the info provided by the BE
  - Added right-click `Manage Game->Game Info` to display info for the selected content. The related dialog is `DialogGameInfo()` and it makes use of the shared BE `GetContentInfo()` method
  - Implemented new methods previously present (with limitations) in `main_window.cpp`:
    - `BatchRemoveHDD1Caches()`
    - `BatchRemoveAllCaches()`
    - `BatchRemoveContentList()`

    They all are compliant with other similar existing methods in `game_list_frame.cpp` such as `BatchRemovePPUCaches()` etc. so they will provide a progress bar for the task in progress
  - Existing `BatchActionBySerials()` method extended to provide also an action on task finish. It is needed by `BatchRemoveContentLists()` to finalize the list of titles to be removed from the game list and to refresh the list
  - Some code reduction and more robust checks provided by the use of methods:
    - `IsGameRunning()`
    - `ValidateRemoval()`
    - `ValidateBatchRemoval()`

    These methods are largely used by all the batch and non-batch removal methods such as `BatchRemovePPUCaches()`, `RemovePPUCache()` etc. allowing to reduce code and to better control preliminary checks
  - Some utility functions created on `system_utils.cpp`. A lot of them are functions providing emulator's paths avoiding the possibility of mistakes possible when creating paths on-the-fly (unfortunately largely used in all the code).
    Of course the functions have been used only by the new code in this PR
 
- `main_window.cpp`:
  - Following methods replaced by the 3 batch methods provided (reported above) in `game_list_frame.cpp`:
    - `RemoveHDD1Caches()`
    - `RemoveAllCaches()`
    - `RemoveSavestates()`

</br>

### Multi-selection:

<img width="3682" height="1181" alt="image" src="https://github.com/user-attachments/assets/cb8b5f91-5500-4c35-b60e-2fb80d6b7fab" />

</br>

### Main context menu:

![pr_main_menu](https://github.com/user-attachments/assets/03cdbf6e-1693-4dbc-8402-2faf24f0a303)

</br>

### Remove menu:

![pr_remove_menu](https://github.com/user-attachments/assets/4225043e-371d-4d8a-a744-a8d78653e70f)

</br>

### Manage Game menu:

![pr_manage_menu](https://github.com/user-attachments/assets/4cf04500-62b6-4bb8-89af-232aae1834b7)

</br>

### Game Info dialog:

![pr_game_info_dialog](https://github.com/user-attachments/assets/e1ad7024-6882-455b-bafd-b23116a1516a)

</br>

### Remove Game dialog:

![pr_remove_game_dialog](https://github.com/user-attachments/assets/a7480e56-2ebd-49bd-9861-4429bd826084)
