### PR TITLE
Fix two more ASan shutdown bugs

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -70,6 +70,8 @@ LOG_CHANNEL(sys_log, "SYS");
 // Preallocate 32 MiB
 stx::manual_typemap<void, 0x20'00000, 128> g_fixed_typemap;
 
+static constinit atomic_t<bool> s_emulator_available{false};
+
 std::string g_cfg_defaults;
 
 atomic_t<u64> g_watchdog_hold_ctr{0};
@@ -116,6 +118,21 @@ namespace atomic_wait
 namespace rsx
 {
 	void set_native_ui_flip();
+}
+
+Emulator::Emulator() noexcept
+{
+	s_emulator_available = true;
+}
+
+Emulator::~Emulator() noexcept
+{
+	s_emulator_available = false;
+}
+
+bool Emulator::IsAvailable() noexcept
+{
+	return s_emulator_available.load();
 }
 
 template<>

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -201,8 +201,10 @@ public:
 	static constexpr std::string_view game_id_boot_prefix = "%RPCS3_GAMEID%:";
 	static constexpr std::string_view vfs_boot_prefix = "%RPCS3_VFS%:";
 
-	Emulator() noexcept = default;
-	~Emulator() noexcept = default;
+	Emulator() noexcept;
+	~Emulator() noexcept;
+
+	static bool IsAvailable() noexcept;
 
 	void SetCallbacks(EmuCallbacks&& cb)
 	{

--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -185,16 +185,23 @@ std::set<std::string> get_one_drive_paths()
 			fmt::append(buf, "\nSerialized Object: %s", g_tls_serialize_name);
 		}
 
-		const system_state state = Emu.GetStatus(false);
-
-		if (state == system_state::stopped)
+		if (Emulator::IsAvailable())
 		{
-			fmt::append(buf, "\nEmulation is stopped");
+			const system_state state = Emu.GetStatus(false);
+
+			if (state == system_state::stopped)
+			{
+				fmt::append(buf, "\nEmulation is stopped");
+			}
+			else
+			{
+				const std::string name = Emu.GetTitleAndTitleID();
+				fmt::append(buf, "\nTitle: \"%s\" (emulation is %s)", name.empty() ? "N/A" : name.c_str(), state == system_state::stopping ? "stopping" : "running");
+			}
 		}
 		else
 		{
-			const std::string& name = Emu.GetTitleAndTitleID();
-			fmt::append(buf, "\nTitle: \"%s\" (emulation is %s)", name.empty() ? "N/A" : name.data(), state == system_state::stopping ? "stopping" : "running");
+			fmt::append(buf, "\nEmulation object is unavailable (process teardown)");
 		}
 
 		fmt::append(buf, "\nBuild: \"%s\"", rpcs3::get_verbose_version());

--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -656,7 +656,7 @@ int run_rpcs3(int argc, char** argv)
 	// Initialize thread pool finalizer (on first use)
 	static_cast<void>(named_thread("", [](int) {}));
 
-	static std::unique_ptr<logs::listener> log_file;
+	std::unique_ptr<logs::listener> log_file;
 	{
 		// Check free space
 		fs::device_stat stats{};
@@ -669,8 +669,16 @@ int run_rpcs3(int argc, char** argv)
 		log_file = logs::make_file_listener(log_name, stats.avail_free / 4);
 	}
 
-	static std::unique_ptr<fatal_error_listener> fatal_listener = std::make_unique<fatal_error_listener>();
+	auto fatal_listener = std::make_unique<fatal_error_listener>();
 	logs::listener::add(fatal_listener.get());
+
+	struct log_listener_shutdown_guard
+	{
+		~log_listener_shutdown_guard()
+		{
+			logs::listener::shutdown_all();
+		}
+	} log_listener_shutdown;
 
 	{
 		// Write RPCS3 version

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -372,6 +372,16 @@ void logs::listener::sync_all()
 	}
 }
 
