### PR TITLE
input: simplify mmjoy handler

### DIFF
--- a/rpcs3/Emu/Io/PadHandler.cpp
+++ b/rpcs3/Emu/Io/PadHandler.cpp
@@ -11,17 +11,69 @@ PadHandlerBase::PadHandlerBase(pad_handler type) : m_type(type)
 {
 }
 
-std::set<u32> PadHandlerBase::narrow_set(const std::set<u64>& src)
+std::set<u32> PadHandlerBase::FindKeyCodes(const std::unordered_map<u32, std::string>& map, const cfg::string& cfg_string, bool fallback)
 {
-	if (src.empty())
-		return {};
+	std::set<u32> key_codes;
 
-	std::set<u32> dst;
-	for (const u64& s : src)
+	const std::string& def = cfg_string.def;
+	const std::vector<std::string> names = cfg_pad::get_buttons(cfg_string.to_string());
+	u32 def_code = umax;
+
+	for (const std::string& nam : names)
 	{
-		dst.insert(::narrow<u32>(s));
+		for (const auto& [code, name] : map)
+		{
+			if (name == nam)
+			{
+				key_codes.insert(code);
+			}
+
+			if (fallback && name == def)
+				def_code = code;
+		}
 	}
-	return dst;
+
+	if (!key_codes.empty())
+	{
+		return key_codes;
+	}
+
+	if (fallback)
+	{
+		if (!names.empty())
+			input_log.error("FindKeyCode for [name = %s] returned with [def_code = %d] for [def = %s]", cfg_string.to_string(), def_code, def);
+
+		if (def_code != umax)
+		{
+			return { def_code };
+		}
+	}
+
+	return {};
+}
+
+std::set<u32> PadHandlerBase::FindKeyCodes(const std::unordered_map<u32, std::string>& map, const std::vector<std::string>& names)
+{
+	std::set<u32> key_codes;
+
+	for (const std::string& name : names)
+	{
+		for (const auto& [code, nam] : map)
+		{
+			if (nam == name)
+			{
+				key_codes.insert(code);
+				break;
+			}
+		}
+	}
+
+	if (!key_codes.empty())
+	{
+		return key_codes;
+	}
+
+	return {};
 }
 
 s32 PadHandlerBase::MultipliedInput(s32 raw_value, s32 multiplier)
@@ -396,7 +448,7 @@ void PadHandlerBase::convert_stick_values(u16& x_out, u16& y_out, s32 x_in, s32 
 }
 
 // Update the pad button values based on their type and thresholds. With this you can use axis or triggers as buttons or vice versa
