### PR TITLE
Revert "vk: Disable VK_EXT_attachment_feedback_loop_layout support for adrenalin driver"

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -102,7 +102,7 @@ namespace vk
 		multidraw_support.max_batch_size = 65536;
 
 		optional_features_support.barycentric_coords  = !!shader_barycentric_info.fragmentShaderBarycentric;
-		optional_features_support.framebuffer_loops   = !!fbo_loops_info.attachmentFeedbackLoopLayout && get_driver_vendor() != driver_vendor::AMD;
+		optional_features_support.framebuffer_loops   = !!fbo_loops_info.attachmentFeedbackLoopLayout;
 		optional_features_support.extended_device_fault = !!device_fault_info.deviceFault;
 
 		features = features2.features;


### PR DESCRIPTION
This partially reverts commit ee06dccdea91814bf7d76b3037371a6477458722.

The recent cleanup of VVL warnings solved the crashing.
Closes https://github.com/RPCS3/rpcs3/issues/18077
Closes https://github.com/RPCS3/rpcs3/issues/18058