### PR TITLE
CPUThread: fix ASAN use-after-free

### DIFF
--- a/rpcs3/Emu/CPU/CPUThread.cpp
+++ b/rpcs3/Emu/CPU/CPUThread.cpp
@@ -729,8 +729,14 @@ void cpu_thread::operator()()
 		{
 			if (_this)
 			{
-				sys_log.warning("CPU Thread '%s' terminated abnormally!", name);
 				cleanup();
+
+				auto log_thread = named_thread("CPU Thread Cleanup Logger", [name = name]()
+				{
+					sys_log.warning("CPU Thread '%s' terminated abnormally!", name);
+				});
+
+				log_thread();
 			}
 		}
 	} cleanup;


### PR DESCRIPTION
```
=================================================================
==35776==ERROR: AddressSanitizer: heap-use-after-free on address 0x128532653900 at pc 0x7ff7a395ae8c bp 0x006dbcabd100 sp 0x006dbcabd148
WRITE of size 1 at 0x128532653900 thread T-1
    #0 0x7ff7a395ae8b in std::__1::char_traits<char>::assign[abi:nqn220102](char&, char const&) C:/msys64/clang64/include/c++/v1/__string/char_traits.h:93:10
    #1 0x7ff7a395ae8b in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::clear[abi:nqn220102]() C:/msys64/clang64/include/c++/v1/string:3391:5
    #2 0x7ff7a395ae8b in logs::message::broadcast(char const*, fmt_type_info const*, ...) const C:/src/rpcs3/rpcs3/util/logs.cpp:408:7
    #3 0x7ff7a3d42b7a in void logs::message::operator()<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(const_str_t<18446744073709551615ull> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const C:/src/rpcs3/rpcs3/Emu/../util/logs.hpp:154:5
    #4 0x7ff7a3d42b7a in cpu_thread::operator()()::thread_cleanup_t::~thread_cleanup_t() C:/src/rpcs3/rpcs3/Emu/CPU/CPUThread.cpp:732:5
    #5 0x7ff7a3d1eaf3 in run_dtor_list D:/W/B/src/mingw-w64/mingw-w64-crt/crt/tls_atexit.c:62:5   
    #6 0x7ff7a3d1eaf3 in tls_callback D:/W/B/src/mingw-w64/mingw-w64-crt/crt/tls_atexit.c:165:5   
    #7 0x7ffe03dc99ba  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800e99ba)
    #8 0x7ffe03e3f739  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18015f739)
    #9 0x7ffe03cebc32  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18000bc32)
    #10 0x7ffe03cebfdd  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18000bfdd)
    #11 0x7ffe03d6c9d4  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c9d4)
    #12 0x7ffe03d6c515  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c515)
    #13 0x7ffe0165395d  (C:\WINDOWS\System32\ucrtbase.dll+0x18000395d)
    #14 0x7ffe01653898  (C:\WINDOWS\System32\ucrtbase.dll+0x180003898)
    #15 0x7ff7a39996e6 in thread_ctrl::emergency_exit(std::__1::basic_string_view<char, std::__1::char_traits<char>>) C:/src/rpcs3/Utilities/Thread.cpp:2944:3
    #16 0x7ff7a3944582 in fmt::raw_throw_exception(std::__1::source_location, char const*, fmt_type_info const*, unsigned long long const*) C:/src/rpcs3/Utilities/StrFmt.cpp:670:3
    #17 0x7ff7a3ea1718 in fmt::throw_exception<char, 42ull, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, fs::error>::throw_exception(char const (&) [42], std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, fs::error const&, fmt::throw_exception<char, 42ull, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, fs::error>::args_break_t, std::__1::source_location) C:/src/rpcs3/rpcs3/Emu/../../Utilities/StrFmt.h:393:4
    #18 0x7ff7a3ea1718 in ppu_initialize(ppu_module<lv2_obj> const&, bool, unsigned long long) C:/src/rpcs3/rpcs3/Emu/Cell/PPUThread.cpp:4592:4
    #19 0x7ff7a4271650 in prx_load_module(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, fs::file, long long) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/sys_prx.cpp:299:2
    #20 0x7ff7a42732b8 in _sys_prx_load_module(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/sys_prx.cpp:512:9
    #21 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<4u, 256u, 512u, 768u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u, 512u, 768u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:183:10
    #22 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, 256u, 512u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u, 512u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #23 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, 256u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #24 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10     
    #25 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<...>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #26 0x7ff7a3d9cd05 in ppu_func_detail::func_binder<error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>::do_call(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>)) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:246:61
    #27 0x7ff7a3d9cd05 in void ppu_func_detail::do_call<error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>)) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:253:3
    #28 0x7ff7a3d9cd05 in $_263::operator()(ppu_thread&, ppu_opcode_t, stx::se_t<unsigned int, true, 4ull>*, ppu_intrp_func*) const C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:529:2
    #29 0x7ff7a3d9cd05 in $_263::__invoke(ppu_thread&, ppu_opcode_t, stx::se_t<unsigned int, true, 4ull>*, ppu_intrp_func*) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:529:2
    #30 0x7ff7a3d5a88a in ppu_execute_syscall(ppu_thread&, unsigned long long) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:1258:4
    #31 0x12c0a0f8f2a3  (<unknown module>)

0x128532653900 is located 0 bytes inside of 6336-byte region [0x128532653900,0x1285326551c0)
freed by thread T0 here:
    #0 0x7ffda071d941 in free (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x18004d941)
    #1 0x7ff7a3d1eaf3 in run_dtor_list D:/W/B/src/mingw-w64/mingw-w64-crt/crt/tls_atexit.c:62:5   
    #2 0x7ff7a3d1eaf3 in tls_callback D:/W/B/src/mingw-w64/mingw-w64-crt/crt/tls_atexit.c:165:5   
    #3 0x7ffe03dc99ba  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800e99ba)
    #4 0x7ffe03e3f739  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18015f739)
    #5 0x7ffe03cebc32  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18000bc32)
    #6 0x7ffe03cebfdd  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18000bfdd)
    #7 0x7ffe03d6c9d4  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c9d4)
    #8 0x7ffe03d6c515  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c515)
    #9 0x7ffe0165395d  (C:\WINDOWS\System32\ucrtbase.dll+0x18000395d)
    #10 0x7ffe01653898  (C:\WINDOWS\System32\ucrtbase.dll+0x180003898)
    #11 0x7ff7a39996e6 in thread_ctrl::emergency_exit(std::__1::basic_string_view<char, std::__1::char_traits<char>>) C:/src/rpcs3/Utilities/Thread.cpp:2944:3
    #12 0x7ff7a3944582 in fmt::raw_throw_exception(std::__1::source_location, char const*, fmt_type_info const*, unsigned long long const*) C:/src/rpcs3/Utilities/StrFmt.cpp:670:3
    #13 0x7ff7a3ea1718 in fmt::throw_exception<char, 42ull, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, fs::error>::throw_exception(char const (&) [42], std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, fs::error const&, fmt::throw_exception<char, 42ull, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, fs::error>::args_break_t, std::__1::source_location) C:/src/rpcs3/rpcs3/Emu/../../Utilities/StrFmt.h:393:4
    #14 0x7ff7a3ea1718 in ppu_initialize(ppu_module<lv2_obj> const&, bool, unsigned long long) C:/src/rpcs3/rpcs3/Emu/Cell/PPUThread.cpp:4592:4
    #15 0x7ff7a4271650 in prx_load_module(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, fs::file, long long) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/sys_prx.cpp:299:2
    #16 0x7ff7a42732b8 in _sys_prx_load_module(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/sys_prx.cpp:512:9
    #17 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<4u, 256u, 512u, 768u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u, 512u, 768u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:183:10
    #18 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, 256u, 512u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u, 512u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #19 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, 256u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #20 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10     
    #21 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<...>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #22 0x7ff7a3d9cd05 in ppu_func_detail::func_binder<error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>::do_call(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>)) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:246:61
    #23 0x7ff7a3d9cd05 in void ppu_func_detail::do_call<error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>)) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:253:3
    #24 0x7ff7a3d9cd05 in $_263::operator()(ppu_thread&, ppu_opcode_t, stx::se_t<unsigned int, true, 4ull>*, ppu_intrp_func*) const C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:529:2
    #25 0x7ff7a3d9cd05 in $_263::__invoke(ppu_thread&, ppu_opcode_t, stx::se_t<unsigned int, true, 4ull>*, ppu_intrp_func*) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:529:2
    #26 0x7ff7a3d5a88a in ppu_execute_syscall(ppu_thread&, unsigned long long) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:1258:4
    #27 0x12c0a0f8f2a3  (<unknown module>)

previously allocated by thread T138 here:
    #0 0x7ffda071da51 in malloc (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x18004da51)
    #1 0x7ffdc9807e97 in .weak._Znwy.default.__clang_call_terminate (C:\msys64\clang64\bin\libc++.dll+0x180027e97)
    #2 0x7ffdc982e2e9 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__grow_by_and_replace(unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, char const*) (C:\msys64\clang64\bin\libc++.dll+0x18004e2e9)
    #3 0x7ff7a393ea52 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::append(char const*, unsigned long long) C:/msys64/clang64/include/c++/v1/string:3037:5
    #4 0x7ff7a393ea52 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::append[abi:nqn220102](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/msys64/clang64/include/c++/v1/string:1400:12
    #5 0x7ff7a393ea52 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::operator+=[abi:nqn220102](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/msys64/clang64/include/c++/v1/string:1371:12
    #6 0x7ff7a393ea52 in fmt_class_string<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>::format(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, unsigned long long) C:/src/rpcs3/Utilities/StrFmt.cpp:325:6
    #7 0x7ff7a394d792 in fmt::cfmt_src::fmt_string(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, unsigned long long) const C:/src/rpcs3/Utilities/StrFmt.cpp:709:3
    #8 0x7ff7a394d792 in unsigned long long cfmt_append<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, char, fmt::cfmt_src>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char const*, fmt::cfmt_src&&) C:/src/rpcs3/Utilities/cfmt.h:339:25
    #9 0x7ff7a39445ba in fmt::raw_append(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char const*, fmt_type_info const*, unsigned long long const*) C:/src/rpcs3/Utilities/StrFmt.cpp:747:2
    #10 0x7ff7a395a66a in logs::message::broadcast(char const*, fmt_type_info const*, ...) const C:/src/rpcs3/rpcs3/util/logs.cpp:416:2
    #11 0x7ff7a3999725 in void logs::message::operator()<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(const_str_t<18446744073709551615ull> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const C:/src/rpcs3/rpcs3/Emu/../util/logs.hpp:154:5
    #12 0x7ff7a3999725 in thread_ctrl::emergency_exit(std::__1::basic_string_view<char, std::__1::char_traits<char>>) C:/src/rpcs3/Utilities/Thread.cpp:2869:3
    #13 0x7ff7a3944582 in fmt::raw_throw_exception(std::__1::source_location, char const*, fmt_type_info const*, unsigned long long const*) C:/src/rpcs3/Utilities/StrFmt.cpp:670:3
    #14 0x7ff7a3ea1718 in fmt::throw_exception<char, 42ull, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, fs::error>::throw_exception(char const (&) [42], std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, fs::error const&, fmt::throw_exception<char, 42ull, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, fs::error>::args_break_t, std::__1::source_location) C:/src/rpcs3/rpcs3/Emu/../../Utilities/StrFmt.h:393:4
    #15 0x7ff7a3ea1718 in ppu_initialize(ppu_module<lv2_obj> const&, bool, unsigned long long) C:/src/rpcs3/rpcs3/Emu/Cell/PPUThread.cpp:4592:4
    #16 0x7ff7a4271650 in prx_load_module(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, fs::file, long long) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/sys_prx.cpp:299:2
    #17 0x7ff7a42732b8 in _sys_prx_load_module(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/sys_prx.cpp:512:9
    #18 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<4u, 256u, 512u, 768u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u, 512u, 768u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:183:10
    #19 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, 256u, 512u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u, 512u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #20 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, 256u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u, 256u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #21 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, 4u, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<4u>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10     
    #22 0x7ff7a3d9cd05 in error_code ppu_func_detail::call<ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>, error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>), ppu_func_detail::arg_info_pack_t<...>) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:213:10
    #23 0x7ff7a3d9cd05 in ppu_func_detail::func_binder<error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>::do_call(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>)) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:246:61
    #24 0x7ff7a3d9cd05 in void ppu_func_detail::do_call<error_code, ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>>(ppu_thread&, error_code (*)(ppu_thread&, vm::_ptr_base<char const, unsigned int>, unsigned long long, vm::_ptr_base<sys_prx_load_module_option_t, unsigned int>)) C:/src/rpcs3/rpcs3/Emu/../Emu/Cell/PPUFunction.h:253:3
    #25 0x7ff7a3d9cd05 in $_263::operator()(ppu_thread&, ppu_opcode_t, stx::se_t<unsigned int, true, 4ull>*, ppu_intrp_func*) const C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:529:2
    #26 0x7ff7a3d9cd05 in $_263::__invoke(ppu_thread&, ppu_opcode_t, stx::se_t<unsigned int, true, 4ull>*, ppu_intrp_func*) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:529:2
    #27 0x7ff7a3d5a88a in ppu_execute_syscall(ppu_thread&, unsigned long long) C:/src/rpcs3/rpcs3/Emu/Cell/lv2/lv2.cpp:1258:4
    #28 0x12c0a0f8f2a3  (<unknown module>)

Thread T138 created by T0 here:
    #0 0x7ffda072f186 in CreateThread (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x18005f186)
    #1 0x7ffe016c9967  (C:\WINDOWS\System32\ucrtbase.dll+0x180079967)
    #2 0x7ff7a399633e in thread_base::start() C:/src/rpcs3/Utilities/Thread.cpp:2217:13
    #3 0x7ff7a3ff3580 in named_thread<ppu_thread>::named_thread<ppu_thread_params&, char const (&) [12], int&, int>(ppu_thread_params&, char const (&) [12], int&, int&&) C:/src/rpcs3/rpcs3/Emu/../../Utilities/Thread.h:553:11
    #4 0x7ff7a3ff30bb in stx::shared_data<named_thread<ppu_thread>>::shared_data<ppu_thread_params&, char const (&) [12], int&, int>(ppu_thread_params&, char const (&) [12], int&, int&&) C:/src/rpcs3/rpcs3/Emu/../util/shared_ptr.hpp:56:6
    #5 0x7ff7a3ff30bb in stx::single_ptr<T> stx::make_single<named_thread<ppu_thread>, true, ppu_thread_params&, char const (&) [12], int&, int>(ppu_thread_params&, char const (&) [12], int&, int&&) C:/src/rpcs3/rpcs3/Emu/../util/shared_ptr.hpp:230:14
    #6 0x7ff7a3ff30bb in stx::shared_ptr<T> stx::make_shared<named_thread<ppu_thread>, ppu_thread_params&, char const (&) [12], int&, int>(T0&&...) C:/src/rpcs3/rpcs3/Emu/../util/shared_ptr.hpp:546:10
    #7 0x7ff7a3ff30bb in stx::shared_ptr<T0> idm::make_ptr<named_thread<ppu_thread>, named_thread<ppu_thread>, ppu_thread_params&, char const (&) [12], int&, int>(T1&&...)::'lambda'()::operator()() const C:/src/rpcs3/rpcs3/Emu/../Emu/IdManager.h:598:51
    #8 0x7ff7a3ff30bb in stx::shared_ptr<T0> idm::create_id<named_thread<ppu_thread>, named_thread<ppu_thread>, stx::shared_ptr<T0> idm::make_ptr<named_thread<ppu_thread>, named_thread<ppu_thread>, ppu_thread_params&, char const (&) [12], int&, int>(T1&&...)::'lambda'()>(stx::shared_ptr<T0> idm::make_ptr<named_thread<ppu_thread>, named_thread<ppu_thread>, ppu_thread_params&, char const (&) [12], int&, int>(T1&&...)::'lambda'()&&, unsigned int) C:/src/rpcs3/rpcs3/Emu/../Emu/IdManager.h:557:22
    #9 0x7ff7a3fc2b44 in stx::shared_ptr<T0> idm::make_ptr<named_thread<ppu_thread>, named_thread<ppu_thread>, ppu_thread_params&, char const (&) [12], int&, int>(T1&&...) C:/src/rpcs3/rpcs3/Emu/../Emu/IdManager.h:598:19
    #10 0x7ff7a3fc2b44 in ppu_load_exec(elf_object<elf_be, unsigned long long, (elf_machine)21, (elf_os)0, (elf_type)2> const&, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, utils::serial*) C:/src/rpcs3/rpcs3/Emu/Cell/PPUModule.cpp:2719:13  
    #11 0x7ff7a39dd62e in Emulator::Load(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, unsigned long long) C:/src/rpcs3/rpcs3/Emu/System.cpp:2450:8
    #12 0x7ff7a39c388f in Emulator::BootGame(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/Emu/System.cpp:994:12
    #13 0x7ff7a3b88aea in main_window::Boot(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, bool, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/rpcs3qt/main_window.cpp:533:29
    #14 0x7ff7a3bdacde in main_window::CreateDockWindows()::$_5::operator()(std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const C:/src/rpcs3/rpcs3/rpcs3qt/main_window.cpp:3646:3
    #15 0x7ff7a3bdacde in QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long long, 0ull, 1ull, 2ull, 3ull>, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void, main_window::CreateDockWindows()::$_5>::call(main_window::CreateDockWindows()::$_5&, void**)::'lambda'()::operator()() const C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:116:24
    #16 0x7ff7a3bdacde in void QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long long, 0ull, 1ull, 2ull, 3ull>, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void, main_window::CreateDockWindows()::$_5>::call(main_window::CreateDockWindows()::$_5&, void**)::'lambda'()>(void**, QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long long, 0ull, 1ull, 2ull, 3ull>, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void, main_window::CreateDockWindows()::$_5>::call(main_window::CreateDockWindows()::$_5&, void**)::'lambda'()&&) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:65:17
    #17 0x7ff7a3bdacde in QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long long, 0ull, 1ull, 2ull, 3ull>, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void, main_window::CreateDockWindows()::$_5>::call(main_window::CreateDockWindows()::$_5&, void**) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:115:13
    #18 0x7ff7a3bdacde in void QtPrivate::FunctorCallable<main_window::CreateDockWindows()::$_5, std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>::call<QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void>(main_window::CreateDockWindows()::$_5&, void*, void**) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:337:13
    #19 0x7ff7a3bdacde in QtPrivate::QCallableObject<main_window::CreateDockWindows()::$_5, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:547:21        
    #20 0x7ffdbabb9e0c in void doActivate<false>(QObject*, int, void**) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x180109e0c)
    #21 0x7ff7a3c5e579 in void QMetaObject::activate<void, std::__1::shared_ptr<gui_game_info>, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(QObject*, QMetaObject const*, int, void*, std::__1::shared_ptr<gui_game_info> const&, cfg_mode const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs.h:319:9
    #22 0x7ff7a3c5e579 in game_list_frame::RequestBoot(std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) E:/build-rpcs3-clang/rpcs3/rpcs3qt/rpcs3_ui_autogen/EWIEGA46WW/moc_game_list_frame.cpp:350:5     
    #23 0x7ff7a47b699a in game_list_frame::doubleClickedSlot(std::__1::shared_ptr<gui_game_info> const&) C:/src/rpcs3/rpcs3/rpcs3qt/game_list_frame.cpp:978:9
    #24 0x7ff7a47b62cb in game_list_frame::doubleClickedSlot(QTableWidgetItem*) C:/src/rpcs3/rpcs3/rpcs3qt/game_list_frame.cpp:967:2
    #25 0x7ffdbabb9e0c in void doActivate<false>(QObject*, int, void**) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x180109e0c)
    #26 0x7ffdb6a8a756 in QTableWidgetPrivate::emitItemDoubleClicked(QModelIndex const&) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18039a756)
    #27 0x7ffdbabb9e0c in void doActivate<false>(QObject*, int, void**) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x180109e0c)
    #28 0x7ffdb6a0fa0b in QAbstractItemView::mouseDoubleClickEvent(QMouseEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18031fa0b)
    #29 0x7ffdb6758ba0 in QWidget::event(QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x180068ba0)
    #30 0x7ffdb67b9abb in QFrame::event(QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x1800c9abb)
    #31 0x7ffdb6a0dd67 in QAbstractItemView::viewportEvent(QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18031dd67)
    #32 0x7ffdbab590bf in QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x1800a90bf)
    #33 0x7ffdb66fa216 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000a216)
    #34 0x7ffdb66fc9d2 in QApplication::notify(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000c9d2)
    #35 0x7ffdbab599da in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x1800a99da)
    #36 0x7ffdb66fa8c9 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000a8c9)
    #37 0x7ffdb6774fc2 in QWidgetWindow::handleMouseEvent(QMouseEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x180084fc2)
    #38 0x7ffdb67740d7 in QWidgetWindow::event(QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x1800840d7)
    #39 0x7ffdb66fa22a in QApplicationPrivate::notify_helper(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000a22a)
    #40 0x7ffdb66fb2fe in QApplication::notify(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000b2fe)
    #41 0x7ffdbab599da in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x1800a99da)
    #42 0x7ffd7219bc08 in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) (E:\build-rpcs3-clang\bin\Qt6Gui.dll+0x18009bc08)
    #43 0x7ffd72211f0a in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) (E:\build-rpcs3-clang\bin\Qt6Gui.dll+0x180111f0a)
    #44 0x7ffdbad2d11f in QEventDispatcherWin32::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x18027d11f)
    #45 0x7ffd72596a98 in QWindowsGuiEventDispatcher::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (E:\build-rpcs3-clang\bin\Qt6Gui.dll+0x180496a98)
    #46 0x7ffdbab64135 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x1800b4135)
    #47 0x7ffdbab59531 in QCoreApplication::exec() (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x1800a9531)
    #48 0x7ff7a39267e8 in run_rpcs3(int, char**) C:/src/rpcs3/rpcs3/rpcs3.cpp:1345:9
    #49 0x7ff7a391150a in main C:/src/rpcs3/rpcs3/main.cpp:8:24
    #50 0x7ff7a39110fd in __tmainCRTStartup D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:260:11
    #51 0x7ff7a3911015 in .l_startw D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:98:9
    #52 0x7ffe0369e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #53 0x7ffe03d6c48b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c48b)

SUMMARY: AddressSanitizer: heap-use-after-free C:/src/rpcs3/rpcs3/util/logs.cpp:408:7 in logs::message::broadcast(char const*, fmt_type_info const*, ...) const
Shadow bytes around the buggy address:
  0x128532653680: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x128532653700: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x128532653780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x128532653800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x128532653880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x128532653900:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x128532653980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x128532653a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x128532653a80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x128532653b00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x128532653b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==35776==ABORTING
```