-void PadHandlerBase::TranslateButtonPress(const std::shared_ptr<PadDevice>& device, u64 keyCode, bool& pressed, u16& val, bool use_stick_multipliers, bool ignore_stick_threshold, bool ignore_trigger_threshold)
+void PadHandlerBase::TranslateButtonPress(const std::shared_ptr<PadDevice>& device, u32 keyCode, bool& pressed, u16& val, bool use_stick_multipliers, bool ignore_stick_threshold, bool ignore_trigger_threshold)
 {
 	if (!device || !device->config)
 	{
@@ -556,63 +608,52 @@ std::array<std::set<u32>, PadHandlerBase::button::button_count> PadHandlerBase::
 	if (!device || !cfg)
 		return mapping;
 
-	device->trigger_code_left  = FindKeyCodes<u32, u64>(button_list, cfg->l2);
-	device->trigger_code_right = FindKeyCodes<u32, u64>(button_list, cfg->r2);
-	device->axis_code_left[0]  = FindKeyCodes<u32, u64>(button_list, cfg->ls_left);
-	device->axis_code_left[1]  = FindKeyCodes<u32, u64>(button_list, cfg->ls_right);
-	device->axis_code_left[2]  = FindKeyCodes<u32, u64>(button_list, cfg->ls_down);
-	device->axis_code_left[3]  = FindKeyCodes<u32, u64>(button_list, cfg->ls_up);
-	device->axis_code_right[0] = FindKeyCodes<u32, u64>(button_list, cfg->rs_left);
-	device->axis_code_right[1] = FindKeyCodes<u32, u64>(button_list, cfg->rs_right);
-	device->axis_code_right[2] = FindKeyCodes<u32, u64>(button_list, cfg->rs_down);
-	device->axis_code_right[3] = FindKeyCodes<u32, u64>(button_list, cfg->rs_up);
+	mapping[button::up]       = FindKeyCodes(button_list, cfg->up);
+	mapping[button::down]     = FindKeyCodes(button_list, cfg->down);
+	mapping[button::left]     = FindKeyCodes(button_list, cfg->left);
+	mapping[button::right]    = FindKeyCodes(button_list, cfg->right);
+	mapping[button::cross]    = FindKeyCodes(button_list, cfg->cross);
+	mapping[button::square]   = FindKeyCodes(button_list, cfg->square);
+	mapping[button::circle]   = FindKeyCodes(button_list, cfg->circle);
+	mapping[button::triangle] = FindKeyCodes(button_list, cfg->triangle);
+	mapping[button::start]    = FindKeyCodes(button_list, cfg->start);
+	mapping[button::select]   = FindKeyCodes(button_list, cfg->select);
+	mapping[button::l1]       = FindKeyCodes(button_list, cfg->l1);
+	mapping[button::l2]       = FindKeyCodes(button_list, cfg->l2);
+	mapping[button::l3]       = FindKeyCodes(button_list, cfg->l3);
+	mapping[button::r1]       = FindKeyCodes(button_list, cfg->r1);
+	mapping[button::r2]       = FindKeyCodes(button_list, cfg->r2);
+	mapping[button::r3]       = FindKeyCodes(button_list, cfg->r3);
+	mapping[button::ls_left]  = FindKeyCodes(button_list, cfg->ls_left);
+	mapping[button::ls_right] = FindKeyCodes(button_list, cfg->ls_right);
+	mapping[button::ls_down]  = FindKeyCodes(button_list, cfg->ls_down);
+	mapping[button::ls_up]    = FindKeyCodes(button_list, cfg->ls_up);
+	mapping[button::rs_left]  = FindKeyCodes(button_list, cfg->rs_left);
+	mapping[button::rs_right] = FindKeyCodes(button_list, cfg->rs_right);
+	mapping[button::rs_down]  = FindKeyCodes(button_list, cfg->rs_down);
+	mapping[button::rs_up]    = FindKeyCodes(button_list, cfg->rs_up);
+	mapping[button::ps]       = FindKeyCodes(button_list, cfg->ps);
 
-	mapping[button::up]       = FindKeyCodes<u32, u32>(button_list, cfg->up);
-	mapping[button::down]     = FindKeyCodes<u32, u32>(button_list, cfg->down);
-	mapping[button::left]     = FindKeyCodes<u32, u32>(button_list, cfg->left);
-	mapping[button::right]    = FindKeyCodes<u32, u32>(button_list, cfg->right);
-	mapping[button::cross]    = FindKeyCodes<u32, u32>(button_list, cfg->cross);
-	mapping[button::square]   = FindKeyCodes<u32, u32>(button_list, cfg->square);
-	mapping[button::circle]   = FindKeyCodes<u32, u32>(button_list, cfg->circle);
-	mapping[button::triangle] = FindKeyCodes<u32, u32>(button_list, cfg->triangle);
-	mapping[button::start]    = FindKeyCodes<u32, u32>(button_list, cfg->start);
-	mapping[button::select]   = FindKeyCodes<u32, u32>(button_list, cfg->select);
-	mapping[button::l1]       = FindKeyCodes<u32, u32>(button_list, cfg->l1);
-	mapping[button::l2]       = narrow_set(device->trigger_code_left);
-	mapping[button::l3]       = FindKeyCodes<u32, u32>(button_list, cfg->l3);
-	mapping[button::r1]       = FindKeyCodes<u32, u32>(button_list, cfg->r1);
-	mapping[button::r2]       = narrow_set(device->trigger_code_right);
-	mapping[button::r3]       = FindKeyCodes<u32, u32>(button_list, cfg->r3);
-	mapping[button::ls_left]  = narrow_set(device->axis_code_left[0]);
-	mapping[button::ls_right] = narrow_set(device->axis_code_left[1]);
-	mapping[button::ls_down]  = narrow_set(device->axis_code_left[2]);
-	mapping[button::ls_up]    = narrow_set(device->axis_code_left[3]);
-	mapping[button::rs_left]  = narrow_set(device->axis_code_right[0]);
-	mapping[button::rs_right] = narrow_set(device->axis_code_right[1]);
-	mapping[button::rs_down]  = narrow_set(device->axis_code_right[2]);
-	mapping[button::rs_up]    = narrow_set(device->axis_code_right[3]);
-	mapping[button::ps]       = FindKeyCodes<u32, u32>(button_list, cfg->ps);
-
-	mapping[button::skateboard_ir_nose]    = FindKeyCodes<u32, u32>(button_list, cfg->ir_nose);
-	mapping[button::skateboard_ir_tail]    = FindKeyCodes<u32, u32>(button_list, cfg->ir_tail);
-	mapping[button::skateboard_ir_left]    = FindKeyCodes<u32, u32>(button_list, cfg->ir_left);
-	mapping[button::skateboard_ir_right]   = FindKeyCodes<u32, u32>(button_list, cfg->ir_right);
-	mapping[button::skateboard_tilt_left]  = FindKeyCodes<u32, u32>(button_list, cfg->tilt_left);
-	mapping[button::skateboard_tilt_right] = FindKeyCodes<u32, u32>(button_list, cfg->tilt_right);
+	mapping[button::skateboard_ir_nose]    = FindKeyCodes(button_list, cfg->ir_nose);
+	mapping[button::skateboard_ir_tail]    = FindKeyCodes(button_list, cfg->ir_tail);
+	mapping[button::skateboard_ir_left]    = FindKeyCodes(button_list, cfg->ir_left);
+	mapping[button::skateboard_ir_right]   = FindKeyCodes(button_list, cfg->ir_right);
+	mapping[button::skateboard_tilt_left]  = FindKeyCodes(button_list, cfg->tilt_left);
+	mapping[button::skateboard_tilt_right] = FindKeyCodes(button_list, cfg->tilt_right);
 
 	if (b_has_pressure_intensity_button)
 	{
-		mapping[button::pressure_intensity_button] = FindKeyCodes<u32, u32>(button_list, cfg->pressure_intensity_button);
+		mapping[button::pressure_intensity_button] = FindKeyCodes(button_list, cfg->pressure_intensity_button);
 	}
 
 	if (b_has_analog_limiter_button)
 	{
-		mapping[button::analog_limiter_button] = FindKeyCodes<u32, u32>(button_list, cfg->analog_limiter_button);
+		mapping[button::analog_limiter_button] = FindKeyCodes(button_list, cfg->analog_limiter_button);
 	}
 
 	if (b_has_orientation)
 	{
-		mapping[button::orientation_reset_button] = FindKeyCodes<u32, u32>(button_list, cfg->orientation_reset_button);
+		mapping[button::orientation_reset_button] = FindKeyCodes(button_list, cfg->orientation_reset_button);
 	}
 
 	return mapping;

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -36,10 +36,6 @@ public:
 	u8 small_motor{0};
 	bool new_output_data{true};
 	steady_clock::time_point last_output;
-	std::set<u64> trigger_code_left{};
-	std::set<u64> trigger_code_right{};
-	std::array<std::set<u64>, 4> axis_code_left{};
-	std::array<std::set<u64>, 4> axis_code_right{};
 
 	struct color
 	{
@@ -196,76 +192,11 @@ protected:
 
 	std::shared_ptr<Pad> m_pad_for_pad_settings;
 
-	static std::set<u32> narrow_set(const std::set<u64>& src);
+	// Search an unordered map for a string value and return found keycode
+	static std::set<u32> FindKeyCodes(const std::unordered_map<u32, std::string>& map, const cfg::string& cfg_string, bool fallback = true);
 
 	// Search an unordered map for a string value and return found keycode
-	template <typename S, typename T>
-	static std::set<T> FindKeyCodes(const std::unordered_map<S, std::string>& map, const cfg::string& cfg_string, bool fallback = true)
-	{
-		std::set<T> key_codes;
-
-		const std::string& def = cfg_string.def;
-		const std::vector<std::string> names = cfg_pad::get_buttons(cfg_string.to_string());
-		T def_code = umax;
-
-		for (const std::string& nam : names)
-		{
-			for (const auto& [code, name] : map)
-			{
-				if (name == nam)
-				{
-					key_codes.insert(static_cast<T>(code));
-				}
-
-				if (fallback && name == def)
-					def_code = static_cast<T>(code);
-			}
-		}
-
-		if (!key_codes.empty())
-		{
-			return key_codes;
-		}
-
-		if (fallback)
-		{
-			if (!names.empty())
-				input_log.error("FindKeyCode for [name = %s] returned with [def_code = %d] for [def = %s]", cfg_string.to_string(), def_code, def);
-
-			if (def_code != umax)
-			{
-				return { def_code };
-			}
-		}
-
-		return {};
-	}
-
-	// Search an unordered map for a string value and return found keycode
-	template <typename S, typename T>
-	static std::set<T> FindKeyCodes(const std::unordered_map<S, std::string>& map, const std::vector<std::string>& names)
-	{
-		std::set<T> key_codes;
-
-		for (const std::string& name : names)
-		{
-			for (const auto& [code, nam] : map)
-			{
-				if (nam == name)
-				{
-					key_codes.insert(static_cast<T>(code));
-					break;
-				}
-			}
-		}
-
-		if (!key_codes.empty())
-		{
-			return key_codes;
-		}
-
-		return {};
-	}
+	static std::set<u32> FindKeyCodes(const std::unordered_map<u32, std::string>& map, const std::vector<std::string>& names);
 
 	// Get normalized trigger value based on the range defined by a threshold
 	u16 NormalizeTriggerInput(u16 value, u32 threshold) const;
@@ -375,23 +306,23 @@ public:
 
 private:
 	virtual std::shared_ptr<PadDevice> get_device(const std::string& /*device*/) { return nullptr; }
-	virtual bool get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
-	virtual bool get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
-	virtual bool get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
-	virtual bool get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
-	virtual bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u64 /*keyCode*/) { return false; }
+	virtual bool get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 /*keyCode*/) { return false; }
+	virtual bool get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 /*keyCode*/) { return false; }
+	virtual bool get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 /*keyCode*/) { return false; }
+	virtual bool get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 /*keyCode*/) { return false; }
+	virtual bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u32 /*keyCode*/) { return false; }
 	virtual PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& /*device*/) { return connection::disconnected; }
 	virtual void get_extended_info(const pad_ensemble& /*binding*/) {}
 	virtual void apply_pad_data(const pad_ensemble& /*binding*/) {}
-	virtual std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& /*device*/) { return {}; }
-	virtual pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& /*data*/) { return {}; }
+	virtual std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& /*device*/) { return {}; }
+	virtual pad_preview_values get_preview_values(const std::unordered_map<u32, u16>& /*data*/) { return {}; }
 
 	void get_orientation(const pad_ensemble& binding) const;
 
 protected:
 	virtual std::array<std::set<u32>, PadHandlerBase::button::button_count> get_mapped_key_codes(const std::shared_ptr<PadDevice>& device, const cfg_pad* cfg);
 	virtual void get_mapping(const pad_ensemble& binding);
