### PR TITLE
Final sys_ fixes

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_config.h
+++ b/rpcs3/Emu/Cell/lv2/sys_config.h
@@ -296,10 +296,9 @@ private:
 
 	// The service listener owns the service events - service events will not be freed as long as their corresponding listener exists
 	// This has been confirmed to be the case in realhw
+	shared_mutex mutex_service_events;
 	std::vector<shared_ptr<lv2_config_service_event>> service_events;
 	shared_ptr<lv2_config_handle> handle;
-
-	bool notify(const shared_ptr<lv2_config_service_event>& event);
 
 public:
 	const sys_config_service_id service_id;
@@ -370,14 +369,14 @@ public:
 	// This has been confirmed to be the case in realhw
 	const shared_ptr<lv2_config_handle> handle;
 	const shared_ptr<lv2_config_service> service;
-	const lv2_config_service_listener& listener;
+	const u32 listener_id;
 
 	// Constructors (should not be used directly)
 	lv2_config_service_event(shared_ptr<lv2_config_handle> _handle, shared_ptr<lv2_config_service> _service, const lv2_config_service_listener& _listener) noexcept
 		: id(get_next_id())
 		, handle(std::move(_handle))
 		, service(std::move(_service))
-		, listener(_listener)
+		, listener_id(_listener.get_id())
 	{
 	}
 

--- a/rpcs3/Emu/Cell/lv2/sys_dbg.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_dbg.cpp
@@ -105,7 +105,7 @@ error_code sys_dbg_write_process_memory(s32 pid, u32 address, u32 size, vm::cptr
 			i += op_size;
 		}
 
-		if (!is_exec || i >= end)
+		if ((!is_exec || i >= end) && exec_update_size > 0)
 		{
 			// Commit executable data update
 			// The read memory is also super ptr so memmove can work correctly on all implementations

--- a/rpcs3/Emu/Cell/lv2/sys_event.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_event.cpp
@@ -308,6 +308,15 @@ error_code sys_event_queue_destroy(ppu_thread& ppu, u32 equeue_id, s32 mode)
 			return CELL_EBUSY;
 		}
 
+		for (auto cpu = head; cpu; cpu = cpu->get_next_cpu())
+		{
+			if (cpu->state & cpu_flag::again)
+			{
+				ppu.state += cpu_flag::again;
+				return CELL_EAGAIN;
+			}
+		}
+
 		if (!queue.events.empty())
 		{
 			// Copy events for logging, does not empty
@@ -319,17 +328,6 @@ error_code sys_event_queue_destroy(ppu_thread& ppu, u32 equeue_id, s32 mode)
 		if (!head)
 		{
 			qlock.unlock();
-		}
-		else
-		{
-			for (auto cpu = head; cpu; cpu = cpu->get_next_cpu())
-			{
-				if (cpu->state & cpu_flag::again)
-				{
-					ppu.state += cpu_flag::again;
-					return CELL_EAGAIN;
-				}
-			}
 		}
 
 		return {};

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
@@ -104,7 +104,7 @@ public:
 	virtual void close()          = 0;
 	virtual s32 shutdown(s32 how) = 0;
 
-	virtual s32 poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd)                           = 0;
+	virtual void poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) = 0;
 	virtual std::tuple<bool, bool, bool> select(bs_t<poll_t> selected, pollfd& native_pfd) = 0;
 
 	error_code abort_socket(s32 flags);

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.cpp
@@ -1147,14 +1147,14 @@ s32 lv2_socket_native::shutdown(s32 how)
 	return -get_last_error(false);
 }
 
-s32 lv2_socket_native::poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd)
+void lv2_socket_native::poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd)
 {
 	// Check for fake packet for dns interceptions
 	auto& dnshook = g_fxo->get<np::dnshook>();
 	if (sn_pfd.events & SYS_NET_POLLIN && dnshook.is_dns(sn_pfd.fd) && dnshook.is_dns_queue(sn_pfd.fd))
 	{
 		sn_pfd.revents |= SYS_NET_POLLIN;
-		return 1;
+		return;
 	}
 	if (sn_pfd.events & ~(SYS_NET_POLLIN | SYS_NET_POLLOUT | SYS_NET_POLLERR))
 	{
@@ -1171,8 +1171,6 @@ s32 lv2_socket_native::poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd)
 	{
 		native_pfd.events |= POLLOUT;
 	}
-
-	return 0;
 }
 
 std::tuple<bool, bool, bool> lv2_socket_native::select(bs_t<lv2_socket::poll_t> selected, pollfd& native_pfd)

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_native.h
@@ -50,7 +50,7 @@ public:
 	std::optional<s32> sendto(s32 flags, const std::vector<u8>& buf, std::optional<sys_net_sockaddr> opt_sn_addr, bool is_lock = true) override;
 	std::optional<s32> sendmsg(s32 flags, const sys_net_msghdr& msg, bool is_lock = true) override;
 
