### PR TITLE
[macOS] Update MoltenVK and restore Game Mode support

### DIFF
--- a/.ci/deploy-mac.sh
+++ b/.ci/deploy-mac.sh
@@ -4,7 +4,7 @@
 cd build || exit 1
 
 cd bin
-git clone --revision=32dceb35e2c95b46cec501033cbc3a1ddf32d6e8 https://github.com/KhronosGroup/MoltenVK.git
+git clone --revision=a075e5e417f87675ea3137b7365f3e5a99608d72 https://github.com/KhronosGroup/MoltenVK.git
 cd MoltenVK
 ./fetchDependencies --macos
 sudo xcode-select -switch /Applications/Xcode_16.2.app/Contents/Developer

--- a/rpcs3/rpcs3.plist.in
+++ b/rpcs3/rpcs3.plist.in
@@ -28,6 +28,8 @@
 	<string>Licensed under GPLv2</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.4</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
MoltenVK reverted the responsible problematic PR here: https://github.com/KhronosGroup/MoltenVK/pull/2725, after some testing I can confirm that Game Mode no longer causes any kind of performance degradation/throttling after 15 seconds or longer with the latest MVK versions. Hence this PR updates MVK and restores macOS Game Mode support and all benefits that can bring (increased BT polling rate being the big one really).