-	void TranslateButtonPress(const std::shared_ptr<PadDevice>& device, u64 keyCode, bool& pressed, u16& val, bool use_stick_multipliers, bool ignore_stick_threshold = false, bool ignore_trigger_threshold = false);
+	void TranslateButtonPress(const std::shared_ptr<PadDevice>& device, u32 keyCode, bool& pressed, u16& val, bool use_stick_multipliers, bool ignore_stick_threshold = false, bool ignore_trigger_threshold = false);
 	void init_configs();
 	cfg_pad* get_config(const std::string& pad_id);
 

--- a/rpcs3/Input/ds3_pad_handler.cpp
+++ b/rpcs3/Input/ds3_pad_handler.cpp
@@ -348,9 +348,9 @@ ds3_pad_handler::DataStatus ds3_pad_handler::get_data(ds3_device* ds3dev)
 	return DataStatus::NoNewData;
 }
 
-std::unordered_map<u64, u16> ds3_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
+std::unordered_map<u32, u16> ds3_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
-	std::unordered_map<u64, u16> key_buf;
+	std::unordered_map<u32, u16> key_buf;
 	ds3_device* dev = static_cast<ds3_device*>(device.get());
 	if (!dev)
 		return key_buf;
@@ -397,7 +397,7 @@ std::unordered_map<u64, u16> ds3_pad_handler::get_button_values(const std::share
 	return key_buf;
 }
 
-pad_preview_values ds3_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
+pad_preview_values ds3_pad_handler::get_preview_values(const std::unordered_map<u32, u16>& data)
 {
 	return {
 		::at32(data, L2),
@@ -460,17 +460,17 @@ void ds3_pad_handler::get_extended_info(const pad_ensemble& binding)
 	set_raw_orientation(*pad);
 }
 
-bool ds3_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds3_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == DS3KeyCodes::L2;
 }
 
-bool ds3_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds3_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == DS3KeyCodes::R2;
 }
 
-bool ds3_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds3_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -484,7 +484,7 @@ bool ds3_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*devi
 	}
 }
 
-bool ds3_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds3_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{

--- a/rpcs3/Input/ds3_pad_handler.h
+++ b/rpcs3/Input/ds3_pad_handler.h
@@ -147,13 +147,13 @@ private:
 	int send_output_report(ds3_device* ds3dev) override;
 	void check_add_device(hid_device* hidDevice, hid_enumerated_device_view path, std::wstring_view serial) override;
 
-	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
-	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;
+	std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
+	pad_preview_values get_preview_values(const std::unordered_map<u32, u16>& data) override;
 };

--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -250,9 +250,9 @@ void ds4_pad_handler::SetPadData(const std::string& padId, u8 player_id, u8 larg
 	}
 }
 
-std::unordered_map<u64, u16> ds4_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
+std::unordered_map<u32, u16> ds4_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
-	std::unordered_map<u64, u16> keyBuffer;
+	std::unordered_map<u32, u16> keyBuffer;
 	DS4Device* dev = static_cast<DS4Device*>(device.get());
 	if (!dev)
 		return keyBuffer;
@@ -405,7 +405,7 @@ std::unordered_map<u64, u16> ds4_pad_handler::get_button_values(const std::share
 	return keyBuffer;
 }
 
-pad_preview_values ds4_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
+pad_preview_values ds4_pad_handler::get_preview_values(const std::unordered_map<u32, u16>& data)
 {
 	return {
 		::at32(data, L2),
@@ -774,17 +774,17 @@ ds4_pad_handler::DataStatus ds4_pad_handler::get_data(DS4Device* device)
 	return DataStatus::NewData;
 }
 
-bool ds4_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds4_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == DS4KeyCodes::L2;
 }
 
-bool ds4_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds4_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == DS4KeyCodes::R2;
 }
 
-bool ds4_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds4_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -798,7 +798,7 @@ bool ds4_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*devi
 	}
 }
 
-bool ds4_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds4_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -812,7 +812,7 @@ bool ds4_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*dev
 	}
 }
 
-bool ds4_pad_handler::get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ds4_pad_handler::get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{

--- a/rpcs3/Input/ds4_pad_handler.h
+++ b/rpcs3/Input/ds4_pad_handler.h
@@ -186,14 +186,14 @@ private:
 	int send_output_report(DS4Device* device) override;
 	void check_add_device(hid_device* hidDevice, hid_enumerated_device_view path, std::wstring_view serial) override;
 
-	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
-	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;
+	std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
+	pad_preview_values get_preview_values(const std::unordered_map<u32, u16>& data) override;
 };

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -505,17 +505,17 @@ bool dualsense_pad_handler::get_calibration_data(DualSenseDevice* dev) const
 	return true;
 }
 
-bool dualsense_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool dualsense_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == DualSenseKeyCodes::L2;
 }
 
-bool dualsense_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool dualsense_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == DualSenseKeyCodes::R2;
 }
 
-bool dualsense_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool dualsense_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -529,7 +529,7 @@ bool dualsense_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& 
 	}
 }
 
-bool dualsense_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool dualsense_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -543,7 +543,7 @@ bool dualsense_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>&
 	}
 }
 
-bool dualsense_pad_handler::get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool dualsense_pad_handler::get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -635,9 +635,9 @@ void dualsense_pad_handler::get_extended_info(const pad_ensemble& binding)
 	set_raw_orientation(pad->move_data, accel_x, accel_y, accel_z, gyro_x, gyro_y, gyro_z);
 }
 
-std::unordered_map<u64, u16> dualsense_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
+std::unordered_map<u32, u16> dualsense_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
-	std::unordered_map<u64, u16> keyBuffer;
+	std::unordered_map<u32, u16> keyBuffer;
 	DualSenseDevice* dev = static_cast<DualSenseDevice*>(device.get());
 	if (!dev)
 		return keyBuffer;
@@ -777,7 +777,7 @@ std::unordered_map<u64, u16> dualsense_pad_handler::get_button_values(const std:
 	return keyBuffer;
 }
 
-pad_preview_values dualsense_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
+pad_preview_values dualsense_pad_handler::get_preview_values(const std::unordered_map<u32, u16>& data)
 {
 	return {
 		::at32(data, L2),

--- a/rpcs3/Input/dualsense_pad_handler.h
+++ b/rpcs3/Input/dualsense_pad_handler.h
@@ -248,14 +248,14 @@ private:
 	void check_add_device(hid_device* hidDevice, hid_enumerated_device_view path, std::wstring_view wide_serial) override;
 	int send_output_report(DualSenseDevice* device) override;
 
-	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
-	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;
+	std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
+	pad_preview_values get_preview_values(const std::unordered_map<u32, u16>& data) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
 };

--- a/rpcs3/Input/evdev_joystick_handler.cpp
+++ b/rpcs3/Input/evdev_joystick_handler.cpp
@@ -259,9 +259,9 @@ void evdev_joystick_handler::close_devices()
 	}
 }
 
