### PR TITLE
Revert "Fix hypervisor context memory placement"

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.h
+++ b/rpcs3/Emu/Cell/PPUThread.h
@@ -257,9 +257,6 @@ public:
 	// Sticky saturation bit
 	v128 sat{};
 
-	// Hypervisor context data
-	rpcs3::hypervisor_context_t hv_ctx; // HV context for gate enter exit. Keep at a low struct offset.
-
 	// Optimization: precomputed java-mode mask for handling denormals
 	u32 jm_mask = 0x7f80'0000;
 
@@ -309,6 +306,9 @@ public:
 
 	// Thread name
 	atomic_ptr<std::string> ppu_tname;
+
+	// Hypervisor context data
+	rpcs3::hypervisor_context_t hv_ctx; // HV context for gate enter exit. Keep at a low struct offset.
 
 	u64 last_ftsc = 0;
 	u64 last_ftime = 0;

--- a/rpcs3/Emu/Cell/SPUThread.h
+++ b/rpcs3/Emu/Cell/SPUThread.h
@@ -673,9 +673,6 @@ public:
 	std::array<v128, 128> gpr{};
 	SPU_FPSCR fpscr{};
 
-	// Hypervisor context data
-	rpcs3::hypervisor_context_t hv_ctx; // NOTE: The offset within the class must be within the first 1MiB (10 bits max)
-
 	// MFC command data
 	spu_mfc_cmd ch_mfc_cmd{};
 
@@ -790,6 +787,8 @@ public:
 	u64 block_counter = 0;
 	u64 block_recover = 0;
 	u64 block_failure = 0;
+
+	rpcs3::hypervisor_context_t hv_ctx; // NOTE: The offset within the class must be within the first 1MiB
 
 	u64 ftx = 0; // Failed transactions
 	u64 stx = 0; // Succeeded transactions (pure counters)


### PR DESCRIPTION
Unfortunately this change caused a bigger breakage in macOS, so reverting it ASAP as it was just a minor bugfix without known improvements outside of changing the crash exception type in RPI5.

This reverts commit b1089ab1a3150bd5810c7bf3956987d2ad438639.

Fixes #17882
Fixes #17885