### PR TITLE
Build Apple glew ping version 2.2.0

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -10,7 +10,7 @@ brew install -f --overwrite --quiet ccache "llvm@$LLVM_COMPILER_VER"
 brew link -f --overwrite --quiet "llvm@$LLVM_COMPILER_VER"
 # shellcheck disable=SC3009
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-arch -x86_64 /usr/local/bin/brew install -f --overwrite --quiet python@3.14 opencv@4 ffmpeg@5 "llvm@$LLVM_COMPILER_VER" glew sdl3 vulkan-headers vulkan-loader
+arch -x86_64 /usr/local/bin/brew install -f --overwrite --quiet python@3.14 opencv@4 ffmpeg@5 "llvm@$LLVM_COMPILER_VER" glew@2.2.0 sdl3 vulkan-headers vulkan-loader
 arch -x86_64 /usr/local/bin/brew unlink  --quiet ffmpeg qtbase qtsvg qtdeclarative
 arch -x86_64 /usr/local/bin/brew link -f --overwrite --quiet "llvm@$LLVM_COMPILER_VER" ffmpeg@5
 


### PR DESCRIPTION
fix error missing extension glNamedBufferStorageEXT in 2.3.0

not sure if it's an issue with Glew missing the extension or if it's Apple that removed the extension (given the timing of the issue, I imagine it's the first one)