### PR TITLE
cellSaveData: fix "Your comparator is not a valid strict-weak ordering"

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -876,39 +876,42 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 
 		// Sort the entries
 		{
-			const u32 order = setList->sortOrder;
 			const u32 type = setList->sortType;
 
-			std::sort(save_entries.begin(), save_entries.end(), [order, type](const SaveDataEntry& entry1, const SaveDataEntry& entry2) -> bool
+			auto comp = [type](const SaveDataEntry& entry1, const SaveDataEntry& entry2) -> bool
 			{
 				const bool mtime_lower = entry1.mtime < entry2.mtime;
 				const bool mtime_equal = entry1.mtime == entry2.mtime;
 				const bool subtitle_lower = entry1.subtitle < entry2.subtitle;
 				const bool subtitle_equal = entry1.subtitle == entry2.subtitle;
-				const bool revert_order = order == CELL_SAVEDATA_SORTORDER_DESCENT;
 
 				if (type == CELL_SAVEDATA_SORTTYPE_MODIFIEDTIME)
 				{
 					if (mtime_equal)
 					{
-						return subtitle_lower != revert_order;
+						return subtitle_lower;
 					}
 
-					return mtime_lower != revert_order;
+					return mtime_lower;
 				}
 				else if (type == CELL_SAVEDATA_SORTTYPE_SUBTITLE)
 				{
 					if (subtitle_equal)
 					{
-						return mtime_lower != revert_order;
+						return mtime_lower;
 					}
 
-					return subtitle_lower != revert_order;
+					return subtitle_lower;
 				}
 
 				ensure(false);
 				return true;
-			});
+			};
+
+			if (setList->sortOrder == CELL_SAVEDATA_SORTORDER_ASCENT)
+				std::sort(save_entries.begin(), save_entries.end(), comp);
+			else
+				std::sort(save_entries.rbegin(), save_entries.rend(), comp);
 		}
 
 		// Fill the listGet->dirList array


### PR DESCRIPTION
I get this error in debug mode
```
rpcs3.exe caused a Fast Fail at location 00007FFA931E4ACE in module ucrtbase.dll with code 7 (FATAL_APP_EXIT).

AddrPC           Params
00007FFA931E4ACE 0000000000000003 0000005000000003 00000050CB5FCD00  ucrtbase.dll!abort+0x4e
00007FF9D6377331 0000020CC73C8B60 00007FF7718E8AAF 0000000000000000  libc++.dll!std::__1::__libcpp_verbose_abort+0x41
00007FF76D858BEA 00000050CB5FD680 00007FF76CA2EBBC 00000050CB5FCE50  rpcs3.exe!__check_strict_weak_ordering_sorted<SaveDataEntry *, (lambda at C:/src/rpcs3/rpcs3/Emu/Cell/Modules/cellSaveData.cpp:879:56)>+0x442  [C:/msys64/clang64/include/c++/v1/__debug_utils/strict_weak_ordering_check.h @ 49]
    47:       for (__diff_t __b = __p; __b < __q; ++__b) {
    48:         for (__diff_t __a = __p; __a <= __b; ++__a) {
>   49:           _LIBCPP_ASSERT_SEMANTIC_REQUIREMENT(
    50:               !__comp(*(__first + __a), *(__first + __b)), "Your comparator is not a valid strict-weak ordering");
    51:           _LIBCPP_ASSERT_SEMANTIC_REQUIREMENT(
00007FF76D858679 0000020CC73C8B60 00007FF76D84F33D 0000000000000000  rpcs3.exe!__sort_impl<std::__1::_ClassicAlgPolicy, std::__1::__wrap_iter<SaveDataEntry *>, (lambda at C:/src/rpcs3/rpcs3/Emu/Cell/Modules/cellSaveData.cpp:879:56)>+0x101  [C:/msys64/clang64/include/c++/v1/__algorithm/sort.h @ 939]
   937:     std::__sort_dispatch<_AlgPolicy>(std::__unwrap_iter(__first), std::__unwrap_iter(__last), __comp);
   938:   }
>  939:   std::__check_strict_weak_ordering_sorted(std::__unwrap_iter(__first), std::__unwrap_iter(__last), __comp);
   940: }
   941: 
00007FF76D84F283 0000000000000000 0000000000000000 0000000000000000  rpcs3.exe!sort<std::__1::__wrap_iter<SaveDataEntry *>, (lambda at C:/src/rpcs3/rpcs3/Emu/Cell/Modules/cellSaveData.cpp:879:56)>+0x3b  [C:/msys64/clang64/include/c++/v1/__algorithm/sort.h @ 945]
   943: inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   944: sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
>  945:   std::__sort_impl<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __comp);
   946: }
   947: 
00007FF76D82F9F5 01000000000003C8 00000050CB5FF3F0 00000050CB5FF3DF  rpcs3.exe!savedata_op+0x298d  [C:/src/rpcs3/rpcs3/Emu/Cell/Modules/cellSaveData.cpp @ 879]
   877: // Sort the entries
   878: {
>  879: std::sort(save_entries.begin(), save_entries.end(), [setList](const SaveDataEntry& entry1, const SaveDataEntry& entry2) -> bool
   880: {
   881: const bool mtime_lower = entry1.mtime < entry2.mtime;
00007FF76D83DF9A 01000050CB5FF601 00000050CB5FF690 0000000301EED0B8  rpcs3.exe!cellSaveDataListLoad2+0x462  [C:/src/rpcs3/rpcs3/Emu/Cell/Modules/cellSaveData.cpp @ 2299]
  2297: version, setList, setBuf, funcList, funcStat, funcFile, container, userdata);
  2298: 
> 2299: return savedata_op(ppu, SAVEDATA_OP_LIST_LOAD, version, vm::null, CELL_SAVEDATA_ERRDIALOG_ALWAYS, setList, setBuf, funcList, vm::null, funcStat, funcFile, container, 2, userdata, 0, vm::null);
  2300: }
  2301: 
00007FF76D88B81C FFFFFFFF00000000 0000020C0D05B300 00000000D017ACC0  rpcs3.exe!cellSysutil_SaveData_init()::$_13::operator()+0xd3c  [C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h @ 183]
   181: {
   182: // do the actual function call when all arguments are prepared (simultaneous unpacking of Args... and Info...)
>  183: return func(bind_arg_packed<Args, Info>::get_arg(ppu)...);
   184: }
   185: 
00007FF76D88AAD2 0000000000000000 0000000000000000 0000020C2C452F40  rpcs3.exe!cellSysutil_SaveData_init()::$_13::__invoke+0x3a  [C:/src/rpcs3/rpcs3/Emu/Cell/Modules/cellSaveData.cpp @ 2682]
  2680: REG_FUNC(cellSysutil, cellSaveDataUserListLoad);
  2681: REG_FUNC(cellSysutil, cellSaveDataUserListSave);
> 2682: REG_FUNC(cellSysutil, cellSaveDataListLoad2);
  2683: REG_FUNC(cellSysutil, cellSaveDataListSave2);
  2684: REG_FUNC(cellSysutil, cellSaveDataListLoad);
0000020C2E3C8473 0000000000000000 0000020C2C452F40 000000002C4502B4
```