### PR TITLE
CI: Fix remaining Actions warning

### DIFF
--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -235,7 +235,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup NuGet
-        uses: nuget/setup-nuget@v2
+        uses: nuget/setup-nuget@v4
 
       - name: Restore NuGet packages
         run: nuget restore rpcs3.sln


### PR DESCRIPTION
There is one remaining [Node.JS deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) in the CI. 

This PR bumps `setup-nuget` to `@v4`.
