### PR TITLE
[macOS] Early update to MoltenVK 1.4.2 by building from source

### DIFF
--- a/.ci/deploy-mac.sh
+++ b/.ci/deploy-mac.sh
@@ -4,11 +4,15 @@
 cd build || exit 1
 
 cd bin
+git clone --revision=32dceb35e2c95b46cec501033cbc3a1ddf32d6e8 https://github.com/KhronosGroup/MoltenVK.git
+cd MoltenVK
+./fetchDependencies --macos
+make macos MVK_USE_METAL_PRIVATE_API=1
+cd ../
+
 mkdir -p "rpcs3.app/Contents/Resources/vulkan/icd.d" || true
-wget https://github.com/KhronosGroup/MoltenVK/releases/download/v1.4.1/MoltenVK-macos-privateapi.tar
-tar -xvf MoltenVK-macos-privateapi.tar
-cp "MoltenVK/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib" "rpcs3.app/Contents/Frameworks/libMoltenVK.dylib"
-cp "MoltenVK/MoltenVK/dynamic/dylib/macOS/MoltenVK_icd.json" "rpcs3.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
+cp "MoltenVK/Package/Latest/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib" "rpcs3.app/Contents/Frameworks/libMoltenVK.dylib"
+cp "MoltenVK/Package/Latest/MoltenVK/dynamic/dylib/macOS/MoltenVK_icd.json" "rpcs3.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
 sed -i '' "s/.\//..\/..\/..\/Frameworks\//g" "rpcs3.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
 
 cp "$(realpath $BREW_PATH/opt/llvm@$LLVM_COMPILER_VER/lib/c++/libc++abi.1.0.dylib)" "rpcs3.app/Contents/Frameworks/libc++abi.1.dylib"


### PR DESCRIPTION
This is a hacky stopgap to ensure #17913 is resolved (At least the DeS side of the issue, the TLoU stuff is separate and an issue with relaxed ZCULL). Since MVK 1.4.2 hasn't officially been published yet I'm forced to custom compile it at the stage where the script would usually extract the latest release tar, which adds a few minutes to CI build times. For now this is the best solution that avoids losing functionality (downgrading would bring back #17450, disabling privateAPI would degrade feature support). As soon as 1.4.2 is officially released I'll revert the changes made here to keep CI build times down