### PR TITLE
Add option to derive MAC from PSID

### DIFF
--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -612,6 +612,15 @@ namespace np
 
 	bool np_handler::discover_ether_address()
 	{
+		if (g_cfg.net.derive_mac_from_psid)
+		{
+			const u128 psid = g_cfg.sys.console_psid;
+			memcpy(ether_address.data(), &psid, 6);
+			ether_address[0] &= 0xFE;
+			ether_address[0] |= 0x02;
+			return true;
+		}
+
 #if defined(__FreeBSD__) || defined(__APPLE__)
 		ifaddrs* ifap;
 

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -332,6 +332,7 @@ struct cfg_root : cfg::node
 		cfg::string dns{this, "DNS address", "8.8.8.8"};
 		cfg::string swap_list{this, "IP swap list", ""};
 		cfg::_bool upnp_enabled{this, "UPNP Enabled", false};
+		cfg::_bool derive_mac_from_psid{this, "Derive MAC from PSID", false};
 
 		cfg::_enum<np_psn_status> psn_status{this, "PSN status", np_psn_status::disabled};
 		cfg::string country{this, "PSN Country", "us"};

--- a/rpcs3/rpcs3qt/emu_settings_type.cpp
+++ b/rpcs3/rpcs3qt/emu_settings_type.cpp
@@ -219,6 +219,7 @@ const std::map<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::PSNStatus,      get_cfg_location(local_cfg.net.psn_status) },
 	{ emu_settings_type::BindAddress,    get_cfg_location(local_cfg.net.bind_address) },
 	{ emu_settings_type::EnableUpnp,     get_cfg_location(local_cfg.net.upnp_enabled) },
+	{ emu_settings_type::DeriveMacFromPsid, get_cfg_location(local_cfg.net.derive_mac_from_psid) },
 	{ emu_settings_type::PSNCountry,     get_cfg_location(local_cfg.net.country) },
 	{ emu_settings_type::EnableClans,    get_cfg_location(local_cfg.net.clans_enabled) },
 

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -210,6 +210,7 @@ enum class emu_settings_type
 	PSNStatus,
 	BindAddress,
 	EnableUpnp,
+	DeriveMacFromPsid,
 	PSNCountry,
 	EnableClans,
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1432,14 +1432,19 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	m_emu_settings->EnhanceCheckBox(ui->enable_upnp, emu_settings_type::EnableUpnp);
 	SubscribeTooltip(ui->enable_upnp, tooltips.settings.enable_upnp);
 
+	m_emu_settings->EnhanceCheckBox(ui->derive_mac_from_psid, emu_settings_type::DeriveMacFromPsid);
+	SubscribeTooltip(ui->derive_mac_from_psid, tooltips.settings.derive_mac_from_psid);
+
 	// Comboboxes
 
 	connect(ui->netStatusBox, &QComboBox::currentIndexChanged, [this](int index)
 	{
 		if (index < 0) return;
 		const auto [text, value] = get_data(ui->netStatusBox, index);
-		ui->gb_edit_dns->setEnabled(static_cast<np_internet_status>(value) != np_internet_status::disabled);
-		ui->enable_upnp->setEnabled(static_cast<np_internet_status>(value) != np_internet_status::disabled);
+		const bool internet_enabled = static_cast<np_internet_status>(value) != np_internet_status::disabled;
+		ui->gb_edit_dns->setEnabled(internet_enabled);
+		ui->enable_upnp->setEnabled(internet_enabled);
+		ui->derive_mac_from_psid->setEnabled(internet_enabled);
 
 		if (static_cast<np_internet_status>(value) == np_internet_status::disabled)
 		{

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -2306,6 +2306,13 @@
               </widget>
              </item>
              <item>
+              <widget class="QCheckBox" name="derive_mac_from_psid">
+               <property name="text">
+                <string>Derive ethernet address from PSID</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <spacer name="networkTabSpacerLeft">
                <property name="orientation">
                 <enum>Qt::Orientation::Vertical</enum>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -265,6 +265,7 @@ public:
 		const QString dns_swap      = tr("DNS Swap List.\nOnly available in custom configurations.");
 		const QString bind          = tr("Interface IP Address to bind to.\nOnly available in custom configurations.");
 		const QString enable_upnp   = tr("Enable UPNP.\nThis will automatically forward ports bound on 0.0.0.0 if your router has UPNP enabled.");
+		const QString derive_mac_from_psid = tr("Derive the MAC address from the PSID.");
 		const QString psn_country   = tr("Changes the RPCN country.");
 		const QString enable_clans  = tr("Enable connection to the Clans server.\nOnly affects games supporting the Clans feature.");
 


### PR DESCRIPTION
Simplified version of https://github.com/RPCS3/rpcs3/pull/18697
Adds a checkbox in network config to enable the MAC address to be derived from PSID, config only available when internet is enabled.