### PR TITLE
Qt/cheats: don't accept imported cheats unless valid

### DIFF
--- a/Utilities/cheat_info.cpp
+++ b/Utilities/cheat_info.cpp
@@ -34,7 +34,7 @@ bool cheat_info::from_str(std::string_view cheat_line)
 	s64 val64 = 0;
 	if (cheat_vec.size() != 5 || !try_to_int64(&val64, cheat_vec[2], 0, cheat_type_max - 1))
 	{
-		log_cheat.fatal("Failed to parse cheat line");
+		log_cheat.error("Failed to parse cheat line: '%s'", cheat_line);
 		return false;
 	}
 

--- a/rpcs3/rpcs3qt/cheat_manager.h
+++ b/rpcs3/rpcs3qt/cheat_manager.h
@@ -25,7 +25,7 @@ public:
 	cheat_info* get(const std::string& game, const u32 offset);
 	bool erase(const std::string& game, const u32 offset);
 
-	void import_cheats_from_str(std::string_view str_cheats);
+	bool import_cheats_from_str(std::string_view str_cheats);
 	std::string export_cheats_to_str() const;
 	void save() const;
 


### PR DESCRIPTION
Don't import any cheats if the import failed.

fixes #17922