### PR TITLE
input: log warning instead of throwing an exception when the dpad has an unknown value

### DIFF
--- a/rpcs3/Input/ds4_pad_handler.cpp
+++ b/rpcs3/Input/ds4_pad_handler.cpp
@@ -334,7 +334,12 @@ std::unordered_map<u32, u16> ds4_pad_handler::get_button_values(const std::share
 		keyBuffer[DS4KeyCodes::Right] = 0;
 		break;
 	default:
-		fmt::throw_exception("ds4 dpad state encountered unexpected input");
+		keyBuffer[DS4KeyCodes::Up] = 0;
+		keyBuffer[DS4KeyCodes::Down] = 0;
+		keyBuffer[DS4KeyCodes::Left] = 0;
+		keyBuffer[DS4KeyCodes::Right] = 0;
+		ds4_log.warning("dpad state encountered unexpected input: 0x%x", dpadState);
+		break;
 	}
 
 	// square, cross, circle, triangle

--- a/rpcs3/Input/dualsense_pad_handler.cpp
+++ b/rpcs3/Input/dualsense_pad_handler.cpp
@@ -723,7 +723,12 @@ std::unordered_map<u32, u16> dualsense_pad_handler::get_button_values(const std:
 		keyBuffer[DualSenseKeyCodes::Right] = 0;
 		break;
 	default:
-		fmt::throw_exception("dualsense dpad state encountered unexpected input");
+		keyBuffer[DualSenseKeyCodes::Up]    = 0;
+		keyBuffer[DualSenseKeyCodes::Down]  = 0;
+		keyBuffer[DualSenseKeyCodes::Left]  = 0;
+		keyBuffer[DualSenseKeyCodes::Right] = 0;
+		dualsense_log.warning("dpad state encountered unexpected input: 0x%x", data);
+		break;
 	}
 
 	data = (is_simple_mode ? input.z : input.buttons[0]) >> 4;


### PR DESCRIPTION
fixes exception in #18357

fixes #18357