### PR TITLE
overlays: play SND0.AT3 audio file while game is loading

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -500,6 +500,7 @@ target_sources(rpcs3_emu PRIVATE
     RSX/Overlays/overlays.cpp
     RSX/Overlays/overlay_animated_icon.cpp
     RSX/Overlays/overlay_animation.cpp
+    RSX/Overlays/overlay_audio.cpp
     RSX/Overlays/overlay_compile_notification.cpp
     RSX/Overlays/overlay_controls.cpp
     RSX/Overlays/overlay_cursor.cpp

--- a/rpcs3/Emu/RSX/Overlays/overlay_audio.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_audio.cpp
@@ -1,0 +1,30 @@
+#include "stdafx.h"
+#include "overlay_audio.h"
+#include "Emu/System.h"
+
+namespace rsx
+{
+	namespace overlays
+	{
+		audio_player::audio_player(const std::string& audio_path)
+		{
+			init_audio(audio_path);
+		}
+
+		void audio_player::init_audio(const std::string& audio_path)
+		{
+			if (audio_path.empty()) return;
+
+			m_video_source = ensure(Emu.GetCallbacks().make_video_source());
+			m_video_source->set_audio_path(audio_path);
+		}
+
+		void audio_player::set_active(bool active)
+		{
+			if (m_video_source)
+			{
+				m_video_source->set_active(active);
+			}
+		}
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_audio.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_audio.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "util/video_source.h"
+
+namespace rsx
+{
+	namespace overlays
+	{
+		class audio_player
+		{
+		public:
+			audio_player(const std::string& audio_path);
+			~audio_player() = default;
+
+			void set_active(bool active);
+
+		private:
+			void init_audio(const std::string& audio_path);
+
+			std::unique_ptr<video_source> m_video_source;
+		};
+	}
+}

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -167,6 +167,23 @@ namespace rsx
 			}
 		}
 
+		void display_manager::start_audio(const std::string& audio_path)
+		{
+			if (audio_path.empty())
+			{
+				m_audio_player.reset();
+				return;
+			}
+
+			m_audio_player = std::make_unique<audio_player>(audio_path);
+			m_audio_player->set_active(true);
+		}
+
+		void display_manager::stop_audio()
+		{
+			m_audio_player.reset();
+		}
+
 		void display_manager::on_overlay_activated(const std::shared_ptr<overlay>& /*item*/)
 		{
 			// TODO: Internal management, callbacks, etc

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "overlays.h"
+#include "overlay_audio.h"
 
 #include "Emu/IdManager.h"
 #include "Utilities/mutex.h"
@@ -24,6 +25,8 @@ namespace rsx
 			lf_queue<u32> m_uids_to_remove;
 			lf_queue<u32> m_type_ids_to_remove;
 			atomic_t<u32> m_pending_removals_count = 0;
+
+			std::unique_ptr<audio_player> m_audio_player;
 
 			bool remove_type(u32 type_id);
 
@@ -166,6 +169,9 @@ namespace rsx
 				std::function<void()> on_input_loop_enter = nullptr,     // [optional] What to do before running the input routine
 				std::function<void(s32)> on_input_loop_exit = nullptr,   // [optional] What to do with the result if any
 				std::function<s32()> input_loop_override = nullptr);     // [optional] What to do during the input loop. By default calls user_interface::run_input_loop
+
+			void start_audio(const std::string& audio_path);
+			void stop_audio();
 
 		private:
 			struct overlay_input_thread

--- a/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_save_dialog.cpp
@@ -9,10 +9,11 @@ namespace rsx
 	{
 		save_dialog::save_dialog_entry::save_dialog_entry(const std::string& text1, const std::string& text2, const std::string& text3, u8 resource_id, const std::vector<u8>& icon_buf, const std::string& video_path)
 		{
+			const std::string audio_path; // no audio here
 			std::unique_ptr<overlay_element> image = resource_id != image_resource_id::raw_image
-				? std::make_unique<video_view>(video_path, resource_id)
-				: !icon_buf.empty() ? std::make_unique<video_view>(video_path, icon_buf)
-				                    : std::make_unique<video_view>(video_path, resource_config::standard_image_resource::save); // Fallback
+				? std::make_unique<video_view>(video_path, audio_path, resource_id)
+				: !icon_buf.empty() ? std::make_unique<video_view>(video_path, audio_path, icon_buf)
+				                    : std::make_unique<video_view>(video_path, audio_path, resource_config::standard_image_resource::save); // Fallback
 			image->set_size(160, 110);
 			image->set_padding(36, 36, 11, 11); // Square image, 88x88
 

--- a/rpcs3/Emu/RSX/Overlays/overlay_video.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_video.cpp
@@ -6,9 +6,9 @@ namespace rsx
 {
 	namespace overlays
 	{
-		video_view::video_view(const std::string& video_path, const std::string& thumbnail_path)
+		video_view::video_view(const std::string& video_path, const std::string& audio_path, const std::string& thumbnail_path)
 		{
-			init_video(video_path);
+			init_video(video_path, audio_path);
 
 			if (!thumbnail_path.empty())
 			{
@@ -17,9 +17,9 @@ namespace rsx
 			}
 		}
 
-		video_view::video_view(const std::string& video_path, const std::vector<u8>& thumbnail_buf)
+		video_view::video_view(const std::string& video_path, const std::string& audio_path, const std::vector<u8>& thumbnail_buf)
 		{
-			init_video(video_path);
+			init_video(video_path, audio_path);
 
 			if (!thumbnail_buf.empty())
 			{
@@ -28,10 +28,10 @@ namespace rsx
 			}
 		}
 
-		video_view::video_view(const std::string& video_path, u8 thumbnail_id)
+		video_view::video_view(const std::string& video_path, const std::string& audio_path, u8 thumbnail_id)
 			: m_thumbnail_id(thumbnail_id)
 		{
-			init_video(video_path);
+			init_video(video_path, audio_path);
 			set_image_resource(thumbnail_id);
 		}
 
@@ -39,13 +39,11 @@ namespace rsx
 		{
 		}
 
-		void video_view::init_video(const std::string& video_path)
+		void video_view::init_video(const std::string& video_path, const std::string& audio_path)
 		{
 			if (video_path.empty()) return;
 
-			m_video_source = Emu.GetCallbacks().make_video_source();
-			ensure(!!m_video_source);
-
+			m_video_source = ensure(Emu.GetCallbacks().make_video_source());
 			m_video_source->set_update_callback([this]()
 			{
 				if (m_video_active)
@@ -54,6 +52,7 @@ namespace rsx
 				}
 			});
 			m_video_source->set_video_path(video_path);
+			m_video_source->set_audio_path(audio_path);
 		}
 
 		void video_view::set_active(bool active)

--- a/rpcs3/Emu/RSX/Overlays/overlay_video.h
+++ b/rpcs3/Emu/RSX/Overlays/overlay_video.h
@@ -19,9 +19,9 @@ namespace rsx
 		class video_view final : public image_view
 		{
 		public:
-			video_view(const std::string& video_path, const std::string& thumbnail_path);
-			video_view(const std::string& video_path, const std::vector<u8>& thumbnail_buf);
-			video_view(const std::string& video_path, u8 thumbnail_id);
+			video_view(const std::string& video_path, const std::string& audio_path, const std::string& thumbnail_path);
+			video_view(const std::string& video_path, const std::string& audio_path, const std::vector<u8>& thumbnail_buf);
+			video_view(const std::string& video_path, const std::string& audio_path, u8 thumbnail_id);
 			virtual ~video_view();
 
 			void set_active(bool active);
@@ -30,7 +30,7 @@ namespace rsx
 			compiled_resource& get_compiled() override;
 
 		private:
-			void init_video(const std::string& video_path);
+			void init_video(const std::string& video_path, const std::string& audio_path);
 
 			usz m_buffer_index = 0;
 			std::array<std::unique_ptr<video_info>, 2> m_video_info; // double buffer

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -711,6 +711,11 @@ namespace rsx
 		if (g_cfg.misc.use_native_interface && (g_cfg.video.renderer == video_renderer::opengl || g_cfg.video.renderer == video_renderer::vulkan))
 		{
 			m_overlay_manager = g_fxo->init<rsx::overlays::display_manager>(0);
+
+			if (const std::string audio_path = Emu.GetSfoDir(true) + "/SND0.AT3"; fs::is_file(audio_path))
+			{
+				m_overlay_manager->start_audio(audio_path);
+			}
 		}
 
 		if (!_ar)
@@ -1099,6 +1104,11 @@ namespace rsx
 		if (g_cfg.core.thread_scheduler != thread_scheduler_mode::os)
 		{
 			thread_ctrl::set_thread_affinity_mask(thread_ctrl::get_affinity_mask(thread_class::rsx));
+		}
+
+		if (auto manager = g_fxo->try_get<rsx::overlays::display_manager>())
+		{
+			manager->stop_audio();
 		}
 
 		while (!test_stopped())

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="Emu\RSX\Overlays\Network\overlay_recvmessage_dialog.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\Network\overlay_sendmessage_dialog.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_animated_icon.cpp" />
+    <ClCompile Include="Emu\RSX\Overlays\overlay_audio.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_controls.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_cursor.cpp" />
     <ClCompile Include="Emu\RSX\Overlays\overlay_debug_overlay.cpp" />
@@ -704,6 +705,7 @@
     <ClInclude Include="Emu\RSX\Overlays\Network\overlay_recvmessage_dialog.h" />
     <ClInclude Include="Emu\RSX\Overlays\Network\overlay_sendmessage_dialog.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_animated_icon.h" />
+    <ClInclude Include="Emu\RSX\Overlays\overlay_audio.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_cursor.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_debug_overlay.h" />
     <ClInclude Include="Emu\RSX\Overlays\overlay_edit_text.hpp" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1411,6 +1411,9 @@
     <ClCompile Include="Loader\ISO.cpp">
       <Filter>Loader</Filter>
     </ClCompile>
+    <ClCompile Include="Emu\RSX\Overlays\overlay_audio.cpp">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Crypto\aes.h">
@@ -2832,6 +2835,9 @@
     </ClInclude>
     <ClInclude Include="Loader\ISO.h">
       <Filter>Loader</Filter>
+    </ClInclude>
+    <ClInclude Include="Emu\RSX\Overlays\overlay_audio.h">
+      <Filter>Emu\GPU\RSX\Overlays</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/qt_video_source.cpp
+++ b/rpcs3/rpcs3qt/qt_video_source.cpp
@@ -335,7 +335,11 @@ void qt_video_source_wrapper::set_video_path(const std::string& video_path)
 {
 	Emu.CallFromMainThread([this, path = video_path]()
 	{
-		m_qt_video_source = std::make_unique<qt_video_source>();
+		if (!m_qt_video_source)
+		{
+			m_qt_video_source = std::make_unique<qt_video_source>();
+		}
+
 		m_qt_video_source->m_image_change_callback = [this](const QVideoFrame& frame)
 		{
 			std::unique_lock lock(m_qt_video_source->m_image_mutex);
@@ -371,7 +375,12 @@ void qt_video_source_wrapper::set_audio_path(const std::string& audio_path)
 {
 	Emu.CallFromMainThread([this, path = audio_path]()
 	{
-		// TODO
+		if (!m_qt_video_source)
+		{
+			m_qt_video_source = std::make_unique<qt_video_source>();
+		}
+
+		m_qt_video_source->set_audio_path(path);
 	});
 }
 
@@ -379,6 +388,7 @@ void qt_video_source_wrapper::set_active(bool active)
 {
 	Emu.CallFromMainThread([this, active]()
 	{
+		ensure(m_qt_video_source);
 		m_qt_video_source->set_active(true);
 	});
 }


### PR DESCRIPTION
- Plays the game's SND0.AT3 audio file while the game is loading if available
- Additionally added support for audio in video_view elements (currently only used for savegame videos, so no audio there anyway)

fixes #18314