### PR TITLE
sceNpClans: cleanup

### DIFF
--- a/rpcs3/Emu/Cell/Modules/sceNp.h
+++ b/rpcs3/Emu/Cell/Modules/sceNp.h
@@ -1265,7 +1265,7 @@ struct SceNpCommunicationId
 // OnlineId structure
 struct SceNpOnlineId
 {
-	char data[16 + 1]; // char term;
+	char data[SCE_NET_NP_ONLINEID_MAX_LENGTH + 1]; // char term;
 	char dummy[3];
 };
 

--- a/rpcs3/Emu/NP/clans_client.cpp
+++ b/rpcs3/Emu/NP/clans_client.cpp
@@ -128,18 +128,18 @@ void fmt_class_string<clan::ClanRequestAction>::format(std::string& out, u64 arg
 
 namespace clan
 {
-    struct curl_memory
-    {
+	struct curl_memory
+	{
 		char* response;
 		size_t size;
-    };
+	};
 
 	size_t clans_client::curl_write_callback(void* data, size_t size, size_t nmemb, void* clientp)
 	{
-		size_t realsize = size * nmemb;
+		const size_t realsize = size * nmemb;
 		std::vector<char>* mem = static_cast<std::vector<char>*>(clientp);
 
-		size_t old_size = mem->size();
+		const size_t old_size = mem->size();
 		mem->resize(old_size + realsize);
 		memcpy(mem->data() + old_size, data, realsize);
 
@@ -169,11 +169,11 @@ namespace clan
 		CURL* curl = nullptr;
 
 		// TODO: this was arbitrarily chosen -- see if there's a real amount
-		static const u32 SCE_NP_CLANS_MAX_CTX_NUM = 16;
-		
-		static const u32 id_base = 0xA001;
-		static const u32 id_step = 1;
-		static const u32 id_count = SCE_NP_CLANS_MAX_CTX_NUM;
+		static constexpr u32 SCE_NP_CLANS_MAX_CTX_NUM = 16;
+
+		static constexpr u32 id_base = 0xA001;
+		static constexpr u32 id_step = 1;
+		static constexpr u32 id_count = SCE_NP_CLANS_MAX_CTX_NUM;
 		SAVESTATE_INIT_POS(55);
 	};
 
@@ -187,7 +187,7 @@ namespace clan
 		idm::clear<clan_request_ctx>();
 	}
 
-	SceNpClansError clans_client::create_request(s32* req_id)
+	SceNpClansError clans_client::create_request(s32& req_id)
 	{
 		if (!g_cfg.net.clans_enabled)
 		{
@@ -201,14 +201,14 @@ namespace clan
 			return SceNpClansError::SCE_NP_CLANS_ERROR_EXCEEDS_MAX;
 		}
 
-		auto ctx = idm::get_unlocked<clan_request_ctx>(id);
+		const auto ctx = idm::get_unlocked<clan_request_ctx>(id);
 		if (!ctx || !ctx->curl)
 		{
 			idm::remove<clan_request_ctx>(id);
 			return SceNpClansError::SCE_NP_CLANS_ERROR_NOT_INITIALIZED;
 		}
 
-		*req_id = id;
+		req_id = id;
 
 		return SceNpClansError::SCE_NP_CLANS_SUCCESS;
 	}
@@ -221,7 +221,7 @@ namespace clan
 		return SceNpClansError::SCE_NP_CLANS_ERROR_INVALID_ARGUMENT;
 	}
 
-	SceNpClansError clans_client::send_request(u32 req_id, ClanRequestAction action, ClanManagerOperationType op_type, pugi::xml_document* xml_body, pugi::xml_document* out_response)
+	SceNpClansError clans_client::send_request(u32 req_id, ClanRequestAction action, ClanManagerOperationType op_type, const pugi::xml_document& xml_body, pugi::xml_document& out_response)
 	{
 		auto ctx = idm::get_unlocked<clan_request_ctx>(req_id);
 
@@ -231,20 +231,20 @@ namespace clan
 		CURL* curl = ctx->curl;
 
 		ClanRequestType req_type = ClanRequestType::FUNC;
-		pugi::xml_node clan = xml_body->child("clan");
+		const pugi::xml_node clan = xml_body.child("clan");
 		if (clan && clan.child("ticket"))
 		{
 			req_type = ClanRequestType::SEC;
 		}
 
-		std::string host = g_cfg_clans.get_host();
-		std::string protocol = g_cfg_clans.get_use_https() ? "https" : "http";
-		std::string url = fmt::format("%s://%s/clan_manager_%s/%s/%s", protocol, host, op_type, req_type, action);
+		const std::string host = g_cfg_clans.get_host();
+		const std::string protocol = g_cfg_clans.get_use_https() ? "https" : "http";
+		const std::string url = fmt::format("%s://%s/clan_manager_%s/%s/%s", protocol, host, op_type, req_type, action);
 
 		std::ostringstream oss;
-		xml_body->save(oss, "\t", 8U);
+		xml_body.save(oss, "\t", 8U);
 
-		std::string xml = oss.str();
+		const std::string xml = oss.str();
 
 		char err_buf[CURL_ERROR_SIZE];
 		err_buf[0] = '\0';
@@ -264,11 +264,10 @@ namespace clan
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, xml.c_str());
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, xml.size());
 
-		CURLcode res = curl_easy_perform(curl);
+		const CURLcode res = curl_easy_perform(curl);
 
 		if (res != CURLE_OK)
 		{
-			out_response = nullptr;
 			clan_log.error("curl_easy_perform() failed: %s", curl_easy_strerror(res));
 			clan_log.error("Error buffer: %s", err_buf);
 			return SCE_NP_CLANS_ERROR_BAD_REQUEST;
@@ -276,22 +275,22 @@ namespace clan
 
 		response_buffer.push_back('\0');
 
-		pugi::xml_parse_result xml_res = out_response->load_string(response_buffer.data());
+		const pugi::xml_parse_result xml_res = out_response.load_string(response_buffer.data());
 		if (!xml_res)
 		{
 			clan_log.error("XML parsing failed: %s", xml_res.description());
 			return SCE_NP_CLANS_ERROR_BAD_RESPONSE;
 		}
 
-		pugi::xml_node clan_result = out_response->child("clan");
+		const pugi::xml_node clan_result = out_response.child("clan");
 		if (!clan_result)
 			return SCE_NP_CLANS_ERROR_BAD_RESPONSE;
 
-		pugi::xml_attribute result = clan_result.attribute("result");
+		const pugi::xml_attribute result = clan_result.attribute("result");
 		if (!result)
 			return SCE_NP_CLANS_ERROR_BAD_RESPONSE;
 
-		std::string result_str = result.as_string();
+		const std::string result_str = result.as_string();
 		if (result_str != "00")
 			return static_cast<SceNpClansError>(0x80022800 | std::stoul(result_str, nullptr, 16));
 
@@ -331,16 +330,16 @@ namespace clan
 		std::vector<byte> ticket_bytes(1024);
 		uint32_t ticket_size = UINT32_MAX;
 
-		Base64_Encode_NoNl(clan_ticket.data(), clan_ticket.size(), ticket_bytes.data(), &ticket_size);
-		std::string ticket_str = std::string(reinterpret_cast<char*>(ticket_bytes.data()), ticket_size);
+		Base64_Encode_NoNl(clan_ticket.data(), static_cast<u32>(clan_ticket.size()), ticket_bytes.data(), &ticket_size);
+		const std::string ticket_str = std::string(reinterpret_cast<char*>(ticket_bytes.data()), ticket_size);
 
 		return ticket_str;
 	}
 
 #pragma region Outgoing API Requests
