### PR TITLE
config: Enable start in fullscreen mode by default

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -347,7 +347,7 @@ struct cfg_root : cfg::node
 		cfg::_bool autostart{ this, "Automatically start games after boot", true, true };
 		cfg::_bool autoexit{ this, "Exit RPCS3 when process finishes", false, true };
 		cfg::_bool autopause{ this, "Pause emulation on RPCS3 focus loss", false, true };
-		cfg::_bool start_fullscreen{ this, "Start games in fullscreen mode", false, true };
+		cfg::_bool start_fullscreen{ this, "Start games in fullscreen mode", true, true };
 		cfg::_bool prevent_display_sleep{ this, "Prevent display sleep while running games", true, true };
 		cfg::_bool show_trophy_popups{ this, "Show trophy popups", true, true };
 		cfg::_bool show_rpcn_popups{ this, "Show RPCN popups", true, true };


### PR DESCRIPTION
This is part of the UX work for handheld / couch gaming. As almost all PC games already do by default, we should launch games in fullscreen mode by default.

Of course, the `Start games in fullscreen mode` setting remains for those who want to disable it, and fullscreen/windowed modes can already be toggled during gameplay from the native overlay's main menu, or with the Alt+Enter shortcut as well.