### PR TITLE
More sys_ fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -170,8 +170,7 @@ CellError lv2_event_queue::send(lv2_event event, bool* notified_thread, lv2_even
 		{
 			if (auto cpu = get_current_cpu_thread())
 			{
-				cpu->state += cpu_flag::again;
-				cpu->state += cpu_flag::exit;
+				cpu->state += cpu_flag::again + cpu_flag::exit;
 			}
 
 			sys_event.warning("Ignored event!");

--- a/rpcs3/Emu/Cell/lv2/sys_mutex.h
+++ b/rpcs3/Emu/Cell/lv2/sys_mutex.h
@@ -173,7 +173,11 @@ struct lv2_mutex final : lv2_obj
 
 				if (sq == data.sq)
 				{
-					atomic_storage<u32>::release(control.raw().owner, res->id);
+					if (cpu_flag::again - res->state)
+					{
+						atomic_storage<u32>::release(control.raw().owner, res->id);
+					}
+
 					return false;
 				}
 

--- a/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_rwlock.cpp
@@ -441,6 +441,8 @@ error_code sys_rwlock_wlock(ppu_thread& ppu, u32 rw_lock_id, u64 timeout)
 					continue;
 				}
 
+				ppu.state += cpu_flag::wait;
+
 				std::lock_guard lock(rwlock->mutex);
 
 				if (!rwlock->unqueue(rwlock->wq, &ppu))

--- a/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_semaphore.cpp
@@ -72,7 +72,7 @@ error_code sys_semaphore_create(ppu_thread& ppu, vm::ptr<u32> sem_id, vm::ptr<sy
 		return error;
 	}
 
-	static_cast<void>(ppu.test_stopped());
+	ppu.check_state();
 
 	*sem_id = idm::last_id();
 	return CELL_OK;
@@ -358,7 +358,7 @@ error_code sys_semaphore_get_value(ppu_thread& ppu, u32 sem_id, vm::ptr<s32> cou
 		return CELL_EFAULT;
 	}
 
-	static_cast<void>(ppu.test_stopped());
+	ppu.check_state();
 
 	*count = sema.ret;
 	return CELL_OK;


### PR DESCRIPTION
A lot of minor stuff but one interesting fix in sys_mutex.h. When, in sys_mutex_unlock, again is set, schedule doesn't remove anything from the queue which means (sq == data.sq) is true, which triggers a change of the owner mutex owner. Then it returns. This is no issue when the emulator stops normally but as the owner gets serialized in the savestate.

After the savestate is restarted:

The current thread will try sys_mutex_unlock => fail because it is not the owner.
The thread trying to lock => fail because it already owns the lock.

Also of note:
Changed 2 `static_cast<void>(ppu.test_stopped());` to `ppu.check_state();`, `ppu.state += cpu_flag::wait;`  is set at the top of the function, the extra shortcut exit of test_stopped is pointless here.
sys_rwlock_wlock was missing a ppu.state += cpu_flag::wait; on the slow path.
