### PR TITLE
Qt/input: Do not send gui input release events until there was at least one button press

### DIFF
--- a/rpcs3/Input/gui_pad_thread.cpp
+++ b/rpcs3/Input/gui_pad_thread.cpp
@@ -109,9 +109,8 @@ bool gui_pad_thread::init()
 {
 	m_handler.reset();
 	m_pad.reset();
+	m_last_button_state.clear();
 
-	// Initialize last button states as pressed to avoid unwanted button presses when starting the thread.
-	m_last_button_state.fill(true);
 	m_timestamp = steady_clock::now();
 	m_initial_timestamp = steady_clock::now();
 	m_last_auto_repeat_button = pad_button::pad_button_max_enum;
@@ -412,7 +411,18 @@ void gui_pad_thread::process_input()
 			return;
 		}
 
-		bool& last_state = m_last_button_state[static_cast<u32>(button_id)];
+		if (!m_last_button_state.contains(button_id))
+		{
+			// Ignore button presses and releases if there was no release detected at least once.
+			if (!pressed)
+			{
+				m_last_button_state[button_id] = false;
+			}
+
+			return;
+		}
+
+		bool& last_state = m_last_button_state[button_id];
 
 		if (pressed)
 		{

--- a/rpcs3/Input/gui_pad_thread.h
+++ b/rpcs3/Input/gui_pad_thread.h
@@ -65,7 +65,7 @@ protected:
 	atomic_t<bool> m_allow_global_input = false;
 	static atomic_t<bool> m_reset;
 
-	std::array<bool, static_cast<u32>(pad_button::pad_button_max_enum)> m_last_button_state{};
+	std::map<pad_button, bool> m_last_button_state{};
 
 	steady_clock::time_point m_timestamp;
 	steady_clock::time_point m_initial_timestamp;


### PR DESCRIPTION
- Do not send gui input release events until there was at least one button press

I already did this in the other direction before, so no press was sent until there was at least one release.
Turns out sending the release without the press can also cause weird things to happen, like opening a context menu.

probably fixes  #17804