### PR TITLE
rsx: Log an error instead of asserting on unaligned io_buffer

### DIFF
--- a/rpcs3/Emu/RSX/Common/io_buffer.h
+++ b/rpcs3/Emu/RSX/Common/io_buffer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "../rsx_utils.h"
 #include <util/types.hpp>
 #include <util/bless.hpp>
 #include <span>
@@ -81,7 +82,11 @@ namespace rsx
 		std::span<T> as_span() const
 		{
 			auto bytes = data();
-			ensure((reinterpret_cast<uintptr_t>(bytes) & (sizeof(T) - 1)) == 0, "IO buffer span cast requires naturally aligned pointers.");
+			if ((reinterpret_cast<uintptr_t>(bytes) & (sizeof(T) - 1)) != 0)
+			{
+				rsx_log.error("IO buffer span cast requires naturally aligned pointers: data=0x%x, sizeof(T)=%d, unalignment=0x%x", 
+					reinterpret_cast<uintptr_t>(bytes), sizeof(T), (reinterpret_cast<uintptr_t>(bytes) & (sizeof(T) - 1)));
+			}
 			return { utils::bless<T>(bytes), m_size / sizeof(T) };
 		}
 


### PR DESCRIPTION
Restores the previous behaviour prior to #17725 of not asserting on unaligned buffers, but with an extra of error logging when it's unaligned. This is not a fix for the underlying issue, so we log it as an error every time it happens so it's clear something is off.

This fixes the regression crash in #18388 without any visual impact to graphics.

The logged output when you open the browser in GTA IV:
```
RSX: IO buffer span cast requires naturally aligned pointers: data=0x3c7e2a388, sizeof(T)=16, unalignment=0x8
RSX: IO buffer span cast requires naturally aligned pointers: data=0x3c7e2a0e8, sizeof(T)=16, unalignment=0x8
RSX: IO buffer span cast requires naturally aligned pointers: data=0x3c7e29e48, sizeof(T)=16, unalignment=0x8
RSX: IO buffer span cast requires naturally aligned pointers: data=0x3c7e29ba8, sizeof(T)=16, unalignment=0x8
RSX: IO buffer span cast requires naturally aligned pointers: data=0x3c7e29908, sizeof(T)=16, unalignment=0x8
RSX: IO buffer span cast requires naturally aligned pointers: data=0x3c7e29668, sizeof(T)=16, unalignment=0x8
RSX: IO buffer span cast requires naturally aligned pointers: data=0x3c7e293c8, sizeof(T)=16, unalignment=0x8
```