### PR TITLE
Update docker and ccache

### DIFF
--- a/.ci/setup-llvm.sh
+++ b/.ci/setup-llvm.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 # Resource/dependency URLs
-CCACHE_URL="https://github.com/ccache/ccache/releases/download/v4.11.2/ccache-4.11.2-windows-x86_64.zip"
+CCACHE_URL="https://github.com/ccache/ccache/releases/download/v4.12.3/ccache-4.12.3-windows-x86_64.zip"
 
 DEP_URLS="         \
     $CCACHE_URL"

--- a/.ci/setup-windows.sh
+++ b/.ci/setup-windows.sh
@@ -17,7 +17,7 @@ QT_SVG_URL="${QT_HOST}${QT_PREFIX}${QT_PREFIX_2}qtsvg${QT_SUFFIX}"
 QT_TRANSLATIONS_URL="${QT_HOST}${QT_PREFIX}${QT_PREFIX_2}qttranslations${QT_SUFFIX}"
 LLVMLIBS_URL="https://github.com/RPCS3/llvm-mirror/releases/download/custom-build-win-${LLVM_VER}/llvmlibs_mt.7z"
 VULKAN_SDK_URL="https://www.dropbox.com/scl/fi/sjjh0fc4ld281pjbl2xzu/VulkanSDK-${VULKAN_VER}-Installer.exe?rlkey=f6wzc0lvms5vwkt2z3qabfv9d&dl=1"
-CCACHE_URL="https://github.com/ccache/ccache/releases/download/v4.11.2/ccache-4.11.2-windows-x86_64.zip"
+CCACHE_URL="https://github.com/ccache/ccache/releases/download/v4.12.3/ccache-4.12.3-windows-x86_64.zip"
 
 DEP_URLS="         \
     $QT_BASE_URL   \

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-2025
     env:
       COMPILER: msvc
-      CCACHE_SHA: '1f39f3ad5aae3fe915e99ad1302633bc8f6718e58fa7c0de2b0ba7e080f0f08c'
+      CCACHE_SHA: '859141059ac950e1e8cd042c66f842f26b9e3a62a1669a69fe6ba180cb58bbdf'
       CCACHE_BIN_DIR: 'C:\ccache_bin'
       CCACHE_DIR: 'C:\ccache'
       CCACHE_INODECACHE: 'true'

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -30,23 +30,23 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            docker_img: "rpcs3/rpcs3-ci-jammy:1.7"
+            docker_img: "rpcs3/rpcs3-ci-jammy:1.8"
             build_sh: "/rpcs3/.ci/build-linux.sh"
             compiler: clang
             UPLOAD_COMMIT_HASH: d812f1254a1157c80fd402f94446310560f54e5f
             UPLOAD_REPO_FULL_NAME: "rpcs3/rpcs3-binaries-linux"
           - os: ubuntu-24.04
-            docker_img: "rpcs3/rpcs3-ci-jammy:1.7"
+            docker_img: "rpcs3/rpcs3-ci-jammy:1.8"
             build_sh: "/rpcs3/.ci/build-linux.sh"
             compiler: gcc
           - os: ubuntu-24.04-arm
-            docker_img: "rpcs3/rpcs3-ci-jammy-aarch64:1.7"
+            docker_img: "rpcs3/rpcs3-ci-jammy-aarch64:1.8"
             build_sh: "/rpcs3/.ci/build-linux-aarch64.sh"
             compiler: clang
             UPLOAD_COMMIT_HASH: a1d35836e8d45bfc6f63c26f0a3e5d46ef622fe1
             UPLOAD_REPO_FULL_NAME: "rpcs3/rpcs3-binaries-linux-arm64"
           - os: ubuntu-24.04-arm
-            docker_img: "rpcs3/rpcs3-ci-jammy-aarch64:1.7"
+            docker_img: "rpcs3/rpcs3-ci-jammy-aarch64:1.8"
             build_sh: "/rpcs3/.ci/build-linux-aarch64.sh"
             compiler: gcc
     name: RPCS3 Linux ${{ matrix.os }} ${{ matrix.compiler }}
@@ -219,7 +219,7 @@ jobs:
       LLVM_VER: '19.1.7'
       VULKAN_VER: '1.3.268.0'
       VULKAN_SDK_SHA: '8459ef49bd06b697115ddd3d97c9aec729e849cd775f5be70897718a9b3b9db5'
-      CCACHE_SHA: '1f39f3ad5aae3fe915e99ad1302633bc8f6718e58fa7c0de2b0ba7e080f0f08c'
+      CCACHE_SHA: '859141059ac950e1e8cd042c66f842f26b9e3a62a1669a69fe6ba180cb58bbdf'
       CCACHE_BIN_DIR: 'C:\ccache_bin'
       CCACHE_DIR: 'C:\ccache'
       CCACHE_INODECACHE: 'true'


### PR DESCRIPTION
As per https://github.com/RPCS3/rpcs3-docker/pull/14:
    Install libpipewire-dev for openal usage
    ninja: Update to 1.13.2
    Qt: Update to 6.10.2
    SDL: Update to 3.4.0
    ffmpeg: Update to 7.1.3

And update our ccache version on our Windows builds.