### PR TITLE
fix wrong folder creation in cellHddGameCheck

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGame.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGame.cpp
@@ -520,10 +520,11 @@ error_code cellHddGameCheck(ppu_thread& ppu, u32 version, vm::cptr<char> dirName
 				return CELL_GAMEDATA_ERROR_PARAM;
 			}
 
-			if (!fs::create_path(vfs::get(usrdir)))
-			{
-				return {CELL_GAME_ERROR_ACCESS_ERROR, usrdir};
-			}
+			// Nuked until correctly reversed engineered
+			//if (!fs::create_path(vfs::get(usrdir)))
+			//{
+			//	return {CELL_GAME_ERROR_ACCESS_ERROR, usrdir};
+			//}
 		}
 
 		// Nuked until correctly reversed engineered


### PR DESCRIPTION
Fix #15659 regressed by #8893.
The regression causes the creation of an empty folder (also reported as possibly wrong by Elad in #8893) of the full game `NPEB00023/USRDIR` at game boot, meaning on subsequent boots the game wrongly try to access the files of the full game causing the crash (no files are found) until the folder `NPEB00023` is manually deleted.
Folder `NPEB00023` is not created on PS3 and the game properly boots.

**NOTE:** Other changes made in #8893 have been reverted in the last years in the same function target of this PR. It seems another section needs to be nuked

fixes #15659

