### PR TITLE
Fix iso shortcuts

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1329,18 +1329,18 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 				argv.emplace_back(m_path);
 			}
 
-			resolve_path_as_vfs_path =  true;
+			resolve_path_as_vfs_path = true;
 		}
 		else if (m_path.starts_with(game_id_boot_prefix))
 		{
 			// Try to boot a game through game ID only
-			m_title_id = m_path.substr(game_id_boot_prefix.size());
-			m_title_id = m_title_id.substr(0, m_title_id.find_first_of(fs::delim));
+			const std::string_view boot_suffix = std::string_view(m_path).substr(game_id_boot_prefix.size());
+			m_title_id = boot_suffix.substr(0, boot_suffix.find_first_of(fs::delim));
 
 			if (m_title_id.size() < 3 && m_title_id.find_first_not_of('.') == umax)
 			{
 				// Do not allow if TITLE_ID result in path redirection
-				sys_log.fatal("Game directory not found using GAMEID token. ('%s')", m_title_id);
+				sys_log.fatal("Game directory not found using GAMEID token. (m_path='%s', title_id='%s')", m_title_id);
 				return game_boot_result::invalid_file_or_folder;
 			}
 
@@ -1361,19 +1361,27 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 				title_path = std::move(game_path);
 			}
 
-			for (std::string test_path :
+			if (is_file_iso(title_path))
 			{
-				rpcs3::utils::get_hdd0_dir() + "game/" + m_title_id + "/USRDIR/EBOOT.BIN"
-				, tail.empty() ? "" : title_path + tail + "/USRDIR/EBOOT.BIN"
-				, title_path + "/PS3_GAME/USRDIR/EBOOT.BIN"
-				, title_path + "/USRDIR/EBOOT.BIN"
-			})
+				m_path = std::move(title_path);
+				ok = true;
+			}
+			else
 			{
-				if (!test_path.empty() && fs::is_file(test_path))
+				for (std::string test_path :
 				{
-					m_path = std::move(test_path);
-					ok = true;
-					break;
+					rpcs3::utils::get_hdd0_dir() + "game/" + m_title_id + "/USRDIR/EBOOT.BIN"
+					, tail.empty() ? "" : title_path + tail + "/USRDIR/EBOOT.BIN"
+					, title_path + "/PS3_GAME/USRDIR/EBOOT.BIN"
+					, title_path + "/USRDIR/EBOOT.BIN"
+				})
+				{
+					if (!test_path.empty() && fs::is_file(test_path))
+					{
+						m_path = std::move(test_path);
+						ok = true;
+						break;
+					}
 				}
 			}
 

--- a/rpcs3/rpcs3qt/game_list_actions.cpp
+++ b/rpcs3/rpcs3qt/game_list_actions.cpp
@@ -7,6 +7,7 @@
 #include "progress_dialog.h"
 
 #include "Utilities/File.h"
+#include "Loader/ISO.h"
 
 #include "Emu/System.h"
 #include "Emu/system_utils.hpp"
@@ -1460,7 +1461,11 @@ void game_list_actions::CreateShortcuts(const std::vector<game_info>& games, con
 
 		const std::string dev_flash = g_cfg_vfs.get_dev_flash();
 
-		if (gameinfo->info.category == "DG" && !fs::is_file(rpcs3::utils::get_hdd0_dir() + "/game/" + gameinfo->info.serial + "/USRDIR/EBOOT.BIN"))
+		if (is_file_iso(gameinfo->info.path))
+		{
+			gameid_token_value = gameinfo->info.serial;
+		}
+		else if (gameinfo->info.category == "DG" && !fs::is_file(rpcs3::utils::get_hdd0_dir() + "/game/" + gameinfo->info.serial + "/USRDIR/EBOOT.BIN"))
 		{
 			const usz ps3_game_dir_pos = fs::get_parent_dir(gameinfo->info.path).size();
 			std::string relative_boot_dir = gameinfo->info.path.substr(ps3_game_dir_pos);


### PR DESCRIPTION
It's probably not handling every edge case, but creating an ISO shortcut will now use the TITLE ID of the ISO and running the shortcut will restore the proper path later during boot.

Fixes #18100