### PR TITLE
game_list: Fix ISO cache bypass in is_from_yml branch for multi-game ISOs

### DIFF
--- a/rpcs3/Loader/iso_cache.cpp
+++ b/rpcs3/Loader/iso_cache.cpp
@@ -19,16 +19,22 @@ namespace
 		return dir;
 	}
 
-	// FNV-64 hash of the ISO path used as the cache filename stem.
-	std::string get_cache_stem(const std::string& iso_path)
+	// FNV-64 hash of the given key used as the cache filename stem.
+	std::string get_cache_stem(const std::string& key)
 	{
 		usz hash = rpcs3::fnv_seed;
-		for (const char c : iso_path)
+		for (const char c : key)
 		{
 			hash ^= static_cast<u8>(c);
 			hash *= rpcs3::fnv_prime;
 		}
 		return fmt::format("%016llx", hash);
+	}
+
+	// Separate stem for the per-ISO subdir index entry.
+	std::string get_index_stem(const std::string& iso_path)
+	{
+		return get_cache_stem(iso_path + "//index");
 	}
 }
 
@@ -134,15 +140,87 @@ namespace iso_cache
 		}
 	}
 
+	bool load_index(const std::string& iso_path, std::vector<std::string>& out_subdirs)
+	{
+		fs::stat_t iso_stat{};
+		if (!fs::get_stat(iso_path, iso_stat) || iso_stat.is_directory)
+		{
+			return false;
+		}
+
+		const std::string dir      = get_cache_dir();
+		const std::string yml_path = dir + get_index_stem(iso_path) + ".yml";
+
+		const fs::file yml_file(yml_path);
+		if (!yml_file)
+		{
+			return false;
+		}
+
+		auto [node, error] = yaml_load(yml_file.to_string());
+		if (!error.empty())
+		{
+			iso_cache_log.warning("Failed to parse index YAML for '%s': %s", iso_path, error);
+			return false;
+		}
+
+		const s64 cached_mtime = node["mtime"].as<s64>(0);
+		if (cached_mtime != iso_stat.mtime)
+		{
+			return false;
+		}
+
+		const YAML::Node subdirs_node = node["subdirs"];
+		if (!subdirs_node || !subdirs_node.IsSequence())
+		{
+			return false;
+		}
+
+		for (const auto& entry : subdirs_node)
+		{
+			out_subdirs.push_back(entry.as<std::string>(""));
+		}
+
+		return !out_subdirs.empty();
+	}
+
+	void save_index(const std::string& iso_path, s64 mtime, const std::vector<std::string>& subdirs)
+	{
+		const std::string dir      = get_cache_dir();
+		const std::string yml_path = dir + get_index_stem(iso_path) + ".yml";
+
+		YAML::Emitter out;
+		out << YAML::BeginMap;
+		out << YAML::Key << "mtime"   << YAML::Value << static_cast<long long>(mtime);
+		out << YAML::Key << "subdirs" << YAML::Value << YAML::BeginSeq;
+		for (const std::string& s : subdirs)
+		{
+			out << s;
+		}
+		out << YAML::EndSeq;
+		out << YAML::EndMap;
+
+		if (fs::pending_file yml_file(yml_path); yml_file.file)
+		{
+			yml_file.file.write(out.c_str(), out.size());
+			yml_file.commit();
+		}
+		else
+		{
+			iso_cache_log.warning("Failed to write index YAML for '%s'", iso_path);
+		}
+	}
+
 	void cleanup(const std::unordered_set<std::string>& valid_iso_paths)
 	{
 		const std::string dir = get_cache_dir();
 
-		// Build a set of stems that should exist.
+		// Build a set of stems that should exist, including index entries.
 		std::unordered_set<std::string> valid_stems;
 		for (const std::string& path : valid_iso_paths)
 		{
 			valid_stems.insert(get_cache_stem(path));
+			valid_stems.insert(get_index_stem(path));
 		}
 
 		// Delete any cache files whose stem is not in the valid set.

--- a/rpcs3/Loader/iso_cache.cpp
+++ b/rpcs3/Loader/iso_cache.cpp
@@ -157,7 +157,7 @@ namespace iso_cache
 			return false;
 		}
 
