### PR TITLE
Qt: Fix game list selection after Refresh(true)

### DIFF
--- a/rpcs3/rpcs3qt/game_list_table.cpp
+++ b/rpcs3/rpcs3qt/game_list_table.cpp
@@ -412,10 +412,21 @@ void game_list_table::populate(
 		row++;
 	}
 
+	bool first_index = true;
+
 	for (int selected_row : selected_rows)
 	{
-		selectionModel()->select(model()->index(selected_row, 0), QItemSelectionModel::Select | QItemSelectionModel::Rows);
+		const QModelIndex index = model()->index(selected_row, 0);
+
+		selectionModel()->select(index, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+
+		if (first_index)
+		{
+			selectionModel()->setCurrentIndex(index, QItemSelectionModel::NoUpdate);
+			first_index = false;
+		}
 	}
+	Q_EMIT itemSelectionChanged();
 }
 
 void game_list_table::repaint_icons(std::vector<game_info>& game_data, const QColor& icon_color, const QSize& icon_size, qreal device_pixel_ratio)


### PR DESCRIPTION
Fixes disabled buttons in toolbar after refreshing the game list, even if there is something selected