### PR TITLE
improve menus hierarchy

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2460,8 +2460,8 @@ void main_window::CreateActions()
 	m_icon_size_act_group->addAction(ui->setIconSizeLargeAct);
 
 	m_list_mode_act_group = new QActionGroup(this);
-	m_list_mode_act_group->addAction(ui->setlistModeListAct);
-	m_list_mode_act_group->addAction(ui->setlistModeGridAct);
+	m_list_mode_act_group->addAction(ui->setListModeAct);
+	m_list_mode_act_group->addAction(ui->setGridModeAct);
 }
 
 void main_window::CreateConnects()
@@ -2924,7 +2924,7 @@ void main_window::CreateConnects()
 			QMessageBox::critical(this, tr("Error: Emulation Running"), tr("You need to stop the emulator before editing Clans connection information!"), QMessageBox::Ok);
 			return;
 		}
-		
+
 		clans_settings_dialog dlg(this);
 		dlg.exec();
 	});
@@ -3335,7 +3335,7 @@ void main_window::CreateConnects()
 
 	connect(m_list_mode_act_group, &QActionGroup::triggered, this, [this](QAction* act)
 	{
-		const bool is_list_act = act == ui->setlistModeListAct;
+		const bool is_list_act = act == ui->setListModeAct;
 		if (is_list_act == m_is_list_mode)
 			return;
 
@@ -3373,11 +3373,11 @@ void main_window::CreateConnects()
 		}
 	});
 
-	connect(ui->toolbar_controls, &QAction::triggered, this, open_pad_settings);
 	connect(ui->toolbar_config, &QAction::triggered, this, [=]() { open_settings(0); });
-	connect(ui->toolbar_list, &QAction::triggered, this, [this]() { ui->setlistModeListAct->trigger(); });
-	connect(ui->toolbar_grid, &QAction::triggered, this, [this]() { ui->setlistModeGridAct->trigger(); });
+	connect(ui->toolbar_controls, &QAction::triggered, this, open_pad_settings);
 	connect(ui->toolbar_rpcn, &QAction::triggered, this, open_rpcn_settings);
