### PR TITLE
Fix RPCN replies ordering

### DIFF
--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -1702,4 +1702,16 @@ namespace np
 		return ctx;
 	}
 
+	void np_handler::callback_info::queue_callback(u32 req_id, u32 event_key, s32 error_code, u32 data_size) const
+	{
+		if (cb)
+		{
+			sysutil_register_cb([=, ctx_id = this->ctx_id, event_type = this->event_type, cb = this->cb, cb_arg = this->cb_arg](ppu_thread& cb_ppu) -> s32
+				{
+					cb(cb_ppu, ctx_id, req_id, event_type, event_key, error_code, data_size, cb_arg);
+					return 0;
+				});
+		}
+	}
+
 } // namespace np

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -373,17 +373,7 @@ namespace np
 			vm::ptr<void> cb_arg;
 			SceNpMatching2Event event_type;
 
-			void queue_callback(u32 req_id, u32 event_key, s32 error_code, u32 data_size) const
-			{
-				if (cb)
-				{
-					sysutil_register_cb([=, ctx_id = this->ctx_id, event_type = this->event_type, cb = this->cb, cb_arg = this->cb_arg](ppu_thread& cb_ppu) -> s32
-					{
-						cb(cb_ppu, ctx_id, req_id, event_type, event_key, error_code, data_size, cb_arg);
-						return 0;
-					});
-				}
-			}
+			void queue_callback(u32 req_id, u32 event_key, s32 error_code, u32 data_size) const;
 		};
 
 		u32 generate_callback_info(SceNpMatching2ContextId ctx_id, vm::cptr<SceNpMatching2RequestOptParam> optParam, SceNpMatching2Event event_type);

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -1495,7 +1495,7 @@ namespace rpcn
 		return notifs;
 	}
 
-	std::unordered_map<u32, std::pair<rpcn::CommandType, std::vector<u8>>> rpcn_client::get_replies()
+	std::map<u32, std::pair<rpcn::CommandType, std::vector<u8>>> rpcn_client::get_replies()
 	{
 		std::lock_guard lock(mutex_replies);
 		auto ret_replies = std::move(replies);

--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -314,7 +314,7 @@ namespace rpcn
 		std::optional<std::pair<std::string, friend_online_data>> get_friend_presence_by_npid(const std::string& npid);
 
 		std::vector<std::pair<rpcn::NotificationType, std::vector<u8>>> get_notifications();
-		std::unordered_map<u32, std::pair<rpcn::CommandType, std::vector<u8>>> get_replies();
+		std::map<u32, std::pair<rpcn::CommandType, std::vector<u8>>> get_replies();
 		std::unordered_map<std::string, friend_online_data> get_presence_updates();
 		std::map<std::string, friend_online_data> get_presence_states();
 
@@ -428,8 +428,8 @@ namespace rpcn
 
 		shared_mutex mutex_notifs, mutex_replies, mutex_replies_sync, mutex_presence_updates;
 		std::vector<std::pair<rpcn::NotificationType, std::vector<u8>>> notifications;       // notif type / data
-		std::unordered_map<u32, std::pair<rpcn::CommandType, std::vector<u8>>> replies;      // req id / (command / data)
-		std::unordered_map<u64, std::pair<rpcn::CommandType, std::vector<u8>>> replies_sync; // same but for sync replies(see handle_input())
+		std::map<u32, std::pair<rpcn::CommandType, std::vector<u8>>> replies;      // req id / (command / data)
+		std::map<u64, std::pair<rpcn::CommandType, std::vector<u8>>> replies_sync; // same but for sync replies(see handle_input())
 		std::unordered_map<std::string, friend_online_data> presence_updates;                // npid / presence data
 
 		// Messages


### PR DESCRIPTION
While investigating an unrelated bug I noticed the np callbacks were not called in the same order as the commands were issued, turns out I had used an unordered_map to store the replies.