### PR TITLE
hle: Register some missing Spurs/Font/SaveData/Fs/Sysmodule/sceNpTrophy OS functions

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellFont.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellFont.cpp
@@ -2228,6 +2228,12 @@ error_code cellFontStatic()
 	return CELL_OK;
 }
 
+error_code cellFontsetUSleep()
+{
+	cellFont.todo("cellFontsetUSleep()");
+	return CELL_OK;
+}
+
 DECLARE(ppu_module_manager::cellFont)("cellFont", []()
 {
 
@@ -2315,4 +2321,5 @@ DECLARE(ppu_module_manager::cellFont)("cellFont", []()
 	REG_FUNC(cellFont, cellFontGraphicsGetLineRGBA);
 	REG_FUNC(cellFont, cellFontControl);
 	REG_FUNC(cellFont, cellFontStatic);
+	REG_FUNC(cellFont, cellFontsetUSleep);
 });

--- a/rpcs3/Emu/Cell/Modules/cellFs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellFs.cpp
@@ -1034,6 +1034,18 @@ s32 cellFsUnregisterL10nCallbacks()
 	return CELL_OK;
 }
 
+s32 cellFsGetDirent()
+{
+	cellFs.todo("cellFsGetDirent()");
+	return CELL_OK;
+}
+
+s32 cellFsGetDirentCount()
+{
+	cellFs.todo("cellFsGetDirentCount()");
+	return CELL_OK;
+}
+
 DECLARE(ppu_module_manager::cellFs)("sys_fs", []()
 {
 	REG_FUNC(sys_fs, cellFsAccess);
@@ -1065,6 +1077,8 @@ DECLARE(ppu_module_manager::cellFs)("sys_fs", []()
 	REG_FUNC(sys_fs, cellFsGetBlockSize);
 	REG_FUNC(sys_fs, cellFsGetBlockSize2);
 	REG_FUNC(sys_fs, cellFsGetDirectoryEntries);
+	REG_FUNC(sys_fs, cellFsGetDirent);
+	REG_FUNC(sys_fs, cellFsGetDirentCount);
 	REG_FUNC(sys_fs, cellFsGetFreeSize);
 	REG_FUNC(sys_fs, cellFsGetPath);
 	REG_FUNC(sys_fs, cellFsLink);

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -2514,13 +2514,24 @@ error_code cellSaveDataUserFixedDelete(ppu_thread& ppu, u32 userId, PSetList set
 	return savedata_op(ppu, SAVEDATA_OP_FIXED_DELETE, 0, vm::null, 1, setList, setBuf, vm::null, funcFixed, vm::null, vm::null, container, 6, userdata, userId, funcDone);
 }
 
+error_code cellSaveDataGetEnableOverlay()
+{
+	cellSaveData.todo("cellSaveDataGetEnableOverlay()");
+
+	// auto& manager = g_fxo->get<savedata_manager>();
+	// manager.enable_overlay;
+
+	// TODO
+	
+	return CELL_OK;
+}
+
 void cellSaveDataEnableOverlay(s32 enable)
 {
 	cellSaveData.notice("cellSaveDataEnableOverlay(enable=%d)", enable);
 	auto& manager = g_fxo->get<savedata_manager>();
 	manager.enable_overlay = enable != 0;
 }
-
 
 // Functions (Extensions)
 error_code cellSaveDataListDelete(ppu_thread& ppu, PSetList setList, PSetBuf setBuf, PFuncList funcList, PFuncDone funcDone, u32 container, vm::ptr<void> userdata)
@@ -2678,6 +2689,7 @@ void cellSysutil_SaveData_init()
 	REG_VAR(cellSysutil, g_savedata_context).flag(MFF_HIDDEN);
 
 	// libsysutil functions:
+	REG_FUNC(cellSysutil, cellSaveDataGetEnableOverlay);
 	REG_FUNC(cellSysutil, cellSaveDataEnableOverlay);
 
 	REG_FUNC(cellSysutil, cellSaveDataDelete2);

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -1438,6 +1438,13 @@ s32 cellSpursInitializeWithAttribute2(ppu_thread& ppu, vm::ptr<CellSpurs> spurs,
 		attr->swlIsPreem);
 }
 
+// Initialise SPURS
+s32 cellSpursInitializeForSpuSharing()
+{
+	cellSpurs.todo("cellSpursInitializeForSpuSharing()");
+	return CELL_OK;
+}
+
 /// Initialise SPURS attribute
 s32 _cellSpursAttributeInitialize(vm::ptr<CellSpursAttribute> attr, u32 revision, u32 sdkVersion, u32 nSpus, s32 spuPriority, s32 ppuPriority, b8 exitIfNoWork)
 {
@@ -5390,6 +5397,7 @@ DECLARE(ppu_module_manager::cellSpurs)("cellSpurs", [](ppu_static_module* _this)
 	REG_FUNC(cellSpurs, cellSpursInitialize);
 	REG_FUNC(cellSpurs, cellSpursInitializeWithAttribute);
 	REG_FUNC(cellSpurs, cellSpursInitializeWithAttribute2);
+	REG_FUNC(cellSpurs, cellSpursInitializeForSpuSharing);
 	REG_FUNC(cellSpurs, cellSpursFinalize);
 	REG_FUNC(cellSpurs, _cellSpursAttributeInitialize);
 	REG_FUNC(cellSpurs, cellSpursAttributeSetMemoryContainerForSpuThread);

--- a/rpcs3/Emu/Cell/Modules/cellSysmodule.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSysmodule.cpp
@@ -406,6 +406,30 @@ error_code cellSysmoduleIsLoadedEx()
 	return CELL_OK;
 }
 
+error_code cellSysmoduleLoadModuleFile()
+{
+	UNIMPLEMENTED_FUNC(cellSysmodule);
+	return CELL_OK;
+}
+
+error_code cellSysmoduleUnloadModuleFile()
+{
+	UNIMPLEMENTED_FUNC(cellSysmodule);
+	return CELL_OK;
+}
+
+error_code cellSysmoduleSetDebugmode()
+{
+	UNIMPLEMENTED_FUNC(cellSysmodule);
+	return CELL_OK;
+}
+
+error_code cellSysmoduleSetInternalmode()
+{
+	UNIMPLEMENTED_FUNC(cellSysmodule);
+	return CELL_OK;
+}
+
 DECLARE(ppu_module_manager::cellSysmodule)("cellSysmodule", []()
 {
 	REG_FUNC(cellSysmodule, cellSysmoduleInitialize);
@@ -421,4 +445,8 @@ DECLARE(ppu_module_manager::cellSysmodule)("cellSysmodule", []()
 	REG_FUNC(cellSysmodule, cellSysmoduleUnloadModuleEx);
 	REG_FUNC(cellSysmodule, cellSysmoduleLoadModuleEx);
 	REG_FUNC(cellSysmodule, cellSysmoduleIsLoadedEx);
+	REG_FUNC(cellSysmodule, cellSysmoduleLoadModuleFile);
+	REG_FUNC(cellSysmodule, cellSysmoduleUnloadModuleFile);
+	REG_FUNC(cellSysmodule, cellSysmoduleSetDebugmode);
+	REG_FUNC(cellSysmodule, cellSysmoduleSetInternalmode);
 });

--- a/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
+++ b/rpcs3/Emu/Cell/Modules/sceNpTrophy.cpp
@@ -1529,6 +1529,11 @@ error_code sceNpTrophyGetTrophyIcon(u32 context, u32 handle, s32 trophyId, vm::p
 	return CELL_OK;
 }
 
+error_code sceNpTrophyNetworkSync()
+{
+	UNIMPLEMENTED_FUNC(sceNpTrophy);
+	return CELL_OK;
+}
 
 DECLARE(ppu_module_manager::sceNpTrophy)("sceNpTrophy", []()
 {
@@ -1553,4 +1558,5 @@ DECLARE(ppu_module_manager::sceNpTrophy)("sceNpTrophy", []()
 	REG_FUNC(sceNpTrophy, sceNpTrophyGetTrophyDetails);
 	REG_FUNC(sceNpTrophy, sceNpTrophyGetTrophyInfo);
 	REG_FUNC(sceNpTrophy, sceNpTrophyGetGameIcon);
+	REG_FUNC(sceNpTrophy, sceNpTrophyNetworkSync);
 });


### PR DESCRIPTION
**Exported with latest PS3 OFW 4.92**

**Newly found unregistered functions**
- cellFontsetUSleep: 0x67e805c3
- cellSpursInitializeForSpuSharing: 0x90C82BFC
- cellSaveDataGetEnableOverlay: 0xB96F2F5D
- sceNpTrophyNetworkSync: 0x014786F2
- cellFsGetDirent: 0xF44C0E1D
- cellFsGetDirentCount: 0xCBF1758B
- cellSysmoduleLoadModuleFile: 0xC93200DE
- cellSysmoduleUnloadModuleFile: 0x205FE2A0
- cellSysmoduleSetDebugmode: 0x03D90241
- cellSysmoduleSetInternalmode: 0x002CD0BF

**List of exports**
- cellFont export: (0x67e805c3) at 0x1ae5138 [at:0x1adc6ec, rtoc:same-above]:  0x67E805C3
- cellSpurs export: (0x90c82bfc) at 0x0383264 [at:0x0358328, rtoc:same-above]:  0x90C82BFC
- cellSysutil export: (0xb96f2f5d) at 0x02e0390 [at:0x02cc1d4, rtoc:same-above]:  0xB96F2F5D
- sceNpTrophy export: (0x014786f2) at 0x03c0114 [at:0x03b1230, rtoc:0x003c81b0]:  0x014786F2
- sys_fs export: (0xf44c0e1d) at 0x03a0b48 [at:0x0394824, rtoc:same-above]:  0xF44C0E1D
- sys_fs export: (0xcbf1758b) at 0x03a0b68 [at:0x0394d44, rtoc:same-above]:  0xCBF1758B
- cellSysmodule export: (0xc93200de) at 0x02b0e48 [at:0x02a1b38, rtoc:same-above]:  0xC93200DE
- cellSysmodule export: (0x205fe2a0) at 0x02b0e50 [at:0x02a1e5c, rtoc:same-above]:  0x205FE2A0
- cellSysmodule export: (0x03d90241) at 0x02b0e70 [at:0x02a26b4, rtoc:same-above]:  0x03D90241
- cellSysmodule export: (0x002cd0bf) at 0x02b0e78 [at:0x02a2734, rtoc:0x002b9420]:  0x002CD0BF