-	SceNpClansError clans_client::get_clan_list(np::np_handler& nph, u32 req_id, SceNpClansPagingRequest* paging, SceNpClansEntry* clan_list, SceNpClansPagingResult* page_result)
+	SceNpClansError clans_client::get_clan_list(np::np_handler& nph, u32 req_id, const SceNpClansPagingRequest& paging, std::vector<SceNpClansEntry>& clan_list, SceNpClansPagingResult& page_result)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -348,47 +347,47 @@ namespace clan
 		pugi::xml_node clan = doc.append_child("clan");
 
 		clan.append_child("ticket").text().set(ticket.c_str());
-		clan.append_child("start").text().set(paging->startPos);
-		clan.append_child("max").text().set(paging->max);
+		clan.append_child("start").text().set(paging.startPos);
+		clan.append_child("max").text().set(paging.max);
 
 		pugi::xml_document response = pugi::xml_document();
-		SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetClanList, ClanManagerOperationType::VIEW, &doc, &response);
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetClanList, ClanManagerOperationType::VIEW, doc, response);
 
 		if (clan_res != SCE_NP_CLANS_SUCCESS)
 			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-		pugi::xml_node list = clan_result.child("list");
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_node list = clan_result.child("list");
 
-		pugi::xml_attribute results = list.attribute("results");
-		uint32_t results_count = results.as_uint();
+		const pugi::xml_attribute results = list.attribute("results");
+		const uint32_t results_count = results.as_uint();
 
-		pugi::xml_attribute total = list.attribute("total");
-		uint32_t total_count = total.as_uint();
+		const pugi::xml_attribute total = list.attribute("total");
+		const uint32_t total_count = total.as_uint();
 
 		int i = 0;
 		for (pugi::xml_node info = list.child("info"); info; info = info.next_sibling("info"), i++)
 		{
-			pugi::xml_attribute id = info.attribute("id");
-			uint32_t clan_id = id.as_uint();
+			const pugi::xml_attribute id = info.attribute("id");
+			const uint32_t clan_id = id.as_uint();
 
-			pugi::xml_node name = info.child("name");
-			std::string name_str = name.text().as_string();
+			const pugi::xml_node name = info.child("name");
+			const std::string name_str = name.text().as_string();
 
-			pugi::xml_node tag = info.child("tag");
-			std::string tag_str = tag.text().as_string();
+			const pugi::xml_node tag = info.child("tag");
+			const std::string tag_str = tag.text().as_string();
 
-			pugi::xml_node role = info.child("role");
-			int32_t role_int = role.text().as_uint();
+			const pugi::xml_node role = info.child("role");
+			const int32_t role_int = role.text().as_uint();
 
-			pugi::xml_node status = info.child("status");
-			uint32_t status_int = status.text().as_uint();
+			const pugi::xml_node status = info.child("status");
+			const uint32_t status_int = status.text().as_uint();
 
-			pugi::xml_node onlinename = info.child("onlinename");
-			std::string onlinename_str = onlinename.text().as_string();
+			const pugi::xml_node onlinename = info.child("onlinename");
+			const std::string onlinename_str = onlinename.text().as_string();
 
-			pugi::xml_node members = info.child("members");
-			uint32_t members_int = members.text().as_uint();
+			const pugi::xml_node members = info.child("members");
+			const uint32_t members_int = members.text().as_uint();
 
 			SceNpClansEntry entry = SceNpClansEntry{
 				.info = SceNpClansClanBasicInfo{
@@ -402,41 +401,41 @@ namespace clan
 				.status = static_cast<SceNpClansMemberStatus>(status_int)};
 
 			strcpy_trunc(entry.info.name, name_str);
-            strcpy_trunc(entry.info.tag, tag_str);
+			strcpy_trunc(entry.info.tag, tag_str);
 
-			clan_list[i] = entry;
+			::at32(clan_list, i) = std::move(entry);
 			i++;
 		}
 
-		*page_result = SceNpClansPagingResult{
+		page_result = SceNpClansPagingResult{
 			.count = results_count,
 			.total = total_count};
 
 		return SCE_NP_CLANS_SUCCESS;
 	}
 
-	SceNpClansError clans_client::get_clan_info(u32 req_id, SceNpClanId clan_id, SceNpClansClanInfo* clan_info)
+	SceNpClansError clans_client::get_clan_info(u32 req_id, SceNpClanId clan_id, SceNpClansClanInfo& clan_info)
 	{
 		pugi::xml_document doc = pugi::xml_document();
 		pugi::xml_node clan = doc.append_child("clan");
 		clan.append_child("id").text().set(clan_id);
 
 		pugi::xml_document response = pugi::xml_document();
-		SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetClanInfo, ClanManagerOperationType::VIEW, &doc, &response);
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetClanInfo, ClanManagerOperationType::VIEW, doc, response);
 
 		if (clan_res != SCE_NP_CLANS_SUCCESS)
 			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-		pugi::xml_node info = clan_result.child("info");
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_node info = clan_result.child("info");
 
-		std::string name_str = info.child("name").text().as_string();
-		std::string tag_str = info.child("tag").text().as_string();
-		uint32_t members_int = info.child("members").text().as_uint();
-		std::string date_created_str = info.child("date-created").text().as_string();
-		std::string description_str = info.child("description").text().as_string();
+		const std::string name_str = info.child("name").text().as_string();
+		const std::string tag_str = info.child("tag").text().as_string();
+		const uint32_t members_int = info.child("members").text().as_uint();
+		const std::string date_created_str = info.child("date-created").text().as_string();
+		const std::string description_str = info.child("description").text().as_string();
 
-		*clan_info = SceNpClansClanInfo{
+		clan_info = SceNpClansClanInfo{
 			.info = SceNpClansClanBasicInfo{
 				.clanId = clan_id,
 				.numMembers = members_int,
@@ -447,16 +446,16 @@ namespace clan
 				.description = "",
 			}};
 
-		strcpy_trunc(clan_info->info.name, name_str);
-		strcpy_trunc(clan_info->info.tag, tag_str);
-		strcpy_trunc(clan_info->updatable.description, description_str);
+		strcpy_trunc(clan_info.info.name, name_str);
+		strcpy_trunc(clan_info.info.tag, tag_str);
+		strcpy_trunc(clan_info.updatable.description, description_str);
 
 		return SCE_NP_CLANS_SUCCESS;
 	}
 
-	SceNpClansError clans_client::get_member_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMemberEntry* mem_info)
+	SceNpClansError clans_client::get_member_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMemberEntry& mem_info)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -464,22 +463,22 @@ namespace clan
 		pugi::xml_node clan = doc.append_child("clan");
 		clan.append_child("ticket").text().set(ticket.c_str());
 		clan.append_child("id").text().set(clan_id);