-std::unordered_map<u64, std::pair<u16, bool>> evdev_joystick_handler::GetButtonValues(const std::shared_ptr<EvdevDevice>& device)
+std::unordered_map<u32, std::pair<u16, bool>> evdev_joystick_handler::GetButtonValues(const std::shared_ptr<EvdevDevice>& device)
 {
-	std::unordered_map<u64, std::pair<u16, bool>> button_values;
+	std::unordered_map<u32, std::pair<u16, bool>> button_values;
 	if (!device)
 		return button_values;
 
@@ -379,23 +379,23 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 
 		const auto set_value = [&value, &data](u32 code, bool dir)
 		{
-			if (const auto it = data.find(static_cast<u64>(code)); it != data.cend() && dir == it->second.second)
+			if (const auto it = data.find(code); it != data.cend() && dir == it->second.second)
 			{
 				value = std::max(value, it->second.first);
 			}
 		};
 
-		for (const u32 code : FindKeyCodes<u32, u32>(rev_axis_list, names))
+		for (const u32 code : FindKeyCodes(rev_axis_list, names))
 		{
 			set_value(code, true);
 		}
 
-		for (const u32 code : FindKeyCodes<u32, u32>(axis_list, names))
+		for (const u32 code : FindKeyCodes(axis_list, names))
 		{
 			set_value(code, false);
 		}
 
-		for (const u32 code : FindKeyCodes<u32, u32>(button_list, names))
+		for (const u32 code : FindKeyCodes(button_list, names))
 		{
 			set_value(code, false);
 		}
@@ -435,7 +435,7 @@ PadHandlerBase::connection evdev_joystick_handler::get_next_button_press(const s
 			return;
 
 		// Ignore codes that aren't part of the latest events. Otherwise we will get value 0 which will reset our min_value.
-		const auto it = data.find(static_cast<u64>(code));
+		const auto it = data.find(code);
 		if (it == data.cend())
 		{
 			if (call_type == gui_call_type::reset_input)
@@ -1351,17 +1351,17 @@ bool evdev_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad)
 		// In evdev we store indices to an EvdevButton vector in our pad objects instead of the usual key codes.
 		std::set<u32> indices;
 
-		for (const u32 code : FindKeyCodes<u32, u32>(axis_list, names))
+		for (const u32 code : FindKeyCodes(axis_list, names))
 		{
 			indices.insert(register_evdevbutton(code, true, false));
 		}
 
-		for (const u32 code : FindKeyCodes<u32, u32>(rev_axis_list, names))
+		for (const u32 code : FindKeyCodes(rev_axis_list, names))
 		{
 			indices.insert(register_evdevbutton(code, true, true));
 		}
 
-		for (const u32 code : FindKeyCodes<u32, u32>(button_list, names))
+		for (const u32 code : FindKeyCodes(button_list, names))
 		{
 			indices.insert(register_evdevbutton(code, false, false));
 		}
@@ -1376,7 +1376,7 @@ bool evdev_joystick_handler::bindPadToDevice(std::shared_ptr<Pad> pad)
 		e_sensor.mirrored = sensor.mirrored.get();
 		e_sensor.shift = sensor.shift.get();
 
-		const std::set<u32> keys = FindKeyCodes<u32, u32>(motion_axis_list, sensor.axis);
+		const std::set<u32> keys = FindKeyCodes(motion_axis_list, sensor.axis);
 		if (!keys.empty()) e_sensor.code = *keys.begin(); // We should only have one key for each of our sensors
 		return e_sensor;
 	};
@@ -1533,24 +1533,24 @@ bool evdev_joystick_handler::check_button_sets(const std::array<std::set<u32>, 4
 	return std::any_of(sets.begin(), sets.end(), [this, code](const std::set<u32>& indices) { return check_button_set(indices, code); });
 };
 
-bool evdev_joystick_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool evdev_joystick_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
-	return check_button_set(m_dev->trigger_left, static_cast<u32>(keyCode));
+	return check_button_set(m_dev->trigger_left, keyCode);
 }
 
-bool evdev_joystick_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool evdev_joystick_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
-	return check_button_set(m_dev->trigger_right, static_cast<u32>(keyCode));
+	return check_button_set(m_dev->trigger_right, keyCode);
 }
 
-bool evdev_joystick_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool evdev_joystick_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
-	return check_button_sets(m_dev->axis_left, static_cast<u32>(keyCode));
+	return check_button_sets(m_dev->axis_left, keyCode);
 }
 
-bool evdev_joystick_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool evdev_joystick_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
-	return check_button_sets(m_dev->axis_right, static_cast<u32>(keyCode));
+	return check_button_sets(m_dev->axis_right, keyCode);
 }
 
 #endif

--- a/rpcs3/Input/evdev_joystick_handler.h
+++ b/rpcs3/Input/evdev_joystick_handler.h
@@ -397,7 +397,7 @@ private:
 	bool update_device(const std::shared_ptr<PadDevice>& device);
 	std::shared_ptr<evdev_joystick_handler::EvdevDevice> add_device(const std::string& device, bool in_settings = false);
 	std::shared_ptr<evdev_joystick_handler::EvdevDevice> add_motion_device(const std::string& device, bool in_settings);
-	std::unordered_map<u64, std::pair<u16, bool>> GetButtonValues(const std::shared_ptr<EvdevDevice>& device);
+	std::unordered_map<u32, std::pair<u16, bool>> GetButtonValues(const std::shared_ptr<EvdevDevice>& device);
 	void SetRumble(EvdevDevice* device, u8 large, u8 small);
 
 	positive_axis m_pos_axis_config;
@@ -420,10 +420,10 @@ protected:
 	void get_mapping(const pad_ensemble& binding) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
