### PR TITLE
gui/input: disable stick anti deadzone in gui pad navigation

### DIFF
--- a/rpcs3/Input/gui_pad_thread.cpp
+++ b/rpcs3/Input/gui_pad_thread.cpp
@@ -137,7 +137,7 @@ bool gui_pad_thread::init()
 	for (usz i = 0; i < g_cfg_input.player.size(); i++)
 	{
 		std::shared_ptr<PadHandlerBase> handler;
-		gui_pad_thread::InitPadConfig(g_cfg_input.player[i]->config, g_cfg_input.player[i]->handler, handler);
+		gui_pad_thread::init_pad_config(g_cfg_input.player[i]->config, g_cfg_input.player[i]->handler, handler);
 	}
 
 	// Reload with proper defaults
@@ -153,12 +153,16 @@ bool gui_pad_thread::init()
 		cfg_player* cfg = g_cfg_input.player[i];
 
 		const pad_handler handler_type = cfg->handler.get();
-		std::shared_ptr<PadHandlerBase> cur_pad_handler = GetHandler(handler_type);
+		std::shared_ptr<PadHandlerBase> cur_pad_handler = get_handler(handler_type);
 
 		if (!cur_pad_handler)
 		{
 			continue;
 		}
+
+		// Disable stick anti-deadzone. We are not trying to emulate the PS3's behavior here.
+		cfg->config.lstick_anti_deadzone.set(0);
+		cfg->config.rstick_anti_deadzone.set(0);
 
 		cur_pad_handler->Init();
 
@@ -229,7 +233,7 @@ bool gui_pad_thread::init()
 	return true;
 }
 
-std::shared_ptr<PadHandlerBase> gui_pad_thread::GetHandler(pad_handler type)
+std::shared_ptr<PadHandlerBase> gui_pad_thread::get_handler(pad_handler type)
 {
 	switch (type)
 	{
@@ -265,14 +269,14 @@ std::shared_ptr<PadHandlerBase> gui_pad_thread::GetHandler(pad_handler type)
 	return nullptr;
 }
 
-void gui_pad_thread::InitPadConfig(cfg_pad& cfg, pad_handler type, std::shared_ptr<PadHandlerBase>& handler)
+void gui_pad_thread::init_pad_config(cfg_pad& cfg, pad_handler type, std::shared_ptr<PadHandlerBase>& handler)
 {
 	// We need to restore the original defaults first.
 	cfg.restore_defaults();
 
 	if (!handler)
 	{
-		handler = GetHandler(type);
+		handler = get_handler(type);
 	}
 
 	if (handler)

--- a/rpcs3/Input/gui_pad_thread.h
+++ b/rpcs3/Input/gui_pad_thread.h
@@ -19,8 +19,8 @@ public:
 
 	void update_settings(const std::shared_ptr<gui_settings>& settings);
 
-	static std::shared_ptr<PadHandlerBase> GetHandler(pad_handler type);
-	static void InitPadConfig(cfg_pad& cfg, pad_handler type, std::shared_ptr<PadHandlerBase>& handler);
+	static std::shared_ptr<PadHandlerBase> get_handler(pad_handler type);
+	static void init_pad_config(cfg_pad& cfg, pad_handler type, std::shared_ptr<PadHandlerBase>& handler);
 
 	static void reset()
 	{


### PR DESCRIPTION
- Disable stick anti deadzone in gui pad navigation. This is only meant for game emulation and causes stick drift otherwise.
- Add some more trace logging to the gui pad thread