-		
-        std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
-        clan.append_child("jid").text().set(jid_str.c_str());
+
+		const std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
+		clan.append_child("jid").text().set(jid_str.c_str());
 
 		pugi::xml_document response = pugi::xml_document();
-		SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetMemberInfo, ClanManagerOperationType::VIEW, &doc, &response);
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetMemberInfo, ClanManagerOperationType::VIEW, doc, response);
 
 		if (clan_res != SCE_NP_CLANS_SUCCESS)
 			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-		pugi::xml_node member_info = clan_result.child("info");
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_node member_info = clan_result.child("info");
 
-		pugi::xml_attribute member_jid = member_info.attribute("jid");
-		std::string member_jid_str = member_jid.as_string();
-		std::string member_username = fmt::split(member_jid_str, {"@"})[0];
+		const pugi::xml_attribute member_jid = member_info.attribute("jid");
+		const std::string member_jid_str = member_jid.as_string();
+		const std::string member_username = fmt::split(member_jid_str, {"@"})[0];
 
 		SceNpId member_npid;
 		if (strncmp(member_username.c_str(), nph.get_npid().handle.data, 16) == 0)
@@ -491,18 +490,18 @@ namespace clan
 			np::string_to_npid(member_username, member_npid);
 		}
 
-		pugi::xml_node role = member_info.child("role");
-		uint32_t role_int = role.text().as_uint();
+		const pugi::xml_node role = member_info.child("role");
+		const uint32_t role_int = role.text().as_uint();
 
-		pugi::xml_node status = member_info.child("status");
-		uint32_t status_int = status.text().as_uint();
+		const pugi::xml_node status = member_info.child("status");
+		const uint32_t status_int = status.text().as_uint();
 
-		pugi::xml_node description = member_info.child("description");
-		std::string description_str = description.text().as_string();
+		const pugi::xml_node description = member_info.child("description");
+		const std::string description_str = description.text().as_string();
 
-		*mem_info = SceNpClansMemberEntry
+		mem_info = SceNpClansMemberEntry
 		{
-			.npid = member_npid,
+			.npid = std::move(member_npid),
 			.role = static_cast<SceNpClansMemberRole>(role_int),
 			.status = static_cast<SceNpClansMemberStatus>(status_int),
 			.updatable = SceNpClansUpdatableMemberInfo{
@@ -510,47 +509,47 @@ namespace clan
 			}
 		};
 
-		strcpy_trunc(mem_info->updatable.description, description_str);
+		strcpy_trunc(mem_info.updatable.description, description_str);
 
 		return SCE_NP_CLANS_SUCCESS;
 	}
 
-	SceNpClansError clans_client::get_member_list(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansPagingRequest* paging, SceNpClansMemberStatus /*status*/, SceNpClansMemberEntry* mem_list, SceNpClansPagingResult* page_result)
-	{	
-		std::string ticket = get_clan_ticket(nph);
+	SceNpClansError clans_client::get_member_list(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansPagingRequest& paging, SceNpClansMemberStatus /*status*/, std::vector<SceNpClansMemberEntry>& mem_list, SceNpClansPagingResult& page_result)
+	{
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
-        pugi::xml_document doc = pugi::xml_document();
+		pugi::xml_document doc = pugi::xml_document();
 		pugi::xml_node clan = doc.append_child("clan");
 		clan.append_child("ticket").text().set(ticket.c_str());
 		clan.append_child("id").text().set(clan_id);
-		clan.append_child("start").text().set(paging->startPos);
-        clan.append_child("max").text().set(paging->max);
+		clan.append_child("start").text().set(paging.startPos);
+		clan.append_child("max").text().set(paging.max);
 
 		pugi::xml_document response = pugi::xml_document();
-		SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetMemberList, ClanManagerOperationType::VIEW, &doc, &response);
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetMemberList, ClanManagerOperationType::VIEW, doc, response);
 
 		if (clan_res != SCE_NP_CLANS_SUCCESS)
 			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-        pugi::xml_node list = clan_result.child("list");
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_node list = clan_result.child("list");
 
-        pugi::xml_attribute results = list.attribute("results");
-        uint32_t results_count = results.as_uint();
+		const pugi::xml_attribute results = list.attribute("results");
+		const uint32_t results_count = results.as_uint();
 
-        pugi::xml_attribute total = list.attribute("total");
-        uint32_t total_count = total.as_uint();
-        
-        int i = 0;
-        for (pugi::xml_node member_info = list.child("info"); member_info; member_info = member_info.next_sibling("info"))
-        {
-            std::string member_jid = member_info.attribute("jid").as_string();
-			std::string member_username = fmt::split(member_jid, {"@"})[0];
+		const pugi::xml_attribute total = list.attribute("total");
+		const uint32_t total_count = total.as_uint();
+
+		int i = 0;
+		for (pugi::xml_node member_info = list.child("info"); member_info; member_info = member_info.next_sibling("info"))
+		{
+			const std::string member_jid = member_info.attribute("jid").as_string();
+			const std::string member_username = fmt::split(member_jid, {"@"})[0];
 
 			SceNpId member_npid;
-			if (strncmp(member_username.c_str(), nph.get_npid().handle.data, 16) == 0)
+			if (strncmp(member_username.c_str(), nph.get_npid().handle.data, SCE_NET_NP_ONLINEID_MAX_LENGTH) == 0)
 			{
 				member_npid = nph.get_npid();
 			}
@@ -559,67 +558,67 @@ namespace clan
 				np::string_to_npid(member_username, member_npid);
 			}
 
-            uint32_t role_int = member_info.child("role").text().as_uint();
-            uint32_t status_int = member_info.child("status").text().as_uint();
-            std::string description_str = member_info.child("description").text().as_string();
+			const uint32_t role_int = member_info.child("role").text().as_uint();
+			const uint32_t status_int = member_info.child("status").text().as_uint();
+			const std::string description_str = member_info.child("description").text().as_string();
 
-            SceNpClansMemberEntry entry = SceNpClansMemberEntry
-            {
-                .npid = member_npid,
-                .role = static_cast<SceNpClansMemberRole>(role_int),
-                .status = static_cast<SceNpClansMemberStatus>(status_int),
-            };
+			SceNpClansMemberEntry entry = SceNpClansMemberEntry
+			{
+				.npid = std::move(member_npid),
+				.role = static_cast<SceNpClansMemberRole>(role_int),
+				.status = static_cast<SceNpClansMemberStatus>(status_int),
+			};
 
 			strcpy_trunc(entry.updatable.description, description_str);
-            
-			mem_list[i] = entry;
-            i++;
-        }
 
-		*page_result = SceNpClansPagingResult
-        {
+			::at32(mem_list, i) = std::move(entry);
+			i++;
+		}
+
+		page_result = SceNpClansPagingResult
+		{
 			.count = results_count,
 			.total = total_count
-        };
+		};
 
 		return SCE_NP_CLANS_SUCCESS;
 	}
 
