### PR TITLE
Qt: Do not check return code of rpcs3 download

### DIFF
--- a/rpcs3/rpcs3qt/downloader.cpp
+++ b/rpcs3/rpcs3qt/downloader.cpp
@@ -34,7 +34,7 @@ downloader::~downloader()
 	}
 }
 
-void downloader::start(const std::string& url, bool follow_location, bool show_progress_dialog, const QString& progress_dialog_title, bool keep_progress_dialog_open, int expected_size, bool check_return_code, bool again)
+void downloader::start(const std::string& url, bool follow_location, bool show_progress_dialog, bool check_return_code, const QString& progress_dialog_title, bool keep_progress_dialog_open, int expected_size, bool again)
 {
 	network_log.notice("Starting download from URL: %s", url);
 
@@ -121,7 +121,7 @@ void downloader::start(const std::string& url, bool follow_location, bool show_p
 				{
 					network_log.error("Error during download. Trying to download again (attempts=%d, return_code=%d)", m_download_attempts, return_code);
 					std::this_thread::sleep_for(500ms); // Wait for a little while
-					start(url, follow_location, show_progress_dialog, progress_dialog_title, keep_progress_dialog_open, expected_size, check_return_code, true);
+					start(url, follow_location, show_progress_dialog, check_return_code, progress_dialog_title, keep_progress_dialog_open, expected_size, true);
 					return;
 				}
 			}

--- a/rpcs3/rpcs3qt/downloader.h
+++ b/rpcs3/rpcs3qt/downloader.h
@@ -21,7 +21,7 @@ public:
 	explicit downloader(QWidget* parent = nullptr);
 	~downloader();
 
-	void start(const std::string& url, bool follow_location, bool show_progress_dialog, const QString& progress_dialog_title = "", bool keep_progress_dialog_open = false, int expected_size = -1, bool check_return_code = true, bool again = false);
+	void start(const std::string& url, bool follow_location, bool show_progress_dialog, bool check_return_code, const QString& progress_dialog_title = "", bool keep_progress_dialog_open = false, int expected_size = -1, bool again = false);
 	usz update_buffer(char* data, usz size);
 
 	void update_progress_dialog(const QString& title) const;

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -36,7 +36,7 @@ void game_compatibility::handle_download_finished(const QByteArray& content)
 	compat_log.notice("Database download finished");
 
 	// Create new map from database and write database to file if database was valid
-	if (ReadJSON(QJsonDocument::fromJson(content).object(), true))
+	if (handle_json(content, true))
 	{
 		// Write database to file
 		QFile file(m_filepath);
@@ -67,8 +67,9 @@ void game_compatibility::handle_download_canceled()
 	Q_EMIT DownloadCanceled();
 }
 
-bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_download)
+bool game_compatibility::handle_json(const QByteArray& data, bool after_download)
 {
+	const QJsonObject json_data = QJsonDocument::fromJson(data).object();
 	const int return_code = json_data["return_code"].toInt(-255);
 
 	if (return_code < 0)
@@ -101,7 +102,7 @@ bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_downl
 
 	m_compat_database.clear();
 
-	QJsonObject json_results = json_data["results"].toObject();
+	const QJsonObject json_results = json_data["results"].toObject();
 
 	// Retrieve status data for every valid entry
 	for (const auto& key : json_results.keys())
@@ -112,7 +113,7 @@ bool game_compatibility::ReadJSON(const QJsonObject& json_data, bool after_downl
 			continue;
 		}
 
-		QJsonObject json_result = json_results[key].toObject();
+		const QJsonObject json_result = json_results[key].toObject();
 
 		// Retrieve compatibility information from json
 		compat::status status = ::at32(Status_Data, json_result.value("status").toString("NoResult"));
@@ -210,15 +211,14 @@ void game_compatibility::RequestCompatibility(bool online)
 		compat_log.notice("Finished reading database from file: %s", m_filepath);
 
 		// Create new map from database
-		ReadJSON(QJsonDocument::fromJson(content).object(), online);
-
+		handle_json(content, online);
 		return;
 	}
 
 	const std::string url = "https://rpcs3.net/compatibility?api=v1&export";
 	compat_log.notice("Beginning compatibility database download from: %s", url);
 
-	m_downloader->start(url, true, true, tr("Downloading Database"));
+	m_downloader->start(url, true, true, true, tr("Downloading Database"));
 
 	// We want to retrieve a new database, therefore refresh gamelist and indicate that
 	Q_EMIT DownloadStarted();

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -138,7 +138,7 @@ private:
 	std::map<std::string, compat::status> m_compat_database;
 
 	/** Creates new map from the database */
-	bool ReadJSON(const QJsonObject& json_data, bool after_download);
+	bool handle_json(const QByteArray& data, bool after_download);
 
 public:
 	/** Handles reads, writes and downloads for the compatibility database */

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -1163,7 +1163,7 @@ void patch_manager_dialog::download_update(bool automatic, bool auto_accept)
 		}
 	}
 
-	m_downloader->start(url, true, !m_download_automatic, tr("Downloading latest patches"));
+	m_downloader->start(url, true, !m_download_automatic, true, tr("Downloading latest patches"));
 }
 
 bool patch_manager_dialog::handle_json(const QByteArray& data)

--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -110,7 +110,7 @@ void update_manager::check_for_updates(bool automatic, bool check_only, bool aut
 	const std::string url = fmt::format("https://update.rpcs3.net/?api=v3&c=%s&os_type=%s&os_arch=%s&os_version=%i.%i.%i",
 		rpcs3::get_commit_and_hash().second, os.type, os.arch, os.version_major, os.version_minor, os.version_patch);
 
-	m_downloader->start(url, true, !automatic, tr("Checking For Updates"), true);
+	m_downloader->start(url, true, !automatic, true, tr("Checking For Updates"), true);
 }
 
 bool update_manager::handle_json(bool automatic, bool check_only, bool auto_accept, const QByteArray& data)
@@ -440,7 +440,7 @@ void update_manager::update(bool auto_accept)
 	});
 
 	update_log.notice("Downloading update...");
-	m_downloader->start(m_request_url, true, true, tr("Downloading Update"), true, m_expected_size);
+	m_downloader->start(m_request_url, true, true, false, tr("Downloading Update"), true, m_expected_size);
 }
 
 bool update_manager::handle_rpcs3(const QByteArray& data, bool auto_accept)


### PR DESCRIPTION
I accidentally also checked the json return code when downloading the rpcs3 file (thanks to the argument default value).

- Make check_return_code argument mandatory
- Don't check return code in rpcs3 download (it's not a json)
- Clean up some random code