-		auto [node, error] = yaml_load(yml_file.to_string());
+		const auto [node, error] = yaml_load(yml_file.to_string());
 		if (!error.empty())
 		{
 			iso_cache_log.warning("Failed to parse index YAML for '%s': %s", iso_path, error);
@@ -178,7 +178,11 @@ namespace iso_cache
 
 		for (const auto& entry : subdirs_node)
 		{
-			out_subdirs.push_back(entry.as<std::string>(""));
+			const std::string name = entry.as<std::string>("");
+			if (!name.empty())
+			{
+				out_subdirs.push_back(name);
+			}
 		}
 
 		return !out_subdirs.empty();

--- a/rpcs3/Loader/iso_cache.cpp
+++ b/rpcs3/Loader/iso_cache.cpp
@@ -20,7 +20,7 @@ namespace
 	}
 
 	// FNV-64 hash of the given key used as the cache filename stem.
-	std::string get_cache_stem(const std::string& key)
+	std::string get_cache_stem(std::string_view key)
 	{
 		usz hash = rpcs3::fnv_seed;
 		for (const char c : key)
@@ -188,14 +188,19 @@ namespace iso_cache
 		return !out_subdirs.empty();
 	}
 
-	void save_index(const std::string& iso_path, s64 mtime, const std::vector<std::string>& subdirs)
+	void save_index(const std::string& iso_path, const std::vector<std::string>& subdirs)
 	{
+		fs::stat_t iso_stat{};
+		if (!fs::get_stat(iso_path, iso_stat))
+		{
+			return;
+		}
 		const std::string dir      = get_cache_dir();
 		const std::string yml_path = dir + get_index_stem(iso_path) + ".yml";
 
 		YAML::Emitter out;
 		out << YAML::BeginMap;
-		out << YAML::Key << "mtime"   << YAML::Value << static_cast<long long>(mtime);
+		out << YAML::Key << "mtime"   << YAML::Value << static_cast<long long>(iso_stat.mtime);
 		out << YAML::Key << "subdirs" << YAML::Value << YAML::BeginSeq;
 		for (const std::string& s : subdirs)
 		{

--- a/rpcs3/Loader/iso_cache.cpp
+++ b/rpcs3/Loader/iso_cache.cpp
@@ -178,10 +178,10 @@ namespace iso_cache
 
 		for (const auto& entry : subdirs_node)
 		{
-			const std::string name = entry.as<std::string>("");
+			std::string name = entry.as<std::string>("");
 			if (!name.empty())
 			{
-				out_subdirs.push_back(name);
+				out_subdirs.push_back(std::move(name));
 			}
 		}
 

--- a/rpcs3/Loader/iso_cache.h
+++ b/rpcs3/Loader/iso_cache.h
@@ -29,7 +29,7 @@ namespace iso_cache
 	void save(const std::string& iso_path, const std::string& cache_key, const iso_metadata_cache_entry& entry);
 
 	bool load_index(const std::string& iso_path, std::vector<std::string>& out_subdirs);
-	void save_index(const std::string& iso_path, s64 mtime, const std::vector<std::string>& subdirs);
+	void save_index(const std::string& iso_path, const std::vector<std::string>& subdirs);
 
 	// Remove cache entries for ISOs that are no longer in the scanned set.
 	void cleanup(const std::unordered_set<std::string>& valid_iso_paths);

--- a/rpcs3/Loader/iso_cache.h
+++ b/rpcs3/Loader/iso_cache.h
@@ -17,6 +17,7 @@ struct iso_metadata_cache_entry
 	std::vector<u8> icon_data{};
 	std::string movie_path{};
 	std::string audio_path{};
+	std::vector<std::string> subdirs{};
 };
 
 namespace iso_cache
@@ -26,6 +27,9 @@ namespace iso_cache
 
 	// Persists a populated cache entry to disk.
 	void save(const std::string& iso_path, const std::string& cache_key, const iso_metadata_cache_entry& entry);
+
+	bool load_index(const std::string& iso_path, std::vector<std::string>& out_subdirs);
+	void save_index(const std::string& iso_path, s64 mtime, const std::vector<std::string>& subdirs);
 
 	// Remove cache entries for ISOs that are no longer in the scanned set.
 	void cleanup(const std::unordered_set<std::string>& valid_iso_paths);

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -870,44 +870,42 @@ void game_list_frame::OnParsingFinished()
 						if (m_refresh_watcher.isCanceled()) break;
 						add_game(entry.path, name);
 					}
+
+					return;
 				}