+void logs::listener::shutdown_all()
+{
+	std::lock_guard lock(g_mutex);
+
+	for (listener* lis = get_logger()->m_next.exchange(nullptr); lis;)
+	{
+		lis = lis->m_next.exchange(nullptr);
+	}
+}
+
 void logs::listener::close_all_prematurely()
 {
 	for (listener* lis = get_logger(); lis; lis = lis->m_next)

--- a/rpcs3/util/logs.hpp
+++ b/rpcs3/util/logs.hpp
@@ -98,6 +98,9 @@ namespace logs
 		// Flush log to disk
 		static void sync_all();
 
+		// Detach all listeners before controlled shutdown tears them down.
+		static void shutdown_all();
+
 		// Close file handle after flushing to disk (hazardous)
 		static void close_all_prematurely();
 	};


### PR DESCRIPTION
I fixed these two with the help of Copilot, but I reviewed the code myself.
```
=================================================================
==16592==ERROR: AddressSanitizer: heap-use-after-free on address 0x130ec4968a00 at pc 0x7ff6a0de9f5c bp 0x00d4367ff1a0 sp 0x00d4367ff1e8
READ of size 8 at 0x130ec4968a00 thread T0
    #0 0x7ff6a0de9f5b in logs::listener::sync_all() C:/src/rpcs3/rpcs3/util/logs.cpp:371:8
    #1 0x7ff6a0e29494 in thread_ctrl::emergency_exit(std::__1::basic_string_view<char, std::__1::char_traits<char>>) C:/src/rpcs3/Utilities/Thread.cpp:2899:2
    #2 0x7ff6a0dd3e75 in fmt::raw_verify_error(std::__1::source_location, char8_t const*, unsigned long long) C:/src/rpcs3/Utilities/StrFmt.cpp:630:3
    #3 0x7ff6a11bed89 in decltype(auto) ensure<bool>(bool&&, const_str_t<18446744073709551615ull>, std::__1::source_location) C:/src/rpcs3/rpcs3/Emu/../util/types.hpp:976:2
    #4 0x7ff6a11bed89 in vm::block_t::~block_t() C:/src/rpcs3/rpcs3/Emu/Memory/vm.cpp
    #5 0x7ff6a11cd0f9 in std::__1::__shared_count::__release_shared[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__memory/shared_count.h:65:7
    #6 0x7ff6a11cd0f9 in std::__1::__shared_weak_count::__release_shared[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__memory/shared_count.h:100:25
    #7 0x7ff6a11cd0f9 in std::__1::shared_ptr<vm::block_t>::~shared_ptr[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__memory/shared_ptr.h:501:17
    #8 0x7ff6a11cd0f9 in void std::__1::__destroy_at[abi:nqn220103]<std::__1::shared_ptr<vm::block_t>>(std::__1::shared_ptr<vm::block_t>*) C:/msys64/clang64/include/c++/v1/__memory/construct_at.h:67:13       
    #9 0x7ff6a11cd0f9 in void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::destroy[abi:nqn220103]<std::__1::shared_ptr<vm::block_t>, 0>(std::__1::allocator<std::__1::shared_ptr<vm::block_t>>&, std::__1::shared_ptr<vm::block_t>*) C:/msys64/clang64/include/c++/v1/__memory/allocator_traits.h:313:5
    #10 0x7ff6a11cd0f9 in std::__1::vector<std::__1::shared_ptr<vm::block_t>, std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::__base_destruct_at_end[abi:nqn220103](std::__1::shared_ptr<vm::block_t>*) C:/msys64/clang64/include/c++/v1/__vector/vector.h:776:7
    #11 0x7ff6a11cd0f9 in std::__1::vector<std::__1::shared_ptr<vm::block_t>, std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::clear[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__vector/vector.h:564:5
    #12 0x7ff6a11cd0f9 in std::__1::vector<std::__1::shared_ptr<vm::block_t>, std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::__destroy_vector::operator()[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__vector/vector.h:249:16
    #13 0x7ff6a11b5f7d in std::__1::vector<std::__1::shared_ptr<vm::block_t>, std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::~vector[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__vector/vector.h:260:67
    #14 0x7ff6a11b5f7d in __dtor__ZN2vm11g_locationsE C:/src/rpcs3/rpcs3/Emu/Memory/vm.cpp
    #15 0x7ffe0169bc74  (C:\WINDOWS\System32\ucrtbase.dll+0x18004bc74)
    #16 0x7ffe0169b896  (C:\WINDOWS\System32\ucrtbase.dll+0x18004b896)
    #17 0x7ffe0169b84c  (C:\WINDOWS\System32\ucrtbase.dll+0x18004b84c)
    #18 0x7ffe0169af48  (C:\WINDOWS\System32\ucrtbase.dll+0x18004af48)
    #19 0x7ffe0169aeda  (C:\WINDOWS\System32\ucrtbase.dll+0x18004aeda)
    #20 0x7ffe016f0039  (C:\WINDOWS\System32\ucrtbase.dll+0x1800a0039)
    #21 0x7ff6a0da13b9 in __tmainCRTStartup D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:262:7       
    #22 0x7ff6a0da1015 in .l_startw D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:98:9
    #23 0x7ffe0369e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #24 0x7ffe03d6c48b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c48b)

0x130ec4968a00 is located 66048 bytes inside of 66176-byte region [0x130ec4958800,0x130ec4968a80)
freed by thread T0 here:
    #0 0x7ffd5f5008c6 in operator delete(void*, std::align_val_t) (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x1800608c6)
    #1 0x7ffe0169bc74  (C:\WINDOWS\System32\ucrtbase.dll+0x18004bc74)
    #2 0x7ffe0169b896  (C:\WINDOWS\System32\ucrtbase.dll+0x18004b896)
    #3 0x7ffe0169b84c  (C:\WINDOWS\System32\ucrtbase.dll+0x18004b84c)
    #4 0x7ffe0169af48  (C:\WINDOWS\System32\ucrtbase.dll+0x18004af48)
    #5 0x7ffe0169aeda  (C:\WINDOWS\System32\ucrtbase.dll+0x18004aeda)
    #6 0x7ffe016f0039  (C:\WINDOWS\System32\ucrtbase.dll+0x1800a0039)
    #7 0x7ff6a0da13b9 in __tmainCRTStartup D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:262:7        
    #8 0x7ff6a0da1015 in .l_startw D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:98:9
    #9 0x7ffe0369e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #10 0x7ffe03d6c48b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c48b)

previously allocated by thread T0 here:
    #0 0x7ffd5f4ffec6 in operator new(unsigned long long, std::align_val_t) (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x18005fec6)
    #1 0x7ff6a0def182 in std::__1::unique_ptr<logs::file_listener, std::__1::default_delete<logs::file_listener>> std::__1::make_unique[abi:nqn220103]<logs::file_listener, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long long&, 0>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long long&) C:/msys64/clang64/include/c++/v1/__memory/unique_ptr.h:756:26
    #2 0x7ff6a0def182 in logs::make_file_listener(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, unsigned long long) C:/src/rpcs3/rpcs3/util/logs.cpp:834:43      
    #3 0x7ff6a0da8b19 in run_rpcs3(int, char**) C:/src/rpcs3/rpcs3/rpcs3.cpp:669:14
    #4 0x7ff6a0da150a in main C:/src/rpcs3/rpcs3/main.cpp:8:24
    #5 0x7ff6a0da10fd in __tmainCRTStartup D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:260:11       
    #6 0x7ff6a0da1015 in .l_startw D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:98:9
    #7 0x7ffe0369e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #8 0x7ffe03d6c48b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c48b)

SUMMARY: AddressSanitizer: heap-use-after-free C:/src/rpcs3/rpcs3/util/logs.cpp:371:8 in logs::listener::sync_all()
Shadow bytes around the buggy address:
  0x130ec4968780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x130ec4968800: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x130ec4968880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x130ec4968900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x130ec4968980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x130ec4968a00:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x130ec4968a80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x130ec4968b00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x130ec4968b80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x130ec4968c00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x130ec4968c80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==16592==ABORTING
```

