### PR TITLE
rsx: Allow negative src and dst pitch in nv0039

### DIFF
--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -14,7 +14,7 @@ namespace rsx
 	namespace nv0039
 	{
 		// Transfer with stride
-		inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 width, u32 height, u32 src_pitch, u32 dst_pitch, u8 src_stride, u8 dst_stride)
+		inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 width, u32 height, s32 src_pitch, s32 dst_pitch, u8 src_stride, u8 dst_stride)
 		{
 			for (u32 row = 0; row < height; ++row)
 			{
@@ -33,7 +33,7 @@ namespace rsx
 			}
 		}
 
-		inline void block2d_copy(u8* dst, const u8* src, u32 width, u32 height, u32 src_pitch, u32 dst_pitch)
+		inline void block2d_copy(u8* dst, const u8* src, u32 width, u32 height, s32 src_pitch, s32 dst_pitch)
 		{
 			for (u32 i = 0; i < height; ++i)
 			{


### PR DESCRIPTION
Restores old RPCS3 behavior with 0039 negative pitch transfers.
Behavior is confirmed with hardware tests.

PS3 Output:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/27ad8453-c440-4d1a-a380-7cd260584cb6" />

Testcase: [transfer2d_tests.zip](https://github.com/user-attachments/files/26489295/transfer2d_tests.zip)

Fixes #17730
Fixes #18195
Fixes #18073