### PR TITLE
ARM64: Use ISB instead of yield in place of x86 pause

### DIFF
--- a/rpcs3/util/asm.hpp
+++ b/rpcs3/util/asm.hpp
@@ -175,7 +175,7 @@ namespace utils
 	inline void pause()
 	{
 #if defined(ARCH_ARM64)
-		__asm__ volatile("yield");
+		__asm__ volatile("isb" ::: "memory");
 #elif defined(ARCH_X64)
 		_mm_pause();
 #else


### PR DESCRIPTION
ISB isn't an exact match for pause, but it does slow down execution at least a little. Unfortunately, yield does nothing on machines without SMT (99% of aarch64 machines)

For reference, arm has a blog on this subject: https://developer.arm.com/community/arm-community-blogs/b/architectures-and-processors-blog/posts/multi-threaded-applications-arm

Cause I was curious, I wrote a little program calling various spinlock methods in a loop:

Idle Baseline: 564.3 mA (2216.0 mW)
Testing Busy Spin         ... Current:   921.0 mA | Power:  3603.6 mW
Testing ASM Yield         ... Current:   939.0 mA | Power:  3672.5 mW
Testing ASM ISB           ... Current:   845.1 mA | Power:  3307.6 mW
Testing Hardware WFE      ... Current:   569.5 mA | Power:  2235.4 mW
Testing Sched Yield       ... Current:   958.4 mA | Power:  3747.1 mW

ISB saves a little power over yield or a pure busy wait loop, but really we want to be using WFE to implement spinlocks as the power usage is only slightly over the idle baseline (also the wake latency of WFE is very excellent, only losing to the pure busy spin, and over 10x faster than Sched Yield)

WFE can monitor a cacheline similar to monitorx/waitx on AMD, and umonitor/umwait on Intel. So we can build a nice interface to spinlock on userspace for everyone.

Anyways for now, just use ISB in place of the yield instruction, this should be a small win over yield.