### PR TITLE
[macOS Updater] Cleanup remnants of the old app bundle post-update

### DIFF
--- a/rpcs3/update_helper.sh
+++ b/rpcs3/update_helper.sh
@@ -10,5 +10,6 @@ fi
 new_app="$1/"
 old_app="$2/"
 
-cp -Rf -p "$new_app" "$old_app"
+rm -rf "$old_app"
+mv "$new_app" "$old_app"
 open -n -a "$2" --args --updating


### PR DESCRIPTION
Was a bit befuddled when I updated RPCS3 to the latest version, including my slimmed build changes, yet the bundle grew by about 50MB in size. Turns out the remnants of the older app bundle weren't being cleaned up by the update script, this PR fixes that by removing the old bundle and using mv to copy in the new bundle, works solidly from repeat testing.