### PR TITLE
gl: Do not overwrite texture-cache image dimensions when updating format

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -669,8 +669,8 @@ namespace gl
 			}
 			else
 			{
-				//TODO: More tests on byte order
-				//ARGB8+native+unswizzled is confirmed with Dark Souls II character preview
+				// TODO: More tests on byte order
+				// ARGB8+native+unswizzled is confirmed with Dark Souls II character preview
 				switch (gcm_format)
 				{
 				case CELL_GCM_TEXTURE_A8R8G8B8:
@@ -697,8 +697,7 @@ namespace gl
 					fmt::throw_exception("Unexpected gcm format 0x%X", gcm_format);
 				}
 
-				//NOTE: Protection is handled by the caller
-				cached.set_dimensions(width, height, depth, (rsx_range.length() / height));
+				// NOTE: Protection is handled by the caller
 				no_access_range = cached.get_min_max(no_access_range, rsx::section_bounds::locked_range);
 			}
 


### PR DESCRIPTION
The code was an outdated relic from the early days. The calculated pitch was wrong as it did not take 2D subregions (incomplete rows) into account.

Closes https://github.com/RPCS3/rpcs3/issues/15418