### PR TITLE
cellDmuxPamf (+adec, atracXdec): process PPU state after lv2 syscalls

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAdec.cpp
@@ -261,7 +261,7 @@ void LpcmDecContext::exec(ppu_thread& ppu)
 		savestate = lpcm_dec_state::waiting_for_output_mutex_lock;
 		output_mutex_lock:
 
-		error_occurred |= static_cast<u32>(sys_mutex_lock(ppu, output_mutex, 0) != CELL_OK);
+		error_occurred |= static_cast<u32>(lv2_syscall<sys_mutex_lock>(ppu, output_mutex, 0) != CELL_OK);
 
 		if (ppu.state & cpu_flag::again)
 		{
@@ -273,7 +273,7 @@ void LpcmDecContext::exec(ppu_thread& ppu)
 			savestate = lpcm_dec_state::waiting_for_output_cond_wait;
 			output_cond_wait:
 
-			ensure(sys_cond_wait(ppu, output_consumed, 0) == CELL_OK); // Error code isn't checked on LLE
+			ensure(lv2_syscall<sys_cond_wait>(ppu, output_consumed, 0) == CELL_OK); // Error code isn't checked on LLE
 
 			if (ppu.state & cpu_flag::again)
 			{
@@ -287,7 +287,7 @@ void LpcmDecContext::exec(ppu_thread& ppu)
 		savestate = lpcm_dec_state::queue_mutex_lock;
 		queue_mutex_lock:
 
-		ensure(sys_mutex_lock(ppu, queue_mutex, 0) == CELL_OK); // Error code isn't checked on LLE
+		ensure(lv2_syscall<sys_mutex_lock>(ppu, queue_mutex, 0) == CELL_OK); // Error code isn't checked on LLE
 
 		if (ppu.state & cpu_flag::again)
 		{
@@ -703,7 +703,7 @@ error_code LpcmDecContext::send_command(ppu_thread& ppu, auto&&... args)
 {
 	ppu.state += cpu_flag::wait;
 
-	if (error_code ret = sys_mutex_lock(ppu, queue_size_mutex, 0); ret != CELL_OK)
+	if (error_code ret = lv2_syscall<sys_mutex_lock>(ppu, queue_size_mutex, 0); ret != CELL_OK)
 	{
 		return ret;
 	}
@@ -720,7 +720,7 @@ error_code LpcmDecContext::send_command(ppu_thread& ppu, auto&&... args)
 		*lpcm_param = { args... };
 	}
 
-	if (error_code ret = sys_mutex_lock(ppu, queue_mutex, 0); ret != CELL_OK)
+	if (error_code ret = lv2_syscall<sys_mutex_lock>(ppu, queue_mutex, 0); ret != CELL_OK)
 	{
 		ensure(sys_mutex_unlock(ppu, queue_size_mutex) == CELL_OK); // Error code isn't checked on LLE
 		return ret;
@@ -740,14 +740,14 @@ error_code LpcmDecContext::send_command(ppu_thread& ppu, auto&&... args)
 
 inline error_code LpcmDecContext::release_output(ppu_thread& ppu)
 {
-	if (error_code ret = sys_mutex_lock(ppu, output_mutex, 0); ret != CELL_OK)
+	if (error_code ret = lv2_syscall<sys_mutex_lock>(ppu, output_mutex, 0); ret != CELL_OK)
 	{
 		return ret;
 	}
 
 	output_locked = false;
 
-	if (error_code ret = sys_cond_signal(ppu, output_consumed); ret != CELL_OK)
+	if (error_code ret = lv2_syscall<sys_cond_signal>(ppu, output_consumed); ret != CELL_OK)
 	{
 		return ret; // LLE doesn't unlock the mutex
 	}
@@ -865,8 +865,8 @@ error_code _CellAdecCoreOpClose_lpcm(ppu_thread& ppu, vm::ptr<LpcmDecContext> ha
 
 	cellAdec.notice("_CellAdecCoreOpClose_lpcm(handle=*0x%x)", handle);
 
-	if (error_code ret = sys_mutex_lock(ppu, handle->queue_size_mutex, 0); ret != CELL_OK
-		|| (ret = sys_mutex_lock(ppu, handle->queue_mutex, 0)) != CELL_OK)
+	if (error_code ret = lv2_syscall<sys_mutex_lock>(ppu, handle->queue_size_mutex, 0); ret != CELL_OK
+		|| (ret = lv2_syscall<sys_mutex_lock>(ppu, handle->queue_mutex, 0)) != CELL_OK)
 	{
 		return ret;
 	}
@@ -1091,7 +1091,7 @@ error_code AdecContext::set_pcm_item(s32 pcm_handle, vm::ptr<void> pcm_addr, u32
 
 error_code AdecContext::link_frame(ppu_thread& ppu, s32 pcm_handle)
 {
-	ensure(sys_mutex_lock(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
+	ensure(lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
 
 	if (verify_pcm_handle(pcm_handle) == static_cast<s32>(CELL_ADEC_ERROR_FATAL))
 	{
@@ -1125,7 +1125,7 @@ error_code AdecContext::link_frame(ppu_thread& ppu, s32 pcm_handle)
 
 error_code AdecContext::unlink_frame(ppu_thread& ppu, s32 pcm_handle)
 {
-	ensure(sys_mutex_lock(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
+	ensure(lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
 
 	if (verify_pcm_handle(pcm_handle) == static_cast<s32>(CELL_ADEC_ERROR_FATAL))
 	{

--- a/rpcs3/Emu/Cell/Modules/cellAdec.h
+++ b/rpcs3/Emu/Cell/Modules/cellAdec.h
@@ -485,6 +485,19 @@ struct AdecFrame
 
 CHECK_SIZE(AdecFrame, 0x68);
 
+template <auto Syscall>
+static auto lv2_syscall(ppu_thread& ppu, auto&&... args)
+{
+	const auto ret = Syscall(ppu, std::forward<decltype(args)>(args)...);
+
+	if (ppu.test_stopped())
+	{
+		ppu.state += cpu_flag::again;
+	}
+
+	return ret;
+}
+
 class AdecOutputQueue
 {
 	struct entry
@@ -539,7 +552,7 @@ public:
 
 	error_code push(ppu_thread& ppu, vm::ptr<CellAdecPcmItem> pcm_item, s32 pcm_handle)
 	{
-		ensure(sys_mutex_lock(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
+		ensure(lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
 
 		if (entries[back].state != 0xff)
 		{
@@ -560,7 +573,7 @@ public:
 
 	const entry* pop(ppu_thread& ppu)
 	{
-		ensure(sys_mutex_lock(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
+		ensure(lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
 
 		if (ppu.state & cpu_flag::again) // Savestate was created while waiting on the mutex
 		{
@@ -587,7 +600,7 @@ public:
 
 	const entry& peek(ppu_thread& ppu) const
 	{
-		ensure(sys_mutex_lock(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
+		ensure(lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) == CELL_OK); // Error code isn't checked on LLE
 		const entry& ret = entries[front];
 		ensure(sys_mutex_unlock(ppu, mutex) == CELL_OK); // Error code isn't checked on LLE
 		return ret;
@@ -728,14 +741,14 @@ public:
 
 	error_code release(ppu_thread& ppu)
 	{
-		if (error_code ret = sys_mutex_lock(ppu, mutex, 0); ret != CELL_OK)
+		if (error_code ret = lv2_syscall<sys_mutex_lock>(ppu, mutex, 0); ret != CELL_OK)
 		{
 			return ret;
 		}
 
 		value++;
 
-		if (error_code ret = sys_cond_signal(ppu, cond); ret != CELL_OK)
+		if (error_code ret = lv2_syscall<sys_cond_signal>(ppu, cond); ret != CELL_OK)
 		{
 			return ret; // LLE doesn't unlock the mutex
 		}
@@ -752,7 +765,7 @@ public:
 
 		savestate = lpcm_dec_state::waiting_for_cmd_mutex_lock;
 
-		if (error_code ret = sys_mutex_lock(ppu, mutex, 0); ret != CELL_OK)
+		if (error_code ret = lv2_syscall<sys_mutex_lock>(ppu, mutex, 0); ret != CELL_OK)
 		{
 			return ret;
 		}
@@ -767,7 +780,7 @@ public:
 			savestate = lpcm_dec_state::waiting_for_cmd_cond_wait;
 			cond_wait:
 
-			if (error_code ret = sys_cond_wait(ppu, cond, 0); ret != CELL_OK)
+			if (error_code ret = lv2_syscall<sys_cond_wait>(ppu, cond, 0); ret != CELL_OK)
 			{
 				return ret; // LLE doesn't unlock the mutex
 			}

--- a/rpcs3/Emu/Cell/Modules/cellAtracXdec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAtracXdec.cpp
@@ -295,7 +295,7 @@ void AtracXdecContext::exec(ppu_thread& ppu)
 		{
 			savestate = atracxdec_state::initial;
 
-			ensure(sys_mutex_lock(ppu, queue_mutex, 0) == CELL_OK);
+			ensure(lv2_syscall<sys_mutex_lock>(ppu, queue_mutex, 0) == CELL_OK);
 
 			if (ppu.state & cpu_flag::again)
 			{
@@ -310,7 +310,7 @@ void AtracXdecContext::exec(ppu_thread& ppu)
 			savestate = atracxdec_state::waiting_for_cmd;
 			label1_wait_for_cmd_state:
 
-			ensure(sys_cond_wait(ppu, queue_not_empty, 0) == CELL_OK);
+			ensure(lv2_syscall<sys_cond_wait>(ppu, queue_not_empty, 0) == CELL_OK);
 
 			if (ppu.state & cpu_flag::again)
 			{
@@ -327,7 +327,7 @@ void AtracXdecContext::exec(ppu_thread& ppu)
 		savestate = atracxdec_state::checking_run_thread_1;
 		label2_check_run_thread_1_state:
 
-		ensure(sys_mutex_lock(ppu, run_thread_mutex, 0) == CELL_OK);
+		ensure(lv2_syscall<sys_mutex_lock>(ppu, run_thread_mutex, 0) == CELL_OK);
 
 		if (ppu.state & cpu_flag::again)
 		{
@@ -392,7 +392,7 @@ void AtracXdecContext::exec(ppu_thread& ppu)
 
 			cellAtracXdec.trace("Waiting for output to be consumed...");
 
-			ensure(sys_mutex_lock(ppu, output_mutex, 0) == CELL_OK);
+			ensure(lv2_syscall<sys_mutex_lock>(ppu, output_mutex, 0) == CELL_OK);
 
 			if (ppu.state & cpu_flag::again)
 			{
@@ -404,7 +404,7 @@ void AtracXdecContext::exec(ppu_thread& ppu)
 				savestate = atracxdec_state::waiting_for_output;
 				label4_wait_for_output_state:
 
-				ensure(sys_cond_wait(ppu, output_consumed, 0) == CELL_OK);
+				ensure(lv2_syscall<sys_cond_wait>(ppu, output_consumed, 0) == CELL_OK);
 
 				if (ppu.state & cpu_flag::again)
 				{
@@ -417,7 +417,7 @@ void AtracXdecContext::exec(ppu_thread& ppu)
 			savestate = atracxdec_state::checking_run_thread_2;
 			label5_check_run_thread_2_state:
 
-			ensure(sys_mutex_lock(ppu, run_thread_mutex, 0) == CELL_OK);
+			ensure(lv2_syscall<sys_mutex_lock>(ppu, run_thread_mutex, 0) == CELL_OK);
 
 			if (ppu.state & cpu_flag::again)
 			{
@@ -680,7 +680,7 @@ error_code AtracXdecContext::send_command(ppu_thread& ppu, auto&&... args)
 
 	if (!signal)
 	{
-		ensure(sys_mutex_lock(ppu, queue_mutex, 0) == CELL_OK);
+		ensure(lv2_syscall<sys_mutex_lock>(ppu, queue_mutex, 0) == CELL_OK);
 
 		if (ppu.state & cpu_flag::again)
 		{
@@ -708,7 +708,7 @@ error_code AtracXdecContext::send_command(ppu_thread& ppu, auto&&... args)
 		ensure(sys_mutex_unlock(ppu, queue_mutex) == CELL_OK);
 	}
 
-	ensure(sys_cond_signal(ppu, queue_not_empty) == CELL_OK);
+	ensure(lv2_syscall<sys_cond_signal>(ppu, queue_not_empty) == CELL_OK);
 
 	if (ppu.state & cpu_flag::again)
 	{
@@ -794,9 +794,9 @@ error_code _CellAdecCoreOpOpenExt_atracx(ppu_thread& ppu, vm::ptr<AtracXdecConte
 	ensure(sys_mutex_create(ppu, handle.ptr(&AtracXdecContext::output_mutex), mutex_attr) == CELL_OK);
 	ensure(sys_cond_create(ppu, handle.ptr(&AtracXdecContext::output_consumed), handle->output_mutex, cond_attr) == CELL_OK);
 
-	ensure(sys_mutex_lock(ppu, handle->output_mutex, 0) == CELL_OK);
+	ensure(lv2_syscall<sys_mutex_lock>(ppu, handle->output_mutex, 0) == CELL_OK);
 	handle->output_locked = false;
-	ensure(sys_cond_signal(ppu, handle->output_consumed) == CELL_OK);
+	ensure(lv2_syscall<sys_cond_signal>(ppu, handle->output_consumed) == CELL_OK);
 	ensure(sys_mutex_unlock(ppu, handle->output_mutex) == CELL_OK);
 
 	const vm::var<char[]> _name = vm::make_str("HLE ATRAC3plus decoder");
@@ -829,19 +829,19 @@ error_code _CellAdecCoreOpClose_atracx(ppu_thread& ppu, vm::ptr<AtracXdecContext
 
 	ensure(!!handle); // Not checked on LLE
 
-	ensure(sys_mutex_lock(ppu, handle->run_thread_mutex, 0) == CELL_OK);
+	ensure(lv2_syscall<sys_mutex_lock>(ppu, handle->run_thread_mutex, 0) == CELL_OK);
 	handle->run_thread = false;
 	ensure(sys_mutex_unlock(ppu, handle->run_thread_mutex) == CELL_OK);
 
 	handle->send_command<AtracXdecCmdType::close>(ppu);
 
-	ensure(sys_mutex_lock(ppu, handle->output_mutex, 0) == CELL_OK);
+	ensure(lv2_syscall<sys_mutex_lock>(ppu, handle->output_mutex, 0) == CELL_OK);
 	handle->output_locked = false;
 	ensure(sys_mutex_unlock(ppu, handle->output_mutex) == CELL_OK);
-	ensure(sys_cond_signal(ppu, handle->output_consumed) == CELL_OK);
+	ensure(lv2_syscall<sys_cond_signal>(ppu, handle->output_consumed) == CELL_OK);
 
 	vm::var<u64> thread_ret;
-	ensure(sys_ppu_thread_join(ppu, static_cast<u32>(handle->thread_id), +thread_ret) == CELL_OK);
+	ensure(lv2_syscall<sys_ppu_thread_join>(ppu, static_cast<u32>(handle->thread_id), +thread_ret) == CELL_OK);
 
 	error_code ret = sys_cond_destroy(ppu, handle->queue_not_empty);
 	ret = ret ? ret : sys_cond_destroy(ppu, handle->run_thread_cond);
@@ -921,7 +921,7 @@ error_code _CellAdecCoreOpReleasePcm_atracx(ppu_thread& ppu, vm::ptr<AtracXdecCo
 
 	if (!signal)
 	{
-		ensure(sys_mutex_lock(ppu, handle->output_mutex, 0) == CELL_OK);
+		ensure(lv2_syscall<sys_mutex_lock>(ppu, handle->output_mutex, 0) == CELL_OK);
 
 		if (ppu.state & cpu_flag::again)
 		{
@@ -931,7 +931,7 @@ error_code _CellAdecCoreOpReleasePcm_atracx(ppu_thread& ppu, vm::ptr<AtracXdecCo
 		handle->output_locked = false;
 	}
 
-	ensure(sys_cond_signal(ppu, handle->output_consumed) == CELL_OK);
+	ensure(lv2_syscall<sys_cond_signal>(ppu, handle->output_consumed) == CELL_OK);
 
 	if (ppu.state & cpu_flag::again)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellDmuxPamf.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellDmuxPamf.cpp
@@ -1154,6 +1154,19 @@ void dmux_pamf_spu_context::save(utils::serial& ar)
 
 // PPU thread
 
+template <auto Syscall>
+static auto lv2_syscall(ppu_thread& ppu, auto&&... args)
+{
+	const auto ret = Syscall(ppu, std::forward<decltype(args)>(args)...);
+
+	if (ppu.test_stopped())
+	{
+		ppu.state += cpu_flag::again;
+	}
+
+	return ret;
+}
+
 template <DmuxPamfCommandType type>
 void DmuxPamfContext::send_spu_command_and_wait(ppu_thread& ppu, bool waiting_for_spu_state, auto&&... cmd_params)
 {
@@ -1195,7 +1208,7 @@ error_code DmuxPamfContext::wait_au_released_or_stream_reset(ppu_thread& ppu, u6
 		goto label1_waiting_for_au_released_state;
 	}
 
-	if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+	if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 	{
 		return CELL_DMUX_PAMF_ERROR_FATAL;
 	}
@@ -1214,7 +1227,7 @@ error_code DmuxPamfContext::wait_au_released_or_stream_reset(ppu_thread& ppu, u6
 			savestate = dmux_pamf_state::waiting_for_au_released;
 			label1_waiting_for_au_released_state:
 
-			if (sys_cond_wait(ppu, cond, 0) != CELL_OK)
+			if (lv2_syscall<sys_cond_wait>(ppu, cond, 0) != CELL_OK)
 			{
 				sys_mutex_unlock(ppu, mutex);
 				return CELL_DMUX_PAMF_ERROR_FATAL;
@@ -1240,7 +1253,7 @@ error_code DmuxPamfContext::wait_au_released_or_stream_reset(ppu_thread& ppu, u6
 template <bool reset>
 error_code DmuxPamfContext::set_au_reset(ppu_thread& ppu)
 {
-	if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+	if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 	{
 		return CELL_DMUX_PAMF_ERROR_FATAL;
 	}
@@ -1358,7 +1371,7 @@ void DmuxPamfContext::exec(ppu_thread& ppu)
 			savestate = dmux_pamf_state::starting_demux_done;
 			label4_starting_demux_done_state:
 
-			if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+			if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 			{
 				savestate = dmux_pamf_state::starting_demux_done_mutex_lock_error;
 				label5_starting_demux_done_mutex_lock_error_state:
@@ -1423,7 +1436,7 @@ void DmuxPamfContext::exec(ppu_thread& ppu)
 		{
 		case DmuxPamfEventType::au_found:
 		{
-			if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+			if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 			{
 				savestate = dmux_pamf_state::sending_fatal_err;
 				continue;
@@ -1537,7 +1550,7 @@ void DmuxPamfContext::exec(ppu_thread& ppu)
 			savestate = dmux_pamf_state::demux_done_mutex_lock;
 			label15_demux_done_mutex_lock_state:
 
-			if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+			if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 			{
 				savestate = dmux_pamf_state::sending_fatal_err;
 				continue;
@@ -1552,7 +1565,7 @@ void DmuxPamfContext::exec(ppu_thread& ppu)
 				savestate = dmux_pamf_state::demux_done_cond_signal;
 				label16_demux_done_cond_signal_state:
 
-				if (sys_cond_signal_all(ppu, cond) != CELL_OK)
+				if (lv2_syscall<sys_cond_signal_all>(ppu, cond) != CELL_OK)
 				{
 					sys_mutex_unlock(ppu, mutex);
 
@@ -1578,7 +1591,7 @@ void DmuxPamfContext::exec(ppu_thread& ppu)
 		}
 		case DmuxPamfEventType::flush_done:
 		{
-			if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+			if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 			{
 				savestate = dmux_pamf_state::sending_fatal_err;
 				continue;
@@ -1632,7 +1645,7 @@ void DmuxPamfContext::exec(ppu_thread& ppu)
 			savestate = dmux_pamf_state::resuming_demux_mutex_lock;
 			label17_resuming_demux_mutex_lock_state:
 
-			if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+			if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 			{
 				savestate = dmux_pamf_state::sending_fatal_err;
 				continue;
@@ -2118,7 +2131,7 @@ error_code DmuxPamfContext::reset_stream(ppu_thread& ppu)
 	switch (savestate)
 	{
 	case 0:
-		if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+		if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 		{
 			return CELL_DMUX_PAMF_ERROR_FATAL;
 		}
@@ -2149,7 +2162,7 @@ error_code DmuxPamfContext::reset_stream(ppu_thread& ppu)
 		[[fallthrough]];
 
 	case 2:
-		if (const error_code ret = sys_cond_signal_to(ppu, cond, static_cast<u32>(thread_id)); ret != CELL_OK && ret != static_cast<s32>(CELL_EPERM))
+		if (const error_code ret = lv2_syscall<sys_cond_signal_to>(ppu, cond, static_cast<u32>(thread_id)); ret != CELL_OK && ret != static_cast<s32>(CELL_EPERM))
 		{
 			sys_mutex_unlock(ppu, mutex);
 			return CELL_DMUX_PAMF_ERROR_FATAL;
@@ -2216,7 +2229,7 @@ error_code _CellDmuxCoreOpCreateThread(ppu_thread& ppu, vm::ptr<CellDmuxPamfHand
 
 error_code DmuxPamfContext::join_thread(ppu_thread& ppu)
 {
-	if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+	if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 	{
 		return CELL_DMUX_PAMF_ERROR_FATAL;
 	}
@@ -2232,7 +2245,7 @@ error_code DmuxPamfContext::join_thread(ppu_thread& ppu)
 		return CELL_DMUX_PAMF_ERROR_FATAL;
 	}
 
-	return sys_ppu_thread_join(ppu, static_cast<u32>(thread_id), +vm::var<u64>{}) == CELL_OK ? static_cast<error_code>(CELL_OK) : CELL_DMUX_PAMF_ERROR_FATAL;
+	return lv2_syscall<sys_ppu_thread_join>(ppu, static_cast<u32>(thread_id), +vm::var<u64>{}) == CELL_OK ? static_cast<error_code>(CELL_OK) : CELL_DMUX_PAMF_ERROR_FATAL;
 }
 
 error_code _CellDmuxCoreOpJoinThread(ppu_thread& ppu, vm::ptr<CellDmuxPamfHandle> handle)
@@ -2265,7 +2278,7 @@ error_code DmuxPamfContext::set_stream(ppu_thread& ppu, vm::cptr<u8> stream_addr
 
 	if (!waiting_for_spu_state)
 	{
-		if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+		if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 		{
 			return CELL_DMUX_PAMF_ERROR_FATAL;
 		}
@@ -2321,7 +2334,7 @@ error_code DmuxPamfElementaryStream::release_au(ppu_thread& ppu, vm::ptr<u8> au_
 	switch (savestate)
 	{
 	case 0:
-		if (sys_mutex_lock(ppu, demuxer->mutex, 0) != CELL_OK)
+		if (lv2_syscall<sys_mutex_lock>(ppu, demuxer->mutex, 0) != CELL_OK)
 		{
 			return CELL_DMUX_PAMF_ERROR_FATAL;
 		}
@@ -2347,7 +2360,7 @@ error_code DmuxPamfElementaryStream::release_au(ppu_thread& ppu, vm::ptr<u8> au_
 		[[fallthrough]];
 
 	case 2:
-		if (const error_code ret = sys_cond_signal_to(ppu, demuxer->cond, static_cast<u32>(demuxer->thread_id)); ret != CELL_OK && ret != static_cast<s32>(CELL_EPERM))
+		if (const error_code ret = lv2_syscall<sys_cond_signal_to>(ppu, demuxer->cond, static_cast<u32>(demuxer->thread_id)); ret != CELL_OK && ret != static_cast<s32>(CELL_EPERM))
 		{
 			sys_mutex_unlock(ppu, demuxer->mutex);
 			return CELL_DMUX_PAMF_ERROR_FATAL;
@@ -2462,7 +2475,7 @@ error_code DmuxPamfContext::enable_es(ppu_thread& ppu, u16 stream_id, u16 privat
 			return CELL_DMUX_PAMF_ERROR_ARG;
 		}
 
-		if (const error_code ret = sys_mutex_lock(ppu, mutex, 0); ret != CELL_OK)
+		if (const error_code ret = lv2_syscall<sys_mutex_lock>(ppu, mutex, 0); ret != CELL_OK)
 		{
 			return CELL_DMUX_PAMF_ERROR_FATAL;
 		}
@@ -2615,7 +2628,7 @@ error_code DmuxPamfElementaryStream::disable_es(ppu_thread& ppu)
 	switch (savestate)
 	{
 	case 0:
-		if (sys_mutex_lock(ppu, dmux->mutex, 0) != CELL_OK)
+		if (lv2_syscall<sys_mutex_lock>(ppu, dmux->mutex, 0) != CELL_OK)
 		{
 			return CELL_DMUX_PAMF_ERROR_FATAL;
 		}
@@ -2660,7 +2673,7 @@ error_code DmuxPamfElementaryStream::disable_es(ppu_thread& ppu)
 		[[fallthrough]];
 
 	case 2:
-		if (const error_code ret = sys_cond_signal_to(ppu, dmux->cond, static_cast<u32>(dmux->thread_id)); ret != CELL_OK && ret != static_cast<s32>(CELL_EPERM))
+		if (const error_code ret = lv2_syscall<sys_cond_signal_to>(ppu, dmux->cond, static_cast<u32>(dmux->thread_id)); ret != CELL_OK && ret != static_cast<s32>(CELL_EPERM))
 		{
 			sys_mutex_unlock(ppu, dmux->mutex);
 			return CELL_DMUX_PAMF_ERROR_FATAL;
@@ -2699,7 +2712,7 @@ error_code DmuxPamfElementaryStream::flush_es(ppu_thread& ppu) const
 
 	if (!waiting_for_spu_state)
 	{
-		if (sys_mutex_lock(ppu, demuxer->mutex, 0) != CELL_OK)
+		if (lv2_syscall<sys_mutex_lock>(ppu, demuxer->mutex, 0) != CELL_OK)
 		{
 			return CELL_DMUX_PAMF_ERROR_FATAL;
 		}
@@ -2742,7 +2755,7 @@ error_code DmuxPamfElementaryStream::reset_es(ppu_thread& ppu) const
 
 	if (!waiting_for_spu_state)
 	{
-		if (sys_mutex_lock(ppu, demuxer->mutex, 0) != CELL_OK)
+		if (lv2_syscall<sys_mutex_lock>(ppu, demuxer->mutex, 0) != CELL_OK)
 		{
 			return CELL_DMUX_PAMF_ERROR_FATAL;
 		}
@@ -2798,7 +2811,7 @@ error_code DmuxPamfContext::reset_stream_and_wait_done(ppu_thread& ppu)
 		return {};
 	}
 
-	if (sys_mutex_lock(ppu, mutex, 0) != CELL_OK)
+	if (lv2_syscall<sys_mutex_lock>(ppu, mutex, 0) != CELL_OK)
 	{
 		return CELL_DMUX_PAMF_ERROR_FATAL;
 	}
@@ -2810,7 +2823,7 @@ error_code DmuxPamfContext::reset_stream_and_wait_done(ppu_thread& ppu)
 
 	while (sequence_state != DmuxPamfSequenceState::dormant)
 	{
-		if (sys_cond_wait(ppu, cond, 0) != CELL_OK)
+		if (lv2_syscall<sys_cond_wait>(ppu, cond, 0) != CELL_OK)
 		{
 			sys_mutex_unlock(ppu, mutex);
 			return CELL_DMUX_PAMF_ERROR_FATAL;


### PR DESCRIPTION
Should fix #18360, please test the games that are affected.

Unfortunately, White Knight Chronicles II still freezes occasionally during FMVs (though you are still able to skip any FMV after it has frozen with Start), so I didn't set cellDmuxPamf back to HLE by default yet.
Please let me know if any of the other games that were crashing before with `PPU: sleep() failed (signaled) (dmuxPamfEntry)` are freezing now.