### PR TITLE
SaveStates: Fix restart after saving

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_savestate.cpp
+++ b/rpcs3/Emu/RSX/Overlays/HomeMenu/overlay_home_menu_savestate.cpp
@@ -26,7 +26,7 @@ namespace rsx
 				{
 					if (!suspend_mode)
 					{
-						Emu.after_kill_callback = []() { Emu.Restart(); };
+						Emu.after_kill_callback = []() { Emu.Restart(true, false); };
 
 						// Make sure we keep the game window opened
 						Emu.SetContinuousMode(true);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3996,7 +3996,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 	}));
 }
 
-game_boot_result Emulator::Restart(bool graceful)
+game_boot_result Emulator::Restart(bool graceful, bool reset_path)
 {
 	if (m_state == system_state::stopping)
 	{
@@ -4004,7 +4004,7 @@ game_boot_result Emulator::Restart(bool graceful)
 		return game_boot_result::still_running;
 	}
 
-	Emu.after_kill_callback = [this]
+	Emu.after_kill_callback = [this, reset_path]
 	{
 		// Reset boot path in case of ISO
 		if (m_path.starts_with(iso_device::virtual_device_name))
@@ -4016,7 +4016,7 @@ game_boot_result Emulator::Restart(bool graceful)
 		}
 
 		// If continuous mode changed the path, restart from the original executable
-		if (!m_path_original.empty() && m_path_original != m_path)
+		if (reset_path && !m_path_original.empty() && m_path_original != m_path)
 		{
 			sys_log.notice("Restart: Resetting boot path from '%s' to original '%s'", m_path, m_path_original);
 			m_path = m_path_original;

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -442,7 +442,7 @@ public:
 	void Resume();
 	void GracefulShutdown(bool allow_autoexit = true, bool async_op = false, bool savestate = false, bool continuous_mode = false);
 	void Kill(bool allow_autoexit = true, bool savestate = false, savestate_stage* stage = nullptr);
-	game_boot_result Restart(bool graceful = true);
+	game_boot_result Restart(bool graceful = true, bool reset_path = true);
 	bool Quit(bool force_quit);
 	static void CleanUp();
 

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -362,7 +362,7 @@ void gs_frame::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const QKey
 		{
 			Emu.after_kill_callback = []()
 			{
-				Emu.Restart();
+				Emu.Restart(true, false);
 			};
 
 			// Make sure we keep the game window opened

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2538,7 +2538,7 @@ void main_window::CreateConnects()
 		{
 			Emu.after_kill_callback = []()
 			{
-				Emu.Restart();
+				Emu.Restart(true, false);
 			};
 
 			// Make sure we keep the game window opened


### PR DESCRIPTION
Savestate saving used the wrong saving file for reload causing some confusion among users. This seems to be recent regression from emulation restart fixes that regressed savestates.
Fixes #18458