### PR TITLE
fix some bugs on ISO loader + some cleanup

### DIFF
--- a/rpcs3/Loader/ISO.cpp
+++ b/rpcs3/Loader/ISO.cpp
@@ -11,30 +11,33 @@
 
 LOG_CHANNEL(sys_log, "SYS");
 
+const int ISO_BLOCK_SIZE = 2048;
+
 bool is_file_iso(const std::string& path)
 {
-	if (path.empty()) return false;
-	if (fs::is_dir(path)) return false;
+	if (path.empty() || fs::is_dir(path))
+	{
+		return false;
+	}
 
 	return is_file_iso(fs::file(path));
 }
 
 bool is_file_iso(const fs::file& file)
 {
-	if (!file) return false;
-	if (file.size() < 32768 + 6) return false;
+	if (!file || file.size() < 32768 + 6)
+	{
+		return false;
+	}
 
 	file.seek(32768);
 
 	char magic[5];
 	file.read_at(32768 + 1, magic, 5);
 
-	return magic[0] == 'C' && magic[1] == 'D'
-		&& magic[2] == '0' && magic[3] == '0'
-		&& magic[4] == '1';
+	return magic[0] == 'C' && magic[1] == 'D' && magic[2] == '0' && magic[3] == '0' && magic[4] == '1';
 }
 
-const int ISO_BLOCK_SIZE = 2048;
 
 template<typename T>
 inline T read_both_endian_int(fs::file& file)
@@ -55,30 +58,33 @@ inline T read_both_endian_int(fs::file& file)
 	return out;
 }
 
