### PR TITLE
P2P: Allow broadcast socket

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket.h
@@ -138,6 +138,8 @@ protected:
 	// Socket options value keepers
 	// Non-blocking IO option
 	s32 so_nbio = 0;
+	// Broadcast option
+	s32 so_broadcast = 0;
 	// Error, only used for connection result for non blocking stream sockets
 	s32 so_error = 0;
 	// Unsupported option

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
@@ -288,6 +288,12 @@ std::optional<s32> lv2_socket_p2p::sendto(s32 flags, const std::vector<u8>& buf,
 	inet_ntop(AF_INET, &native_addr.sin_addr, ip_str, sizeof(ip_str));
 	sys_net.trace("[P2P] Sending a packet to %s:%d:%d", ip_str, p2p_port, p2p_vport);
 
+	if (native_addr.sin_addr.s_addr == 0xFFFFFFFF && !so_broadcast)
+	{
+		sys_net.error("[P2P] Tried to send to broadcast address without SO_BROADCAST");
+		return {-SYS_NET_EACCES};
+	}
+
 	std::vector<u8> p2p_data(buf.size() + VPORT_P2P_HEADER_SIZE);
 	const le_t<u16> p2p_vport_le = p2p_vport;
 	const le_t<u16> src_vport_le = vport;

--- a/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/lv2_socket_p2p.cpp
@@ -219,6 +219,10 @@ s32 lv2_socket_p2p::setsockopt(s32 level, s32 optname, const std::vector<u8>& op
 	{
 		so_nbio = native_int;
 	}
+	else if (level == SYS_NET_SOL_SOCKET && optname == SYS_NET_SO_BROADCAST)
+	{
+		so_broadcast = native_int;
+	}
 
 	const u64 key = (static_cast<u64>(level) << 32) | static_cast<u64>(optname);
 	sockopt_cache cache{};

--- a/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_net/nt_p2p_port.cpp
@@ -58,6 +58,10 @@ nt_p2p_port::nt_p2p_port(u16 port)
 	if (setsockopt(p2p_socket, SOL_SOCKET, SO_RCVBUF, reinterpret_cast<const char*>(&optval), sizeof(optval)) != 0)
 		fmt::throw_exception("Error setsockopt SO_RCVBUF on P2P socket: %s", get_last_error(true));
 
+	optval = 1;
+	if (setsockopt(p2p_socket, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<const char*>(&optval), sizeof(optval)) != 0)
+		fmt::throw_exception("Error setsockopt SO_BROADCAST on P2P socket: %s", get_last_error(true));
+
 	int ret_bind = 0;
 	const u16 be_port = std::bit_cast<u16, be_t<u16>>(port);
 	auto& nph = g_fxo->get<named_thread<np::np_handler>>();


### PR DESCRIPTION
If a game tries to create a broadcast socket in P2P it will fail, logging `sys_net: Socket error EACCES`

This fix allows the native socket to have the option broadcast enabled.