### PR TITLE
sys_fs: Fix checks for flash device aliases

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -398,7 +398,10 @@ lv2_fs_mount_point* lv2_fs_object::get_mp(std::string_view filename, std::string
 			const auto& device_alias_check = !is_path && (
 				(mp == &g_mp_sys_dev_hdd0 && mp_name == "CELL_FS_IOS:PATA0_HDD_DRIVE"sv) ||
 				(mp == &g_mp_sys_dev_hdd1 && mp_name == "CELL_FS_IOS:PATA1_HDD_DRIVE"sv) ||
-				(mp == &g_mp_sys_dev_flash2 && mp_name == "CELL_FS_IOS:BUILTIN_FLASH"sv)); // TODO confirm
+				(mp == &g_mp_sys_dev_flash && mp_name == "CELL_FS_IOS:BUILTIN_FLASH"sv) ||
+				(mp == &g_mp_sys_dev_flash && mp_name == "CELL_FS_IOS:BUILTIN_FLSH1"sv) ||
+				(mp == &g_mp_sys_dev_flash2 && mp_name == "CELL_FS_IOS:BUILTIN_FLSH2"sv) ||
+				(mp == &g_mp_sys_dev_flash3 && mp_name == "CELL_FS_IOS:BUILTIN_FLSH3"sv)); // TODO confirm
 
 			if (mp == &g_mp_sys_dev_usb)
 			{


### PR DESCRIPTION
This was previously causing dev_flash2 to be remounted as dev_flash.

```
·! 0:00:06.484009 {PPU[0x1000000] Thread (main_thread) [0x000294ac]} VFS: About to unmount '/dev_flash'
·! 0:00:06.484011 {PPU[0x1000000] Thread (main_thread) [0x000294ac]} VFS: Unmounting 'dev_flash' = 'G:/Programming/rpcs3/rpcs3/bin/dev_flash/'
·W 0:00:06.484021 {PPU[0x1000000] Thread (main_thread) [0x000285d4]} sys_fs: sys_fs_mount(dev_name=“CELL_FS_IOS:BUILTIN_FLASH”, file_system=“CELL_FS_FAT”, path=“/dev_flash”, unk1=0x0, prot=0, unk3=0x0, str1=“”, str_len=0)
·! 0:00:06.484094 {PPU[0x1000000] Thread (main_thread) [0x000285d4]} VFS: Mounted path "/dev_flash" to "G:/Programming/rpcs3/rpcs3/bin/dev_flash2/"
```

and after
```
·W 0:00:20.447267 {PPU[0x1000000] Thread (main_thread) [0x000294ac]} sys_fs: sys_fs_unmount(path=“/dev_flash”, unk1=0x0, force=0)
·! 0:00:20.447324 {PPU[0x1000000] Thread (main_thread) [0x000294ac]} VFS: About to unmount '/dev_flash'
·! 0:00:20.447326 {PPU[0x1000000] Thread (main_thread) [0x000294ac]} VFS: Unmounting 'dev_flash' = 'G:/Programming/rpcs3/rpcs3/bin/dev_flash/'
·W 0:00:20.447335 {PPU[0x1000000] Thread (main_thread) [0x000285d4]} sys_fs: sys_fs_mount(dev_name=“CELL_FS_IOS:BUILTIN_FLASH”, file_system=“CELL_FS_FAT”, path=“/dev_flash”, unk1=0x0, prot=0, unk3=0x0, str1=“”, str_len=0)
·! 0:00:20.447407 {PPU[0x1000000] Thread (main_thread) [0x000285d4]} VFS: Mounted path "/dev_flash" to "G:/Programming/rpcs3/rpcs3/bin/dev_flash/"
```