### PR TITLE
Microphone fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMic.cpp
@@ -634,7 +634,7 @@ u32 microphone_device::capture_audio()
 		if (ALCenum err = alcGetError(micdevice.device); err != ALC_NO_ERROR)
 		{
 			cellMic.error("Error getting number of captured samples of device '%s' (error=%s)", micdevice.name, fmt::alc_error{micdevice.device, err});
-			return CELL_MICIN_ERROR_FATAL;
+			return 0;
 		}
 
 		num_samples = std::min<u32>(num_samples, samples_in);

--- a/rpcs3/Emu/Cell/Modules/cellMic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMic.h
@@ -238,7 +238,7 @@ public:
 		if (over_size > Size)
 		{
 			m_tail += (over_size - Size);
-			if (m_tail > Size)
+			if (m_tail >= Size)
 				m_tail -= Size;
 
 			m_used = Size;

--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -556,6 +556,8 @@ usb_handler_thread::usb_handler_thread()
 
 	switch (g_cfg.audio.microphone_type)
 	{
+		case microphone_handler::null:
+			break;
 		case microphone_handler::standard:
 			usb_devices.push_back(std::make_shared<usb_device_mic>(0, get_new_location(), MicType::Logitech));
 			break;

--- a/rpcs3/Emu/RSX/Program/GLSLTypes.h
+++ b/rpcs3/Emu/RSX/Program/GLSLTypes.h
@@ -9,7 +9,7 @@ namespace glsl
 		glsl_compute_program = 2,
 
 		// Meta
-		glsl_invalid_program = 0xff
+		glsl_invalid_program = 7
 	};
 
 	enum glsl_rules : unsigned char

--- a/rpcs3/util/atomic.hpp
+++ b/rpcs3/util/atomic.hpp
@@ -1011,7 +1011,12 @@ struct atomic_storage<T, 16> : atomic_storage<T, 0>
 	static inline T exchange(T& dest, T value)
 	{
 		__atomic_thread_fence(__ATOMIC_ACQ_REL);
+		// GCC has recently started thinking using this instrinsic is breaking strict aliasing rules
+		// TODO: remove if this ever get fixed in GCC
+		#pragma GCC diagnostic push
+		#pragma GCC diagnostic ignored "-Wstrict-aliasing"
 		return std::bit_cast<T>(__sync_lock_test_and_set(reinterpret_cast<u128*>(&dest), std::bit_cast<u128>(value)));
+		#pragma GCC diagnostic pop
 	}
 
 	static inline void store(T& dest, T value)


### PR DESCRIPTION
We returned CELL_MICIN_ERROR_FATAL(0x8014010F) samples available if we failed to read number of samples, probably happened in a refactor?

Fixes an error by one in the ringbuffer handling.