### PR TITLE
change velocity for RB3 pro guitar when it stays the same twice in a row

### DIFF
--- a/rpcs3/Emu/Io/RB3MidiGuitar.cpp
+++ b/rpcs3/Emu/Io/RB3MidiGuitar.cpp
@@ -266,7 +266,7 @@ void usb_device_rb3_midi_guitar::parse_midi_message(u8* msg, usz size)
 	if (size == 8 && msg[0] == 0xF0 && msg[4] == 0x05)
 	{
         // if the velocity remains the same, the game does not know that you've just played a string
-        u8& velocity = ::at32(button_state.string_velocities, msg[5] - 1]);
+        u8& velocity = ::at32(button_state.string_velocities, msg[5] - 1);
         if (msg[6] != 0 && msg[6] == velocity)
         {
 		    velocity = msg[6] ^ 1;  // to be sure to change the velocity


### PR DESCRIPTION
There is a bug when you play twice in a row with the same velocity on a string. The second note is not taken into account as the game does not notice any change in the velocity.

It is because the velocity is never reset (or at least not very often). The idea is to check if the velocity of the string is the same as the previous one. And if it is, we just flip the last bit. Since the accepted values goes from 6 to 127, from what I've seen, it should be ok.

I don't have an official RB3 pro guitar, but I have a YouRock Guitar that is compatible and works perfectly with a real MPA. When I use midi in rpcs3, I miss notes because of that bug. I've add a log message to test the patch and in a streak of nearly 150 notes, I should have missed nearly 20 notes. I had absolutely no missed note with thanks to the patch.

fixes https://github.com/RPCS3/rpcs3/issues/18062