### PR TITLE
input: fix input guard button offsets for closing native overlays

### DIFF
--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -631,15 +631,18 @@ void pad_thread::operator()()
 				if (!pad->is_connected())
 					continue;
 
-				for (const auto& button : pad->m_buttons)
+				for (const Button& button : pad->m_buttons)
 				{
 					if (button.m_pressed && (
-						button.m_outKeyCode == CELL_PAD_CTRL_CROSS ||
-						button.m_outKeyCode == CELL_PAD_CTRL_CIRCLE ||
-						button.m_outKeyCode == CELL_PAD_CTRL_TRIANGLE ||
-						button.m_outKeyCode == CELL_PAD_CTRL_SQUARE ||
-						button.m_outKeyCode == CELL_PAD_CTRL_START ||
-						button.m_outKeyCode == CELL_PAD_CTRL_SELECT))
+						(button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL1 && (
+							button.m_outKeyCode == CELL_PAD_CTRL_START ||
+							button.m_outKeyCode == CELL_PAD_CTRL_SELECT)) ||
+						(button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL2 && (
+							button.m_outKeyCode == CELL_PAD_CTRL_CROSS ||
+							button.m_outKeyCode == CELL_PAD_CTRL_CIRCLE ||
+							button.m_outKeyCode == CELL_PAD_CTRL_TRIANGLE ||
+							button.m_outKeyCode == CELL_PAD_CTRL_SQUARE))
+						))
 					{
 						any_button_pressed = true;
 						break;
@@ -676,7 +679,7 @@ void pad_thread::operator()()
 					break;
 				}
 
-				for (const auto& button : pad->m_buttons)
+				for (const Button& button : pad->m_buttons)
 				{
 					if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL1 && button.m_outKeyCode == CELL_PAD_CTRL_PS && button.m_pressed)
 					{
@@ -735,7 +738,7 @@ void pad_thread::operator()()
 				if (!pad->is_connected())
 					continue;
 
-				for (const auto& button : pad->m_buttons)
+				for (const Button& button : pad->m_buttons)
 				{
 					if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL1 && button.m_outKeyCode == CELL_PAD_CTRL_START && button.m_pressed)
 					{


### PR DESCRIPTION
L2, R1 and all hat buttons were incorrectly enforcing the pad interception after closing a native dialog.

Fixes #6547