### PR TITLE
RSX Debugger: populate Captured Draw Calls list

### DIFF
--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -259,6 +259,10 @@ rsx_debugger::rsx_debugger(std::shared_ptr<gui_settings> gui_settings, QWidget* 
 	for (u32 i = 0; i < frame_debug.command_queue.size(); i++)
 		m_list_captured_frame->insertRow(i);
 
+	// Fill the draw calls
+	for (u32 i = 0; i < frame_debug.draw_calls.size(); i++)
+		m_list_captured_draw_calls->insertRow(i);
+
 	restoreGeometry(m_gui_settings->GetValue(gui::rsx_geometry).toByteArray());
 
 	// Check for updates every ~100 ms


### PR DESCRIPTION
Noticed the Captured Draw Calls tab in the RSX Debugger always shows up empty after a frame capture. The constructor adds rows to the table for command_queue but doesn't do the same for draw_calls, so the setItem calls in GetMemory just don't do anything.

Adding the missing loop fixes it. Verified by taking a capture in-game and opening the debugger - draw calls show up now.