-				else
+
+				iso_archive archive(entry.path);
+				const iso_fs_node& root = archive.root();
+				const std::regex ps3_gm_regex("^PS3_GM[[:digit:]]{2}$");
+
+				for (const auto& child : root.children)
 				{
-					iso_archive archive(entry.path);
-					const iso_fs_node& root = archive.root();
-					const std::regex ps3_gm_regex("^PS3_GM[[:digit:]]{2}$");
-
-					for (const auto& child : root.children)
+					if (m_refresh_watcher.isCanceled())
 					{
-						if (m_refresh_watcher.isCanceled())
-						{
-							break;
-						}
-
-						if (!child->metadata.is_directory)
-						{
-							continue;
-						}
-
-						const std::string& name = child->metadata.name;
-						if (name == "PS3_GAME" || std::regex_match(name, ps3_gm_regex))
-						{
-							subdirs.push_back(name);
-							add_game(entry.path, name);
-						}
+						break;
+					}
+					if (!child->metadata.is_directory)
+					{
+						continue;
 					}
 
-					if(subdirs.empty())
+					const std::string& name = child->metadata.name;
+					if (name == "PS3_GAME" || std::regex_match(name, ps3_gm_regex))
 					{
-						add_game(entry.path);
-						subdirs.push_back("PS3_GAME");
+						subdirs.push_back(name);
+						add_game(entry.path, name);
 					}
+				}
+				if (subdirs.empty())
+				{
+					add_game(entry.path);
+					subdirs.push_back("PS3_GAME");
+				}
 
-					fs::stat_t iso_stat{};
-					if (fs::get_stat(entry.path, iso_stat))
-					{
-						iso_cache::save_index(entry.path, iso_stat.mtime, subdirs);
-					}
+				fs::stat_t iso_stat{};
+				if (fs::get_stat(entry.path, iso_stat))
+				{
+					iso_cache::save_index(entry.path, iso_stat.mtime, subdirs);
 				}
 
 				return;

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -901,11 +901,9 @@ void game_list_frame::OnParsingFinished()
 					add_game(entry.path);
 					subdirs.push_back("PS3_GAME");
 				}
-
-				fs::stat_t iso_stat{};
-				if (fs::get_stat(entry.path, iso_stat))
+				if (!m_refresh_watcher.isCanceled())
 				{
-					iso_cache::save_index(entry.path, iso_stat.mtime, subdirs);
+					iso_cache::save_index(entry.path, subdirs);
 				}
 
 				return;

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -861,35 +861,53 @@ void game_list_frame::OnParsingFinished()
 		{
 			if (is_iso_file(entry.path))
 			{
-				iso_archive archive(entry.path);
-				const iso_fs_node& root = archive.root();
-				const std::regex ps3_gm_regex("^PS3_GM[[:digit:]]{2}$");
-				bool found = false;
+				std::vector<std::string> subdirs;
 
-				for (const auto& child : root.children)
+				if (iso_cache::load_index(entry.path, subdirs))
 				{
-					if (m_refresh_watcher.isCanceled())
+					for (const std::string& name : subdirs)
 					{
-						break;
-					}
-
-					if (!child->metadata.is_directory)
-					{
-						continue;
-					}
-
-					const std::string& name = child->metadata.name;
-
-					if (name == "PS3_GAME" || std::regex_match(name, ps3_gm_regex))
-					{
+						if (m_refresh_watcher.isCanceled()) break;
 						add_game(entry.path, name);
-						found = true;
 					}
 				}
-
-				if (!found)
+				else
 				{
-					add_game(entry.path);
+					iso_archive archive(entry.path);
+					const iso_fs_node& root = archive.root();
+					const std::regex ps3_gm_regex("^PS3_GM[[:digit:]]{2}$");
+
+					for (const auto& child : root.children)
+					{
+						if (m_refresh_watcher.isCanceled())
+						{
+							break;
+						}
+
+						if (!child->metadata.is_directory)
+						{
+							continue;
+						}
+
+						const std::string& name = child->metadata.name;
+						if (name == "PS3_GAME" || std::regex_match(name, ps3_gm_regex))
+						{
+							subdirs.push_back(name);
+							add_game(entry.path, name);
+						}
+					}
+
+					if(subdirs.empty())
+					{
+						add_game(entry.path);
+						subdirs.push_back("PS3_GAME");
+					}
+
+					fs::stat_t iso_stat{};
+					if (fs::get_stat(entry.path, iso_stat))
+					{
+						iso_cache::save_index(entry.path, iso_stat.mtime, subdirs);
+					}
 				}
 
 				return;


### PR DESCRIPTION
Fixes regression from #18546 and #18679.

## Problem
The is_from_yml ISO branch constructed iso_archive unconditionally, bypassing the cache check inside add_game, making the cache write-only for yml-sourced ISOs.

## Fix
Added a lightweight index cache entry (iso_path + "//index") storing the subdir list + mtime. On hit, skips archive construction entirely. On miss, walks as before and writes the index.

## Testing
Cold cache, warm cache, and mtime invalidation tested with a multi-game ISO (Disgaea Triple Play Collection) and single game ISOs.