-    SceNpClansError clans_client::get_blacklist(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansPagingRequest* paging, SceNpClansBlacklistEntry* bl, SceNpClansPagingResult* page_result)
-    {
-        std::string ticket = get_clan_ticket(nph);
+	SceNpClansError clans_client::get_blacklist(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansPagingRequest& paging, std::vector<SceNpClansBlacklistEntry>& bl, SceNpClansPagingResult& page_result)
+	{
+		const std::string ticket = get_clan_ticket(nph);
 
-        pugi::xml_document doc = pugi::xml_document();
-        pugi::xml_node clan = doc.append_child("clan");
-        clan.append_child("ticket").text().set(ticket.c_str());
-        clan.append_child("id").text().set(clan_id);
-        clan.append_child("start").text().set(paging->startPos);
-        clan.append_child("max").text().set(paging->max);
+		pugi::xml_document doc = pugi::xml_document();
+		pugi::xml_node clan = doc.append_child("clan");
+		clan.append_child("ticket").text().set(ticket.c_str());
+		clan.append_child("id").text().set(clan_id);
+		clan.append_child("start").text().set(paging.startPos);
+		clan.append_child("max").text().set(paging.max);
 
-        pugi::xml_document response = pugi::xml_document();
-        SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetBlacklist, ClanManagerOperationType::VIEW, &doc, &response);
+		pugi::xml_document response = pugi::xml_document();
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::GetBlacklist, ClanManagerOperationType::VIEW, doc, response);
 
-        if (clan_res != SCE_NP_CLANS_SUCCESS)
-            return clan_res;
+		if (clan_res != SCE_NP_CLANS_SUCCESS)
+			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-        pugi::xml_node list = clan_result.child("list");
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_node list = clan_result.child("list");
 
-        pugi::xml_attribute results = list.attribute("results");
-        uint32_t results_count = results.as_uint();
+		const pugi::xml_attribute results = list.attribute("results");
+		const uint32_t results_count = results.as_uint();
 
-        pugi::xml_attribute total = list.attribute("total");
-        uint32_t total_count = total.as_uint();
+		const pugi::xml_attribute total = list.attribute("total");
+		const uint32_t total_count = total.as_uint();
 
-        int i = 0;
-        for (pugi::xml_node member = list.child("entry"); member; member = member.next_sibling("entry"))
-        {
-            pugi::xml_node member_jid = member.child("jid");
-            std::string member_jid_str = member_jid.text().as_string();
-			std::string member_username = fmt::split(member_jid_str, {"@"})[0];
+		int i = 0;
+		for (pugi::xml_node member = list.child("entry"); member; member = member.next_sibling("entry"))
+		{
+			const pugi::xml_node member_jid = member.child("jid");
+			const std::string member_jid_str = member_jid.text().as_string();
+			const std::string member_username = fmt::split(member_jid_str, {"@"})[0];
 
 			SceNpId member_npid = {};
-			if (strncmp(member_username.c_str(), nph.get_npid().handle.data, 16) == 0)
+			if (strncmp(member_username.c_str(), nph.get_npid().handle.data, SCE_NET_NP_ONLINEID_MAX_LENGTH) == 0)
 			{
 				member_npid = nph.get_npid();
 			}
@@ -628,27 +627,27 @@ namespace clan
 				np::string_to_npid(member_username.c_str(), member_npid);
 			}
 
-            SceNpClansBlacklistEntry entry = SceNpClansBlacklistEntry
-            {
-                .entry = member_npid,
-            };
+			SceNpClansBlacklistEntry entry = SceNpClansBlacklistEntry
+			{
+				.entry = std::move(member_npid),
+			};
 
-            bl[i] = entry;
-            i++;
-        }
+			::at32(bl, i) = std::move(entry);
+			i++;
+		}
 
-        *page_result = SceNpClansPagingResult
-        {
-            .count = results_count,
-            .total = total_count
-        };
+		page_result = SceNpClansPagingResult
+		{
+			.count = results_count,
+			.total = total_count
+		};
 
-        return SCE_NP_CLANS_SUCCESS;
-    }
+		return SCE_NP_CLANS_SUCCESS;
+	}
 
