### PR TITLE
Opt out of Game Mode on macOS due to throttling

### DIFF
--- a/rpcs3/rpcs3.plist.in
+++ b/rpcs3/rpcs3.plist.in
@@ -28,8 +28,6 @@
 	<string>Licensed under GPLv2</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.4</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
GOW3 consistently exhibits throttling behaviour on my M4 Pro MBP when I run it with Game Mode enabled, in the Realm of Hades section after ~1 minute or so performance will usually throttle from ~60fps to ~45fps in the area I tested (I can provide saves + logs if necessary), but performance recovers and is sustained at ~60fps as soon as Game Mode is disabled. Activity Monitor's CPU Usage window provided some more insight, P Core utilisation seemed to also drop off with fewer peaks around 100% util appearing after that 1 minute throttle window elapsed with Game Mode on, with it off I saw far more regular peaks for P Core utilisation.

Shame I have to opt out of Game Mode then but it doesn't seem fit for RPCS3, even if the doubled Bluetooth sampling rate would be nice to have still. Howard Oakley suggested Game Mode could prioritise E cores, presumably for power savings in GPU constrained native Mac games, I didn't see much of this in Activity Monitor's usage but it may explain what's going on (https://eclecticlight.co/2023/10/18/how-game-mode-manages-cpu-and-gpu/)