### PR TITLE
LLVM: enable FMA for ARM cpus unconditionally

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -201,14 +201,6 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 		m_use_vnni = true;
 		m_use_gfni = true;
 	}
-
-	// Aarch64 CPUs
-	if (cpu == "cyclone" || cpu.contains("cortex"))
-	{
-		m_use_fma = true;
-		// AVX does not use intrinsics so far
-		m_use_avx = true;
-	}
 }
 
 llvm::Value* cpu_translator::bitcast(llvm::Value* val, llvm::Type* type) const

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3081,13 +3081,22 @@ protected:
 
 	// Allow PSHUFB intrinsic
 	bool m_use_ssse3 = true;
+#ifdef ARCH_ARM64
+	// all arm CPUS have FMA
+	bool m_use_fma = true;
 
+	// Should be nonsense to set this for ARM,
+	// but this flag is only used in SPU verification
+	// For now, setting this flag will speed up SPU verification
+	// but I will remove this later with explicit parralelism - Whatcookie
+	bool m_use_avx = true;
+#else
 	// Allow FMA
 	bool m_use_fma = false;
 
 	// Allow AVX
 	bool m_use_avx = false;
-
+#endif
 	// Allow skylake-x tier AVX-512
 	bool m_use_avx512 = false;
 


### PR DESCRIPTION
All armv8 machines should have FMA.
Should be a speedup for snapdragon elite and apple machines.

Would appreciate it if someone on apple/snapdragon elite could run the spurs_test.elf before and after this pull request.