### PR TITLE
Increase FAudio buffer

### DIFF
--- a/rpcs3/Emu/Audio/FAudio/FAudioBackend.cpp
+++ b/rpcs3/Emu/Audio/FAudio/FAudioBackend.cpp
@@ -210,12 +210,12 @@ bool FAudioBackend::Open(std::string_view dev_id, AudioFreq freq, AudioSampleSiz
 
 f64 FAudioBackend::GetCallbackFrameLen()
 {
-	constexpr f64 _10ms = 0.01;
+	constexpr f64 _20ms = 0.02;
 
 	if (m_instance == nullptr)
 	{
 		FAudio_.error("GetCallbackFrameLen() called uninitialized");
-		return _10ms;
+		return _20ms;
 	}
 
 	f64 min_latency{};
@@ -228,7 +228,7 @@ f64 FAudioBackend::GetCallbackFrameLen()
 		min_latency = static_cast<f64>(samples_per_q) / freq;
 	}
 
-	return std::max<f64>(min_latency, _10ms);
+	return std::max<f64>(min_latency, _20ms);
 }
 
 void FAudioBackend::OnVoiceProcessingPassStart_func(FAudioVoiceCallback *cb_obj, u32 BytesRequired)


### PR DESCRIPTION
I was investigating why my local build differed from the AppImage when it came to FAudio when used without Buffering, on my local build it heavily stuttered while on the AppImage it worked fine.
It turns out that FAudio uses SDL which supports 3 main backends on Linux, Pulseaudio, Pipewire and Alsa.
My local build used Pipewire by default while the Appimage used Pulseaudio.

Forcing Pulseaudio through setting `SDL_AUDIODRIVER=pulseaudio` did make my local build behave the same as the AppImage.
Pipewire and Alsa both heavily stuttered. Investigating SDL backend implementation it seems the Pulseaudio backend is a lot more resilient to jitter with a buffering layer while alsa and pipewire backends are simple and basically require the full buffer to be submitted(as far as I understood it, I have very little knowledge about audio processing). Sadly no easy fix for Pipewire/Alsa.

Increasing buffer size on our side is an easy "fix" though it increases latency. Using buffering also fixes the issue but I don't think having unbuffered being a broken mess by default with Faudio using pipewire/alsa is a good idea.

Generally cubeb is a better RPCS3 backend imo and it is the default so it is not critical issue.