### PR TITLE
Include <pthread.h> for pthread_self

### DIFF
--- a/rpcs3/util/atomic.cpp
+++ b/rpcs3/util/atomic.cpp
@@ -51,6 +51,10 @@ static bool has_waitv()
 #include <random>
 #include <climits>
 
+#ifdef __linux__
+#include <pthread.h>
+#endif
+
 #include "asm.hpp"
 #include "endian.hpp"
 #include "tsc.hpp"


### PR DESCRIPTION
Fixes compilation on Gentoo Linux with clang/libc++ 21.