### PR TITLE
rsx: Fixup get_address() after #18038

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -156,10 +156,10 @@ namespace rsx
 				{
 					bool ok = true;
 
-					for (u32 offs_index = 0x100000; offs_index < size_to_check; offs_index += 0x100000)
+					for (u32 offs_index = 0x100000; offs_index < size_to_check + (offset & 0xfffff); offs_index += 0x100000)
 					{
 						// This check does not check continuity but rather that it's mapped at all
-						if (render->iomap_table.get_addr(offs_index) == umax)
+						if (render->iomap_table.get_addr(offset + offs_index) == umax)
 						{
 							ok = false;
 						}


### PR DESCRIPTION
Although a critical bug it does not likely to have broken most games lol. (because games map IO in bulk from address 0x0 and 0x0 is always mapped for GCM)