-	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
 };
 
 #endif

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -980,7 +980,7 @@ bool keyboard_pad_handler::bindPadToDevice(std::shared_ptr<Pad> pad)
 
 	const auto find_keys = [this](const cfg::string& name)
 	{
-		std::set<u32> keys = FindKeyCodes<u32, u32>(mouse_list, name, false);
+		std::set<u32> keys = FindKeyCodes(mouse_list, name, false);
 		for (const u32& key : GetKeyCodes(name)) keys.insert(key);
 
 		if (!keys.empty())

--- a/rpcs3/Input/mm_joystick_handler.cpp
+++ b/rpcs3/Input/mm_joystick_handler.cpp
@@ -34,23 +34,23 @@ void mm_joystick_handler::init_config(cfg_pad* cfg)
 	cfg->rs_down.def  = ::at32(axis_list, mmjoy_axis::joy_r_neg);
 	cfg->rs_right.def = ::at32(axis_list, mmjoy_axis::joy_z_pos);
 	cfg->rs_up.def    = ::at32(axis_list, mmjoy_axis::joy_r_pos);
-	cfg->start.def    = ::at32(button_list, JOY_BUTTON9);
-	cfg->select.def   = ::at32(button_list, JOY_BUTTON10);
-	cfg->ps.def       = ::at32(button_list, JOY_BUTTON17);
-	cfg->square.def   = ::at32(button_list, JOY_BUTTON4);
-	cfg->cross.def    = ::at32(button_list, JOY_BUTTON3);
-	cfg->circle.def   = ::at32(button_list, JOY_BUTTON2);
-	cfg->triangle.def = ::at32(button_list, JOY_BUTTON1);
-	cfg->left.def     = ::at32(pov_list, JOY_POVLEFT);
-	cfg->down.def     = ::at32(pov_list, JOY_POVBACKWARD);
-	cfg->right.def    = ::at32(pov_list, JOY_POVRIGHT);
-	cfg->up.def       = ::at32(pov_list, JOY_POVFORWARD);
-	cfg->r1.def       = ::at32(button_list, JOY_BUTTON8);
-	cfg->r2.def       = ::at32(button_list, JOY_BUTTON6);
-	cfg->r3.def       = ::at32(button_list, JOY_BUTTON12);
-	cfg->l1.def       = ::at32(button_list, JOY_BUTTON7);
-	cfg->l2.def       = ::at32(button_list, JOY_BUTTON5);
-	cfg->l3.def       = ::at32(button_list, JOY_BUTTON11);
+	cfg->start.def    = ::at32(button_list, static_cast<u32>(JOY_BUTTON9));
+	cfg->select.def   = ::at32(button_list, static_cast<u32>(JOY_BUTTON10));
+	cfg->ps.def       = ::at32(button_list, static_cast<u32>(JOY_BUTTON17));
+	cfg->square.def   = ::at32(button_list, static_cast<u32>(JOY_BUTTON4));
+	cfg->cross.def    = ::at32(button_list, static_cast<u32>(JOY_BUTTON3));
+	cfg->circle.def   = ::at32(button_list, static_cast<u32>(JOY_BUTTON2));
+	cfg->triangle.def = ::at32(button_list, static_cast<u32>(JOY_BUTTON1));
+	cfg->left.def     = ::at32(pov_list,    static_cast<u32>(JOY_POVLEFT));
+	cfg->down.def     = ::at32(pov_list,    static_cast<u32>(JOY_POVBACKWARD));
+	cfg->right.def    = ::at32(pov_list,    static_cast<u32>(JOY_POVRIGHT));
+	cfg->up.def       = ::at32(pov_list,    static_cast<u32>(JOY_POVFORWARD));
+	cfg->r1.def       = ::at32(button_list, static_cast<u32>(JOY_BUTTON8));
+	cfg->r2.def       = ::at32(button_list, static_cast<u32>(JOY_BUTTON6));
+	cfg->r3.def       = ::at32(button_list, static_cast<u32>(JOY_BUTTON12));
+	cfg->l1.def       = ::at32(button_list, static_cast<u32>(JOY_BUTTON7));
+	cfg->l2.def       = ::at32(button_list, static_cast<u32>(JOY_BUTTON5));
+	cfg->l3.def       = ::at32(button_list, static_cast<u32>(JOY_BUTTON11));
 
 	cfg->pressure_intensity_button.def = ::at32(button_list, NO_BUTTON);
 	cfg->analog_limiter_button.def = ::at32(button_list, NO_BUTTON);
@@ -102,7 +102,7 @@ void mm_joystick_handler::enumerate_devices()
 	{
 		MMJOYDevice dev;
 
-		if (GetMMJOYDevice(i, &dev) == false)
+		if (get_device(i, &dev) == false)
 			continue;
 
 		auto it = m_devices.find(dev.device_name);
@@ -145,20 +145,18 @@ std::vector<pad_list_entry> mm_joystick_handler::list_devices()
 	return devices;
 }
 
-template <typename T>
-std::set<T> mm_joystick_handler::find_keys(const cfg::string& cfg_string) const
+std::set<u32> mm_joystick_handler::find_keys(const cfg::string& cfg_string) const
 {
-	return find_keys<T>(cfg_pad::get_buttons(cfg_string.to_string()));
+	return find_keys(cfg_pad::get_buttons(cfg_string.to_string()));
 }
 
-template <typename T>
-std::set<T> mm_joystick_handler::find_keys(const std::vector<std::string>& names) const
+std::set<u32> mm_joystick_handler::find_keys(const std::vector<std::string>& names) const
 {
-	std::set<T> keys;
+	std::set<u32> keys;
 
-	for (const T& k : FindKeyCodes<u64, T>(axis_list, names)) keys.insert(k);
-	for (const T& k : FindKeyCodes<u64, T>(pov_list, names)) keys.insert(k);
-	for (const T& k : FindKeyCodes<u64, T>(button_list, names)) keys.insert(k);
+	for (u32 k : FindKeyCodes(axis_list, names)) keys.insert(k);
+	for (u32 k : FindKeyCodes(pov_list, names)) keys.insert(k);
+	for (u32 k : FindKeyCodes(button_list, names)) keys.insert(k);
 
 	return keys;
 }
@@ -171,58 +169,58 @@ std::array<std::set<u32>, PadHandlerBase::button::button_count> mm_joystick_hand
 	if (!dev || !cfg)
 		return mapping;
 
-	dev->trigger_code_left  = find_keys<u64>(cfg->l2);
-	dev->trigger_code_right = find_keys<u64>(cfg->r2);
-	dev->axis_code_left[0]  = find_keys<u64>(cfg->ls_left);
-	dev->axis_code_left[1]  = find_keys<u64>(cfg->ls_right);
-	dev->axis_code_left[2]  = find_keys<u64>(cfg->ls_down);
-	dev->axis_code_left[3]  = find_keys<u64>(cfg->ls_up);
-	dev->axis_code_right[0] = find_keys<u64>(cfg->rs_left);
-	dev->axis_code_right[1] = find_keys<u64>(cfg->rs_right);
-	dev->axis_code_right[2] = find_keys<u64>(cfg->rs_down);
-	dev->axis_code_right[3] = find_keys<u64>(cfg->rs_up);
+	dev->trigger_code_left  = find_keys(cfg->l2);
+	dev->trigger_code_right = find_keys(cfg->r2);
+	dev->axis_code_left[0]  = find_keys(cfg->ls_left);
+	dev->axis_code_left[1]  = find_keys(cfg->ls_right);
+	dev->axis_code_left[2]  = find_keys(cfg->ls_down);
+	dev->axis_code_left[3]  = find_keys(cfg->ls_up);
+	dev->axis_code_right[0] = find_keys(cfg->rs_left);
+	dev->axis_code_right[1] = find_keys(cfg->rs_right);
+	dev->axis_code_right[2] = find_keys(cfg->rs_down);
+	dev->axis_code_right[3] = find_keys(cfg->rs_up);
 
-	mapping[button::up]       = find_keys<u32>(cfg->up);
-	mapping[button::down]     = find_keys<u32>(cfg->down);
-	mapping[button::left]     = find_keys<u32>(cfg->left);
-	mapping[button::right]    = find_keys<u32>(cfg->right);
-	mapping[button::cross]    = find_keys<u32>(cfg->cross);
-	mapping[button::square]   = find_keys<u32>(cfg->square);
-	mapping[button::circle]   = find_keys<u32>(cfg->circle);
-	mapping[button::triangle] = find_keys<u32>(cfg->triangle);
-	mapping[button::l1]       = find_keys<u32>(cfg->l1);
-	mapping[button::l2]       = narrow_set(dev->trigger_code_left);
-	mapping[button::l3]       = find_keys<u32>(cfg->l3);
-	mapping[button::r1]       = find_keys<u32>(cfg->r1);
-	mapping[button::r2]       = narrow_set(dev->trigger_code_right);
-	mapping[button::r3]       = find_keys<u32>(cfg->r3);
-	mapping[button::start]    = find_keys<u32>(cfg->start);
-	mapping[button::select]   = find_keys<u32>(cfg->select);
-	mapping[button::ps]       = find_keys<u32>(cfg->ps);
-	mapping[button::ls_left]  = narrow_set(dev->axis_code_left[0]);
-	mapping[button::ls_right] = narrow_set(dev->axis_code_left[1]);
-	mapping[button::ls_down]  = narrow_set(dev->axis_code_left[2]);
-	mapping[button::ls_up]    = narrow_set(dev->axis_code_left[3]);
-	mapping[button::rs_left]  = narrow_set(dev->axis_code_right[0]);
-	mapping[button::rs_right] = narrow_set(dev->axis_code_right[1]);
-	mapping[button::rs_down]  = narrow_set(dev->axis_code_right[2]);
-	mapping[button::rs_up]    = narrow_set(dev->axis_code_right[3]);
+	mapping[button::up]       = find_keys(cfg->up);
+	mapping[button::down]     = find_keys(cfg->down);
+	mapping[button::left]     = find_keys(cfg->left);
+	mapping[button::right]    = find_keys(cfg->right);
+	mapping[button::cross]    = find_keys(cfg->cross);
+	mapping[button::square]   = find_keys(cfg->square);
+	mapping[button::circle]   = find_keys(cfg->circle);
+	mapping[button::triangle] = find_keys(cfg->triangle);
+	mapping[button::l1]       = find_keys(cfg->l1);
+	mapping[button::l2]       = dev->trigger_code_left;
+	mapping[button::l3]       = find_keys(cfg->l3);
+	mapping[button::r1]       = find_keys(cfg->r1);
+	mapping[button::r2]       = dev->trigger_code_right;
+	mapping[button::r3]       = find_keys(cfg->r3);
+	mapping[button::start]    = find_keys(cfg->start);
+	mapping[button::select]   = find_keys(cfg->select);
+	mapping[button::ps]       = find_keys(cfg->ps);
+	mapping[button::ls_left]  = dev->axis_code_left[0];
+	mapping[button::ls_right] = dev->axis_code_left[1];
+	mapping[button::ls_down]  = dev->axis_code_left[2];
+	mapping[button::ls_up]    = dev->axis_code_left[3];
+	mapping[button::rs_left]  = dev->axis_code_right[0];
+	mapping[button::rs_right] = dev->axis_code_right[1];
+	mapping[button::rs_down]  = dev->axis_code_right[2];
+	mapping[button::rs_up]    = dev->axis_code_right[3];
 
-	mapping[button::skateboard_ir_nose]    = find_keys<u32>(cfg->ir_nose);
-	mapping[button::skateboard_ir_tail]    = find_keys<u32>(cfg->ir_tail);
-	mapping[button::skateboard_ir_left]    = find_keys<u32>(cfg->ir_left);
-	mapping[button::skateboard_ir_right]   = find_keys<u32>(cfg->ir_right);
-	mapping[button::skateboard_tilt_left]  = find_keys<u32>(cfg->tilt_left);
-	mapping[button::skateboard_tilt_right] = find_keys<u32>(cfg->tilt_right);
+	mapping[button::skateboard_ir_nose]    = find_keys(cfg->ir_nose);
+	mapping[button::skateboard_ir_tail]    = find_keys(cfg->ir_tail);
+	mapping[button::skateboard_ir_left]    = find_keys(cfg->ir_left);
+	mapping[button::skateboard_ir_right]   = find_keys(cfg->ir_right);
+	mapping[button::skateboard_tilt_left]  = find_keys(cfg->tilt_left);
+	mapping[button::skateboard_tilt_right] = find_keys(cfg->tilt_right);
 
 	if (b_has_pressure_intensity_button)
 	{
-		mapping[button::pressure_intensity_button] = find_keys<u32>(cfg->pressure_intensity_button);
+		mapping[button::pressure_intensity_button] = find_keys(cfg->pressure_intensity_button);
 	}
 
 	if (b_has_analog_limiter_button)
 	{
-		mapping[button::analog_limiter_button] = find_keys<u32>(cfg->analog_limiter_button);
+		mapping[button::analog_limiter_button] = find_keys(cfg->analog_limiter_button);
 	}
 
 	return mapping;
@@ -295,7 +293,7 @@ PadHandlerBase::connection mm_joystick_handler::get_next_button_press(const std:
 			std::string name;
 		} pressed_button{};
 
-		const auto set_button_press = [&](const u64& keycode, const std::string& name, std::string_view type, u16 threshold)
+		const auto set_button_press = [&](u32 keycode, const std::string& name, std::string_view type, u16 threshold)
 		{
 			if (call_type != gui_call_type::blacklist && m_blacklist.contains(keycode))
 				return;
@@ -365,7 +363,7 @@ PadHandlerBase::connection mm_joystick_handler::get_next_button_press(const std:
 				const auto get_key_value = [this, &data](const std::string& str) -> u16
 				{
 					u16 value{};
-					for (u32 key_code : find_keys<u32>(cfg_pad::get_buttons(str)))
+					for (u32 key_code : find_keys(cfg_pad::get_buttons(str)))
 					{
 						if (const auto it = data.find(key_code); it != data.cend())
 						{
@@ -399,9 +397,9 @@ PadHandlerBase::connection mm_joystick_handler::get_next_button_press(const std:
 	return connection::no_data;
 }
 
-std::unordered_map<u64, u16> mm_joystick_handler::GetButtonValues(const JOYINFOEX& js_info, const JOYCAPS& js_caps)
+std::unordered_map<u32, u16> mm_joystick_handler::GetButtonValues(const JOYINFOEX& js_info, const JOYCAPS& js_caps)
 {
-	std::unordered_map<u64, u16> button_values;
+	std::unordered_map<u32, u16> button_values;
 
 	for (const auto& entry : button_list)
 	{
@@ -424,7 +422,7 @@ std::unordered_map<u64, u16> mm_joystick_handler::GetButtonValues(const JOYINFOE
 			}
 			else
 			{
-				auto emplacePOVs = [&](float val, u64 pov_neg, u64 pov_pos)
+				const auto emplacePOVs = [&](float val, u32 pov_neg, u32 pov_pos)
 				{
 					if (val < 0)
 					{
@@ -461,7 +459,7 @@ std::unordered_map<u64, u16> mm_joystick_handler::GetButtonValues(const JOYINFOE
 		}
 	}
 
-	auto add_axis_value = [&](DWORD axis, UINT min, UINT max, u64 pos, u64 neg)
+	auto add_axis_value = [&](DWORD axis, UINT min, UINT max, u32 pos, u32 neg)
 	{
 		constexpr f32 deadzone = 0.0f;
 		const float val = ScaledAxisInput(static_cast<f32>(axis), static_cast<f32>(min), static_cast<f32>(max), deadzone);
@@ -495,11 +493,11 @@ std::unordered_map<u64, u16> mm_joystick_handler::GetButtonValues(const JOYINFOE
 	return button_values;
 }
 
-std::unordered_map<u64, u16> mm_joystick_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
+std::unordered_map<u32, u16> mm_joystick_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
 	MMJOYDevice* dev = static_cast<MMJOYDevice*>(device.get());
 	if (!dev)
-		return std::unordered_map<u64, u16>();
+		return std::unordered_map<u32, u16>();
 	return GetButtonValues(dev->device_info, dev->device_caps);
 }
 
@@ -539,7 +537,7 @@ std::shared_ptr<mm_joystick_handler::MMJOYDevice> mm_joystick_handler::create_de
 	return dev;
 }
 
-bool mm_joystick_handler::GetMMJOYDevice(int index, MMJOYDevice* dev) const
+bool mm_joystick_handler::get_device(int index, MMJOYDevice* dev) const
 {
 	if (!dev)
 		return false;
@@ -578,28 +576,28 @@ std::shared_ptr<PadDevice> mm_joystick_handler::get_device(const std::string& de
 	return get_device_by_name(device);
 }
 
-bool mm_joystick_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode)
+bool mm_joystick_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode)
 {
 	const MMJOYDevice* dev = static_cast<MMJOYDevice*>(device.get());
 	return dev && dev->trigger_code_left.contains(keyCode);
 }
 
-bool mm_joystick_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode)
+bool mm_joystick_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode)
 {
 	const MMJOYDevice* dev = static_cast<MMJOYDevice*>(device.get());
 	return dev && dev->trigger_code_right.contains(keyCode);
 }
 
-bool mm_joystick_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode)
+bool mm_joystick_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode)
 {
 	const MMJOYDevice* dev = static_cast<MMJOYDevice*>(device.get());
-	return dev && std::any_of(dev->axis_code_left.cbegin(), dev->axis_code_left.cend(), [&keyCode](const std::set<u64>& s){ return s.contains(keyCode); });
+	return dev && std::any_of(dev->axis_code_left.cbegin(), dev->axis_code_left.cend(), [&keyCode](const std::set<u32>& s){ return s.contains(keyCode); });
 }
 
-bool mm_joystick_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode)
+bool mm_joystick_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode)
 {
 	const MMJOYDevice* dev = static_cast<MMJOYDevice*>(device.get());
-	return dev && std::any_of(dev->axis_code_right.cbegin(), dev->axis_code_right.cend(), [&keyCode](const std::set<u64>& s){ return s.contains(keyCode); });
+	return dev && std::any_of(dev->axis_code_right.cbegin(), dev->axis_code_right.cend(), [&keyCode](const std::set<u32>& s){ return s.contains(keyCode); });
 }
 
 PadHandlerBase::connection mm_joystick_handler::update_connection(const std::shared_ptr<PadDevice>& device)
@@ -630,7 +628,7 @@ PadHandlerBase::connection mm_joystick_handler::update_connection(const std::sha
 	}
 
 	// Try to connect properly again
-	if (GetMMJOYDevice(dev->device_id, dev))
+	if (get_device(dev->device_id, dev))
 		return connection::connected;
 
 	return connection::disconnected;

--- a/rpcs3/Input/mm_joystick_handler.h
+++ b/rpcs3/Input/mm_joystick_handler.h
@@ -16,10 +16,10 @@
 
 class mm_joystick_handler final : public PadHandlerBase
 {
-	static constexpr u64 NO_BUTTON = u64{umax};
+	static constexpr u32 NO_BUTTON = u32{umax};
 
 	// Unique names for the config files and our pad settings dialog
-	const std::unordered_map<u64, std::string> button_list =
+	const std::unordered_map<u32, std::string> button_list =
 	{
 		{ NO_BUTTON   , ""          },
 		{ JOY_BUTTON1 , "Button 1"  },
@@ -57,7 +57,7 @@ class mm_joystick_handler final : public PadHandlerBase
 	};
 
 	// Unique names for the config files and our pad settings dialog
-	const std::unordered_map<u64, std::string> pov_list =
+	const std::unordered_map<u32, std::string> pov_list =
 	{
 		{ JOY_POVFORWARD,  "POV Up"    },
 		{ JOY_POVRIGHT,    "POV Right" },
@@ -65,7 +65,7 @@ class mm_joystick_handler final : public PadHandlerBase
 		{ JOY_POVLEFT,     "POV Left"  }
 	};
 
-	enum mmjoy_axis
+	enum mmjoy_axis : u32
 	{
 		joy_x_pos = 9700,
 		joy_x_neg,
@@ -82,7 +82,7 @@ class mm_joystick_handler final : public PadHandlerBase
 	};
 
 	// Unique names for the config files and our pad settings dialog
-	const std::unordered_map<u64, std::string> axis_list =
+	const std::unordered_map<u32, std::string> axis_list =
 	{
 		{ joy_x_pos, "X+" },
 		{ joy_x_neg, "X-" },
@@ -106,6 +106,10 @@ class mm_joystick_handler final : public PadHandlerBase
 		JOYCAPS device_caps{};
 		MMRESULT device_status = JOYERR_UNPLUGGED;
 		steady_clock::time_point last_update{};
+		std::set<u32> trigger_code_left{};
+		std::set<u32> trigger_code_right{};
+		std::array<std::set<u32>, 4> axis_code_left{};
+		std::array<std::set<u32>, 4> axis_code_right{};
 	};
 
 public:
@@ -118,31 +122,28 @@ public:
 	void init_config(cfg_pad* cfg) override;
 
 private:
-	std::unordered_map<u64, u16> GetButtonValues(const JOYINFOEX& js_info, const JOYCAPS& js_caps);
+	std::unordered_map<u32, u16> GetButtonValues(const JOYINFOEX& js_info, const JOYCAPS& js_caps);
 	std::shared_ptr<MMJOYDevice> get_device_by_name(const std::string& name);
 	std::shared_ptr<MMJOYDevice> create_device_by_name(const std::string& name);
-	bool GetMMJOYDevice(int index, MMJOYDevice* dev) const;
+	bool get_device(int index, MMJOYDevice* dev) const;
 	void enumerate_devices();
 
 	bool m_is_init = false;
 
-	std::set<u64> m_blacklist;
-	std::unordered_map<u64, u16> m_min_button_values;
+	std::set<u32> m_blacklist;
+	std::unordered_map<u32, u16> m_min_button_values;
 	std::map<std::string, std::shared_ptr<MMJOYDevice>> m_devices;
 
-	template <typename T>
-	std::set<T> find_keys(const std::vector<std::string>& names) const;
-
-	template <typename T>
-	std::set<T> find_keys(const cfg::string& cfg_string) const;
+	std::set<u32> find_keys(const std::vector<std::string>& names) const;
+	std::set<u32> find_keys(const cfg::string& cfg_string) const;
 
 	std::array<std::set<u32>, PadHandlerBase::button::button_count> get_mapped_key_codes(const std::shared_ptr<PadDevice>& device, const cfg_pad* cfg) override;
 	std::shared_ptr<PadDevice> get_device(const std::string& device) override;
-	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
-	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
+	std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
 };
 #endif

--- a/rpcs3/Input/ps_move_handler.cpp
+++ b/rpcs3/Input/ps_move_handler.cpp
@@ -580,21 +580,21 @@ void ps_move_handler::handle_external_device(const pad_ensemble& binding)
 	move_data.external_device_write_requested = false;
 }
 
-bool ps_move_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ps_move_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	// We also report the T button as left trigger
 	return keyCode == ps_move_key_codes::L2 || keyCode == ps_move_key_codes::t;
 }
 