-	SceNpClansError clans_client::add_blacklist_entry(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id)
+	SceNpClansError clans_client::add_blacklist_entry(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -657,14 +656,14 @@ namespace clan
 		clan.append_child("ticket").text().set(ticket.c_str());
 		clan.append_child("id").text().set(clan_id);
 
-		std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
+		const std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
 		clan.append_child("jid").text().set(jid_str.c_str());
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::RecordBlacklistEntry, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::RecordBlacklistEntry, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
-	SceNpClansError clans_client::remove_blacklist_entry(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id)
+	SceNpClansError clans_client::remove_blacklist_entry(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id)
 	{
 		std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
@@ -674,50 +673,50 @@ namespace clan
 		pugi::xml_node clan = doc.append_child("clan");
 		clan.append_child("ticket").text().set(ticket.c_str());
 		clan.append_child("id").text().set(clan_id);
-		
-        std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
-        clan.append_child("jid").text().set(jid_str.c_str());
+
+		const std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
+		clan.append_child("jid").text().set(jid_str.c_str());
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::DeleteBlacklistEntry, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::DeleteBlacklistEntry, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
-	SceNpClansError clans_client::clan_search(u32 req_id, SceNpClansPagingRequest* paging, SceNpClansSearchableName* search, SceNpClansClanBasicInfo* clan_list, SceNpClansPagingResult* page_result)
+	SceNpClansError clans_client::clan_search(u32 req_id, const SceNpClansPagingRequest& paging, const SceNpClansSearchableName& search, std::vector<SceNpClansClanBasicInfo>& clan_list, SceNpClansPagingResult& page_result)
 	{
 		pugi::xml_document doc = pugi::xml_document();
-        pugi::xml_node clan = doc.append_child("clan");
-        clan.append_child("start").text().set(paging->startPos);
-        clan.append_child("max").text().set(paging->max);
+		pugi::xml_node clan = doc.append_child("clan");
+		clan.append_child("start").text().set(paging.startPos);
+		clan.append_child("max").text().set(paging.max);
 
 		pugi::xml_node filter = clan.append_child("filter");
 		pugi::xml_node name = filter.append_child("name");
-		
-		std::string op_name = fmt::format("%s", static_cast<ClanSearchFilterOperator>(static_cast<s32>(search->nameSearchOp)));
+
+		const std::string op_name = fmt::format("%s", static_cast<ClanSearchFilterOperator>(static_cast<s32>(search.nameSearchOp)));
 		name.append_attribute("op").set_value(op_name.c_str());
-		name.append_attribute("value").set_value(search->name);
+		name.append_attribute("value").set_value(search.name);
 
-        pugi::xml_document response = pugi::xml_document();
-        SceNpClansError clan_res = send_request(req_id, ClanRequestAction::ClanSearch, ClanManagerOperationType::VIEW, &doc, &response);
+		pugi::xml_document response = pugi::xml_document();
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::ClanSearch, ClanManagerOperationType::VIEW, doc, response);
 
-        if (clan_res != SCE_NP_CLANS_SUCCESS)
-            return clan_res;
+		if (clan_res != SCE_NP_CLANS_SUCCESS)
+			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-        pugi::xml_node list = clan_result.child("list");
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_node list = clan_result.child("list");
 
-        pugi::xml_attribute results = list.attribute("results");
-        uint32_t results_count = results.as_uint();
+		const pugi::xml_attribute results = list.attribute("results");
+		const uint32_t results_count = results.as_uint();
 
-        pugi::xml_attribute total = list.attribute("total");
-        uint32_t total_count = total.as_uint();
+		const pugi::xml_attribute total = list.attribute("total");
+		const uint32_t total_count = total.as_uint();
 
-        int i = 0;
-        for (pugi::xml_node node = list.child("info"); node; node = node.next_sibling("info"))
-        {
-            uint32_t clan_id = node.attribute("id").as_uint();
-            std::string name_str = node.child("name").text().as_string();
-			std::string tag_str = node.child("tag").text().as_string();
-			uint32_t members_int = node.child("members").text().as_uint();
+		int i = 0;
+		for (pugi::xml_node node = list.child("info"); node; node = node.next_sibling("info"))
+		{
+			const uint32_t clan_id = node.attribute("id").as_uint();
+			const std::string name_str = node.child("name").text().as_string();
+			const std::string tag_str = node.child("tag").text().as_string();
+			const uint32_t members_int = node.child("members").text().as_uint();
 
 			SceNpClansClanBasicInfo entry = SceNpClansClanBasicInfo
 			{
@@ -731,22 +730,22 @@ namespace clan
 			strcpy_trunc(entry.name, name_str);
 			strcpy_trunc(entry.tag, tag_str);
 
-            clan_list[i] = entry;
-            i++;
-        }
+			::at32(clan_list, i) = std::move(entry);
+			i++;
+		}
 
-        *page_result = SceNpClansPagingResult
-        {
-            .count = results_count,
-            .total = total_count
-        };
+		page_result = SceNpClansPagingResult
+		{
+			.count = results_count,
+			.total = total_count
+		};
 
-        return SCE_NP_CLANS_SUCCESS;
+		return SCE_NP_CLANS_SUCCESS;
 	}
 
 	SceNpClansError clans_client::create_clan(np::np_handler& nph, u32 req_id, std::string_view name, std::string_view tag, vm::ptr<SceNpClanId> clan_id)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -758,14 +757,14 @@ namespace clan
 		clan.append_child("tag").text().set(tag.data());
 
 		pugi::xml_document response = pugi::xml_document();
-		SceNpClansError clan_res = send_request(req_id, ClanRequestAction::CreateClan, ClanManagerOperationType::UPDATE, &doc, &response);
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::CreateClan, ClanManagerOperationType::UPDATE, doc, response);
 
 		if (clan_res != SCE_NP_CLANS_SUCCESS)
 			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-		pugi::xml_attribute id = clan_result.attribute("id");
-		uint32_t clan_id_int = id.as_uint();
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_attribute id = clan_result.attribute("id");
+		const uint32_t clan_id_int = id.as_uint();
 
 		*clan_id = clan_id_int;
 
@@ -774,7 +773,7 @@ namespace clan
 
 	SceNpClansError clans_client::disband_dlan(np::np_handler& nph, u32 req_id, SceNpClanId clan_id)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -784,7 +783,7 @@ namespace clan
 		clan.append_child("id").text().set(clan_id);
 
 		pugi::xml_document response = pugi::xml_document();
-		SceNpClansError clan_res = send_request(req_id, ClanRequestAction::DisbandClan, ClanManagerOperationType::UPDATE, &doc, &response);
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::DisbandClan, ClanManagerOperationType::UPDATE, doc, response);
 
 		if (clan_res != SCE_NP_CLANS_SUCCESS)
 			return clan_res;
@@ -792,9 +791,9 @@ namespace clan
 		return SCE_NP_CLANS_SUCCESS;
 	}
 
-	SceNpClansError clans_client::request_membership(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage* /*message*/)
+	SceNpClansError clans_client::request_membership(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage& /*message*/)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -804,12 +803,12 @@ namespace clan
 		clan.append_child("id").text().set(clan_id);
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::RequestMembership, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::RequestMembership, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
 	SceNpClansError clans_client::cancel_request_membership(np::np_handler& nph, u32 req_id, SceNpClanId clan_id)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -819,66 +818,12 @@ namespace clan
 		clan.append_child("id").text().set(clan_id);
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::CancelRequestMembership, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::CancelRequestMembership, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
-	SceNpClansError clans_client::send_membership_response(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMessage* /*message*/, b8 allow)
+	SceNpClansError clans_client::send_membership_response(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMessage& /*message*/, b8 allow)
 	{
-		std::string ticket = get_clan_ticket(nph);
-		if (ticket.empty())
-			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
-
-		pugi::xml_document doc = pugi::xml_document();
-		pugi::xml_node clan = doc.append_child("clan");
-		clan.append_child("ticket").text().set(ticket.c_str());
-		clan.append_child("id").text().set(clan_id);
-		
-        std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
-        clan.append_child("jid").text().set(jid_str.c_str());
-
-		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, allow ? ClanRequestAction::AcceptMembershipRequest : ClanRequestAction::DeclineMembershipRequest, ClanManagerOperationType::UPDATE, &doc, &response);
-	}
-
-	SceNpClansError clans_client::send_invitation(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMessage* /*message*/)
-	{
-		std::string ticket = get_clan_ticket(nph);
-		if (ticket.empty())
-			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
-
-		pugi::xml_document doc = pugi::xml_document();
-		pugi::xml_node clan = doc.append_child("clan");
-		clan.append_child("ticket").text().set(ticket.c_str());
-		clan.append_child("id").text().set(clan_id);
-		
-        std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
-        clan.append_child("jid").text().set(jid_str.c_str());
-
-		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::SendInvitation, ClanManagerOperationType::UPDATE, &doc, &response);
-	}
-
-	SceNpClansError clans_client::cancel_invitation(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id)
-	{
-		std::string ticket = get_clan_ticket(nph);
-		if (ticket.empty())
-			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
-
-		pugi::xml_document doc = pugi::xml_document();
-		pugi::xml_node clan = doc.append_child("clan");
-		clan.append_child("ticket").text().set(ticket.c_str());
-		clan.append_child("id").text().set(clan_id);
-		
-        std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
-        clan.append_child("jid").text().set(jid_str.c_str());
-
-		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::CancelInvitation, ClanManagerOperationType::UPDATE, &doc, &response);
-	}
-
-	SceNpClansError clans_client::send_invitation_response(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage* /*message*/, b8 accept)
-	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -887,13 +832,67 @@ namespace clan
 		clan.append_child("ticket").text().set(ticket.c_str());
 		clan.append_child("id").text().set(clan_id);
 
