### PR TITLE
[macOS CI] Fix broken macOS builds again

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -13,6 +13,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
 export HOMEBREW_NO_ENV_HINTS=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
+brew update
 brew install -f --overwrite --quiet ccache "llvm@$LLVM_COMPILER_VER"
 brew link -f --overwrite --quiet "llvm@$LLVM_COMPILER_VER"
 if [ "$AARCH64" -eq 1 ]; then


### PR DESCRIPTION
GitHub downgraded the runner image for macOS-14 (due to some other projects having build fails afaik), restoring a known broken version of Homebrew that causes the protobuf unlink to fail (which is now causing some extra breakage in recent macOS builds as a result). I've gone and just added a step to update brew manually to the latest version to (hopefully) prevent this from happening again, unless brew pushes more broken changes in the future of course 😭. 