### PR TITLE
Fix use of database config when booting from the UI without a title_id

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -935,6 +935,8 @@ game_boot_result Emulator::GetElfPathFromDir(std::string& elf_path, const std::s
 
 game_boot_result Emulator::BootGame(const std::string& path, const std::string& title_id, bool direct, cfg_mode config_mode, const std::string& config_path, const std::optional<std::string>& db_config)
 {
+	sys_log.notice("Emulator::BootGame: path='%s', title_id='%s', direct=%d, config_mode='%s', config_path='%s', db_config=(set=%d, valid=%d)", path, title_id, direct, config_mode, config_path, db_config.has_value(), db_config && !db_config->empty());
+
 	if (m_restrict_emu_state_change)
 	{
 		return game_boot_result::currently_restricted;
@@ -1625,7 +1627,13 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 						{
 							g_cfg.name = config_path;
 							m_config_path = config_path;
-							m_add_database_config = false; // A custom config exists. Do not add the database config.
+
+							if (m_add_database_config)
+							{
+								// A custom config exists. Do not add the database config.
+								sys_log.notice("Found custom config. Ignoring database config");
+								m_add_database_config = false;
+							}
 							break;
 						}
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -121,6 +121,7 @@ namespace rsx
 }
 
 Emulator::Emulator() noexcept
+	: m_default_renderer(video_renderer::null)
 {
 	s_emulator_available = true;
 }

--- a/rpcs3/Loader/ISO.cpp
+++ b/rpcs3/Loader/ISO.cpp
@@ -384,7 +384,7 @@ bool iso_file_decryption::init(const std::string& path, iso_archive* archive)
 
 	if (!is_iso_file(iso_file))
 	{
-		iso_log.error("init: Failed to recognize ISO file: %s", path);
+		iso_log.error("init: Failed to recognize ISO file: '%s'", path);
 		return false;
 	}
 
@@ -395,13 +395,13 @@ bool iso_file_decryption::init(const std::string& path, iso_archive* archive)
 
 	if (iso_file.size() < sec0_sec1.size())
 	{
-		iso_log.error("init: Found only %llu sector(s) (minimum required is 2): %s", iso_file.size(), path);
+		iso_log.error("init: Found only %llu sector(s) (minimum required is 2): '%s'", iso_file.size(), path);
 		return false;
 	}
 
 	if (iso_file.read(sec0_sec1.data(), sec0_sec1.size()) != sec0_sec1.size())
 	{
-		iso_log.error("init: Failed to read file: %s", path);
+		iso_log.error("init: Failed to read file: '%s'", path);
 		return false;
 	}
 
@@ -415,7 +415,7 @@ bool iso_file_decryption::init(const std::string& path, iso_archive* archive)
 	// Ensure the region count is a proper value
 	if (region_count < 1 || region_count > 127) // It's non-PS3ISO
 	{
-		iso_log.error("init: Failed to read region information (region_count=%lu): %s", region_count, path);
+		iso_log.error("init: Failed to read region information (region_count=%lu): '%s'", region_count, path);
 		return false;
 	}
 
@@ -452,17 +452,17 @@ bool iso_file_decryption::init(const std::string& path, iso_archive* archive)
 	switch (status)
 	{
 	case iso_type_status::NOT_ISO:
-		iso_log.warning("init: Failed to recognize ISO file: %s", path);
+		iso_log.warning("init: Failed to recognize ISO file: '%s'", path);
 		break;
 	case iso_type_status::REDUMP_ISO:
-		iso_log.warning("init: Found matching key file: %s", key_path);
+		iso_log.warning("init: Found matching key file: '%s'", key_path);
 		m_enc_type = iso_encryption_type::REDUMP; // SET ENCRYPTION TYPE: REDUMP
 		break;
 	case iso_type_status::ERROR_OPENING_KEY:
-		iso_log.warning("init: Failed to open, or missing, key file: %s", key_path);
+		iso_log.warning("init: Failed to open, or missing, key file: '%s'", key_path);
 		break;
 	case iso_type_status::ERROR_PROCESSING_KEY:
-		iso_log.error("init: Failed to process key file: %s", key_path);
+		iso_log.error("init: Failed to process key file: '%s'", key_path);
 		break;
 	default:
 		break;
@@ -507,7 +507,7 @@ bool iso_file_decryption::init(const std::string& path, iso_archive* archive)
 
 			if (m_enc_type == iso_encryption_type::NONE) // If encryption type was not set to ENC_3K3Y for any reason
 			{
-				iso_log.error("init: Failed to set encryption type to ENC_3K3Y: %s", path);
+				iso_log.error("init: Failed to set encryption type to ENC_3K3Y: '%s'", path);
 			}
 		}
 		else if (std::memcmp(&k3k3y_dec_watermark[0], &sec0_sec1[0xF70], sizeof(k3k3y_dec_watermark)) == 0)
@@ -519,16 +519,16 @@ bool iso_file_decryption::init(const std::string& path, iso_archive* archive)
 	switch (m_enc_type)
 	{
 	case iso_encryption_type::REDUMP:
-		iso_log.warning("init: Set 'enc type': REDUMP, 'reg count': %u: %s", m_region_info.size(), path);
+		iso_log.warning("init: Set 'enc type': REDUMP, 'reg count': %u: '%s'", m_region_info.size(), path);
 		break;
 	case iso_encryption_type::ENC_3K3Y:
-		iso_log.warning("init: Set 'enc type': ENC_3K3Y, 'reg count': %u: %s", m_region_info.size(), path);
+		iso_log.warning("init: Set 'enc type': ENC_3K3Y, 'reg count': %u: '%s'", m_region_info.size(), path);
 		break;
 	case iso_encryption_type::DEC_3K3Y:
-		iso_log.warning("init: Set 'enc type': DEC_3K3Y, 'reg count': %u: %s", m_region_info.size(), path);
+		iso_log.warning("init: Set 'enc type': DEC_3K3Y, 'reg count': %u: '%s'", m_region_info.size(), path);
 		break;
 	case iso_encryption_type::NONE: // If encryption type was not set for any reason
-		iso_log.warning("init: Set 'enc type': NONE, 'reg count': %u: %s", m_region_info.size(), path);
+		iso_log.warning("init: Set 'enc type': NONE, 'reg count': %u: '%s'", m_region_info.size(), path);
 		break;
 	}
 
@@ -972,7 +972,7 @@ iso_archive::iso_archive(const std::string& path)
 	if (!iso_file || !is_iso_file(iso_file))
 	{
 		// Not ISO... TODO: throw something?
-		iso_log.error("iso_archive: Failed to recognize ISO file: %s", path);
+		iso_log.error("iso_archive: Failed to recognize ISO file: '%s'", path);
 		return;
 	}
 
@@ -1153,7 +1153,7 @@ iso_file::iso_file(const std::string& path, bs_t<fs::open_mode> mode)
 	if (!m_file)
 	{
 		// Should never happen... TODO: throw something?
-		iso_log.error("iso_file: Failed to open file: %s", path);
+		iso_log.error("iso_file: Failed to open file: '%s'", path);
 		return;
 	}
 
@@ -1173,7 +1173,7 @@ iso_file::iso_file(const std::string& path, bs_t<fs::open_mode> mode, const iso_
 	if (!m_file)
 	{
 		// Should never happen... TODO: throw something?
-		iso_log.error("iso_file: Failed to open file: %s", path);
+		iso_log.error("iso_file: Failed to open file: '%s'", path);
 		return;
 	}
 

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -412,16 +412,22 @@ EmuCallbacks main_application::CreateCallbacks()
 
 	callbacks.get_database_config = [](const std::string& title_id)
 	{
-		if (title_id.empty())
-			return std::string();
-
 		sys_log.notice("Trying to retrieve database config for: '%s'", title_id);
+
+		if (title_id.empty())
+		{
+			sys_log.warning("Cannot retrieve database config for empty title_id");
+			return std::string();
+		}
 
 		config_database config_db(nullptr);
 		config_db.request_config_database(false);
 
 		if (!config_db.has_config(title_id))
+		{
+			sys_log.notice("Cannot find database config for: '%s'", title_id);
 			return std::string();
+		}
 
 		if (const auto config = config_db.get_config(title_id))
 		{
@@ -429,6 +435,7 @@ EmuCallbacks main_application::CreateCallbacks()
 			return config.value();
 		}
 
+		sys_log.error("Failed to retrieve database config for: '%s'", title_id);
 		return std::string();
 	};
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -554,7 +554,7 @@ void main_window::Boot(const std::string& path, const std::string& title_id, boo
 
 	m_app_icon = gui::utils::get_app_icon_from_path(path, title_id);
 
-	std::string db_config;
+	std::optional<std::string> db_config = std::nullopt;
 
 	// Get database config if possible or if we are in database_config mode (to ensure we see an error on invalid use)
 	if (config_database* db = m_game_list_frame->GetConfigDatabase();
@@ -571,6 +571,10 @@ void main_window::Boot(const std::string& path, const std::string& title_id, boo
 
 		gui_log.notice("Found database config for: '%s'", title_id);
 		db_config = *config;
+	}
+	else if (!title_id.empty())
+	{
+		db_config = std::string(); // Set empty string to prevent another check in the emulator code
 	}
 
 	if (const auto error = Emu.BootGame(path, title_id, direct, config_mode, config_path, db_config); error != game_boot_result::no_errors)
@@ -4228,6 +4232,8 @@ void main_window::dropEvent(QDropEvent* event)
 		Emu.GracefulShutdown(false);
 
 		const std::string path = drop_paths.first().toStdString();
+
+		gui_log.notice("Booting from drag and drop...");
 
 		if (const auto error = Emu.BootGame(path, "", true); error != game_boot_result::no_errors)
 		{

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -569,6 +569,7 @@ void main_window::Boot(const std::string& path, const std::string& title_id, boo
 			return;
 		}
 
+		gui_log.notice("Found database config for: '%s'", title_id);
 		db_config = *config;
 	}
 


### PR DESCRIPTION
- Add some more logging for use of database config
- Fix db_config argument when booting without a title_id

fixes #18657