### PR TITLE
Qt: Disambiguate offset direction labels from DPad/Stick labels

### DIFF
--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -152,6 +152,17 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 
 	ui->buttonBox->button(QDialogButtonBox::Reset)->setText(tr("Filter Noise"));
 
+	// Disambiguate "Left"/"Right" for offset direction labels from stick/DPad direction labels.
+	// This allows translators to use shorter abbreviations where screen space is tight
+	// (Squircle Values, Stick Multipliers, Stick Interpolation) while keeping full forms
+	// for the more spacious D-Pad and Stick binding areas.
+	ui->label_squircle_left->setText(tr("Left", "Offset direction"));
+	ui->label_squircle_right->setText(tr("Right", "Offset direction"));
+	ui->label_stick_multi_left->setText(tr("Left", "Offset direction"));
+	ui->label_stick_multi_right->setText(tr("Right", "Offset direction"));
+	ui->left_stick_lerp_label->setText(tr("Left", "Offset direction"));
+	ui->right_stick_lerp_label->setText(tr("Right", "Offset direction"));
+
 	connect(ui->buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button)
 	{
 		if (button == ui->buttonBox->button(QDialogButtonBox::Save))

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -152,17 +152,6 @@ pad_settings_dialog::pad_settings_dialog(std::shared_ptr<gui_settings> gui_setti
 
 	ui->buttonBox->button(QDialogButtonBox::Reset)->setText(tr("Filter Noise"));
 
-	// Disambiguate "Left"/"Right" for offset direction labels from stick/DPad direction labels.
-	// This allows translators to use shorter abbreviations where screen space is tight
-	// (Squircle Values, Stick Multipliers, Stick Interpolation) while keeping full forms
-	// for the more spacious D-Pad and Stick binding areas.
-	ui->label_squircle_left->setText(tr("Left", "Offset direction"));
-	ui->label_squircle_right->setText(tr("Right", "Offset direction"));
-	ui->label_stick_multi_left->setText(tr("Left", "Offset direction"));
-	ui->label_stick_multi_right->setText(tr("Right", "Offset direction"));
-	ui->left_stick_lerp_label->setText(tr("Left", "Offset direction"));
-	ui->right_stick_lerp_label->setText(tr("Right", "Offset direction"));
-
 	connect(ui->buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton* button)
 	{
 		if (button == ui->buttonBox->button(QDialogButtonBox::Save))

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -2348,7 +2348,7 @@
                <item>
                 <widget class="QLabel" name="label_squircle_left">
                  <property name="text">
-                  <string>Left</string>
+                  <string comment="Offset direction">Left</string>
                  </property>
                 </widget>
                </item>
@@ -2378,7 +2378,7 @@
                <item>
                 <widget class="QLabel" name="label_squircle_right">
                  <property name="text">
-                  <string>Right</string>
+                  <string comment="Offset direction">Right</string>
                  </property>
                 </widget>
                </item>
@@ -2429,7 +2429,7 @@
                <item>
                 <widget class="QLabel" name="label_stick_multi_left">
                  <property name="text">
-                  <string>Left</string>
+                  <string comment="Offset direction">Left</string>
                  </property>
                 </widget>
                </item>
@@ -2456,7 +2456,7 @@
                <item>
                 <widget class="QLabel" name="label_stick_multi_right">
                  <property name="text">
-                  <string>Right</string>
+                  <string comment="Offset direction">Right</string>
                  </property>
                 </widget>
                </item>
@@ -2673,7 +2673,7 @@
                    <item>
                     <widget class="QLabel" name="left_stick_lerp_label">
                      <property name="text">
-                      <string>Left</string>
+                      <string comment="Offset direction">Left</string>
                      </property>
                     </widget>
                    </item>
@@ -2703,7 +2703,7 @@
                    <item>
                     <widget class="QLabel" name="right_stick_lerp_label">
                      <property name="text">
-                      <string>Right</string>
+                      <string comment="Offset direction">Right</string>
                      </property>
                     </widget>
                    </item>

--- a/rpcs3/rpcs3qt/pad_settings_dialog.ui
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.ui
@@ -2348,7 +2348,7 @@
                <item>
                 <widget class="QLabel" name="label_squircle_left">
                  <property name="text">
-                  <string comment="Offset direction">Left</string>
+                  <string comment="Analog stick">Left</string>
                  </property>
                 </widget>
                </item>
@@ -2378,7 +2378,7 @@
                <item>
                 <widget class="QLabel" name="label_squircle_right">
                  <property name="text">
-                  <string comment="Offset direction">Right</string>
+                  <string comment="Analog stick">Right</string>
                  </property>
                 </widget>
                </item>
@@ -2429,7 +2429,7 @@
                <item>
                 <widget class="QLabel" name="label_stick_multi_left">
                  <property name="text">
-                  <string comment="Offset direction">Left</string>
+                  <string comment="Analog stick">Left</string>
                  </property>
                 </widget>
                </item>
@@ -2456,7 +2456,7 @@
                <item>
                 <widget class="QLabel" name="label_stick_multi_right">
                  <property name="text">
-                  <string comment="Offset direction">Right</string>
+                  <string comment="Analog stick">Right</string>
                  </property>
                 </widget>
                </item>
@@ -2673,7 +2673,7 @@
                    <item>
                     <widget class="QLabel" name="left_stick_lerp_label">
                      <property name="text">
-                      <string comment="Offset direction">Left</string>
+                      <string comment="Analog stick">Left</string>
                      </property>
                     </widget>
                    </item>
@@ -2703,7 +2703,7 @@
                    <item>
                     <widget class="QLabel" name="right_stick_lerp_label">
                      <property name="text">
-                      <string comment="Offset direction">Right</string>
+                      <string comment="Analog stick">Right</string>
                      </property>
                     </widget>
                    </item>


### PR DESCRIPTION
## Summary

The "Left" and "Right" strings in `pad_settings_dialog` were shared between DPad/Stick direction labels (which have ample space) and offset value labels — Squircle Values, Stick Multipliers, and Stick Interpolation (where space is tight). Translators couldn't abbreviate the offset version without also affecting the direction binding labels.

## Change

Added disambiguation via `comment="Offset direction"` in the `.ui` file's `<string>` elements for the six offset labels:

- `label_squircle_left`
- `label_squircle_right`
- `label_stick_multi_left`
- `label_stick_multi_right`
- `left_stick_lerp_label`
- `right_stick_lerp_label`

Qt now generates separate translation entries, allowing translators to use shorter abbreviations in the tight offset areas while keeping full forms for direction bindings.

**English UI is unchanged** — no visual difference for English users.

Fixes #18691