### PR TITLE
PPU LLVM: Use arm fmax/fmin for vmaxfp/vminfp

### DIFF
--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -1327,7 +1327,11 @@ void PPUTranslator::VMADDFP(ppu_opcode_t op)
 void PPUTranslator::VMAXFP(ppu_opcode_t op)
 {
 	const auto [a, b] = get_vrs<f32[4]>(op.va, op.vb);
+#ifdef ARCH_ARM64
+	set_vr(op.vd, vec_handle_result(fmax(a, b)));
+#else
 	set_vr(op.vd, vec_handle_result(select(fcmp_ord(a < b) | fcmp_uno(b != b), b, a)));
+#endif
 }
 
 void PPUTranslator::VMAXSB(ppu_opcode_t op)
@@ -1389,7 +1393,11 @@ void PPUTranslator::VMHRADDSHS(ppu_opcode_t op)
 void PPUTranslator::VMINFP(ppu_opcode_t op)
 {
 	const auto [a, b] = get_vrs<f32[4]>(op.va, op.vb);
+#ifdef ARCH_ARM64
+	set_vr(op.vd, vec_handle_result(fmin(a, b)));
+#else
 	set_vr(op.vd, vec_handle_result(select(fcmp_ord(a > b) | fcmp_uno(b != b), b, a)));
+#endif
 }
 
 void PPUTranslator::VMINSB(ppu_opcode_t op)


### PR DESCRIPTION
Arm fmax/fmin match altivec behaviour regarding nan behaviour

For reference: 
<img width="1035" height="828" alt="image" src="https://github.com/user-attachments/assets/8ae77ecf-b52e-4d32-bb30-b939b095fece" />

and arm:
<img width="1032" height="732" alt="image" src="https://github.com/user-attachments/assets/31eead0f-126d-401c-b272-65fd127288f0" />
