### PR TITLE
Qt: include territory in language menu labels

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2299,7 +2299,13 @@ void main_window::UpdateLanguageActions(const QStringList& language_codes, const
 		const QLocale locale      = QLocale(code);
 		const QString locale_name = QLocale::languageToString(locale.language());
 		const QString territory   = QLocale::territoryToString(locale.territory());
-		const QString display_name = (!territory.isEmpty() && code.contains('_')) ? QString("%1 (%2)").arg(locale_name, territory) : locale_name;
+
+		const bool is_unique = std::count_if(language_codes.cbegin(), language_codes.cend(), [&locale_name](const QString& code)
+		{
+			return locale_name == QLocale::languageToString(QLocale(code).language());
+		}) == 1;
+
+		const QString display_name = (!is_unique && !territory.isEmpty()) ? QString("%1 (%2)").arg(locale_name, territory) : locale_name;
 
 		// create new action
 		QAction* act = new QAction(display_name, this);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2299,7 +2299,7 @@ void main_window::UpdateLanguageActions(const QStringList& language_codes, const
 		const QLocale locale      = QLocale(code);
 		const QString locale_name = QLocale::languageToString(locale.language());
 		const QString territory   = QLocale::territoryToString(locale.territory());
-		const QString display_name = territory.isEmpty() ? locale_name : QString("%1 (%2)").arg(locale_name, territory);
+		const QString display_name = code.contains('_') ? QString("%1 (%2)").arg(locale_name, territory) : locale_name;
 
 		// create new action
 		QAction* act = new QAction(display_name, this);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2299,7 +2299,7 @@ void main_window::UpdateLanguageActions(const QStringList& language_codes, const
 		const QLocale locale      = QLocale(code);
 		const QString locale_name = QLocale::languageToString(locale.language());
 		const QString territory   = QLocale::territoryToString(locale.territory());
-		const QString display_name = code.contains('_') ? QString("%1 (%2)").arg(locale_name, territory) : locale_name;
+		const QString display_name = (!territory.isEmpty() && code.contains('_')) ? QString("%1 (%2)").arg(locale_name, territory) : locale_name;
 
 		// create new action
 		QAction* act = new QAction(display_name, this);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -2298,11 +2298,13 @@ void main_window::UpdateLanguageActions(const QStringList& language_codes, const
 	{
 		const QLocale locale      = QLocale(code);
 		const QString locale_name = QLocale::languageToString(locale.language());
+		const QString territory   = QLocale::territoryToString(locale.territory());
+		const QString display_name = territory.isEmpty() ? locale_name : QString("%1 (%2)").arg(locale_name, territory);
 
 		// create new action
-		QAction* act = new QAction(locale_name, this);
+		QAction* act = new QAction(display_name, this);
 		act->setData(code);
-		act->setToolTip(locale_name);
+		act->setToolTip(display_name);
 		act->setCheckable(true);
 		act->setChecked(code == language_code);
 


### PR DESCRIPTION
## Summary
Fixes the GUI language dropdown to show territory variants when translation files include country codes.

**Before:** "Portuguese" for both `pt_BR` and `pt_PT`
**After:** "Portuguese (Brazil)" and "Portuguese (Portugal)"

Also fixes the same ambiguity for Chinese and any other language with country variants.

## Implementation
Uses `QLocale::territoryToString()` alongside the existing `QLocale::languageToString()` to construct display labels. When no territory exists (e.g., `en`, `ja`), the label is unchanged.

## Edge cases
- No-territory locales (`en`, `ja`): unchanged — `QLocale::territoryToString(AnyTerritory)` returns empty, guard preserves plain language name
- Territory names are locale-translated (not hardcoded English) — they follow the current UI language, same as `languageToString()`
- `zh_CN` → "Chinese (China)" / `zh_TW` → "Chinese (Taiwan)" (territory-based, unlike the PS3 system language dropdown which uses Simplified/Traditional script names — this is appropriate for the GUI translator selector context)

## Test Plan
- [ ] Language menu shows "Portuguese (Brazil)" when `rpcs3_pt_BR.qm` is present
- [ ] Language menu shows "Chinese (China)" when `rpcs3_zh_CN.qm` is present
- [ ] Plain languages (`en`, `ja`) continue to show without parens

---

<details>
<summary>Review note: territory strings in UI locale</summary>

Territory names render in the current UI language (not forced English). This matches `QLocale::languageToString()` behavior and is consistent with how the rest of the menu renders. If hardcoded English labels are preferred, that can be added after review.
</details>

Fixes #18215