### PR TITLE
Improve vertex cache compatiblity

### DIFF
--- a/rpcs3/Emu/RSX/rsx_cache.h
+++ b/rpcs3/Emu/RSX/rsx_cache.h
@@ -7,6 +7,7 @@
 #include "Common/unordered_map.hpp"
 #include "Emu/System.h"
 #include "Emu/cache_utils.hpp"
+#include "Emu/Memory/vm.h"
 #include "Emu/RSX/Program/RSXVertexProgram.h"
 #include "Emu/RSX/Program/RSXFragmentProgram.h"
 #include "Overlays/Shaders/shader_loading_dialog.h"
@@ -478,6 +479,7 @@ namespace rsx
 			uptr local_address;
 			u32 offset_in_heap;
 			u32 data_length;
+			u64 fingerprint;
 		};
 
 		// A weak vertex cache with no data checks or memory range locks
@@ -502,11 +504,19 @@ namespace rsx
 			{
 				const auto key = hash(local_addr, data_length);
 				const auto found = vertex_ranges.find(key);
+
 				if (found == vertex_ranges.end())
 				{
 					return nullptr;
 				}
 
+				// Check if data in local_address changed vs what was stored in the vertex_cache
+				if (auto sudo_ptr = vm::get_super_ptr<char>(local_addr);
+					data_length >= 8 && found->second.fingerprint != *utils::bless<u64>(sudo_ptr))
+				{
+					vertex_ranges.erase(key);
+					return nullptr;
+				}
 				return std::addressof(found->second);
 			}
 
@@ -516,7 +526,15 @@ namespace rsx
 				v.data_length = data_length;
 				v.local_address = local_addr;
 				v.offset_in_heap = offset_in_heap;
+				v.fingerprint = 0;
 
+				if (data_length >= 8)
+				{
+					// Uses get_super_ptr to access vm memory safely
+					// and bless to avoid endian conversion and circumvent compiler strict aliasing rules.
+					auto sudo_ptr = vm::get_super_ptr<char>(local_addr);
+					v.fingerprint = *utils::bless<u64>(sudo_ptr);
+				}
 				const auto key = hash(local_addr, data_length);
 				vertex_ranges[key] = v;
 			}


### PR DESCRIPTION
Solves intermediate texture render problems on BLJM60292, BLJM60414 due to vertex data being reused incorrectly, using just the first 64bit of the vertex data fixes the bug, reuses the internal FNV hashing function