### PR TITLE
input: Fix SDL buttons

### DIFF
--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -65,16 +65,6 @@ sdl_pad_handler::sdl_pad_handler() : PadHandlerBase(pad_handler::sdl)
 		{ SDLKeyCodes::RSXPos,   "RS X+"    },
 		{ SDLKeyCodes::RSYPos,   "RS Y+"    },
 		{ SDLKeyCodes::RSYNeg,   "RS Y-"    },
-		{ SDLKeyCodes::PressureCross,    "South" }, // Same name as non-pressure button
-		{ SDLKeyCodes::PressureCircle,   "East" },  // Same name as non-pressure button
-		{ SDLKeyCodes::PressureSquare,   "West" },  // Same name as non-pressure button
-		{ SDLKeyCodes::PressureTriangle, "North" }, // Same name as non-pressure button
-		{ SDLKeyCodes::PressureL1,       "LB" },    // Same name as non-pressure button
-		{ SDLKeyCodes::PressureR1,       "RB" },    // Same name as non-pressure button
-		{ SDLKeyCodes::PressureUp,       "Up" },    // Same name as non-pressure button
-		{ SDLKeyCodes::PressureDown,     "Down" },  // Same name as non-pressure button
-		{ SDLKeyCodes::PressureLeft,     "Left" },  // Same name as non-pressure button
-		{ SDLKeyCodes::PressureRight,    "Right" }, // Same name as non-pressure button
 	};
 
 	init_configs();
@@ -940,6 +930,34 @@ std::unordered_map<u32, u16> sdl_pad_handler::get_button_values(const std::share
 	if (!dev || !dev->sdl.gamepad)
 		return values;
 
+	static const std::map<SDLKeyCodes, SDLKeyCodes> button_to_pressure =
+	{
+		{ SDLKeyCodes::South, SDLKeyCodes::PressureCross },
+		{ SDLKeyCodes::East, SDLKeyCodes::PressureCircle },
+		{ SDLKeyCodes::West, SDLKeyCodes::PressureSquare },
+		{ SDLKeyCodes::North, SDLKeyCodes::PressureTriangle },
+		{ SDLKeyCodes::LB, SDLKeyCodes::PressureL1 },
+		{ SDLKeyCodes::RB, SDLKeyCodes::PressureR1 },
+		{ SDLKeyCodes::Up, SDLKeyCodes::PressureUp },
+		{ SDLKeyCodes::Down, SDLKeyCodes::PressureDown },
+		{ SDLKeyCodes::Left, SDLKeyCodes::PressureLeft },
+		{ SDLKeyCodes::Right, SDLKeyCodes::PressureRight }
+	};
+
+	static const std::map<SDLKeyCodes, SDLKeyCodes> pressure_to_button =
+	{
+		{ SDLKeyCodes::PressureCross, SDLKeyCodes::South },
+		{ SDLKeyCodes::PressureCircle, SDLKeyCodes::East },
+		{ SDLKeyCodes::PressureSquare, SDLKeyCodes::West },
+		{ SDLKeyCodes::PressureTriangle, SDLKeyCodes::North },
+		{ SDLKeyCodes::PressureL1, SDLKeyCodes::LB },
+		{ SDLKeyCodes::PressureR1, SDLKeyCodes::RB },
+		{ SDLKeyCodes::PressureUp, SDLKeyCodes::Up },
+		{ SDLKeyCodes::PressureDown, SDLKeyCodes::Down },
+		{ SDLKeyCodes::PressureLeft, SDLKeyCodes::Left },
+		{ SDLKeyCodes::PressureRight, SDLKeyCodes::Right }
+	};
+
 	std::set<SDLKeyCodes> pressed_pressure_buttons;
 
 	for (SDL_GamepadButton button_id : dev->sdl.button_ids)
@@ -964,20 +982,6 @@ std::unordered_map<u32, u16> sdl_pad_handler::get_button_values(const std::share
 			case SDLKeyCodes::LB:
 			case SDLKeyCodes::RB:
 			{
-				static const std::map<SDLKeyCodes, SDLKeyCodes> button_to_pressure =
-				{
-					{ SDLKeyCodes::South, SDLKeyCodes::PressureCross },
-					{ SDLKeyCodes::East, SDLKeyCodes::PressureCircle },
-					{ SDLKeyCodes::West, SDLKeyCodes::PressureSquare },
-					{ SDLKeyCodes::North, SDLKeyCodes::PressureTriangle },
-					{ SDLKeyCodes::LB, SDLKeyCodes::PressureL1 },
-					{ SDLKeyCodes::RB, SDLKeyCodes::PressureR1 },
-					{ SDLKeyCodes::Up, SDLKeyCodes::PressureUp },
-					{ SDLKeyCodes::Down, SDLKeyCodes::PressureDown },
-					{ SDLKeyCodes::Left, SDLKeyCodes::PressureLeft },
-					{ SDLKeyCodes::Right, SDLKeyCodes::PressureRight }
-				};
-
 				if (value)
 				{
 					pressed_pressure_buttons.insert(::at32(button_to_pressure, key_code));
@@ -1025,7 +1029,7 @@ std::unordered_map<u32, u16> sdl_pad_handler::get_button_values(const std::share
 			if (dev->sdl.is_ds3_with_pressure_buttons)
 			{
 				// Get pressure button value from axis
-				if (const int key_code = SDLKeyCodes::PressureBegin + 1 + axis_id - SDL_GAMEPAD_AXIS_COUNT;
+				if (int key_code = SDLKeyCodes::PressureBegin + 1 + axis_id - SDL_GAMEPAD_AXIS_COUNT;
 					key_code > SDLKeyCodes::PressureBegin && key_code < SDLKeyCodes::PressureEnd)
 				{
 					// We need to get the joystick value directly for axis >= SDL_GAMEPAD_AXIS_COUNT
@@ -1036,9 +1040,14 @@ std::unordered_map<u32, u16> sdl_pad_handler::get_button_values(const std::share
 
 					value = static_cast<s16>(ScaledInput(value, SDL_JOYSTICK_AXIS_MIN, SDL_JOYSTICK_AXIS_MAX, 0.0f, 255.0f));
 
-					if (value <= 0 && pressed_pressure_buttons.contains(static_cast<SDLKeyCodes>(key_code)))
+					if (pressed_pressure_buttons.contains(static_cast<SDLKeyCodes>(key_code)))
 					{
-						value = 1;
+						if (value <= 0)
+						{
+							value = 1;
+						}
+
+						key_code = ::at32(pressure_to_button, static_cast<SDLKeyCodes>(key_code));
 					}
 
 					values[key_code] = Clamp0To255(value);


### PR DESCRIPTION
Fixes a regression from #18366 where dpad and face buttons would stop working in SDL

- This was caused by duplicate strings for the DS3 pressure intensity axis in the button map.
Previously they were simply added as alternative input, now they were falsely added as combo.
So the buttons were only working if you had a corresponding DS3 connected.
- I now removed the intensity axis from the map and instead overwrite the original button value.
I hope this doesn't cause regressions for the SDL DS3 pressure intensity

Fixes #18375