### PR TITLE
Deny PKG installation without RAP

### DIFF
--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -361,10 +361,15 @@ public:
 		return m_file;
 	}
 
+	const std::string& gep_needed_rap_file_path() const
+	{
+		return m_rap_file_path;
+	}
+
 private:
 	bool read_header();
 	bool read_metadata();
-	bool read_param_sfo();
+	fs::file read_file(std::string_view relative_path);
 	bool set_decryption_key();
 	bool read_entries(std::vector<PKGEntry>& entries);
 	void archive_seek(s64 new_offset, const fs::seek_mode damode = fs::seek_set);
@@ -400,4 +405,5 @@ private:
 
 	// Expose bootable file installed (if installed such)
 	std::string m_bootable_file_path;
+	std::string m_rap_file_path;
 };

--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -1068,6 +1068,37 @@ bool SELFDecrypter::DecryptNPDRM(u8 *metadata, u32 metadata_size)
 	return true;
 }
 
+std::string SELFDecrypter::GetRapFilePath()
+{
+	// Check if we have a valid NPDRM control info structure.
+	// If not, the data has no NPDRM layer.
+	const NPD_HEADER* npd = GetNPDHeader();
+	if (!npd)
+	{
+		self_log.trace("No NPDRM control info found!");
+		return {};
+	}
+
+	if (npd->license == 1)  // Network license.
+	{
+		return rpcs3::utils::get_rap_file_path(npd->content_id);
+	}
+	else if (npd->license == 2)  // Local license.
+	{
+		return rpcs3::utils::get_rap_file_path(npd->content_id);
+	}
+	else if (npd->license == 3)  // Free license.
+	{
+		//
+	}
+	else
+	{
+		self_log.error("Invalid NPDRM license type!");
+	}
+
+	return {};
+}
+
 const NPD_HEADER* SELFDecrypter::GetNPDHeader() const
 {
 	// Parse the control info structures to find the NPDRM control info.
@@ -1430,6 +1461,46 @@ fs::file decrypt_self(const fs::file& elf_or_self, const u8* klic_key, SelfAddit
 		}
 
 		return e;
+	}
+
+	return {};
+}
+
+std::string get_rap_file_path_of_self(const fs::file& elf_or_self)
+{
+	if (!elf_or_self)
+	{
+		return {};
+	}
+
+	elf_or_self.seek(0);
+
+	// Check SELF header first. Check for a debug SELF.
+	u32 file_type = umax;
+	elf_or_self.read_at(0, &file_type, sizeof(file_type));
+
+	if (file_type == "SCE\0"_u32)
+	{
+		if (fs::file res = CheckDebugSelf(elf_or_self))
+		{
+			return {};
+		}
+
+		// Check the ELF file class (32 or 64 bit).
+		const bool isElf32 = IsSelfElf32(elf_or_self);
+
+		// Start the decrypter on this SELF file.
+		SELFDecrypter self_dec(elf_or_self);
+
+		// Load the SELF file headers.
+		if (!self_dec.LoadHeaders(isElf32, nullptr))
+		{
+			self_log.error("Failed to load SELF file headers!");
+			return {};
+		}
+
+		// Load and decrypt the SELF file metadata.
+		return self_dec.GetRapFilePath();
 	}
 
 	return {};

--- a/rpcs3/Crypto/unself.h
+++ b/rpcs3/Crypto/unself.h
@@ -481,6 +481,7 @@ public:
 	bool DecryptNPDRM(u8 *metadata, u32 metadata_size);
 	const NPD_HEADER* GetNPDHeader() const;
 	static bool GetKeyFromRap(const char *content_id, u8 *npdrm_key);
+	std::string GetRapFilePath();
 
 private:
 	template<typename EHdr, typename SHdr, typename PHdr>
@@ -562,5 +563,6 @@ private:
 fs::file decrypt_self(const fs::file& elf_or_self, const u8* klic_key = nullptr, SelfAdditionalInfo* additional_info = nullptr);
 bool verify_npdrm_self_headers(const fs::file& self, u8* klic_key = nullptr, NPD_HEADER* npd_out = nullptr);
 bool get_npdrm_self_header(const fs::file& self, NPD_HEADER& npd);
+std::string get_rap_file_path_of_self(const fs::file& elf_or_self);
 
 u128 get_default_self_klic();

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -51,6 +51,9 @@ class main_window : public QMainWindow
 	int m_other_slider_pos = 0;
 	std::function<void()> m_notify_batch_game_action_cb;
 
+	QString last_pkg_path_postponed_due_to_missing_rap;
+	QString last_rap_file_needed_for_pkg;
+
 	QIcon m_app_icon;
 	QIcon m_icon_play;
 	QIcon m_icon_pause;


### PR DESCRIPTION
The log error is remained, and if you install multiple PKGs it would only print the missing RAP file path.
<img width="502" height="195" alt="image" src="https://github.com/user-attachments/assets/f3da74a2-2336-4344-bf35-b8e446227ab1" />

Relates to #17805

Edit: Added RAP redemption: if you failed to have RAP while attempting to install PKG, drag-and-droping the needed RAP file would re-attempt the PKG installation like magic. RPCS3 uses advanced AI to read your mind's intentions.