+		const std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
+		clan.append_child("jid").text().set(jid_str.c_str());
+
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, accept ? ClanRequestAction::AcceptInvitation : ClanRequestAction::DeclineInvitation, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, allow ? ClanRequestAction::AcceptMembershipRequest : ClanRequestAction::DeclineMembershipRequest, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
-	SceNpClansError clans_client::update_member_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansUpdatableMemberInfo* info)
+	SceNpClansError clans_client::send_invitation(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMessage& /*message*/)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
+		if (ticket.empty())
+			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
+
+		pugi::xml_document doc = pugi::xml_document();
+		pugi::xml_node clan = doc.append_child("clan");
+		clan.append_child("ticket").text().set(ticket.c_str());
+		clan.append_child("id").text().set(clan_id);
+
+		const std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
+		clan.append_child("jid").text().set(jid_str.c_str());
+
+		pugi::xml_document response = pugi::xml_document();
+		return send_request(req_id, ClanRequestAction::SendInvitation, ClanManagerOperationType::UPDATE, doc, response);
+	}
+
+	SceNpClansError clans_client::cancel_invitation(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id)
+	{
+		const std::string ticket = get_clan_ticket(nph);
+		if (ticket.empty())
+			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
+
+		pugi::xml_document doc = pugi::xml_document();
+		pugi::xml_node clan = doc.append_child("clan");
+		clan.append_child("ticket").text().set(ticket.c_str());
+		clan.append_child("id").text().set(clan_id);
+
+		const std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
+		clan.append_child("jid").text().set(jid_str.c_str());
+
+		pugi::xml_document response = pugi::xml_document();
+		return send_request(req_id, ClanRequestAction::CancelInvitation, ClanManagerOperationType::UPDATE, doc, response);
+	}
+
+	SceNpClansError clans_client::send_invitation_response(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage& /*message*/, b8 accept)
+	{
+		const std::string ticket = get_clan_ticket(nph);
+		if (ticket.empty())
+			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
+
+		pugi::xml_document doc = pugi::xml_document();
+		pugi::xml_node clan = doc.append_child("clan");
+		clan.append_child("ticket").text().set(ticket.c_str());
+		clan.append_child("id").text().set(clan_id);
+
+		pugi::xml_document response = pugi::xml_document();
+		return send_request(req_id, accept ? ClanRequestAction::AcceptInvitation : ClanRequestAction::DeclineInvitation, ClanManagerOperationType::UPDATE, doc, response);
+	}
+
+	SceNpClansError clans_client::update_member_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansUpdatableMemberInfo& info)
+	{
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -906,33 +905,33 @@ namespace clan
 		role.text().set(nph.get_npid().handle.data);
 
 		pugi::xml_node description = clan.append_child("description");
-		description.text().set(info->description);
-		
+		description.text().set(info.description);
+
 		pugi::xml_node status = clan.append_child("bin-attr1");
 
 		byte bin_attr_1[SCE_NP_CLANS_MEMBER_BINARY_ATTRIBUTE1_MAX_SIZE * 2 + 1] = {0};
 		uint32_t bin_attr_1_size = UINT32_MAX;
-		Base64_Encode_NoNl(info->binAttr1, info->binData1Size, bin_attr_1, &bin_attr_1_size);
+		Base64_Encode_NoNl(info.binAttr1, info.binData1Size, bin_attr_1, &bin_attr_1_size);
 
 		if (bin_attr_1_size == UINT32_MAX)
 			return SCE_NP_CLANS_ERROR_INVALID_ARGUMENT;
-		
-        // `reinterpret_cast` used to let the compiler select the correct overload of `set`
+
+		// `reinterpret_cast` used to let the compiler select the correct overload of `set`
 		status.text().set(reinterpret_cast<const char*>(bin_attr_1));
 
 		pugi::xml_node allow_msg = clan.append_child("allow-msg");
-		allow_msg.text().set(static_cast<uint32_t>(info->allowMsg));
+		allow_msg.text().set(static_cast<uint32_t>(info.allowMsg));
 
 		pugi::xml_node size = clan.append_child("size");
-		size.text().set(info->binData1Size);
+		size.text().set(info.binData1Size);
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::UpdateMemberInfo, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::UpdateMemberInfo, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
-	SceNpClansError clans_client::update_clan_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansUpdatableClanInfo* info)
+	SceNpClansError clans_client::update_clan_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansUpdatableClanInfo& info)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -944,15 +943,15 @@ namespace clan
 		// TODO: implement binary and integer attributes (not implemented in server yet)
 
 		pugi::xml_node description = clan.append_child("description");
-		description.text().set(info->description);
+		description.text().set(info.description);
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::UpdateClanInfo, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::UpdateClanInfo, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
 	SceNpClansError clans_client::join_clan(np::np_handler& nph, u32 req_id, SceNpClanId clan_id)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -962,12 +961,12 @@ namespace clan
 		clan.append_child("id").text().set(clan_id);
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::JoinClan, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::JoinClan, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
 	SceNpClansError clans_client::leave_clan(np::np_handler& nph, u32 req_id, SceNpClanId clan_id)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -977,12 +976,12 @@ namespace clan
 		clan.append_child("id").text().set(clan_id);
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::LeaveClan, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::LeaveClan, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
-	SceNpClansError clans_client::kick_member(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMessage* /*message*/)
+	SceNpClansError clans_client::kick_member(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMessage& /*message*/)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -990,17 +989,17 @@ namespace clan
 		pugi::xml_node clan = doc.append_child("clan");
 		clan.append_child("ticket").text().set(ticket.c_str());
 		clan.append_child("id").text().set(clan_id);
-		
-        std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
-        clan.append_child("jid").text().set(jid_str.c_str());
+
+		const std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
+		clan.append_child("jid").text().set(jid_str.c_str());
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::KickMember, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::KickMember, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
-	SceNpClansError clans_client::change_member_role(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMemberRole role)
+	SceNpClansError clans_client::change_member_role(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMemberRole role)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -1008,20 +1007,20 @@ namespace clan
 		pugi::xml_node clan = doc.append_child("clan");
 		clan.append_child("ticket").text().set(ticket.c_str());
 		clan.append_child("id").text().set(clan_id);
-		
-        std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
-        clan.append_child("jid").text().set(jid_str.c_str());
+
+		const std::string jid_str = fmt::format(JID_FORMAT, np_id.handle.data);
+		clan.append_child("jid").text().set(jid_str.c_str());
 
 		pugi::xml_node role_node = clan.append_child("role");
 		role_node.text().set(static_cast<uint32_t>(role));
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::ChangeMemberRole, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::ChangeMemberRole, ClanManagerOperationType::UPDATE, doc, response);
 	}
 
-	SceNpClansError clans_client::retrieve_announcements(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansPagingRequest* paging, SceNpClansMessageEntry* announcements, SceNpClansPagingResult* page_result)
+	SceNpClansError clans_client::retrieve_announcements(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansPagingRequest& paging, std::vector<SceNpClansMessageEntry>& announcements, SceNpClansPagingResult& page_result)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -1029,39 +1028,39 @@ namespace clan
 		pugi::xml_node clan = doc.append_child("clan");
 		clan.append_child("ticket").text().set(ticket.c_str());
 		clan.append_child("id").text().set(clan_id);
-		clan.append_child("start").text().set(paging->startPos);
-		clan.append_child("max").text().set(paging->max);
+		clan.append_child("start").text().set(paging.startPos);
+		clan.append_child("max").text().set(paging.max);
 
 		pugi::xml_document response = pugi::xml_document();
-		SceNpClansError clan_res = send_request(req_id, ClanRequestAction::RetrieveAnnouncements, ClanManagerOperationType::VIEW, &doc, &response);
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::RetrieveAnnouncements, ClanManagerOperationType::VIEW, doc, response);
 
 		if (clan_res != SCE_NP_CLANS_SUCCESS)
 			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-		pugi::xml_node list = clan_result.child("list");
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_node list = clan_result.child("list");
 
