### PR TITLE
game_list: Fix icon display for multi-game collection ISOs

### DIFF
--- a/rpcs3/rpcs3qt/game_list_base.cpp
+++ b/rpcs3/rpcs3qt/game_list_base.cpp
@@ -49,7 +49,7 @@ void game_list_base::IconLoadFunction(game_info game, qreal device_pixel_ratio, 
 	static std::unordered_set<std::string> warn_once_list;
 	static shared_mutex s_mtx;
 
-	if (game->icon.isNull() && !gui::utils::load_icon(game->icon, game->info.icon_path, game->icon_in_archive ? game->info.path : ""))
+	if (game->icon.isNull() && !gui::utils::load_icon(game->icon, game->info.icon_path, game->icon_in_archive ? game->info.path : "", game->info.game_dir))
 	{
 		if (game_list_log.warning)
 		{

--- a/rpcs3/rpcs3qt/qt_utils.cpp
+++ b/rpcs3/rpcs3qt/qt_utils.cpp
@@ -705,7 +705,7 @@ namespace gui
 			return QString("%1 days ago %2").arg(current_date - exctrated_date).arg(date.toString(fmt_relative));
 		}
 
-		bool load_iso_icon(QPixmap& icon, const std::string& icon_path, const std::string& archive_path)
+		bool load_iso_icon(QPixmap& icon, const std::string& icon_path, const std::string& archive_path, const std::string& game_dir)
 		{
 			if (icon_path.empty() || archive_path.empty()) return false;
 
@@ -716,7 +716,9 @@ namespace gui
 
 			// With the exception of raw device, check cache first — avoids constructing a full iso_archive just for the icon.
 			iso_metadata_cache_entry cache_entry{};
-			if (!is_raw_device && iso_cache::load(archive_path, archive_path, cache_entry) && !cache_entry.icon_data.empty())
+			const std::string cache_key = game_dir.empty() ? archive_path : archive_path + "//" + game_dir;
+
+			if (!is_raw_device && iso_cache::load(archive_path, cache_key, cache_entry) && !cache_entry.icon_data.empty())
 			{
 				const QByteArray data(reinterpret_cast<const char*>(cache_entry.icon_data.data()),
 				                      static_cast<qsizetype>(cache_entry.icon_data.size()));
@@ -736,7 +738,7 @@ namespace gui
 			return icon.loadFromData(data);
 		}
 
-		bool load_icon(QPixmap& icon, const std::string& icon_path, const std::string& archive_path)
+		bool load_icon(QPixmap& icon, const std::string& icon_path, const std::string& archive_path, const std::string& game_dir)
 		{
 			if (icon_path.empty()) return false;
 
@@ -745,7 +747,7 @@ namespace gui
 				return icon.load(QString::fromStdString(icon_path));
 			}
 
-			return load_iso_icon(icon, icon_path, archive_path);
+			return load_iso_icon(icon, icon_path, archive_path, game_dir);
 		}
 
 		QString format_timestamp(s64 time, const QString& fmt)

--- a/rpcs3/rpcs3qt/qt_utils.h
+++ b/rpcs3/rpcs3qt/qt_utils.h
@@ -193,10 +193,10 @@ namespace gui
 		}
 
 		// Loads an icon from an (ISO) archive file.
-		bool load_iso_icon(QPixmap& icon, const std::string& icon_path, const std::string& archive_path);
+		bool load_iso_icon(QPixmap& icon, const std::string& icon_path, const std::string& archive_path, const std::string& game_dir = {});
 
 		// Loads an icon (optionally from an (ISO) archive file).
-		bool load_icon(QPixmap& icon, const std::string& icon_path, const std::string& archive_path);
+		bool load_icon(QPixmap& icon, const std::string& icon_path, const std::string& archive_path, const std::string& game_dir = {});
 
 		template <typename T>
 		void stop_future_watcher(QFutureWatcher<T>& watcher, bool cancel, std::shared_ptr<atomic_t<bool>> cancel_flag = nullptr)


### PR DESCRIPTION
## Problem

load_iso_icon always used the ISO path as both the stat key and the cache lookup key, ignoring game_dir. This caused all sub-games in a multi-game ISO to load the cached icon bytes of PS3_GAME, showing the wrong icon for PS3_GM01, PS3_GM02 and so on.

## Fix

Pass game_dir through load_icon -> load_iso_icon and calculate the correct cache key (iso_path + "//" + game_dir) before the cache lookup.

## Testing

Tested with Disgaea Triple Play Collection ISO. All three games now display their correct icons.


Fixes #18692 



## Before
<img width="252" height="124" alt="image" src="https://github.com/user-attachments/assets/0879cf65-fe4e-4533-a275-cc8633be03a8" />


## After
<img width="256" height="133" alt="image" src="https://github.com/user-attachments/assets/f76f1255-a130-440e-a216-c1b9b0629985" />

