### PR TITLE
rsx/common - work around macos posix_memalign quirks

### DIFF
--- a/rpcs3/Emu/RSX/Common/simple_array.hpp
+++ b/rpcs3/Emu/RSX/Common/simple_array.hpp
@@ -12,28 +12,45 @@ namespace rsx
 	namespace aligned_allocator
 	{
 		template <size_t Align>
+			requires (Align != 0) && ((Align & (Align - 1)) == 0)
+		size_t align_up(size_t size)
+		{
+			return (size + (Align - 1)) & ~(Align - 1);
+		}
+
+		template <size_t Align>
+			requires (Align != 0) && ((Align & (Align - 1)) == 0)
 		void* malloc(size_t size)
 		{
-#ifdef _WIN32
+#if defined(_WIN32)
 			return _aligned_malloc(size, Align);
+#elif defined(__APPLE__)
+			constexpr size_t NativeAlign = std::max(Align, sizeof(void*));
+			return std::aligned_alloc(NativeAlign, align_up<NativeAlign>(size));
 #else
-			return std::aligned_alloc(Align, size);
+			return std::aligned_alloc(Align, align_up<Align>(size));
 #endif
 		}
 
 		template <size_t Align>
+			requires (Align != 0) && ((Align & (Align - 1)) == 0)
 		void* realloc(void* prev_ptr, [[maybe_unused]] size_t prev_size, size_t new_size)
 		{
-			if (prev_size >= new_size)
+			if (align_up<Align>(prev_size) >= new_size)
 			{
 				return prev_ptr;
 			}
 
 			ensure(reinterpret_cast<usz>(prev_ptr) % Align == 0, "Pointer not aligned to Align");
-#ifdef _WIN32
+#if defined(_WIN32)
 			return _aligned_realloc(prev_ptr, new_size, Align);
 #else
-			void* ret = std::aligned_alloc(Align, new_size);
+#if defined(__APPLE__)
+			constexpr size_t NativeAlign = std::max(Align, sizeof(void*));
+			void* ret = std::aligned_alloc(NativeAlign, align_up<NativeAlign>(new_size));
+#else
+			void* ret = std::aligned_alloc(Align, align_up<Align>(new_size));
+#endif
 			std::memcpy(ret, prev_ptr, std::min(prev_size, new_size));
 			std::free(prev_ptr);
 			return ret;


### PR DESCRIPTION
The aligned_alloc implementation on macos arm64 clang appears to be broken. It blindly follows the posix spec for memalign while it really shouldn't. If the min alignment available is say 16, then there is no problem using that when trying to get a pointer with alignment of 4 since 16 is a multiple of 4. But on macos we consistently see this failing and returning the same thing that posix_memalign would return which is NULL.
Fixes the test failures and random crashes when running games on macos. Notably, linux on the same devices was completely fine, so its just compiler nonsense.

Thanks to @rcaridade145 for pointing out the memalign rules (at https://pontus.digipen.edu/~mmead/www/docs/sizes.c.html)