### PR TITLE
Move multi-game ISO parsing code path to proper location

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -861,7 +861,38 @@ void game_list_frame::OnParsingFinished()
 		{
 			if (is_iso_file(entry.path))
 			{
-				push_path(entry.path, legit_paths);
+				iso_archive archive(entry.path);
+				const iso_fs_node& root = archive.root();
+				const std::regex ps3_gm_regex("^PS3_GM[[:digit:]]{2}$");
+				bool found = false;
+
+				for (const auto& child : root.children)
+				{
+					if (m_refresh_watcher.isCanceled())
+					{
+						break;
+					}
+
+					if (!child->metadata.is_directory)
+					{
+						continue;
+					}
+
+					const std::string& name = child->metadata.name;
+
+					if (name == "PS3_GAME" || std::regex_match(name, ps3_gm_regex))
+					{
+						add_game(entry.path, name);
+						found = true;
+					}
+				}
+
+				if (!found)
+				{
+					add_game(entry.path);
+				}
+
+				return;
 			}
 			else if (fs::is_file(entry.path + "/PARAM.SFO"))
 			{
@@ -895,41 +926,6 @@ void game_list_frame::OnParsingFinished()
 				}
 
 				add_disc_dir(entry.path, legit_paths);
-			}
-			else if (is_iso_file(entry.path))
-			{
-				iso_archive archive(entry.path);
-				const iso_fs_node& root = archive.root();
-				const std::regex ps3_gm_regex("^PS3_GM[[:digit:]]{2}$");
-				bool found = false;
-
-				for (const auto& child : root.children)
-				{
-					if (m_refresh_watcher.isCanceled())
-					{
-						break;
-					}
-
-					if (!child->metadata.is_directory)
-					{
-						continue;
-					}
-
-					const std::string& name = child->metadata.name;
-
-					if (name == "PS3_GAME" || std::regex_match(name, ps3_gm_regex))
-					{
-						add_game(entry.path, name);
-						found = true;
-					}
-				}
-
-				if (!found)
-				{
-					add_game(entry.path);
-				}
-
-				return;
 			}
 			else
 			{


### PR DESCRIPTION
Per the comments here: https://github.com/RPCS3/rpcs3/pull/18571#issuecomment-4366826196

The original multi-game ISO support PR got merged after several other PRs that adjusted the same region of code, and the functionality it added was inadvertently broken in the process.

This attempts to resolve the issue by moving the contents of the dead `else if (is_iso_file(entry.path))` branch to the newer `if (is_iso_file(entry.path))` branch at the top.

I noticed that this multi-game ISO branch is inconsistent with the new "legit_paths" thing (especially because it relies on a different style `add_game` call), but as this was not addressed in the original multi-game ISO PR, I'm not going to address it in this hotfix.