### PR TITLE
Emu: enable JIT write mode in SPRX Loader on Apple Silicon

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1835,6 +1835,17 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 
 			g_fxo->init<named_thread>("SPRX Loader"sv, [this, dir_queue, is_fast = m_precompilation_option.is_fast]() mutable
 			{
+#ifdef __APPLE__
+				// Apple Silicon W^X: SPRX Loader writes JIT code via ppu_initialize().
+				// Without entering write mode, writes to MAP_JIT pages segfault.
+				pthread_jit_write_protect_np(false);
+
+				// RAII guard so execute mode is restored on every exit path
+				// (return, exception, etc.).
+				struct jit_write_guard {
+					~jit_write_guard() { pthread_jit_write_protect_np(true); }
+				} _jit_guard;
+#endif
 				std::vector<ppu_module<lv2_obj>*> mod_list;
 
 				if (auto& _main = *ensure(g_fxo->try_get<main_ppu_module<lv2_obj>>()); !_main.path.empty())


### PR DESCRIPTION
## Summary

The `SPRX Loader` thread spawned in `Emulator::Load()` (rpcs3/Emu/System.cpp) invokes `ppu_initialize()` and `ppu_precompile()`, both of which write into the PPU JIT code cache. On AArch64 Apple Silicon, MAP_JIT pages default to **execute mode** for newly created threads, so any write into the cache from this thread segfaults before the game can boot.

## Reproducer

Tested on a clean RPCS3 `0.0.40-19340` boot of **Red Dead Redemption (BLUS30418)** on macOS arm64 (Apple M-series):

```
Segfault writing location 0000000300010000 at 000000018b543408.
Emu Thread Name: 'SPRX Loader'.

Thread terminated due to fatal error: Segfault writing location 0000000300010000 at 000000018b543408.
```

The address `0x300010000` is `g_sudo_addr + 0x10000` (the unprotected memory mirror), and the native PC `0x18b543408` is inside the PPU JIT recompiler. Crash reproduces ~12 seconds into boot, before the title screen ever renders.

## Fix

Mirror the W^X handling already used by the PPU thread's `ppu_cmd::initialize` handler at `Emu/Cell/PPUThread.cpp:2218-2241`: enable write mode at SPRX-Loader thread entry, and pair it with an RAII guard so execute mode is restored on every exit path — normal return, early-exit on `Emu.IsStopped()`, or exception unwind.

```cpp
#ifdef __APPLE__
    pthread_jit_write_protect_np(false);

    struct jit_write_guard {
        ~jit_write_guard() { pthread_jit_write_protect_np(true); }
    } _jit_guard;
#endif
```

## Notes

- Entire block is inside `#ifdef __APPLE__`, so no effect on x86_64 or non-Apple ARM64 builds.
- 11-line diff, defensive guard pattern.
- Same pattern as #18701 (SPU worker threads) but for the PPU init path.

cc related: #16495 (macOS-specific crashes)