### PR TITLE
[macOS] Build MVK against Xcode 16.2

### DIFF
--- a/.ci/deploy-mac.sh
+++ b/.ci/deploy-mac.sh
@@ -7,12 +7,13 @@ cd bin
 git clone --revision=32dceb35e2c95b46cec501033cbc3a1ddf32d6e8 https://github.com/KhronosGroup/MoltenVK.git
 cd MoltenVK
 ./fetchDependencies --macos
+sudo xcode-select -switch /Applications/Xcode_16.2.app/Contents/Developer
 make macos MVK_USE_METAL_PRIVATE_API=1
 cd ../
 
 mkdir -p "rpcs3.app/Contents/Resources/vulkan/icd.d" || true
-cp "MoltenVK/Package/Latest/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib" "rpcs3.app/Contents/Frameworks/libMoltenVK.dylib"
-cp "MoltenVK/Package/Latest/MoltenVK/dynamic/dylib/macOS/MoltenVK_icd.json" "rpcs3.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
+cp "MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib" "rpcs3.app/Contents/Frameworks/libMoltenVK.dylib"
+cp "MoltenVK/Package/Release/MoltenVK/dynamic/dylib/macOS/MoltenVK_icd.json" "rpcs3.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
 sed -i '' "s/.\//..\/..\/..\/Frameworks\//g" "rpcs3.app/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
 
 cp "$(realpath $BREW_PATH/opt/llvm@$LLVM_COMPILER_VER/lib/c++/libc++abi.1.0.dylib)" "rpcs3.app/Contents/Frameworks/libc++abi.1.dylib"


### PR DESCRIPTION
~~For some weird reason~~ (Actual reason explained by TellowKrinkle below), the copy of MVK the scripts build against the runner's default of Xcode 15.4 runs significantly worse than official CI releases - or manually building against Xcode 16.2, the latter of which basically serves as the entire reason for this PR. This improves uncapped performance from approximately 170-190fps on the GOW3 main menu to approx 230-240fps on my M4 Pro MacBook Pro.