### PR TITLE
sysinfo.cpp: Replaced PEB read with ntdll's RtlGetVersion

### DIFF
--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -794,14 +794,31 @@ utils::OS_version utils::get_OS_version()
 #endif
 
 #ifdef _WIN32
-	OSVERSIONINFOW osvi{};
-	osvi.dwOSVersionInfoSize = sizeof(osvi);
-
-	// According to MSDN, this API always returns STATUS_SUCCESS
-	RtlGetVersion(&osvi);
-	res.version_major = osvi.dwMajorVersion;
-	res.version_minor = osvi.dwMinorVersion;
-	res.version_patch = osvi.dwBuildNumber;
+	if (RtlGetVersion)
+	{
+	    OSVERSIONINFOW osvi{};
+	    osvi.dwOSVersionInfoSize = sizeof(osvi);
+	    RtlGetVersion(&osvi);
+	    res.version_major = osvi.dwMajorVersion;
+	    res.version_minor = osvi.dwMinorVersion;
+	    res.version_patch = osvi.dwBuildNumber;
+	}
+	else
+	{
+		HKEY hKey;
+		if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+		{
+			const auto [check_major, version_major] = read_reg_dword(hKey, "CurrentMajorVersionNumber");
+			const auto [check_minor, version_minor] = read_reg_dword(hKey, "CurrentMinorVersionNumber");
+			const auto [check_build, version_patch] = read_reg_sz(hKey, "CurrentBuildNumber");
+	
+			if (check_major) res.version_major = version_major;
+			if (check_minor) res.version_minor = version_minor;
+			if (check_build) res.version_patch = stoi(version_patch);
+	
+			RegCloseKey(hKey);
+		}
+	}
 #endif
 #elif defined (__APPLE__)
 	res.version_major = Darwin_Version::getNSmajorVersion();

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -794,27 +794,37 @@ utils::OS_version utils::get_OS_version()
 #endif
 
 #ifdef _WIN32
-	// GetVersionEx is deprecated, RtlGetVersion is kernel-mode only and AnalyticsInfo is UWP only.
-	// So we're forced to read PEB instead to get Windows version info. It's ugly but works.
-#if defined(ARCH_X64)
-	constexpr DWORD peb_offset = 0x60;
-	const INT_PTR peb = __readgsqword(peb_offset);
-	res.version_major = *reinterpret_cast<const DWORD*>(peb + 0x118);
-	res.version_minor = *reinterpret_cast<const DWORD*>(peb + 0x11c);
-	res.version_patch = *reinterpret_cast<const WORD*>(peb + 0x120);
-#else
-	HKEY hKey;
-	if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+	// RtlGetVersion has been exported by ntdll.dll since Windows XP
+	//
+	using RtlGetVersionPtr = NTSTATUS(WINAPI*)(PRTL_OSVERSIONINFOW);
+	const auto rtl_get_version = reinterpret_cast<RtlGetVersionPtr>(
+	    GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetVersion"));
+
+	// In the (extremely) unlikely case this function is not found, fall back to the registry
+	if (rtl_get_version)
 	{
-		const auto [check_major, version_major] = read_reg_dword(hKey, "CurrentMajorVersionNumber");
-		const auto [check_minor, version_minor] = read_reg_dword(hKey, "CurrentMinorVersionNumber");
-		const auto [check_build, version_patch] = read_reg_sz(hKey, "CurrentBuildNumber");
-
-		if (check_major) res.version_major = version_major;
-		if (check_minor) res.version_minor = version_minor;
-		if (check_build) res.version_patch = stoi(version_patch);
-
-		RegCloseKey(hKey);
+	    OSVERSIONINFOW osvi{};
+	    osvi.dwOSVersionInfoSize = sizeof(osvi);
+	    rtl_get_version(&osvi);
+	    res.version_major = osvi.dwMajorVersion;
+	    res.version_minor = osvi.dwMinorVersion;
+	    res.version_patch = osvi.dwBuildNumber;
+	}
+	else
+	{
+		HKEY hKey;
+		if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+		{
+			const auto [check_major, version_major] = read_reg_dword(hKey, "CurrentMajorVersionNumber");
+			const auto [check_minor, version_minor] = read_reg_dword(hKey, "CurrentMinorVersionNumber");
+			const auto [check_build, version_patch] = read_reg_sz(hKey, "CurrentBuildNumber");
+	
+			if (check_major) res.version_major = version_major;
+			if (check_minor) res.version_minor = version_minor;
+			if (check_build) res.version_patch = stoi(version_patch);
+	
+			RegCloseKey(hKey);
+		}
 	}
 #endif
 #elif defined (__APPLE__)

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -804,22 +804,6 @@ utils::OS_version utils::get_OS_version()
 	    res.version_minor = osvi.dwMinorVersion;
 	    res.version_patch = osvi.dwBuildNumber;
 	}
