### PR TITLE
config: Disable pad navigation by default

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -315,7 +315,7 @@ namespace gui
 
 	const gui_save sc_shortcuts = gui_save(sc, "shortcuts", QVariantMap());
 
-	const gui_save nav_enabled = gui_save(navigation, "pad_input_enabled",      true);
+	const gui_save nav_enabled = gui_save(navigation, "pad_input_enabled",      false);
 	const gui_save nav_global  = gui_save(navigation, "allow_global_pad_input", false);
 }
 


### PR DESCRIPTION
Pad navigation is currently crashing with the SDL handler, see #18362. Disable it until the issue is fixed.