### PR TITLE
SPU: Remove RCHCNT loop handling of SPU_WrOutMbox

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -4357,11 +4357,6 @@ public:
 		{
 			switch (op.ra)
 			{
-			case SPU_WrOutIntrMbox:
-			{
-				res.value = wait_rchcnt(::offset32(&spu_thread::ch_out_intr_mbox), true);
-				break;
-			}
 			case SPU_RdSigNotify1:
 			{
 				res.value = wait_rchcnt(::offset32(&spu_thread::ch_snr1));


### PR DESCRIPTION
The loop handling of write channels does not work and causes the SPU thread to deadlock. Instead, we fall back to the regular SPU_WrOutMbox and SPU_WrOutIntrMbox paths.

Fixes freezing in Half-Life 2.
Fixes #17958