-bool ps_move_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool ps_move_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	// We also report the Throttle button as right trigger
 	return keyCode == ps_move_key_codes::R2 || keyCode == ps_move_key_codes::throttle;
 }
 
-std::unordered_map<u64, u16> ps_move_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
+std::unordered_map<u32, u16> ps_move_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
-	std::unordered_map<u64, u16> key_buf;
+	std::unordered_map<u32, u16> key_buf;
 	ps_move_device* dev = static_cast<ps_move_device*>(device.get());
 	if (!dev)
 		return key_buf;
@@ -760,7 +760,7 @@ void ps_move_handler::get_extended_info(const pad_ensemble& binding)
 	handle_external_device(binding);
 }
 
-pad_preview_values ps_move_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
+pad_preview_values ps_move_handler::get_preview_values(const std::unordered_map<u32, u16>& data)
 {
 	return {
 		std::max(::at32(data, ps_move_key_codes::L2), ::at32(data, ps_move_key_codes::t)),

--- a/rpcs3/Input/ps_move_handler.h
+++ b/rpcs3/Input/ps_move_handler.h
@@ -192,11 +192,11 @@ private:
 	void check_add_device(hid_device* hidDevice, hid_enumerated_device_view path, std::wstring_view wide_serial) override;
 	int send_output_report(ps_move_device* device) override;
 
-	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
-	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;
+	std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
+	pad_preview_values get_preview_values(const std::unordered_map<u32, u16>& data) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
 

--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -881,17 +881,17 @@ void sdl_pad_handler::set_rumble(SDLDevice* dev, u8 speed_large, u8 speed_small)
 	}
 }
 
