### PR TITLE
sysinfo: Implement RAM Usage stats for Linux

### DIFF
--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -751,11 +751,11 @@ std::pair<u64, u64> utils::get_memory_usage()
 
 	while (std::getline(proc, line))
 	{
-		if (line.rfind("MemTotal:", 0) == 0)
+		if (line.rfind("MemTotal:", 0) == 0 && line.find("kB") != std::string::npos)
 		{
 			mem_total = std::stoull(line.substr(line.find_first_of("0123456789"))) * 1024;
 		}
-		else if (line.rfind("MemAvailable:", 0) == 0)
+		else if (line.rfind("MemAvailable:", 0) == 0 && line.find("kB") != std::string::npos)
 		{
 			mem_available = std::stoull(line.substr(line.find_first_of("0123456789"))) * 1024;
 			break;


### PR DESCRIPTION
Reads memory statistics from `/proc/meminfo`.

Note: At first I tried using the [sysinfo](https://man7.org/linux/man-pages/man2/sysinfo.2.html) syscall, but it only returns _free_ memory, not _available_ memory, as it doesn't contain cached memory statistics, so the values were completely off.