### PR TITLE
Add recursive scan support

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -4213,54 +4213,62 @@ u32 Emulator::AddGamesFromDir(const std::string& path)
 
 	m_games_config.set_save_on_dirty(false);
 
-	// search dropped path first or else the direct parent to an elf is wrongly skipped
+	// search for a game on the provided path first (game on ISO file or on folder type)
 	if (const game_boot_result error = AddGame(path); error == game_boot_result::no_errors)
 	{
 		games_added++;
 	}
 
-	std::vector<fs::dir_entry> entries;
-
-	for (auto&& dir_entry : fs::dir(path))
+	// search for games on subfolders only if not nested inside a discovered game folder
+	if (games_added == 0)
 	{
-		// Prefetch entries, it is unsafe to keep fs::dir for a long time or for many operations
-		entries.emplace_back(std::move(dir_entry));
-	}
+		std::vector<fs::dir_entry> entries;
 
-	auto path_it = entries.begin();
-
-	qt_events_aware_op(0, [&]()
-	{
-		// search direct subdirectories, that way we can drop one folder containing all games
-		for (; path_it != entries.end(); ++path_it)
+		for (auto&& dir_entry : fs::dir(path))
 		{
-			auto dir_entry = std::move(*path_it);
-
-			if (dir_entry.name == "." || dir_entry.name == "..")
-			{
-				continue;
-			}
-
-			const std::string dir_path = path + '/' + dir_entry.name;
-
-			if (!dir_entry.is_directory && !is_file_iso(dir_path))
-			{
-				continue;
-			}
-
-			if (const game_boot_result error = AddGame(dir_path); error == game_boot_result::no_errors)
-			{
-				games_added++;
-			}
-
-			// Process events
-			++path_it;
-			return false;
+			// Prefetch entries, it is unsafe to keep fs::dir for a long time or for many operations
+			entries.emplace_back(std::move(dir_entry));
 		}
 
-		// Exit loop
-		return true;
-	});
+		auto path_it = entries.begin();
+
+		qt_events_aware_op(0, [&]()
+		{
+			// search direct subdirectories, that way we can drop one folder containing all games
+			for (; path_it != entries.end(); ++path_it)
+			{
+				auto dir_entry = std::move(*path_it);
+
+				if (dir_entry.name == "." || dir_entry.name == "..")
+				{
+					continue;
+				}
+
+				const std::string dir_path = path + '/' + dir_entry.name;
+
+				if (!dir_entry.is_directory && !is_file_iso(dir_path))
+				{
+					continue;
+				}
+
+				if (const game_boot_result error = AddGame(dir_path); error == game_boot_result::no_errors)
+				{
+					games_added++;
+				}
+				else if (g_cfg.misc.use_recursive_scan)
+				{
+					games_added += AddGamesFromDir(dir_path);
+				}
+
+				// Process events
+				++path_it;
+				return false;
+			}
+
+			// Exit loop
+			return true;
+		});
+	}
 
 	m_games_config.set_save_on_dirty(true);
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -361,6 +361,7 @@ struct cfg_root : cfg::node
 		cfg::_bool show_fatal_error_hints{ this, "Show fatal error hints", false, true };
 		cfg::_bool show_capture_hints{ this, "Show capture hints", true, true };
 		cfg::_bool use_native_interface{ this, "Use native user interface", true };
+		cfg::_bool use_recursive_scan{this, "Use recursive scan", false};
 		cfg::string gdb_server{ this, "GDB Server", "127.0.0.1:2345" };
 		cfg::_bool silence_all_logs{ this, "Silence All Logs", false, true };
 		cfg::string title_format{ this, "Window Title Format", "FPS: %F | %R | %V | %T [%t]", true };

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -184,6 +184,7 @@ enum class emu_settings_type
 	ShowTrophyPopups,
 	ShowRpcnPopups,
 	UseNativeInterface,
+	UseRecursiveScan,
 	ShowShaderCompilationHint,
 	ShowPPUCompilationHint,
 	ShowAutosaveAutoloadHint,

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1819,6 +1819,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->useNativeInterface, emu_settings_type::UseNativeInterface);
 	SubscribeTooltip(ui->useNativeInterface, tooltips.settings.use_native_interface);
 
+	m_emu_settings->EnhanceCheckBox(ui->useRecursiveScan, emu_settings_type::UseRecursiveScan);
+	SubscribeTooltip(ui->useRecursiveScan, tooltips.settings.use_recursive_scan);
+
 #if defined(__linux__)
 #if defined(GAMEMODE_AVAILABLE)
 	m_emu_settings->EnhanceCheckBox(ui->enableGamemode, emu_settings_type::EnableGamemode);

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -3012,6 +3012,13 @@
                  </property>
                 </widget>
                </item>
+               <item>
+                <widget class="QCheckBox" name="useRecursiveScan">
+                 <property name="text">
+                  <string>Use recursive scan</string>
+                 </property>
+                </widget>
+               </item>
               </layout>
              </widget>
             </item>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -157,6 +157,7 @@ public:
 		const QString show_fatal_error_hints       = tr("Shows fatal error hints using the native overlay.");
 		const QString show_capture_hints           = tr("Shows screenshot and recording hints using the native overlay.");
 		const QString use_native_interface         = tr("Enables use of native HUD within the game window that can interact with game controllers.\nWhen disabled, regular Qt dialogs are used instead.\nCurrently, the on-screen keyboard only supports the English key layout.");
+		const QString use_recursive_scan           = tr("Enables use of recursive scan on subfolders when scanning games from the selected folder.\nWhen disabled, games are scanned only on the selected folder.");
 		const QString record_with_overlays         = tr("Enables recording with overlays.\nThis also affects screenshots.");
 		const QString pause_during_home_menu       = tr("When enabled, opening the home menu will also pause emulation.\nWhile most games pause themselves while the home menu is shown, some do not.\nIn that case it can be helpful to pause the emulation whenever the home menu is open.");
 		const QString play_music_during_boot       = tr("Play music during boot sequence if available.");


### PR DESCRIPTION
Add support to recursive scan on subfolders when scanning for games from both VFS `games` (managing a dynamic list) and menu `File->Add Games` (managing permanent list).
The feature is configurable on the `Emulator` tab by the setting named `Use recursive scan` (disabled by default).

Tested on a 4TB m.2 and on a 10TB HDD with iso games, folder games, no PS3 games etc. organized on a hierarchy with 6 folder depth. No issue and no performance difference compared to 1 folder depth.

### FIXES:
- Fixed the possibility to add nested games (e.g. `game B` (ISO file or folder) provided inside `game A`'s folder

</br>

closes #18185

</br>

<img width="636" height="472" alt="image" src="https://github.com/user-attachments/assets/74ebafd8-6213-4043-8379-63c5ca2d575d" />

</br>

<img width="1869" height="246" alt="image" src="https://github.com/user-attachments/assets/413b89d5-0325-4779-9706-62f2a41ab750" />

</br>
</br>

Despite the apparent big changes shown by github, the changes on `System.cpp` are only the ones (in red) below (a better comparison than the one shown by github):

</br>

<img width="3810" height="1663" alt="image" src="https://github.com/user-attachments/assets/4b9962f9-9f12-4468-a26c-560bb234f264" />

