### PR TITLE
Fix u32 to s32 in two functions in #17666

### DIFF
--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -14,7 +14,7 @@ namespace rsx
 	namespace nv0039
 	{
 		// Transfer with stride
-		inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 width, u32 height, u32 src_pitch, u32 dst_pitch, u8 src_stride, u8 dst_stride)
+		inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 width, u32 height, s32 src_pitch, s32 dst_pitch, u8 src_stride, u8 dst_stride)
 		{
 			for (u32 row = 0; row < height; ++row)
 			{
@@ -33,7 +33,7 @@ namespace rsx
 			}
 		}
 
-		inline void block2d_copy(u8* dst, const u8* src, u32 width, u32 height, u32 src_pitch, u32 dst_pitch)
+		inline void block2d_copy(u8* dst, const u8* src, u32 width, u32 height, s32 src_pitch, s32 dst_pitch)
 		{
 			for (u32 i = 0; i < height; ++i)
 			{


### PR DESCRIPTION
fixes #17730

Fix signature for the following utility functions implemented in #17666:

```
inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 width, u32 height, u32 src_pitch, u32 dst_pitch, u8 src_stride, u8 dst_stride)

inline void block2d_copy(u8* dst, const u8* src, u32 width, u32 height, u32 src_pitch, u32 dst_pitch)
```

Variables `in_pitch` and `out_pitch` are defined as `s32` but passed as `u32` on those functions so breaking the arithmetic on pointers (e.g. `src += src_pitch;`) in case of negative pitch value.

Just a doubt about:

```
s32 in_pitch = REGS(ctx)->nv0039_input_pitch();
s32 out_pitch = REGS(ctx)->nv0039_output_pitch();
```

`REGS(ctx)->nv0039_input_pitch()` and `REGS(ctx)->nv0039_output_pitch()` return `u32` but assigned to `s32`. Not sure if intended or a possible bug to fix. Apparently it seems intended (e.g. negative values are possible; otherwise this bugfix should not exist) although I don't understand why `REGS-><xx>_pitch()` have been defined as `u32`.

**NOTE:**

Similarly to the reported two bugged functions, I also see in #17666 the use of function `clip_image(....)`. e.g.:

`clip_image(dst.pixels, src.pixels, dst.clip_x, dst.clip_y, dst.clip_width, dst.clip_height, dst.bpp, src.pitch, dst.pitch);
`

Many of the passed variables have a different (and dangerous) type than what the function is expecting. E.g. `src.pitch` is `u32` (while `in_pitch` was `s32`) while the function's signature is expecting an `int` (although on a 64bit arch int should be equivalent iirc to `s64` so covering `u32`. Similar considerations for other arguments.
Just in case it could be something to review and fix to avoid a similar issue as the one fixed by this PR