-// assumed that directory_entry is at file head
-std::optional<iso_fs_metadata> iso_read_directory_entry(fs::file& file, bool names_in_ucs2 = false)
+// Assumed that directory_entry is at file head
+static std::optional<iso_fs_metadata> iso_read_directory_entry(fs::file& file, bool names_in_ucs2 = false)
 {
 	const auto start_pos = file.pos();
 	const u8 entry_length = file.read<u8>();
 
-	if (entry_length == 0) return std::nullopt;
+	if (entry_length == 0)
+	{
+		return std::nullopt;
+	}
 
 	file.seek(1, fs::seek_cur);
+
 	const u32 start_sector = read_both_endian_int<u32>(file);
 	const u32 file_size = read_both_endian_int<u32>(file);
-
 	std::tm file_date = {};
+
 	file_date.tm_year = file.read<u8>();
 	file_date.tm_mon = file.read<u8>() - 1;
 	file_date.tm_mday = file.read<u8>();
 	file_date.tm_hour = file.read<u8>();
 	file_date.tm_min = file.read<u8>();
 	file_date.tm_sec = file.read<u8>();
+
 	const s16 timezone_value = file.read<u8>();
 	const s16 timezone_offset = (timezone_value - 50) * 15 * 60;
-
 	const std::time_t date_time = std::mktime(&file_date) + timezone_offset;
-
 	const u8 flags = file.read<u8>();
 
 	// 2nd flag bit indicates whether a given fs node is a directory
@@ -88,8 +94,8 @@ std::optional<iso_fs_metadata> iso_read_directory_entry(fs::file& file, bool nam
 	file.seek(6, fs::seek_cur);
 
 	const u8 file_name_length = file.read<u8>();
-
 	std::string file_name;
+
 	file.read(file_name, file_name_length);
 
 	if (file_name_length == 1 && file_name[0] == 0)
@@ -100,13 +106,14 @@ std::optional<iso_fs_metadata> iso_read_directory_entry(fs::file& file, bool nam
 	{
 		file_name = "..";
 	}
-	else if (names_in_ucs2) // for strings in joliet descriptor
+	else if (names_in_ucs2) // For strings in joliet descriptor
 	{
-		// characters are stored in big endian format.
+		// Characters are stored in big endian format
+		const u16* raw = reinterpret_cast<const u16*>(file_name.data());
 		std::u16string utf16;
+
 		utf16.resize(file_name_length / 2);
 
-		const u16* raw = reinterpret_cast<const u16*>(file_name.data());
 		for (size_t i = 0; i < utf16.size(); ++i, raw++)
 		{
 			utf16[i] = *reinterpret_cast<const be_t<u16>*>(raw);
@@ -125,7 +132,7 @@ std::optional<iso_fs_metadata> iso_read_directory_entry(fs::file& file, bool nam
 		file_name.pop_back();
 	}
 
-	// skip the rest of the entry.
+	// Skip the rest of the entry
 	file.seek(entry_length + start_pos);
 
 	return iso_fs_metadata
@@ -145,49 +152,57 @@ std::optional<iso_fs_metadata> iso_read_directory_entry(fs::file& file, bool nam
 	};
 }
 
-void iso_form_hierarchy(fs::file& file, iso_fs_node& node, bool use_ucs2_decoding = false, const std::string& parent_path = "")
+static void iso_form_hierarchy(fs::file& file, iso_fs_node& node, bool use_ucs2_decoding = false, const std::string& parent_path = "")
 {
-	if (!node.metadata.is_directory) return;
+	if (!node.metadata.is_directory)
+	{
+		return;
+	}
 
 	std::vector<usz> multi_extent_node_indices;
 
-	// assuming the directory spans a single extent
+	// Assuming the directory spans a single extent
 	const auto& directory_extent = node.metadata.extents[0];
+	const u64 end_pos = directory_extent.size + (directory_extent.start * ISO_BLOCK_SIZE);
 
 	file.seek(directory_extent.start * ISO_BLOCK_SIZE);
 
-	const u64 end_pos = directory_extent.size + (directory_extent.start * ISO_BLOCK_SIZE);
-
-	while(file.pos() < end_pos)
+	while (file.pos() < end_pos)
 	{
 		auto entry = iso_read_directory_entry(file, use_ucs2_decoding);
+
 		if (!entry)
 		{
 			const u64 new_sector = (file.pos() / ISO_BLOCK_SIZE) + 1;
+
 			file.seek(new_sector * ISO_BLOCK_SIZE);
 			continue;
 		}
 
 		bool extent_added = false;
 
-		// find previous extent and merge into it, otherwise we push this node's index
+		// Find previous extent and merge into it, otherwise we push this node's index
 		for (usz index : multi_extent_node_indices)
 		{
 			auto& selected_node = ::at32(node.children, index);
+
 			if (selected_node->metadata.name == entry->name)
 			{
-				// merge into selected_node
+				// Merge into selected_node
 				selected_node->metadata.extents.push_back(entry->extents[0]);
 
 				extent_added = true;
 			}
 		}
 
-		if (extent_added) continue;
+		if (extent_added)
+		{
+			continue;
+		}
 
 		if (entry->has_multiple_extents)
 		{
-			// haven't pushed entry to node.children yet so node.children::size() == entry_index
+			// Haven't pushed entry to node.children yet so node.children::size() == entry_index
 			multi_extent_node_indices.push_back(node.children.size());
 		}
 
@@ -208,6 +223,7 @@ void iso_form_hierarchy(fs::file& file, iso_fs_node& node, bool use_ucs2_decodin
 u64 iso_fs_metadata::size() const
 {
 	u64 total_size = 0;
+
 	for (const auto& extent : extents)
 	{
 		total_size += extent.size;
@@ -223,7 +239,7 @@ iso_archive::iso_archive(const std::string& path)
 
 	if (!is_file_iso(m_file))
 	{
-		// not iso... TODO: throw something??
+		// Not iso... TODO: throw something??
 		return;
 	}
 
@@ -241,7 +257,7 @@ iso_archive::iso_archive(const std::string& path)
 		{
 			use_ucs2_decoding = descriptor_type == 2;
 
-			// skip the rest of descriptor's data
+			// Skip the rest of descriptor's data
 			m_file.seek(155, fs::seek_cur);
 
 			m_root = iso_fs_node
@@ -259,20 +275,27 @@ iso_archive::iso_archive(const std::string& path)
 
 iso_fs_node* iso_archive::retrieve(const std::string& passed_path)
 {
-	if (passed_path.empty()) return nullptr;
+	if (passed_path.empty())
+	{
+		return nullptr;
+	}
 
 	const std::string path = std::filesystem::path(passed_path).string();
 	const std::string_view path_sv = path;
 
 	size_t start = 0;
 	size_t end = path_sv.find_first_of(fs::delim);
-
 	std::stack<iso_fs_node*> search_stack;
+
 	search_stack.push(&m_root);
 
 	do
 	{
-		if (search_stack.empty()) return nullptr;
+		if (search_stack.empty())
+		{
+			return nullptr;
+		}
+
 		const auto* top_entry = search_stack.top();
 
 		if (end == umax)
@@ -280,8 +303,7 @@ iso_fs_node* iso_archive::retrieve(const std::string& passed_path)
 			end = path.size();
 		}
 
-		const std::string_view path_component = path_sv.substr(start, end-start);
-
+		const std::string_view path_component = path_sv.substr(start, end - start);
 		bool found = false;
 
 		if (path_component == ".")
@@ -291,6 +313,7 @@ iso_fs_node* iso_archive::retrieve(const std::string& passed_path)
 		else if (path_component == "..")
 		{
 			search_stack.pop();
+
 			found = true;
 		}
 		else
@@ -307,14 +330,20 @@ iso_fs_node* iso_archive::retrieve(const std::string& passed_path)
 			}
 		}
 
-		if (!found) return nullptr;
+		if (!found)
+		{
+			return nullptr;
+		}
 
 		start = end + 1;
 		end = path_sv.find_first_of(fs::delim, start);
 	}
 	while (start < path.size());
 
-	if (search_stack.empty()) return nullptr;
+	if (search_stack.empty())
+	{
+		return nullptr;
+	}
 
 	return search_stack.top();
 }
@@ -327,7 +356,11 @@ bool iso_archive::exists(const std::string& path)
 bool iso_archive::is_file(const std::string& path)
 {
 	const auto file_node = retrieve(path);
-	if (!file_node) return false;
+
+	if (!file_node)
+	{
+		return false;
+	}
 
 	return !file_node->metadata.is_directory;
 }
@@ -340,7 +373,11 @@ iso_file iso_archive::open(const std::string& path)
 psf::registry iso_archive::open_psf(const std::string& path)
 {
 	auto* archive_file = retrieve(path);
-	if (!archive_file) return psf::registry();
+
+	if (!archive_file)
+	{
+		return psf::registry();
+	}
 
 	const fs::file psf_file(std::make_unique<iso_file>(fs::file(m_path), *archive_file));
 
@@ -389,14 +426,6 @@ std::pair<u64, iso_extent_info> iso_file::get_extent_pos(u64 pos) const
 	return {pos, *it};
 }
 
-// assumed valid and in bounds.
-u64 iso_file::file_offset(u64 pos) const
-{
-	const auto [local_pos, extent] = get_extent_pos(pos);
-
-	return (extent.start * ISO_BLOCK_SIZE) + local_pos;
-}
-
 u64 iso_file::local_extent_remaining(u64 pos) const
 {
 	const auto [local_pos, extent] = get_extent_pos(pos);
@@ -409,26 +438,30 @@ u64 iso_file::local_extent_size(u64 pos) const
 	return get_extent_pos(pos).second.size;
 }
 
+// Assumed valid and in bounds
+u64 iso_file::file_offset(u64 pos) const
+{
+	const auto [local_pos, extent] = get_extent_pos(pos);
+
+	return (extent.start * ISO_BLOCK_SIZE) + local_pos;
+}
+
 u64 iso_file::read(void* buffer, u64 size)
 {
 	const auto r = read_at(m_pos, buffer, size);
+
 	m_pos += r;
 	return r;
 }
 
 u64 iso_file::read_at(u64 offset, void* buffer, u64 size)
 {
-	const u64 local_remaining = local_extent_remaining(offset);
-
-	const u64 total_read = m_file.read_at(file_offset(offset), buffer, std::min(size, local_remaining));
-
-	const auto total_size = this->size();
+	const u64 total_size = this->size();
+	u64 total_read = m_file.read_at(file_offset(offset), buffer, std::min(size, local_extent_remaining(offset)));
 
 	if (size > total_read && (offset + total_read) < total_size)
 	{
-		const u64 second_total_read = read_at(offset + total_read, reinterpret_cast<u8*>(buffer) + total_read, size - total_read);
-
-		return total_read + second_total_read;
+		total_read += read_at(offset + total_read, reinterpret_cast<u8*>(buffer) + total_read, size - total_read);
 	}
 
 	return total_read;
@@ -454,8 +487,10 @@ u64 iso_file::seek(s64 offset, fs::seek_mode whence)
 		return -1;
 	}
 
-	const u64 result = m_file.seek(file_offset(m_pos));
-	if (result == umax) return umax;
+	if (m_file.seek(file_offset(new_pos)) == umax)
+	{
+		return umax;
+	}
 
 	m_pos = new_pos;
 	return m_pos;
@@ -464,6 +499,7 @@ u64 iso_file::seek(s64 offset, fs::seek_mode whence)
 u64 iso_file::size()
 {
 	u64 extent_sizes = 0;
+
 	for (const auto& extent : m_meta.extents)
 	{
 		extent_sizes += extent.size;
@@ -493,18 +529,22 @@ bool iso_dir::read(fs::dir_entry& entry)
 		entry.size = selected.size();
 
 		m_pos++;
-
 		return true;
 	}
 
 	return false;
 }
 
+void iso_dir::rewind()
+{
+	m_pos = 0;
+}
+
 bool iso_device::stat(const std::string& path, fs::stat_t& info)
 {
 	const auto relative_path = std::filesystem::relative(std::filesystem::path(path), std::filesystem::path(fs_prefix)).string();
-
 	const auto node = m_archive.retrieve(relative_path);
+
 	if (!node)
 	{
 		fs::g_tls_error = fs::error::noent;
@@ -530,16 +570,15 @@ bool iso_device::stat(const std::string& path, fs::stat_t& info)
 bool iso_device::statfs(const std::string& path, fs::device_stat& info)
 {
 	const auto relative_path = std::filesystem::relative(std::filesystem::path(path), std::filesystem::path(fs_prefix)).string();
-
 	const auto node = m_archive.retrieve(relative_path);
+
 	if (!node)
 	{
 		fs::g_tls_error = fs::error::noent;
 		return false;
 	}
 
-	const auto& meta = node->metadata;
-	const u64 size = meta.size();
+	const u64 size = node->metadata.size();
 
 	info = fs::device_stat
 	{
@@ -549,14 +588,14 @@ bool iso_device::statfs(const std::string& path, fs::device_stat& info)
 		.avail_free = 0
 	};
 
-	return false;
+	return true;
 }
 
 std::unique_ptr<fs::file_base> iso_device::open(const std::string& path, bs_t<fs::open_mode> mode)
 {
 	const auto relative_path = std::filesystem::relative(std::filesystem::path(path), std::filesystem::path(fs_prefix)).string();
-
 	const auto node = m_archive.retrieve(relative_path);
+
 	if (!node)
 	{
 		fs::g_tls_error = fs::error::noent;
@@ -575,8 +614,8 @@ std::unique_ptr<fs::file_base> iso_device::open(const std::string& path, bs_t<fs
 std::unique_ptr<fs::dir_base> iso_device::open_dir(const std::string& path)
 {
 	const auto relative_path = std::filesystem::relative(std::filesystem::path(path), std::filesystem::path(fs_prefix)).string();
-
 	const auto node = m_archive.retrieve(relative_path);
+
 	if (!node)
 	{
 		fs::g_tls_error = fs::error::noent;
@@ -591,11 +630,6 @@ std::unique_ptr<fs::dir_base> iso_device::open_dir(const std::string& path)
 	}
 
 	return std::make_unique<iso_dir>(*node);
-}
-
-void iso_dir::rewind()
-{
-	m_pos = 0;
 }
 
 void load_iso(const std::string& path)

--- a/rpcs3/Loader/ISO.h
+++ b/rpcs3/Loader/ISO.h
@@ -75,26 +75,25 @@ public:
 	void rewind() override;
 };
 
-// represents the .iso file itself.
+// Represents the .iso file itself
 class iso_archive
 {
 private:
 	std::string m_path;
-	iso_fs_node m_root {};
 	fs::file m_file;
+	iso_fs_node m_root {};
 
 public:
 	iso_archive(const std::string& path);
+
+	const std::string& path() const { return m_path; }
 
 	iso_fs_node* retrieve(const std::string& path);
 	bool exists(const std::string& path);
 	bool is_file(const std::string& path);
 
 	iso_file open(const std::string& path);
-
 	psf::registry open_psf(const std::string& path);
-
-	const std::string& path() const { return m_path; }
 };
 
 class iso_device : public fs::device_base
@@ -111,6 +110,7 @@ public:
 	{
 		fs_prefix = device_name;
 	}
+
 	~iso_device() override = default;
 
 	const std::string& get_loaded_iso() const { return iso_path; }


### PR DESCRIPTION
Some fixes and cleanup on ISO loader as base code for a next PR providing support to encrypted ISO:
- fixed `iso_file::seek()`: new offset was never used. Currently, this bug is not responsible for an issue due to `iso_file::read()` is based on `iso_file::read_at()` so a correct seek is always forced before reading
- fixed return value on `iso_device::statfs()`: Apparently this method is never called so no issue is currently present
- minor optimization on `iso_file::read_at()`
- cleanup: used a common code-style across the code (e.g. separate variable definition from code execution, use capital letter for comments, use `{}` for any `if ()` etc.), should be more compliant to code-style used by main developers