-	s32 poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
+	void poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
 	std::tuple<bool, bool, bool> select(bs_t<poll_t> selected, pollfd& native_pfd) override;
 
 	bool is_socket_connected();

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
@@ -364,7 +364,7 @@ s32 lv2_socket_p2p::shutdown([[maybe_unused]] s32 how)
 	return CELL_OK;
 }
 
-s32 lv2_socket_p2p::poll(sys_net_pollfd& sn_pfd, [[maybe_unused]] pollfd& native_pfd)
+void lv2_socket_p2p::poll(sys_net_pollfd& sn_pfd, [[maybe_unused]] pollfd& native_pfd)
 {
 	std::lock_guard lock(mutex);
 	ensure(vport);
@@ -381,8 +381,6 @@ s32 lv2_socket_p2p::poll(sys_net_pollfd& sn_pfd, [[maybe_unused]] pollfd& native
 	{
 		sn_pfd.revents |= SYS_NET_POLLOUT;
 	}
-
-	return sn_pfd.revents ? 1 : 0;
 }
 
 std::tuple<bool, bool, bool> lv2_socket_p2p::select(bs_t<lv2_socket::poll_t> selected, [[maybe_unused]] pollfd& native_pfd)

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.h
@@ -30,7 +30,7 @@ public:
 	void close() override;
 	s32 shutdown(s32 how) override;
 
-	s32 poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
+	void poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
 	std::tuple<bool, bool, bool> select(bs_t<poll_t> selected, pollfd& native_pfd) override;
 
 	void handle_new_data(sys_net_sockaddr_in_p2p p2p_addr, std::vector<u8> p2p_data);

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.cpp
@@ -985,7 +985,7 @@ s32 lv2_socket_p2ps::shutdown([[maybe_unused]] s32 how)
 	return CELL_OK;
 }
 
-s32 lv2_socket_p2ps::poll(sys_net_pollfd& sn_pfd, [[maybe_unused]] pollfd& native_pfd)
+void lv2_socket_p2ps::poll(sys_net_pollfd& sn_pfd, [[maybe_unused]] pollfd& native_pfd)
 {
 	std::lock_guard lock(mutex);
 	sys_net.trace("[P2PS] poll checking for 0x%X", sn_pfd.events);
@@ -1002,14 +1002,7 @@ s32 lv2_socket_p2ps::poll(sys_net_pollfd& sn_pfd, [[maybe_unused]] pollfd& nativ
 		{
 			sn_pfd.revents |= SYS_NET_POLLOUT;
 		}
-
-		if (sn_pfd.revents)
-		{
-			return 1;
-		}
 	}
-
-	return 0;
 }
 
 std::tuple<bool, bool, bool> lv2_socket_p2ps::select(bs_t<lv2_socket::poll_t> selected, [[maybe_unused]] pollfd& native_pfd)

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2ps.h
@@ -89,7 +89,7 @@ public:
 	void close() override;
 	s32 shutdown(s32 how) override;
 
-	s32 poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
+	void poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
 	std::tuple<bool, bool, bool> select(bs_t<poll_t> selected, pollfd& native_pfd) override;
 
 private:

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.cpp
@@ -134,10 +134,9 @@ s32 lv2_socket_raw::shutdown([[maybe_unused]] s32 how)
 	return {};
 }
 
-s32 lv2_socket_raw::poll([[maybe_unused]] sys_net_pollfd& sn_pfd, [[maybe_unused]] pollfd& native_pfd)
+void lv2_socket_raw::poll([[maybe_unused]] sys_net_pollfd& sn_pfd, [[maybe_unused]] pollfd& native_pfd)
 {
 	LOG_ONCE(raw_poll, "lv2_socket_raw::poll");
-	return {};
 }
 
 std::tuple<bool, bool, bool> lv2_socket_raw::select([[maybe_unused]] bs_t<lv2_socket::poll_t> selected, [[maybe_unused]] pollfd& native_pfd)

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_raw.h
@@ -32,6 +32,6 @@ public:
 	void close() override;
 	s32 shutdown(s32 how) override;
 
-	s32 poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
+	void poll(sys_net_pollfd& sn_pfd, pollfd& native_pfd) override;
 	std::tuple<bool, bool, bool> select(bs_t<poll_t> selected, pollfd& native_pfd) override;
 };

