### PR TITLE
Fix generic_async_transaction_context thread handling

### DIFF
--- a/rpcs3/Emu/NP/np_contexts.cpp
+++ b/rpcs3/Emu/NP/np_contexts.cpp
@@ -17,7 +17,12 @@ generic_async_transaction_context::generic_async_transaction_context(const SceNp
 generic_async_transaction_context::~generic_async_transaction_context()
 {
 	if (thread.joinable())
-		thread.join();
+	{
+		if (std::this_thread::get_id() == thread.get_id())
+			thread.detach();
+		else
+			thread.join();
+	}
 }
 
 std::optional<s32> generic_async_transaction_context::get_transaction_status()

--- a/rpcs3/Emu/NP/rpcn_config.h
+++ b/rpcs3/Emu/NP/rpcn_config.h
@@ -10,7 +10,7 @@ struct cfg_rpcn : cfg::node
 	cfg::string password{this, "Password", ""};
 	cfg::string token{this, "Token", ""};
 	cfg::string hosts{this, "Hosts", "Official RPCN Server|np.rpcs3.net"};
-	cfg::_bool ipv6_support{this, "IPv6 support", true};
+	cfg::_bool ipv6_support{this, "Experimental IPv6 support", false};
 
 	void load();
 	void save() const;

--- a/rpcs3/rpcs3qt/rpcn_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/rpcn_settings_dialog.cpp
@@ -185,8 +185,8 @@ rpcn_account_dialog::rpcn_account_dialog(QWidget* parent)
 	QPushButton* btn_test     = new QPushButton(tr("Test Account"));
 	QLabel* label_npid        = new QLabel();
 
-	QCheckBox* checkbox_disable_ipv6 = new QCheckBox(tr("Disable IPv6"));
-	checkbox_disable_ipv6->setCheckState(g_cfg_rpcn.get_ipv6_support() ? Qt::Unchecked : Qt::Checked);
+	// QCheckBox* checkbox_disable_ipv6 = new QCheckBox(tr("Enable IPv6(Experimental)"));
+	// checkbox_disable_ipv6->setCheckState(g_cfg_rpcn.get_ipv6_support() ? Qt::Checked : Qt::Unchecked);
 
 	const auto update_npid_label = [label_npid]()
 	{
@@ -206,7 +206,7 @@ rpcn_account_dialog::rpcn_account_dialog(QWidget* parent)
 	grp_buttons->setLayout(vbox_buttons);
 
 	vbox_global->addWidget(grp_buttons);
-	vbox_global->addWidget(checkbox_disable_ipv6);
+	// vbox_global->addWidget(checkbox_disable_ipv6);
 
 	setLayout(vbox_global);
 
@@ -359,11 +359,11 @@ rpcn_account_dialog::rpcn_account_dialog(QWidget* parent)
 			QMessageBox::information(this, tr("RPCN Account Valid!"), tr("Your account is valid!"), QMessageBox::Ok);
 		});
 
-	connect(checkbox_disable_ipv6, &QCheckBox::checkStateChanged, this, [this](Qt::CheckState state)
-	{
-		g_cfg_rpcn.set_ipv6_support(state == Qt::Unchecked);
-		g_cfg_rpcn.save();
-	});
+	// connect(checkbox_disable_ipv6, &QCheckBox::checkStateChanged, this, [this](Qt::CheckState state)
+	// {
+	// 	g_cfg_rpcn.set_ipv6_support(state == Qt::Checked);
+	// 	g_cfg_rpcn.save();
+	// });
 }
 
 void rpcn_account_dialog::refresh_combobox()


### PR DESCRIPTION
If the thread itself was the last holder of the generic_async_transaction_context, when it dropped it, the thread tried to join itself and it resulted in a possible crash.

Interestingly the behaviour was different on Linux and Windows. On Linux this causes a SIGSEGV and termination. On Windows this just hanged the thread.

I've added a commit to force disable IPv6 support, I've changed the name of the config, set it to false by default and commented out the UI part. There are too many issues for now to have it enabled by default like it was.