### PR TITLE
Crash Fix

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3393,7 +3393,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 			bool is_being_held_longer = false;
 
-			for (int i = 0; !*join_ended && thread_ctrl::state() != thread_state::aborting;)
+			for (int i = 0; !*join_ended && thread_ctrl::state() != thread_state::aborting; i++)
 			{
 				if (g_watchdog_hold_ctr)
 				{


### PR DESCRIPTION
This fixes a crash that occurs on unsupported (or falsely detected as supported) GPUs when Allow Host GPU Labels (Experimental) is enabled. In my case, it happens on an Apple MacBook with Apple Silicon.

`RPCS3: RSX [0x0014afc]: SIG: Thread terminated due to fatal error: Assertion Failed! Vulkan API call failed with unrecoverable error: Requested feature not available (VK_ERROR_FEATURE_NOT_PRESENT)
(in file /Users/tunacelik/Projects/rpcs3/rpcs3/Emu/RSX/VK/vkutils/buffer_object.cpp:111[:64], in function 'vk::buffer::buffer(const vk::render_device &, VkBufferUsageFlags, void *, u64)') (errno=60=Operation timed out)
(in file /Users/tunacelik/Projects/rpcs3/rpcs3/Emu/RSX/VK/vkutils/shared.cpp:205[:4], in function 'void vk::die_with_error(VkResult, std::string, std::source_location)') (errno=60=Operation timed out)`