### PR TITLE
Avoid to open a virtual drive if no content is present

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1127,6 +1127,13 @@ bool fs::is_optical_raw_device(const std::string& path)
 
 bool fs::get_optical_raw_device(const std::string& path, std::string* raw_device)
 {
+	// Skip a useless check to detect an optical raw device if navigating on subfolders (e.g. C:/subfolder_1/subfolder_2/), it means we are on a hdd/ssd.
+	// A path for an optical drive should include only the drive letter (e.g. E:/)
+	if (path.find_first_of(":") != path.find_last_not_of(delim))
+	{
+		return false;
+	}
+
 	if (fs::is_optical_raw_device(path))
 	{
 		if (raw_device)

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1745,6 +1745,17 @@ fs::file::file(const std::string& path, bs_t<open_mode> mode)
 	// (the following GetFileInformationByHandle() would always fail on a raw device).
 	if (is_optical_raw_device(path))
 	{
+		DISK_GEOMETRY_EX geometry;
+
+		// Try to retrieve information on content. If it fails, no disc is probably mounted so abort the file opening
+		if (!DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_GEOMETRY_EX, nullptr, 0, &geometry, sizeof(geometry), nullptr, nullptr))
+		{
+			const DWORD last_error = GetLastError();
+			CloseHandle(handle);
+			g_tls_error = to_error(last_error);
+			return;
+		}
+
 		m_file = std::make_unique<windows_file>(handle, true);
 		return;
 	}


### PR DESCRIPTION
Related to #18648. A fix in case:
- virtual drives (e.g. provided by power iso etc.) are configured as current `VFS games` folder but no disc is mounted
- an external SCSI HDD is wrongly detected as CDROM instead of removable HDD (thanks to powerful API provided by Windows). The issue is now by-passed in case the configured base folder for games is not the root folder (e.g. `D:/rpcs3` where `D:/` is a SCSI HDD (wrongly) discovered by Windows as CDROM)

**NOTE:** With the exception of virtual drives provided by `Windows`, virtual drives provided by other tools (e.g. power iso) are not supported (they will not work even mounting a valid ISO game). 

### MINOR IMPROVEMENT:
- Skip a useless check to detect an optical raw device if navigating on subfolders (e.g. `C:/subfolder_1/subfolder_2/`), it means we are on a hdd/ssd. A path for an optical drive should include only the drive letter (e.g. `E:/`). This small optimization also allows the fix reported on second bullet above without the need to replace the used `GetDriveType()` function with a more complex code (e.g. based on `DeviceIoControl()` function)
