### PR TITLE
ppu: Enable vector NaN fixup by default

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -69,7 +69,7 @@ struct cfg_root : cfg::node
 		cfg::_bool use_accurate_dfma{ this, "Use Accurate DFMA", true }; // Enable accurate double-precision FMA for CPUs which do not support it natively
 		cfg::_bool ppu_set_sat_bit{ this, "PPU Set Saturation Bit", false }; // Accuracy. If unset, completely disable saturation flag handling.
 		cfg::_bool ppu_use_nj_bit{ this, "PPU Accurate Non-Java Mode", false }; // Accuracy. If set, accurately emulate NJ flag. Implies NJ fixup.
-		cfg::_bool ppu_fix_vnan{ this, "PPU Fixup Vector NaN Values", false }; // Accuracy. Partial.
+		cfg::_bool ppu_fix_vnan{ this, "PPU Fixup Vector NaN Values", true }; // Accuracy. Partial.
 		cfg::_bool ppu_set_vnan{ this, "PPU Accurate Vector NaN Values", false }; // Accuracy. Implies ppu_fix_vnan.
 		cfg::_bool ppu_set_fpcc{ this, "PPU Set FPCC Bits", false }; // Accuracy.
 


### PR DESCRIPTION
Some games are reported having fixed game logic with this. We're already enabling the fixup for denormals by default for a long time, so let's also have the NaN one as well. 

Let's make RPCS3 a bit more accurate by default and have less noise breaking game logic.

Example of games that require this: Strider, SOCOM 4, Rochard, NFL Head Coach 09, and likely many others that no one found out about yet.