--- a/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ppu_thread.cpp
@@ -305,6 +305,7 @@ error_code sys_ppu_thread_detach(ppu_thread& ppu, u32 thread_id)
 		{
 			// Join and notify thread (it is detached from IDM now so it must be done explicitly now)
 			*ptr = thread_state::finished;
+			return CELL_OK;
 		}
 
 		return result;

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -899,7 +899,7 @@ error_code _sys_prx_register_library(ppu_thread& ppu, vm::ptr<void> library)
 			{
 				for (u32 lib_addr = prx.exports_start, index = 0; lib_addr < prx.exports_end; index++, lib_addr += vm::read8(lib_addr) ? vm::read8(lib_addr) : sizeof_lib)
 				{
-					if (std::memcpy(vm::base(lib_addr), mem_copy.data(), sizeof_lib) == 0)
+					if (std::memcmp(vm::base(lib_addr), mem_copy.data(), sizeof_lib) == 0)
 					{
 						atomic_storage<char>::release(prx.m_external_loaded_flags[index], true);
 						return true;

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -24,7 +24,7 @@ struct lv2_update_manager
 
 		// For example, 4.90 should be converted to 0x4900000000000
 		std::erase(version_str, '.');
-		if (std::from_chars(version_str.data(), version_str.data() + version_str.size(), system_sw_version, 16).ec != std::errc{})
+		if (std::from_chars(version_str.data(), version_str.data() + version_str.size(), system_sw_version, 16).ec == std::errc{})
 			system_sw_version <<= 40;
 		else
 			system_sw_version = 0;
@@ -79,6 +79,7 @@ struct lv2_update_manager
 
 		if (malloc_set.count(addr))
 		{
+			malloc_set.erase(addr);
 			return vm::dealloc(addr, vm::main);
 		}
 

--- a/rpcs3/Emu/Cell/lv2/sys_uart.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_uart.cpp
@@ -1531,9 +1531,11 @@ private:
 			}
 		}();
 
+		if (sce_idx == umax)
+			return PS3AV_STATUS_INVALID_VIDEO_PARAM;
+
 		const video_sce_param &sce_param = sce_param_arr[sce_idx];
-		if (sce_idx == umax ||
-			video_head_cfg.video_head > PS3AV_HEAD_B_ANALOG ||
+		if (video_head_cfg.video_head > PS3AV_HEAD_B_ANALOG ||
 			video_head_cfg.video_order > 1 ||
 			video_head_cfg.video_format > 16 ||
 			video_head_cfg.video_out_format > 16 ||

--- a/rpcs3/Emu/Cell/lv2/sys_vm.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_vm.cpp
@@ -97,7 +97,7 @@ error_code sys_vm_memory_map(ppu_thread& ppu, u64 vsize, u64 psize, u32 cid, u64
 	// Look for unmapped space
 	if (const auto area = vm::find_map(0x10000000, 0x10000000, 2 | (flag & SYS_MEMORY_PAGE_SIZE_MASK)))
 	{
-		sys_vm.warning("sys_vm_memory_map(): Found VM 0x%x area (vsize=0x%x)", addr, vsize);
+		sys_vm.warning("sys_vm_memory_map(): Found VM 0x%x area (vsize=0x%x)", area->addr, vsize);
 
 		// Alloc all memory (shall not fail)
 		ensure(area->alloc(static_cast<u32>(vsize)));


### PR DESCRIPTION
Chonkiest one:
sys_ppu_thread_detach was returning CELL_EAGAIN on detaching a zombie thread, changed to CELL_OK.

Chonky ones:
sys_usbd: sys_usbd_get_device_list was corrupting the device list + wrong mutex was used in sys_usbd_receive_event
sys_fs: op_read shortcut was incorrect and always false. I fixed it, removed the region >= 0xC. Isn't region 0 the only one that is guaranteed to be allocated(ie the low 256mb)? + data emplaced using a reference to one of its objects.
sys_mmapper: sys_mmapper_free_address didn't clean the port
sys_net: poll was increasing signaled twice for p2p and dns packets. + select was setting readFds or writeFds incorrectly, now it respects the parameters

Misc ones:
sys_config: Added a mutex to protect service_events and replaced a potential dead reference with id(since the reference was only used to get the id)
sys_event: in sys_event_queue_destroy, early eagain exit before calling lv2_obj::on_id_destroy(queue, queue.key);
sys_ss: condition for transforming the sdk string to a u64 was inverted, it always returned 0 + deallocate didn't clear malloc_set
sys_dbg: minor logical optimization in sys_dbg_write_process_memory
sys_rsxaudio: the setting/status were static so they survived multiple launches + minor boundary fixes