-bool sdl_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool sdl_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == SDLKeyCodes::LT;
 }
 
-bool sdl_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool sdl_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == SDLKeyCodes::RT;
 }
 
-bool sdl_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool sdl_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -905,7 +905,7 @@ bool sdl_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*devi
 	}
 }
 
-bool sdl_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool sdl_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -919,7 +919,7 @@ bool sdl_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*dev
 	}
 }
 
-bool sdl_pad_handler::get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool sdl_pad_handler::get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -933,9 +933,9 @@ bool sdl_pad_handler::get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& 
 	}
 }
 
-std::unordered_map<u64, u16> sdl_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
+std::unordered_map<u32, u16> sdl_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
-	std::unordered_map<u64, u16> values;
+	std::unordered_map<u32, u16> values;
 	SDLDevice* dev = static_cast<SDLDevice*>(device.get());
 	if (!dev || !dev->sdl.gamepad)
 		return values;
@@ -1086,7 +1086,7 @@ std::unordered_map<u64, u16> sdl_pad_handler::get_button_values(const std::share
 	return values;
 }
 
-pad_preview_values sdl_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
+pad_preview_values sdl_pad_handler::get_preview_values(const std::unordered_map<u32, u16>& data)
 {
 	return {
 		::at32(data, LT),

--- a/rpcs3/Input/sdl_pad_handler.h
+++ b/rpcs3/Input/sdl_pad_handler.h
@@ -171,13 +171,13 @@ private:
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
-	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;
+	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_touch_pad_motion(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
+	pad_preview_values get_preview_values(const std::unordered_map<u32, u16>& data) override;
 
 	u32 get_battery_color(int power_level, u32 brightness) const;
 	void set_rumble(SDLDevice* dev, u8 speed_large, u8 speed_small);

--- a/rpcs3/Input/skateboard_pad_handler.cpp
+++ b/rpcs3/Input/skateboard_pad_handler.cpp
@@ -272,9 +272,9 @@ PadHandlerBase::connection skateboard_pad_handler::update_connection(const std::
 	return connection::connected;
 }
 
-std::unordered_map<u64, u16> skateboard_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
+std::unordered_map<u32, u16> skateboard_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
-	std::unordered_map<u64, u16> key_buf;
+	std::unordered_map<u32, u16> key_buf;
 	skateboard_device* dev = static_cast<skateboard_device*>(device.get());
 	if (!dev)
 		return key_buf;
@@ -328,7 +328,7 @@ void skateboard_pad_handler::get_extended_info(const pad_ensemble& binding)
 	set_raw_orientation(*pad);
 }
 
-pad_preview_values skateboard_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& /*data*/)
+pad_preview_values skateboard_pad_handler::get_preview_values(const std::unordered_map<u32, u16>& /*data*/)
 {
 	// There is no proper user interface for skateboard values yet
 	return {};

--- a/rpcs3/Input/skateboard_pad_handler.h
+++ b/rpcs3/Input/skateboard_pad_handler.h
@@ -183,8 +183,8 @@ private:
 	int send_output_report(skateboard_device* device) override;
 
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
-	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;
+	std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
+	pad_preview_values get_preview_values(const std::unordered_map<u32, u16>& data) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
 };

--- a/rpcs3/Input/xinput_pad_handler.cpp
+++ b/rpcs3/Input/xinput_pad_handler.cpp
@@ -201,9 +201,9 @@ int xinput_pad_handler::GetDeviceNumber(const std::string& padId)
 	return device_number;
 }
 
