### PR TITLE
rsx: Implement unwrapping cubemaps with mipchains

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1731,24 +1731,34 @@ namespace rsx
 			}
 			case deferred_request_command::cubemap_unwrap:
 			{
-				rsx::simple_array<copy_region_descriptor> sections(6);
-				for (u16 n = 0; n < 6; ++n)
+				rsx::simple_array<copy_region_descriptor> sections(6 * desc.mipmaps);
+				for (u16 n = 0, section_id = 0; n < 6; ++n)
 				{
-					sections[n] =
+					u16 mip_w = desc.width, mip_h = desc.height;
+					u16 y_offset = static_cast<u16>(desc.slice_h * n);
+
+					for (u8 mip = 0; mip < desc.mipmaps; ++mip)
 					{
-						.src = desc.external_handle,
-						.xform = surface_transform::coordinate_transform,
-						.level = 0,
-						.src_x = 0,
-						.src_y = static_cast<u16>(desc.slice_h * n),
-						.dst_x = 0,
-						.dst_y = 0,
-						.dst_z = n,
-						.src_w = desc.width,
-						.src_h = desc.height,
-						.dst_w = desc.width,
-						.dst_h = desc.height
-					};
+						sections[section_id++] =
+						{
+							.src = desc.external_handle,
+							.xform = surface_transform::coordinate_transform,
+							.level = mip,
+							.src_x = 0,
+							.src_y = y_offset,
+							.dst_x = 0,
+							.dst_y = 0,
+							.dst_z = n,
+							.src_w = mip_w,
+							.src_h = mip_h,
+							.dst_w = mip_w,
+							.dst_h = mip_h
+						};
+
+						y_offset += mip_h;
+						mip_w = std::max<u16>(mip_w / 2, 1);
+						mip_h = std::max<u16>(mip_h / 2, 1);
+					}
 				}
 
 				result = generate_cubemap_from_images(cmd, desc.gcm_format, desc.width, sections, desc.remap);

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -384,7 +384,21 @@ void GLGSRender::load_texture_env()
 			}
 		}
 
-		m_fs_sampler_states[i].apply(tex, fs_sampler_state[i].get());
+		u32 actual_mipcount = 1;
+		if (sampler_state->upload_context == rsx::texture_upload_context::shader_read)
+		{
+			actual_mipcount = tex.get_exact_mipmap_count();
+		}
+		else if (sampler_state->external_subresource_desc.op == rsx::deferred_request_command::mipmap_gather)
+		{
+			actual_mipcount = sampler_state->external_subresource_desc.sections_to_copy.size();
+		}
+		else if (sampler_state->external_subresource_desc.op == rsx::deferred_request_command::cubemap_unwrap)
+		{
+			actual_mipcount = sampler_state->external_subresource_desc.mipmaps;
+		}
+
+		m_fs_sampler_states[i].apply(tex, fs_sampler_state[i].get(), actual_mipcount > 1);
 
 		const auto texture_format = sampler_state->format_ex.format();
 		// Depth format redirected to BGRA8 resample stage. Do not filter to avoid bits leaking.

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -586,7 +586,8 @@ namespace gl
 		gl::texture_view* generate_cubemap_from_images(gl::command_context& cmd, u32 gcm_format, u16 size, const rsx::simple_array<copy_region_descriptor>& sources, const rsx::texture_channel_remap_t& remap_vector) override
 		{
 			auto _template = get_template_from_collection_impl(sources);
-			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_CUBE_MAP, gcm_format, 0, 0, size, size, 1, 1, remap_vector, false);
+			const u8 mip_count = 1 + sources.reduce(0, FN(std::max<u8>(x, y.level)));
+			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_CUBE_MAP, gcm_format, 0, 0, size, size, 1, mip_count, remap_vector, false);
 
 			copy_transfer_regions_impl(cmd, result->image(), sources);
 			return result;

--- a/rpcs3/Emu/RSX/GL/glutils/sampler.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/sampler.cpp
@@ -72,7 +72,7 @@ namespace gl
 	}
 
 	// Apply sampler state settings
-	void sampler_state::apply(const rsx::fragment_texture& tex, const rsx::sampled_image_descriptor_base* sampled_image)
+	void sampler_state::apply(const rsx::fragment_texture& tex, const rsx::sampled_image_descriptor_base* sampled_image, bool allow_mipmaps)
 	{
 		set_parameteri(GL_TEXTURE_WRAP_S, wrap_mode(tex.wrap_s()));
 		set_parameteri(GL_TEXTURE_WRAP_T, wrap_mode(tex.wrap_t()));
@@ -114,8 +114,7 @@ namespace gl
 			}
 		}
 
-		if (sampled_image->upload_context != rsx::texture_upload_context::shader_read ||
-			tex.get_exact_mipmap_count() == 1)
+		if (!allow_mipmaps || tex.get_exact_mipmap_count() == 1)
 		{
 			GLint min_filter = tex_min_filter(tex.min_filter());
 

--- a/rpcs3/Emu/RSX/GL/glutils/sampler.h
+++ b/rpcs3/Emu/RSX/GL/glutils/sampler.h
@@ -75,7 +75,7 @@ namespace gl
 			return (prop == m_propertiesf.end()) ? 0 : prop->second;
 		}
 
-		void apply(const rsx::fragment_texture& tex, const rsx::sampled_image_descriptor_base* sampled_image);
+		void apply(const rsx::fragment_texture& tex, const rsx::sampled_image_descriptor_base* sampled_image, bool allow_mipmaps = true);
 		void apply(const rsx::vertex_texture& tex, const rsx::sampled_image_descriptor_base* sampled_image);
 
 		void apply_defaults(GLenum default_filter = GL_NEAREST);

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -471,6 +471,10 @@ void VKGSRender::load_texture_env()
 				// Clamp min and max lod
 				actual_mipmaps = static_cast<f32>(sampler_state->external_subresource_desc.sections_to_copy.size());
 			}
+			else if (sampler_state->external_subresource_desc.op == rsx::deferred_request_command::cubemap_unwrap)
+			{
+				actual_mipmaps = static_cast<f32>(sampler_state->external_subresource_desc.mipmaps);
+			}
 			else
 			{
 				actual_mipmaps = 1.f;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -761,8 +761,9 @@ namespace vk
 		const rsx::simple_array<copy_region_descriptor>& sections_to_copy, const rsx::texture_channel_remap_t& remap_vector)
 	{
 		auto _template = get_template_from_collection_impl(sections_to_copy);
+		const u8 mip_count = 1 + sections_to_copy.reduce(0, FN(std::max<u8>(x, y.level)));
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
-			VK_IMAGE_VIEW_TYPE_CUBE, gcm_format, 0, 0, size, size, 1, 1, remap_vector, false);
+			VK_IMAGE_VIEW_TYPE_CUBE, gcm_format, 0, 0, size, size, 1, mip_count, remap_vector, false);
 
 		if (!result)
 		{
@@ -772,7 +773,7 @@ namespace vk
 
 		const auto image = result->image();
 		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
-		VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 6 };
+		VkImageSubresourceRange dst_range = { dst_aspect, 0, mip_count, 0, 6 };
 		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
 
 		if (!(dst_aspect & VK_IMAGE_ASPECT_DEPTH_BIT))


### PR DESCRIPTION
Previously only the highest resolution mipmap was decoded. Great for performance but breaks PBR-style materials.

Closes https://github.com/RPCS3/rpcs3/issues/18428
Closes https://github.com/RPCS3/rpcs3/issues/12247