+	connect(ui->toolbar_list, &QAction::triggered, this, [this]() { ui->setListModeAct->trigger(); });
+	connect(ui->toolbar_grid, &QAction::triggered, this, [this]() { ui->setGridModeAct->trigger(); });
 
 	connect(ui->sizeSlider, &QSlider::valueChanged, this, &main_window::ResizeIcons);
 	connect(ui->sizeSlider, &QSlider::sliderReleased, this, [this]
@@ -3627,9 +3627,9 @@ void main_window::ConfigureGuiFromSettings()
 
 	// handle icon size options
 	if (m_is_list_mode)
-		ui->setlistModeListAct->setChecked(true);
+		ui->setListModeAct->setChecked(true);
 	else
-		ui->setlistModeGridAct->setChecked(true);
+		ui->setGridModeAct->setChecked(true);
 
 	const int icon_size_index = m_gui_settings->GetValue(m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid).toInt();
 	m_other_slider_pos = m_gui_settings->GetValue(!m_is_list_mode ? gui::gl_iconSize : gui::gl_iconSizeGrid).toInt();

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -218,7 +218,6 @@
     <addaction name="bootRecentMenu"/>
     <addaction name="separator"/>
     <addaction name="addGamesAct"/>
-    <addaction name="separator"/>
     <addaction name="bootInstallPkgAct"/>
     <addaction name="bootInstallPupAct"/>
     <addaction name="separator"/>
@@ -243,9 +242,25 @@
     <property name="title">
      <string>Configuration</string>
     </property>
-    <widget class="QMenu" name="menuEmulatedPads">
+    <widget class="QMenu" name="menuMice">
      <property name="title">
-      <string>USB Devices</string>
+      <string>Mice</string>
+     </property>
+     <addaction name="actionBasic_Mouse"/>
+     <addaction name="actionRaw_Mouse"/>
+    </widget>
+    <widget class="QMenu" name="menuDevices">
+     <property name="title">
+      <string>Devices</string>
+     </property>
+     <addaction name="confPadsAct"/>
+     <addaction name="menuMice"/>
+     <addaction name="confCamerasAct"/>
+     <addaction name="actionPS_Move_Tracker"/>
+    </widget>
+    <widget class="QMenu" name="menuEmulatedDevices">
+     <property name="title">
+      <string>Emulated Devices</string>
      </property>
      <addaction name="confBuzzAct"/>
      <addaction name="confGHLtarAct"/>
@@ -259,21 +274,8 @@
      <addaction name="confTopShotFearmasterAct"/>
      <addaction name="confLogitechG27Act"/>
     </widget>
-    <widget class="QMenu" name="menuMice">
-     <property name="title">
-      <string>Mice</string>
-     </property>
-     <addaction name="actionBasic_Mouse"/>
-     <addaction name="actionRaw_Mouse"/>
-    </widget>
     <addaction name="confCPUAct"/>
     <addaction name="confGPUAct"/>
-    <addaction name="separator"/>
-    <addaction name="confPadsAct"/>
-    <addaction name="menuMice"/>
-    <addaction name="menuEmulatedPads"/>
-    <addaction name="confCamerasAct"/>
-    <addaction name="actionPS_Move_Tracker"/>
     <addaction name="confAudioAct"/>
     <addaction name="confIOAct"/>
     <addaction name="confSystemAct"/>
@@ -281,6 +283,9 @@
     <addaction name="confAdvAct"/>
     <addaction name="confEmuAct"/>
     <addaction name="confGuiAct"/>
+    <addaction name="separator"/>
+    <addaction name="menuDevices"/>
+    <addaction name="menuEmulatedDevices"/>
     <addaction name="separator"/>
     <addaction name="confShortcutsAct"/>
     <addaction name="actionManage_SoundEffects"/>
@@ -368,12 +373,18 @@
      <addaction name="showCustomIconsAct"/>
      <addaction name="playHoverGifsAct"/>
     </widget>
-    <widget class="QMenu" name="menuGame_List_Mode">
+    <widget class="QMenu" name="menuGame_List_View">
      <property name="title">
-      <string>Game List Mode</string>
+      <string>Game List View</string>
      </property>
-     <addaction name="setlistModeListAct"/>
-     <addaction name="setlistModeGridAct"/>
+     <addaction name="setListModeAct"/>
+     <addaction name="setGridModeAct"/>
+    </widget>
+    <widget class="QMenu" name="menuGame_List_Grid_Mode">
+     <property name="title">
+      <string>Game List in Grid Mode</string>
+     </property>
+     <addaction name="showCompatibilityInGridAct"/>
     </widget>
     <widget class="QMenu" name="menuGame_Categories">
      <property name="title">
@@ -398,15 +409,14 @@
     <addaction name="showToolBarAct"/>
     <addaction name="separator"/>
     <addaction name="showGameListAct"/>
-    <addaction name="separator"/>
     <addaction name="showHiddenEntriesAct"/>
     <addaction name="separator"/>
-    <addaction name="showCompatibilityInGridAct"/>
-    <addaction name="separator"/>
-    <addaction name="refreshGameListAct"/>
-    <addaction name="menuGame_List_Mode"/>
+    <addaction name="menuGame_List_View"/>
+    <addaction name="menuGame_List_Grid_Mode"/>
     <addaction name="menuGame_List_Icons"/>
     <addaction name="menuGame_Categories"/>
+    <addaction name="separator"/>
+    <addaction name="refreshGameListAct"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -418,11 +428,10 @@
      </property>
      <addaction name="languageAct0"/>
     </widget>
-    <addaction name="updateAct"/>
-    <addaction name="welcomeAct"/>
-    <addaction name="separator"/>
     <addaction name="languageMenu"/>
     <addaction name="separator"/>
+    <addaction name="updateAct"/>
+    <addaction name="welcomeAct"/>
     <addaction name="supportAct"/>
     <addaction name="separator"/>
     <addaction name="aboutAct"/>
@@ -661,7 +670,7 @@
   </action>
   <action name="exitAndSaveLogAct">
    <property name="text">
-    <string>Exit And Save Log</string>
+    <string>Exit and Save Log</string>
    </property>
    <property name="toolTip">
     <string>Exit RPCS3, move the log file to a custom location</string>
@@ -818,12 +827,12 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show Game Compatibility in Grid Mode</string>
+    <string>Show Game Compatibility</string>
    </property>
   </action>
   <action name="refreshGameListAct">
    <property name="text">
-    <string>Game List Refresh</string>
+    <string>Refresh Game List</string>
    </property>
   </action>
   <action name="actionManage_RAP_Licenses">
@@ -841,7 +850,7 @@
   </action>
   <action name="welcomeAct">
    <property name="text">
-    <string>View The Welcome Dialog</string>
+    <string>View Welcome Dialog</string>
    </property>
   </action>
   <action name="confVFSDialogAct">
@@ -897,7 +906,7 @@
     <string>Large</string>
    </property>
   </action>
-  <action name="setlistModeListAct">
+  <action name="setListModeAct">
    <property name="checkable">
     <bool>true</bool>
    </property>
@@ -905,15 +914,15 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>List View</string>
+    <string>List Mode</string>
    </property>
   </action>
-  <action name="setlistModeGridAct">
+  <action name="setGridModeAct">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Grid View</string>
+    <string>Grid Mode</string>
    </property>
   </action>
   <action name="sysRebootAct">

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.ui
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.ui
@@ -17,7 +17,7 @@
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>PS Move Tracker Settings</string>
   </property>
   <layout class="QVBoxLayout" name="main_layout" stretch="0,0">
    <item>


### PR DESCRIPTION
Improve hierarchy for the following menus:
- `Configuration`: Physical devices grouped on new `Devices` submenu. `USB Devices` submenu renamed to `Emulated Devices`.

  <strike>**NOTE:** For some reasons (possibly forgotten) the `Network` item (present in the `Config` panel) is missing in the `Configuration` menu. Eventually it should be included by main developers in further PRs</strike> Fixed by #17936
- `View`: `Show Game Compatibility in Grid Mode` item moved (avoiding also that extra long label) to contextual submenu `Game List in Grid Mode`. That submenu follows the `Game List View` submenu reporting the supported views `List Mode` and `Grid Mode` (also renamed to reflect hints and labels shown by the application)
- `Help`: An Help menu provides first the items to properly use the application. `Language` is one of this (usually the first thing requested to be selected during an application installation). Update, Welcome, Support pages (Activation Key if any) etc. are usually grouped together

</br>

### Configuration menu:

</br>

<img width="301" height="935" alt="image" src="https://github.com/user-attachments/assets/dd9d9044-5057-49d2-a081-26042b8c841b" />

</br>
</br>
</br>

<img width="578" height="240" alt="image" src="https://github.com/user-attachments/assets/666d25a8-0fa0-436b-9493-bde34addedd4" />

</br>
</br>
</br>

### View menu:

</br>

<img width="409" height="777" alt="image" src="https://github.com/user-attachments/assets/d6a66233-72c2-494a-bc1e-48d8e9fe98c4" />

</br>
</br>
</br>

<img width="623" height="128" alt="image" src="https://github.com/user-attachments/assets/ca877bac-c09f-4b6c-95c1-ec9104b9bdc6" />

</br>
</br>
</br>

<img width="802" height="79" alt="image" src="https://github.com/user-attachments/assets/f33a2caf-a58a-409b-a6c8-618b17352f6f" />

</br>
</br>
</br>

### Help menu:

</br>

<img width="350" height="448" alt="image" src="https://github.com/user-attachments/assets/29d9f448-563b-41ba-bfe3-9647441c4f25" />