-std::unordered_map<u64, u16> xinput_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
+std::unordered_map<u32, u16> xinput_pad_handler::get_button_values(const std::shared_ptr<PadDevice>& device)
 {
-	PadButtonValues values;
+	std::unordered_map<u32, u16> values;
 	XInputDevice* dev = static_cast<XInputDevice*>(device.get());
 	if (!dev || dev->state != ERROR_SUCCESS) // the state has to be aquired with update_connection before calling this function
 		return values;
@@ -217,9 +217,9 @@ std::unordered_map<u64, u16> xinput_pad_handler::get_button_values(const std::sh
 	return get_button_values_base(dev->state_base, m_trigger_recognition_mode);
 }
 
-xinput_pad_handler::PadButtonValues xinput_pad_handler::get_button_values_base(const XINPUT_STATE& state, trigger_recognition_mode trigger_mode)
+std::unordered_map<u32, u16> xinput_pad_handler::get_button_values_base(const XINPUT_STATE& state, trigger_recognition_mode trigger_mode)
 {
-	PadButtonValues values;
+	std::unordered_map<u32, u16> values;
 
 	// Triggers
 	if (trigger_mode == trigger_recognition_mode::any || trigger_mode == trigger_recognition_mode::one_directional)
@@ -291,9 +291,9 @@ xinput_pad_handler::PadButtonValues xinput_pad_handler::get_button_values_base(c
 	return values;
 }
 
-xinput_pad_handler::PadButtonValues xinput_pad_handler::get_button_values_scp(const SCP_EXTN& state, trigger_recognition_mode trigger_mode)
+std::unordered_map<u32, u16> xinput_pad_handler::get_button_values_scp(const SCP_EXTN& state, trigger_recognition_mode trigger_mode)
 {
-	PadButtonValues values;
+	std::unordered_map<u32, u16> values;
 
 	// Triggers
 	if (trigger_mode == trigger_recognition_mode::any || trigger_mode == trigger_recognition_mode::one_directional)
@@ -359,7 +359,7 @@ xinput_pad_handler::PadButtonValues xinput_pad_handler::get_button_values_scp(co
 	return values;
 }
 
-pad_preview_values xinput_pad_handler::get_preview_values(const std::unordered_map<u64, u16>& data)
+pad_preview_values xinput_pad_handler::get_preview_values(const std::unordered_map<u32, u16>& data)
 {
 	return {
 		::at32(data, LT),
@@ -455,17 +455,17 @@ std::shared_ptr<PadDevice> xinput_pad_handler::get_device(const std::string& dev
 	return dev;
 }
 
-bool xinput_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool xinput_pad_handler::get_is_left_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == XInputKeyCodes::LT;
 }
 
-bool xinput_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool xinput_pad_handler::get_is_right_trigger(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	return keyCode == XInputKeyCodes::RT;
 }
 
-bool xinput_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool xinput_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{
@@ -479,7 +479,7 @@ bool xinput_pad_handler::get_is_left_stick(const std::shared_ptr<PadDevice>& /*d
 	}
 }
 
-bool xinput_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u64 keyCode)
+bool xinput_pad_handler::get_is_right_stick(const std::shared_ptr<PadDevice>& /*device*/, u32 keyCode)
 {
 	switch (keyCode)
 	{

--- a/rpcs3/Input/xinput_pad_handler.h
+++ b/rpcs3/Input/xinput_pad_handler.h
@@ -93,8 +93,6 @@ class xinput_pad_handler final : public PadHandlerBase
 		RSYPos
 	};
 
-	using PadButtonValues = std::unordered_map<u64, u16>;
-
 	struct XInputDevice : public PadDevice
 	{
 		u32 deviceNumber{ 0 };
@@ -123,8 +121,8 @@ private:
 	using PFN_XINPUTGETBATTERYINFORMATION = DWORD(WINAPI*)(DWORD, BYTE, XINPUT_BATTERY_INFORMATION*);
 
 	int GetDeviceNumber(const std::string& padId);
-	static PadButtonValues get_button_values_base(const XINPUT_STATE& state, trigger_recognition_mode trigger_mode);
-	static PadButtonValues get_button_values_scp(const SCP_EXTN& state, trigger_recognition_mode trigger_mode);
+	static std::unordered_map<u32, u16> get_button_values_base(const XINPUT_STATE& state, trigger_recognition_mode trigger_mode);
+	static std::unordered_map<u32, u16> get_button_values_scp(const SCP_EXTN& state, trigger_recognition_mode trigger_mode);
 
 	PFN_XINPUTGETEXTENDED xinputGetExtended{ nullptr };
 	PFN_XINPUTGETCUSTOMDATA xinputGetCustomData{ nullptr };
@@ -134,13 +132,13 @@ private:
 	utils::dynamic_library library;
 
 	std::shared_ptr<PadDevice> get_device(const std::string& device) override;
-	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
-	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u64 keyCode) override;
+	bool get_is_left_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_trigger(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_left_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
+	bool get_is_right_stick(const std::shared_ptr<PadDevice>& device, u32 keyCode) override;
 	PadHandlerBase::connection update_connection(const std::shared_ptr<PadDevice>& device) override;
 	void get_extended_info(const pad_ensemble& binding) override;
 	void apply_pad_data(const pad_ensemble& binding) override;
-	std::unordered_map<u64, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
-	pad_preview_values get_preview_values(const std::unordered_map<u64, u16>& data) override;
+	std::unordered_map<u32, u16> get_button_values(const std::shared_ptr<PadDevice>& device) override;
+	pad_preview_values get_preview_values(const std::unordered_map<u32, u16>& data) override;
 };


### PR DESCRIPTION
Use u32 instead of u64 in the mmjoy pad handler.
I don't know why this was u64. The button IDs all seem to be in u32 range.

This added a mix of u32 and u64 between handlers and therefore a lot of unnecessary complexity.