```
=================================================================
==29632==ERROR: AddressSanitizer: heap-use-after-free on address 0x114562dd8090 at pc 0x7ffd396bd1bc bp 0x000f21ffe2b0 sp 0x000f21ffe2f8
READ of size 31 at 0x114562dd8090 thread T0
    #0 0x7ffd396bd1bb in memmove (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x18004d1bb)
    #1 0x7ffd87b0e334 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__grow_by_and_replace(unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, char const*) (C:\msys64\clang64\bin\libc++.dll+0x18004e334)
    #2 0x7ffd87b0e69c in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::insert(unsigned long long, char const*, unsigned long long) (C:\msys64\clang64\bin\libc++.dll+0x18004e69c)
    #3 0x7ff79302d36d in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::insert[abi:nqn220103](unsigned long long, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/msys64/clang64/include/c++/v1/string:1603:12
    #4 0x7ff79302d36d in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> std::__1::operator+[abi:nqn220103]<char, std::__1::char_traits<char>, std::__1::allocator<char>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&&) C:/msys64/clang64/include/c++/v1/string:3791:26
    #5 0x7ff79302d36d in Emulator::GetTitleAndTitleID() const C:/src/rpcs3/rpcs3/Emu/../Emu/System.h:306:18
    #6 0x7ff793013968 in report_fatal_error(std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool, bool) C:/src/rpcs3/rpcs3/rpcs3.cpp:196:34
    #7 0x7ff7930998ad in thread_ctrl::emergency_exit(std::__1::basic_string_view<char, std::__1::char_traits<char>>) C:/src/rpcs3/Utilities/Thread.cpp:2950:2
    #8 0x7ff793044095 in fmt::raw_verify_error(std::__1::source_location, char8_t const*, unsigned long long) C:/src/rpcs3/Utilities/StrFmt.cpp:630:3
    #9 0x7ff79342f0d9 in decltype(auto) ensure<bool>(bool&&, const_str_t<18446744073709551615ull>, std::__1::source_location) C:/src/rpcs3/rpcs3/Emu/../util/types.hpp:976:2
    #10 0x7ff79342f0d9 in vm::block_t::~block_t() C:/src/rpcs3/rpcs3/Emu/Memory/vm.cpp
    #11 0x7ff79343d449 in std::__1::__shared_count::__release_shared[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__memory/shared_count.h:65:7
    #12 0x7ff79343d449 in std::__1::__shared_weak_count::__release_shared[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__memory/shared_count.h:100:25
    #13 0x7ff79343d449 in std::__1::shared_ptr<vm::block_t>::~shared_ptr[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__memory/shared_ptr.h:501:17
    #14 0x7ff79343d449 in void std::__1::__destroy_at[abi:nqn220103]<std::__1::shared_ptr<vm::block_t>>(std::__1::shared_ptr<vm::block_t>*) C:/msys64/clang64/include/c++/v1/__memory/construct_at.h:67:13
    #15 0x7ff79343d449 in void std::__1::allocator_traits<std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::destroy[abi:nqn220103]<std::__1::shared_ptr<vm::block_t>, 0>(std::__1::allocator<std::__1::shared_ptr<vm::block_t>>&, std::__1::shared_ptr<vm::block_t>*) C:/msys64/clang64/include/c++/v1/__memory/allocator_traits.h:313:5     
    #16 0x7ff79343d449 in std::__1::vector<std::__1::shared_ptr<vm::block_t>, std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::__base_destruct_at_end[abi:nqn220103](std::__1::shared_ptr<vm::block_t>*) C:/msys64/clang64/include/c++/v1/__vector/vector.h:776:7
    #17 0x7ff79343d449 in std::__1::vector<std::__1::shared_ptr<vm::block_t>, std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::clear[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__vector/vector.h:564:5
    #18 0x7ff79343d449 in std::__1::vector<std::__1::shared_ptr<vm::block_t>, std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::__destroy_vector::operator()[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__vector/vector.h:249:16
    #19 0x7ff7934262cd in std::__1::vector<std::__1::shared_ptr<vm::block_t>, std::__1::allocator<std::__1::shared_ptr<vm::block_t>>>::~vector[abi:nqn220103]() C:/msys64/clang64/include/c++/v1/__vector/vector.h:260:67
    #20 0x7ff7934262cd in __dtor__ZN2vm11g_locationsE C:/src/rpcs3/rpcs3/Emu/Memory/vm.cpp
    #21 0x7ffe0169bc74  (C:\WINDOWS\System32\ucrtbase.dll+0x18004bc74)
    #22 0x7ffe0169b896  (C:\WINDOWS\System32\ucrtbase.dll+0x18004b896)
    #23 0x7ffe0169b84c  (C:\WINDOWS\System32\ucrtbase.dll+0x18004b84c)
    #24 0x7ffe0169af48  (C:\WINDOWS\System32\ucrtbase.dll+0x18004af48)
    #25 0x7ffe0169aeda  (C:\WINDOWS\System32\ucrtbase.dll+0x18004aeda)
    #26 0x7ffe016f0039  (C:\WINDOWS\System32\ucrtbase.dll+0x1800a0039)
    #27 0x7ff7930113b9 in __tmainCRTStartup D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:262:7
    #28 0x7ff793011015 in .l_startw D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:98:9
    #29 0x7ffe0369e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #30 0x7ffe03d6c48b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c48b)

0x114562dd8090 is located 0 bytes inside of 48-byte region [0x114562dd8090,0x114562dd80c0)
freed by thread T0 here:
    #0 0x7ffd396d0301 in operator delete(void*) (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x180060301)
    #1 0x7ff793127aa8 in void std::__1::__libcpp_deallocate[abi:nqn220103]<char>(std::__1::__type_identity<char>::type*, std::__1::__element_count, unsigned long long) C:/msys64/clang64/include/c++/v1/__new/allocate.h:62:10
    #2 0x7ff793127aa8 in std::__1::allocator<char>::deallocate[abi:nqn220103](char*, unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocator.h:107:7      
    #3 0x7ff793127aa8 in std::__1::allocator_traits<std::__1::allocator<char>>::deallocate[abi:nqn220103](std::__1::allocator<char>&, char*, unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocator_traits.h:289:9
    #4 0x7ff793127aa8 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__reset_internal_buffer[abi:nqn220103](std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__rep) C:/msys64/clang64/include/c++/v1/string:2292:7
    #5 0x7ff793127aa8 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::~basic_string() C:/msys64/clang64/include/c++/v1/string:1210:58
    #6 0x7ff793127aa8 in Emulator::~Emulator() C:/src/rpcs3/rpcs3/Emu/../Emu/System.h:205:31
    #7 0x7ffe0169bc74  (C:\WINDOWS\System32\ucrtbase.dll+0x18004bc74)
    #8 0x7ffe0169b896  (C:\WINDOWS\System32\ucrtbase.dll+0x18004b896)
    #9 0x7ffe0169b84c  (C:\WINDOWS\System32\ucrtbase.dll+0x18004b84c)
    #10 0x7ffe0169af48  (C:\WINDOWS\System32\ucrtbase.dll+0x18004af48)
    #11 0x7ffe0169aeda  (C:\WINDOWS\System32\ucrtbase.dll+0x18004aeda)
    #12 0x7ffe016f0039  (C:\WINDOWS\System32\ucrtbase.dll+0x1800a0039)
    #13 0x7ff7930113b9 in __tmainCRTStartup D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:262:7
    #14 0x7ff793011015 in .l_startw D:/W/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:98:9
    #15 0x7ffe0369e8d6  (C:\WINDOWS\System32\KERNEL32.DLL+0x18002e8d6)
    #16 0x7ffe03d6c48b  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x18008c48b)

previously allocated by thread T0 here:
    #0 0x7ffd396cfac1 in operator new(unsigned long long) (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x18005fac1)
    #1 0x7ff7930cd0fe in char* std::__1::__libcpp_allocate[abi:nqn220103]<char>(std::__1::__element_count, unsigned long long) C:/msys64/clang64/include/c++/v1/__new/allocate.h:42:28
    #2 0x7ff7930cd0fe in std::__1::allocator<char>::allocate[abi:nqn220103](unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocator.h:92:14
    #3 0x7ff7930cd0fe in std::__1::allocator<char>::allocate_at_least[abi:nqn220103](unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocator.h:99:13      
    #4 0x7ff7930cd0fe in std::__1::allocation_result<char*, unsigned long long> std::__1::allocator_traits<std::__1::allocator<char>>::allocate_at_least[abi:nqn220103]<std::__1::allocator<char>>(std::__1::allocator<char>&, unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocator_traits.h:280:22
    #5 0x7ff7930cd0fe in auto std::__1::__allocate_at_least[abi:nqn220103]<std::__1::allocator<char>>(std::__1::allocator<char>&, unsigned long long) C:/msys64/clang64/include/c++/v1/__memory/allocate_at_least.h:36:16
    #6 0x7ff7930cd0fe in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__allocate_long_buffer[abi:nqn220103](std::__1::allocator<char>&, unsigned long long) C:/msys64/clang64/include/c++/v1/string:2278:21
    #7 0x7ff7930cd0fe in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__init_internal_buffer[abi:nqn220103](unsigned long long) C:/msys64/clang64/include/c++/v1/string:2310:20
    #8 0x7ff7930cd0fe in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__init(char const*, unsigned long long) C:/msys64/clang64/include/c++/v1/string:2663:17
    #9 0x7ff7930cd0fe in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::basic_string[abi:nqn220103]<std::__1::basic_string_view<char, std::__1::char_traits<char>>, 0>(std::__1::basic_string_view<char, std::__1::char_traits<char>> const&) C:/msys64/clang64/include/c++/v1/string:1158:5
    #10 0x7ff7930cd0fe in Emulator::Load(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, unsigned long long) C:/src/rpcs3/rpcs3/Emu/System.cpp:1529:13
    #11 0x7ff7930daa34 in Emulator::Load(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, unsigned long long) C:/src/rpcs3/rpcs3/Emu/System.cpp:2303:42
    #12 0x7ff7930c3bdf in Emulator::BootGame(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/Emu/System.cpp:994:12
    #13 0x7ff793288e6a in main_window::Boot(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, bool, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/src/rpcs3/rpcs3/rpcs3qt/main_window.cpp:533:29
    #14 0x7ff7932db05e in main_window::CreateDockWindows()::$_5::operator()(std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) const C:/src/rpcs3/rpcs3/rpcs3qt/main_window.cpp:3646:3
    #15 0x7ff7932db05e in QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long long, 0ull, 1ull, 2ull, 3ull>, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void, main_window::CreateDockWindows()::$_5>::call(main_window::CreateDockWindows()::$_5&, void**)::'lambda'()::operator()() const C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:116:24
    #16 0x7ff7932db05e in void QtPrivate::FunctorCallBase::call_internal<void, QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long long, 0ull, 1ull, 2ull, 3ull>, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void, main_window::CreateDockWindows()::$_5>::call(main_window::CreateDockWindows()::$_5&, void**)::'lambda'()>(void**, QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long long, 0ull, 1ull, 2ull, 3ull>, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void, main_window::CreateDockWindows()::$_5>::call(main_window::CreateDockWindows()::$_5&, void**)::'lambda'()&&) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:65:17
    #17 0x7ff7932db05e in QtPrivate::FunctorCall<std::__1::integer_sequence<unsigned long long, 0ull, 1ull, 2ull, 3ull>, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void, main_window::CreateDockWindows()::$_5>::call(main_window::CreateDockWindows()::$_5&, void**) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:115:13
    #18 0x7ff7932db05e in void QtPrivate::FunctorCallable<main_window::CreateDockWindows()::$_5, std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>::call<QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void>(main_window::CreateDockWindows()::$_5&, void*, void**) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:337:13
    #19 0x7ff7932db05e in QtPrivate::QCallableObject<main_window::CreateDockWindows()::$_5, QtPrivate::List<std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs_impl.h:547:21
    #20 0x7ffd6e339e0c in void doActivate<false>(QObject*, int, void**) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x180109e0c)
    #21 0x7ff79335e8f9 in void QMetaObject::activate<void, std::__1::shared_ptr<gui_game_info>, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>(QObject*, QMetaObject const*, int, void*, std::__1::shared_ptr<gui_game_info> const&, cfg_mode const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) C:/msys64/clang64/include/qt6/QtCore/qobjectdefs.h:319:9
    #22 0x7ff79335e8f9 in game_list_frame::RequestBoot(std::__1::shared_ptr<gui_game_info> const&, cfg_mode, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) E:/build-rpcs3-clang/rpcs3/rpcs3qt/rpcs3_ui_autogen/EWIEGA46WW/moc_game_list_frame.cpp:350:5
    #23 0x7ff793eb84ba in game_list_frame::doubleClickedSlot(std::__1::shared_ptr<gui_game_info> const&) C:/src/rpcs3/rpcs3/rpcs3qt/game_list_frame.cpp:978:9
    #24 0x7ff793eb7deb in game_list_frame::doubleClickedSlot(QTableWidgetItem*) C:/src/rpcs3/rpcs3/rpcs3qt/game_list_frame.cpp:967:2
    #25 0x7ffd6e339e0c in void doActivate<false>(QObject*, int, void**) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x180109e0c)
    #26 0x7ffd67c5a756 in QTableWidgetPrivate::emitItemDoubleClicked(QModelIndex const&) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18039a756)
    #27 0x7ffd6e339e0c in void doActivate<false>(QObject*, int, void**) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x180109e0c)
    #28 0x7ffd67bdfa0b in QAbstractItemView::mouseDoubleClickEvent(QMouseEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18031fa0b)
    #29 0x7ffd67928ba0 in QWidget::event(QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x180068ba0)
    #30 0x7ffd67989abb in QFrame::event(QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x1800c9abb)
    #31 0x7ffd67bddd67 in QAbstractItemView::viewportEvent(QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18031dd67)
    #32 0x7ffd6e2d90bf in QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x1800a90bf)
    #33 0x7ffd678ca216 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000a216)
    #34 0x7ffd678cc9d2 in QApplication::notify(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000c9d2)
    #35 0x7ffd6e2d99da in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x1800a99da)
    #36 0x7ffd678ca8c9 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000a8c9)
    #37 0x7ffd67944fc2 in QWidgetWindow::handleMouseEvent(QMouseEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x180084fc2)
    #38 0x7ffd679440d7 in QWidgetWindow::event(QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x1800840d7)
    #39 0x7ffd678ca22a in QApplicationPrivate::notify_helper(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000a22a)
    #40 0x7ffd678cb2fe in QApplication::notify(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Widgets.dll+0x18000b2fe)
    #41 0x7ffd6e2d99da in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (E:\build-rpcs3-clang\bin\Qt6Core.dll+0x1800a99da)
    #42 0x7ffd6134bc08 in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) (E:\build-rpcs3-clang\bin\Qt6Gui.dll+0x18009bc08)

SUMMARY: AddressSanitizer: heap-use-after-free (C:\msys64\clang64\bin\libc++.dll+0x18004e334) in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__grow_by_and_replace(unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, unsigned long long, char const*)   
Shadow bytes around the buggy address:
  0x114562dd7e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x114562dd7e80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x114562dd7f00: fa fa fa fa fa fa fa fa fa fa fd fd fd fd fd fd
  0x114562dd7f80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x114562dd8000: fa fa fd fd fd fd fd fd fa fa fa fa fa fa fa fa
=>0x114562dd8080: fa fa[fd]fd fd fd fd fd fa fa fa fa fa fa fa fa
  0x114562dd8100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x114562dd8180: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x114562dd8200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x114562dd8280: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x114562dd8300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==29632==ABORTING
```