### PR TITLE
VK: scale auto shader compiler workers on wide CPUs

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
@@ -220,9 +220,20 @@ namespace vk
 	{
 		if (num_worker_threads == 0)
 		{
-			// Select optimal number of compiler threads
+			// Select a conservative but modern default for async pipeline compilation.
+			// Older heuristics topped out too early on high-core CPUs and left large
+			// shader bursts queued longer than necessary.
 			const auto hw_threads = utils::get_thread_count();
-			if (hw_threads > 12)
+
+			if (hw_threads >= 24)
+			{
+				num_worker_threads = 12;
+			}
+			else if (hw_threads >= 16)
+			{
+				num_worker_threads = 8;
+			}
+			else if (hw_threads > 12)
 			{
 				num_worker_threads = 6;
 			}
@@ -238,6 +249,9 @@ namespace vk
 			{
 				num_worker_threads = 1;
 			}
+
+			rsx_log.notice("Async pipeline compiler auto-selected %d worker(s) for %u host thread(s).",
+				num_worker_threads, hw_threads);
 		}
 
 		ensure(num_worker_threads >= 1);


### PR DESCRIPTION
## Summary
- modernize the Vulkan async pipeline compiler auto-thread heuristic for wide CPUs
- log the selected worker count when auto mode is used

## Why
The previous Vulkan auto mode topped out at 6 shader compiler workers for any host above 12 threads. That was conservative for older systems, but it underutilizes modern high-core CPUs and can leave larger shader bursts queued longer than necessary.

This keeps manual configuration intact while improving the default behavior for users who leave `Shader Compiler Threads` on auto.

## New auto heuristic
- 24+ host threads -> 12 workers
- 16-23 host threads -> 8 workers
- 13-15 host threads -> 6 workers
- 9-12 host threads -> 4 workers
- 8 host threads -> 2 workers
- otherwise -> 1 worker

## Validation
- built successfully in the active Windows test tree
- `rpcs3_test.exe` passes in that tree
- verified in a local MGS4 Vulkan run on a Ryzen 9 9950X host
- runtime log confirmed: `Async pipeline compiler auto-selected 12 worker(s) for 32 host thread(s).`