-	else
-	{
-		HKEY hKey;
-		if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
-		{
-			const auto [check_major, version_major] = read_reg_dword(hKey, "CurrentMajorVersionNumber");
-			const auto [check_minor, version_minor] = read_reg_dword(hKey, "CurrentMinorVersionNumber");
-			const auto [check_build, version_patch] = read_reg_sz(hKey, "CurrentBuildNumber");
-	
-			if (check_major) res.version_major = version_major;
-			if (check_minor) res.version_minor = version_minor;
-			if (check_build) res.version_patch = stoi(version_patch);
-	
-			RegCloseKey(hKey);
-		}
-	}
 #elif defined (__APPLE__)
 	res.version_major = Darwin_Version::getNSmajorVersion();
 	res.version_minor = Darwin_Version::getNSminorVersion();

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -819,7 +819,6 @@ utils::OS_version utils::get_OS_version()
 			RegCloseKey(hKey);
 		}
 	}
-#endif
 #elif defined (__APPLE__)
 	res.version_major = Darwin_Version::getNSmajorVersion();
 	res.version_minor = Darwin_Version::getNSminorVersion();

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -12,6 +12,7 @@
 #include "sysinfoapi.h"
 #include "subauth.h"
 #include "stringapiset.h"
+#include "util/dyn_lib.hpp"
 DYNAMIC_IMPORT("ntdll.dll", RtlGetVersion, NTSTATUS(OSVERSIONINFOW* lpVersionInformation));
 #else
 #include <unistd.h>

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -7,12 +7,12 @@
 #if defined(ARCH_ARM64)
 #include "Emu/CPU/Backends/AArch64/AArch64Common.h"
 #endif
-
 #ifdef _WIN32
 #include "windows.h"
 #include "sysinfoapi.h"
 #include "subauth.h"
 #include "stringapiset.h"
+DYNAMIC_IMPORT("ntdll.dll", RtlGetVersion, NTSTATUS(OSVERSIONINFOW* lpVersionInformation));
 #else
 #include <unistd.h>
 #include <sys/resource.h>

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -794,38 +794,14 @@ utils::OS_version utils::get_OS_version()
 #endif
 
 #ifdef _WIN32
-	// RtlGetVersion has been exported by ntdll.dll since Windows XP
-	//
-	using RtlGetVersionPtr = NTSTATUS(WINAPI*)(PRTL_OSVERSIONINFOW);
-	const auto rtl_get_version = reinterpret_cast<RtlGetVersionPtr>(
-	    GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetVersion"));
+	OSVERSIONINFOW osvi{};
+	osvi.dwOSVersionInfoSize = sizeof(osvi);
 
-	// In the (extremely) unlikely case this function is not found, fall back to the registry
-	if (rtl_get_version)
-	{
-	    OSVERSIONINFOW osvi{};
-	    osvi.dwOSVersionInfoSize = sizeof(osvi);
-	    rtl_get_version(&osvi);
-	    res.version_major = osvi.dwMajorVersion;
-	    res.version_minor = osvi.dwMinorVersion;
-	    res.version_patch = osvi.dwBuildNumber;
-	}
-	else
-	{
-		HKEY hKey;
-		if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
-		{
-			const auto [check_major, version_major] = read_reg_dword(hKey, "CurrentMajorVersionNumber");
-			const auto [check_minor, version_minor] = read_reg_dword(hKey, "CurrentMinorVersionNumber");
-			const auto [check_build, version_patch] = read_reg_sz(hKey, "CurrentBuildNumber");
-	
-			if (check_major) res.version_major = version_major;
-			if (check_minor) res.version_minor = version_minor;
-			if (check_build) res.version_patch = stoi(version_patch);
-	
-			RegCloseKey(hKey);
-		}
-	}
+	// According to MSDN, this API always returns STATUS_SUCCESS
+	RtlGetVersion(&osvi);
+	res.version_major = osvi.dwMajorVersion;
+	res.version_minor = osvi.dwMinorVersion;
+	res.version_patch = osvi.dwBuildNumber;
 #endif
 #elif defined (__APPLE__)
 	res.version_major = Darwin_Version::getNSmajorVersion();


### PR DESCRIPTION
RtlGetVersion is available in user-mode. It has been exported by `ntdll.dll` since [Windows XP](https://github.com/ayyucedemirbas/Windows-Research-Kernel-WRK-/blob/26b524b2d0f18de703018e16ec5377889afcf4ab/WRK-v1.2/public/sdk/inc/ntrtl.h#L7679). 

Although you can link against `ntdll.lib` and use said function directly, I opted to dynamically resolve it using `GetProcAddress` in the *VERY* unlikely case it ever gets modified.