-		pugi::xml_attribute results = list.attribute("results");
-		uint32_t results_count = results.as_uint();
+		const pugi::xml_attribute results = list.attribute("results");
+		const uint32_t results_count = results.as_uint();
 
-		pugi::xml_attribute total = list.attribute("total");
-		uint32_t total_count = total.as_uint();
+		const pugi::xml_attribute total = list.attribute("total");
+		const uint32_t total_count = total.as_uint();
 
 		int i = 0;
 		for (pugi::xml_node node = list.child("msg-info"); node; node = node.next_sibling("msg-info"))
 		{
-			pugi::xml_attribute id = node.attribute("id");
-			uint32_t msg_id = id.as_uint();
+			const pugi::xml_attribute id = node.attribute("id");
+			const uint32_t msg_id = id.as_uint();
 
-			std::string subject_str = node.child("subject").text().as_string();
-			std::string msg_str = node.child("msg").text().as_string();
-			std::string author_jid = node.child("jid").text().as_string();
-			std::string msg_date = node.child("msg-date").text().as_string();
+			const std::string subject_str = node.child("subject").text().as_string();
+			const std::string msg_str = node.child("msg").text().as_string();
+			const std::string author_jid = node.child("jid").text().as_string();
+			const std::string msg_date = node.child("msg-date").text().as_string();
 
 			SceNpId author_npid;
-			std::string author_username = fmt::split(author_jid, {"@"})[0];
+			const std::string author_username = fmt::split(author_jid, {"@"})[0];
 
-			if (strncmp(author_username.c_str(), nph.get_npid().handle.data, 16) == 0)
+			if (strncmp(author_username.c_str(), nph.get_npid().handle.data, SCE_NET_NP_ONLINEID_MAX_LENGTH) == 0)
 			{
 				author_npid = nph.get_npid();
 			}
@@ -1079,18 +1078,18 @@ namespace clan
 					.subject = "",
 					.body = "",
 				},
-				.npid = author_npid,
+				.npid = std::move(author_npid),
 				.postedBy = clan_id,
 			};
 
 			strcpy_trunc(entry.message.subject, subject_str);
 			strcpy_trunc(entry.message.body, msg_str);
 
-			announcements[i] = entry;
+			::at32(announcements, i) = std::move(entry);
 			i++;
 		}
 
-		*page_result = SceNpClansPagingResult
+		page_result = SceNpClansPagingResult
 		{
 			.count = results_count,
 			.total = total_count
@@ -1099,9 +1098,9 @@ namespace clan
 		return SCE_NP_CLANS_SUCCESS;
 	}
 
-	SceNpClansError clans_client::post_announcement(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage* announcement, SceNpClansMessageData* /*data*/, u32 duration, SceNpClansMessageId* msg_id)
+	SceNpClansError clans_client::post_announcement(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansMessage& announcement, const SceNpClansMessageData& /*data*/, u32 duration, SceNpClansMessageId& msg_id)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -1111,30 +1110,30 @@ namespace clan
 		clan.append_child("id").text().set(clan_id);
 
 		pugi::xml_node subject = clan.append_child("subject");
-		subject.text().set(announcement->subject);
+		subject.text().set(announcement.subject);
 
 		pugi::xml_node msg = clan.append_child("msg");
-		msg.text().set(announcement->body);
+		msg.text().set(announcement.body);
 
 		pugi::xml_node expire_date = clan.append_child("expire-date");
 		expire_date.text().set(duration);
 
 		pugi::xml_document response = pugi::xml_document();
-		SceNpClansError clan_res = send_request(req_id, ClanRequestAction::PostAnnouncement, ClanManagerOperationType::UPDATE, &doc, &response);
+		const SceNpClansError clan_res = send_request(req_id, ClanRequestAction::PostAnnouncement, ClanManagerOperationType::UPDATE, doc, response);
 
 		if (clan_res != SCE_NP_CLANS_SUCCESS)
 			return clan_res;
 
-		pugi::xml_node clan_result = response.child("clan");
-		pugi::xml_node msg_id_node = clan_result.child("id");
-		*msg_id = msg_id_node.text().as_uint();
+		const pugi::xml_node clan_result = response.child("clan");
+		const pugi::xml_node msg_id_node = clan_result.child("id");
+		msg_id = msg_id_node.text().as_uint();
 
 		return SCE_NP_CLANS_SUCCESS;
 	}
 
 	SceNpClansError clans_client::delete_announcement(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessageId announcement_id)
 	{
-		std::string ticket = get_clan_ticket(nph);
+		const std::string ticket = get_clan_ticket(nph);
 		if (ticket.empty())
 			return SCE_NP_CLANS_ERROR_SERVICE_UNAVAILABLE;
 
@@ -1145,7 +1144,7 @@ namespace clan
 		clan.append_child("msg-id").text().set(announcement_id);
 
 		pugi::xml_document response = pugi::xml_document();
-		return send_request(req_id, ClanRequestAction::DeleteAnnouncement, ClanManagerOperationType::UPDATE, &doc, &response);
+		return send_request(req_id, ClanRequestAction::DeleteAnnouncement, ClanManagerOperationType::UPDATE, doc, response);
 	}
 }
 #pragma endregion

--- a/rpcs3/Emu/NP/clans_client.h
+++ b/rpcs3/Emu/NP/clans_client.h
@@ -25,15 +25,15 @@ namespace clan
 	};
 
 	enum class ClanSearchFilterOperator : u8
