### PR TITLE
Various sys_ fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_cond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_cond.cpp
@@ -59,6 +59,7 @@ CellError lv2_cond::on_id_create()
 		if (!mutex)
 		{
 			_mutex = static_cast<shared_ptr<lv2_obj>>(ensure(idm::get_unlocked<lv2_obj, lv2_mutex>(mtx_id)));
+			mutex = static_cast<lv2_mutex*>(_mutex.get());
 		}
 
 		// Defer function

--- a/rpcs3/Emu/Cell/lv2/sys_event.h
+++ b/rpcs3/Emu/Cell/lv2/sys_event.h
@@ -7,7 +7,6 @@
 #include <deque>
 
 class cpu_thread;
-class spu_thrread;
 
 // Event Queue Type
 enum : u32

--- a/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_lwcond.cpp
@@ -487,6 +487,8 @@ error_code _sys_lwcond_queue_wait(ppu_thread& ppu, u32 lwcond_id, u32 lwmutex_id
 				{
 					ensure(cond.unqueue(cond.sq, &ppu));
 					ppu.state += cpu_flag::again;
+					cond.lwmutex_waiters--;
+					mutex->lwcond_waiters--;
 					return;
 				}
 

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.cpp
@@ -85,7 +85,7 @@ error_code sys_mutex_create(ppu_thread& ppu, vm::ptr<u32> mutex_id, vm::ptr<sys_
 		sys_mutex.todo("sys_mutex_create(): unexpected adaptive (0x%x)", _attr.adaptive);
 	}
 
-	if (auto error = lv2_obj::create<lv2_mutex>(_attr.pshared, _attr.ipc_key, _attr.flags, [&]()
+	if (auto error = lv2_obj::create<lv2_mutex>(_attr.pshared, ipc_key, _attr.flags, [&]()
 	{
 		return make_shared<lv2_mutex>(
 			_attr.protocol,

--- a/rpcs3/Emu/Cell/lv2/sys_spu.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_spu.cpp
@@ -437,7 +437,7 @@ struct spu_limits_t
 		raw_spu_count += spu_thread::g_raw_spu_ctr;
 
 		// physical_spus_count >= spu_limit returns EBUSY, not EINVAL!
-		if (spu_limit + raw_limit > 6 || raw_spu_count > raw_limit || physical_spus_count >= spu_limit || physical_spus_count > spu_limit || controllable_spu_count > spu_limit)
+		if (spu_limit + raw_limit > 6 || raw_spu_count > raw_limit || physical_spus_count >= spu_limit || controllable_spu_count > spu_limit)
 		{
 			return false;
 		}


### PR DESCRIPTION
A few savestates fixes:
- mutex was never set in on_id_create()
- cond.lwmutex_waiters and mutex->lwcond_waiters were incremented but never decremented when again was set

Other:
- Small code simplification in sys_event_port_connect_local
- Redundant condition in check_busy
- Use ipc_key instead of _attr.ipc_key in sys_mutex_create(ie should be 0 if SYS_SYNC_PROCESS_SHARED is not set)