-    {
-        Equal,
-        NotEqual,
-        GreaterThan,
-        GreaterThanOrEqual,
-        LessThan,
-        LessThanOrEqual,
-        Like,
-    };
+	{
+		Equal,
+		NotEqual,
+		GreaterThan,
+		GreaterThanOrEqual,
+		LessThan,
+		LessThanOrEqual,
+		Like,
+	};
 
 	enum class ClanRequestAction
 	{
@@ -70,9 +70,8 @@ namespace clan
 	{
 	private:
 
-
 		static size_t curl_write_callback(void* data, size_t size, size_t nmemb, void* clientp);
-		SceNpClansError send_request(u32 reqId, ClanRequestAction action, ClanManagerOperationType type, pugi::xml_document* xml_body, pugi::xml_document* out_response);
+		SceNpClansError send_request(u32 reqId, ClanRequestAction action, ClanManagerOperationType type, const pugi::xml_document& xml_body, pugi::xml_document& out_response);
 
 		/// @brief Forge and get a V2.1 Ticket for clan operations
 		std::string get_clan_ticket(np::np_handler& nph);
@@ -81,43 +80,43 @@ namespace clan
 		clans_client();
 		~clans_client();
 
-		SceNpClansError create_request(s32* req_id);
+		SceNpClansError create_request(s32& req_id);
 		SceNpClansError destroy_request(u32 req_id);
 
-		SceNpClansError clan_search(u32 req_id, SceNpClansPagingRequest* paging, SceNpClansSearchableName* search, SceNpClansClanBasicInfo* clan_list, SceNpClansPagingResult* page_result);
+		SceNpClansError clan_search(u32 req_id, const SceNpClansPagingRequest& paging, const SceNpClansSearchableName& search, std::vector<SceNpClansClanBasicInfo>& clan_list, SceNpClansPagingResult& page_result);
 
 		SceNpClansError create_clan(np::np_handler& nph, u32 req_id, std::string_view name, std::string_view tag, vm::ptr<SceNpClanId> clan_id);
 		SceNpClansError disband_dlan(np::np_handler& nph, u32 req_id, SceNpClanId clan_id);
 
-		SceNpClansError get_clan_list(np::np_handler& nph, u32 req_id, SceNpClansPagingRequest* paging, SceNpClansEntry* clan_list, SceNpClansPagingResult* page_result);
-		SceNpClansError get_clan_info(u32 req_id, SceNpClanId clan_id, SceNpClansClanInfo* clan_info);
+		SceNpClansError get_clan_list(np::np_handler& nph, u32 req_id, const SceNpClansPagingRequest&, std::vector<SceNpClansEntry>& clan_list, SceNpClansPagingResult& page_result);
+		SceNpClansError get_clan_info(u32 req_id, SceNpClanId clan_id, SceNpClansClanInfo& clan_info);
 
-		SceNpClansError get_member_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMemberEntry* mem_info);
-		SceNpClansError get_member_list(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansPagingRequest* paging, SceNpClansMemberStatus status, SceNpClansMemberEntry* mem_list, SceNpClansPagingResult* page_result);
+		SceNpClansError get_member_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMemberEntry& mem_info);
+		SceNpClansError get_member_list(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansPagingRequest& paging, SceNpClansMemberStatus status, std::vector<SceNpClansMemberEntry>& mem_list, SceNpClansPagingResult& page_result);
 
-		SceNpClansError get_blacklist(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansPagingRequest* paging, SceNpClansBlacklistEntry* bl, SceNpClansPagingResult* page_result);
-		SceNpClansError add_blacklist_entry(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id);
-		SceNpClansError remove_blacklist_entry(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id);
+		SceNpClansError get_blacklist(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansPagingRequest& paging, std::vector<SceNpClansBlacklistEntry>& bl, SceNpClansPagingResult& page_result);
+		SceNpClansError add_blacklist_entry(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id);
+		SceNpClansError remove_blacklist_entry(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id);
 
-		SceNpClansError request_membership(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage* message);
+		SceNpClansError request_membership(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage& message);
 		SceNpClansError cancel_request_membership(np::np_handler& nph, u32 req_id, SceNpClanId clan_id);
-		SceNpClansError send_membership_response(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMessage* message, b8 allow);
+		SceNpClansError send_membership_response(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMessage& message, b8 allow);
 
-		SceNpClansError send_invitation(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMessage* message);
-		SceNpClansError cancel_invitation(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id);
-		SceNpClansError send_invitation_response(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage* message, b8 accept);
+		SceNpClansError send_invitation(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMessage& message);
+		SceNpClansError cancel_invitation(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id);
+		SceNpClansError send_invitation_response(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage& message, b8 accept);
 
 		SceNpClansError join_clan(np::np_handler& nph, u32 req_id, SceNpClanId clan_id);
 		SceNpClansError leave_clan(np::np_handler& nph, u32 req_id, SceNpClanId clan_id);
 
-		SceNpClansError update_member_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansUpdatableMemberInfo* info);
-		SceNpClansError update_clan_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansUpdatableClanInfo* info);
+		SceNpClansError update_member_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansUpdatableMemberInfo& info);
+		SceNpClansError update_clan_info(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansUpdatableClanInfo& info);
 
-		SceNpClansError kick_member(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMessage* message);
-		SceNpClansError change_member_role(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpId np_id, SceNpClansMemberRole role);
+		SceNpClansError kick_member(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMessage& message);
+		SceNpClansError change_member_role(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpId& np_id, SceNpClansMemberRole role);
 
-		SceNpClansError retrieve_announcements(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansPagingRequest* paging, SceNpClansMessageEntry* announcements, SceNpClansPagingResult* page_result);
-		SceNpClansError post_announcement(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessage* announcement, SceNpClansMessageData* data, u32 duration, SceNpClansMessageId* announcement_id);
+		SceNpClansError retrieve_announcements(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansPagingRequest& paging, std::vector<SceNpClansMessageEntry>& announcements, SceNpClansPagingResult& page_result);
+		SceNpClansError post_announcement(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, const SceNpClansMessage& announcement, const SceNpClansMessageData& data, u32 duration, SceNpClansMessageId& announcement_id);
 		SceNpClansError delete_announcement(np::np_handler& nph, u32 req_id, SceNpClanId clan_id, SceNpClansMessageId announcement_id);
 	};
 } // namespace clan

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -627,6 +627,8 @@
     <ClInclude Include="Emu\IPC_socket.h" />
     <ClInclude Include="Emu\localized_string.h" />
     <ClInclude Include="Emu\localized_string_id.h" />
+    <ClInclude Include="Emu\NP\clans_client.h" />
+    <ClInclude Include="Emu\NP\clans_config.h" />
     <ClInclude Include="Emu\NP\fb_helpers.h" />
     <ClInclude Include="Emu\NP\generated\np2_structs_generated.h" />
     <ClInclude Include="Emu\NP\np_contexts.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1396,6 +1396,12 @@
     <ClCompile Include="Emu\Io\ps_move_data.cpp">
       <Filter>Emu\Io</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\NP\clans_config.cpp">
+      <Filter>Emu\NP</Filter>
+    </ClCompile>
+    <ClCompile Include="Emu\NP\clans_client.cpp">
+      <Filter>Emu\NP</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -2805,6 +2811,12 @@
     </ClInclude>
     <ClInclude Include="Emu\Io\ps_move_data.h">
       <Filter>Emu\Io</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\NP\clans_client.h">
+      <Filter>Emu\NP</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\NP\clans_config.h">
+      <Filter>Emu\NP</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -915,9 +915,6 @@
     <ClCompile Include="rpcs3qt\rpcn_settings_dialog.cpp">
       <Filter>Gui\rpcn</Filter>
     </ClCompile>
-    <ClCompile Include="rpcs3qt\clans_settings_dialog.cpp">
-      <Filter>Gui\clans</Filter>
-    </ClCompile>
     <ClCompile Include="rpcs3qt\sendmessage_dialog_frame.cpp">
       <Filter>Gui\message dialog</Filter>
     </ClCompile>
@@ -1244,6 +1241,9 @@
     </ClCompile>
     <ClCompile Include="gamemode_control.cpp">
       <Filter>rpcs3</Filter>
+    </ClCompile>
+    <ClCompile Include="rpcs3qt\clans_settings_dialog.cpp">
+      <Filter>Gui\rpcn</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Cleanup whitespace
- Use references instead of raw pointers
- Use const and constexpr where possible
- Use std::move where possible
- Use std::vector instead of c style arrays. This fixes some stack size warnings and also adds out of bounds checks.
- Use = operators instead of memcpy to reduce visual clutter and potential errors through typos
- Use SCE_NET_NP_ONLINEID_MAX_LENGTH instead of magic number
- Fix VS filters for new files  