### PR TITLE
Fix VSH on ARM64: Memory management fixes

### DIFF
--- a/Utilities/JIT.h
+++ b/Utilities/JIT.h
@@ -434,13 +434,35 @@ namespace asmjit
 #endif
 }
 
+#ifdef __APPLE__
+struct jit_write_guard
+{
+	jit_write_guard() noexcept
+	{
+		pthread_jit_write_protect_np(false);
+
+		// Ensure stores are not reordered by the compiler
+		atomic_fence_acq_rel();
+	}
+
+	~jit_write_guard() noexcept
+	{
+		// Ensure stores are not reordered by the compiler
+		atomic_fence_seq_cst();
+
+		pthread_jit_write_protect_np(true);
+	}
+};
+#else
+#define jit_write_guard [[maybe_unused]] int
+#endif
+
 // Build runtime function with asmjit::X86Assembler
 template <typename FT, typename Asm = native_asm, typename F>
 inline FT build_function_asm(std::string_view name, F&& builder, ::jit_runtime* custom_runtime = nullptr, bool reduced_size = false)
 {
-#ifdef __APPLE__
-	pthread_jit_write_protect_np(false);
-#endif
+	jit_write_guard jit_guard;
+
 	using namespace asmjit;
 
 	auto& rt = custom_runtime ? *custom_runtime : get_global_runtime();

--- a/Utilities/JITASM.cpp
+++ b/Utilities/JITASM.cpp
@@ -122,7 +122,7 @@ static u8* get_jit_memory()
 	// Reserve 2G memory (magic static)
 	static void* const s_memory2 = []() -> void*
 	{
-		void* ptr = utils::memory_reserve(0x80000000);
+		void* ptr = utils::memory_reserve(0x80000000, true);
 #ifdef CAN_OVERCOMMIT
 		utils::memory_commit(ptr, 0x80000000);
 		utils::memory_protect(ptr, 0x40000000, utils::protection::wx);
@@ -348,7 +348,7 @@ jit_runtime_base& asmjit::get_global_runtime()
 	{
 		custom_runtime() noexcept
 		{
-			ensure(m_pos.raw() = static_cast<uchar*>(utils::memory_reserve(size)));
+			ensure(m_pos.raw() = static_cast<uchar*>(utils::memory_reserve(size, true)));
 
 			// Initialize "end" pointer
 			m_max = m_pos + size;

--- a/Utilities/JITASM.cpp
+++ b/Utilities/JITASM.cpp
@@ -316,10 +316,10 @@ void jit_runtime::finalize() noexcept
 #endif
 	// Reset JIT memory
 #ifdef CAN_OVERCOMMIT
-	utils::memory_reset(get_jit_memory(), 0x80000000);
+	utils::memory_reset(get_jit_memory(), 0x80000000, true);
 	utils::memory_protect(get_jit_memory(), 0x40000000, utils::protection::wx);
 #else
-	utils::memory_decommit(get_jit_memory(), 0x80000000);
+	utils::memory_decommit(get_jit_memory(), 0x80000000, true);
 #endif
 
 	s_code_pos = 0;

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -260,7 +260,7 @@ struct MemoryManager1 : llvm::RTDyldMemoryManager
 		// utils::memory_decommit(m_code_mems, how_much(code_ptr));
 		// utils::memory_decommit(m_data_ro_mems, how_much(data_ro_ptr));
 		// utils::memory_decommit(m_data_rw_mems, how_much(data_rw_ptr));
-		utils::memory_decommit(m_code_mems, c_max_size * 3);
+		utils::memory_decommit(m_code_mems, c_max_size * 3, true);
 	}
 
 	llvm::JITSymbol findSymbol(const std::string& name) override

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -218,7 +218,7 @@ struct MemoryManager1 : llvm::RTDyldMemoryManager
 		// utils::memory_decommit(m_code_mems, how_much(code_ptr));
 		// utils::memory_decommit(m_data_ro_mems, how_much(data_ro_ptr));
 		// utils::memory_decommit(m_data_rw_mems, how_much(data_rw_ptr));
-		utils::memory_decommit(m_code_mems, c_max_size * 3);
+		utils::memory_decommit(m_code_mems, c_max_size * 3, true);
 	}
 
 	llvm::JITSymbol findSymbol(const std::string& name) override

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -241,7 +241,7 @@ struct MemoryManager1 : llvm::RTDyldMemoryManager
 	MemoryManager1(std::function<u64(const std::string&)> symbols_cement = {}) noexcept
 		: m_symbols_cement(std::move(symbols_cement))
 	{
-		auto ptr = reinterpret_cast<u8*>(utils::memory_reserve(c_max_size * 3));
+		auto ptr = reinterpret_cast<u8*>(utils::memory_reserve(c_max_size * 3, true));
 		m_code_mems = ptr;
 		// ptr += c_max_size;
 		// m_data_ro_mems = ptr;

--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -199,7 +199,7 @@ struct MemoryManager1 : llvm::RTDyldMemoryManager
 	MemoryManager1(std::function<u64(const std::string&)> symbols_cement = {}) noexcept
 		: m_symbols_cement(std::move(symbols_cement))
 	{
-		auto ptr = reinterpret_cast<u8*>(utils::memory_reserve(c_max_size * 3));
+		auto ptr = reinterpret_cast<u8*>(utils::memory_reserve(c_max_size * 3, true));
 		m_code_mems = ptr;
 		// ptr += c_max_size;
 		// m_data_ro_mems = ptr;

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2135,6 +2135,37 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 
 	append_thread_name(msg);
 
+#ifdef __APPLE__
+	thread_local bool s_tls_is_attempting_recovery = false;
+	thread_local bool s_tls_last_cause_is_executing = false;
+
+	if (reinterpret_cast<u64>(info->si_addr) < 0x10000)
+	{
+		// Do not recover from the virtual page of 0x0 (such as nullptr)
+	}
+	else if (is_executing || is_writing)
+	{
+		if (s_tls_is_attempting_recovery && s_tls_last_cause_is_executing != is_executing)
+		{
+			// Cause changed, inform recovery
+			s_tls_is_attempting_recovery = false;
+		}
+
+		if (!s_tls_is_attempting_recovery)
+		{
+			s_tls_last_cause_is_executing = is_executing;
+			s_tls_is_attempting_recovery = true;
+			pthread_jit_write_protect_np(is_executing ? true : false);
+
+			sys_log.error("\n%s", msg);
+			sys_log.notice("\n%s", dump_useful_thread_info());
+			sys_log.error("Attempting recovery using pthread_jit_write_protect_np()");
+			logs::listener::sync_all();
+			return;
+		}
+	}
+#endif
+
 	sys_log.fatal("\n%s", msg);
 	sys_log.notice("\n%s", dump_useful_thread_info());
 	logs::listener::sync_all();

--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2191,6 +2191,37 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 
 	append_thread_name(msg);
 
+#ifdef __APPLE__
+	thread_local bool s_tls_is_attempting_recovery = false;
+	thread_local bool s_tls_last_cause_is_executing = false;
+
+	if (reinterpret_cast<u64>(info->si_addr) < 0x10000)
+	{
+		// Do not recover from the virtual page of 0x0 (such as nullptr)
+	}
+	else if (is_executing || is_writing)
+	{
+		if (s_tls_is_attempting_recovery && s_tls_last_cause_is_executing != is_executing)
+		{
+			// Cause changed, inform recovery
+			s_tls_is_attempting_recovery = false;
+		}
+
+		if (!s_tls_is_attempting_recovery)
+		{
+			s_tls_last_cause_is_executing = is_executing;
+			s_tls_is_attempting_recovery = true;
+			pthread_jit_write_protect_np(is_executing ? true : false);
+
+			sys_log.error("\n%s", msg);
+			sys_log.notice("\n%s", dump_useful_thread_info());
+			sys_log.error("Attempting recovery using pthread_jit_write_protect_np()");
+			logs::listener::sync_all();
+			return;
+		}
+	}
+#endif
+
 	sys_log.fatal("\n%s", msg);
 	sys_log.notice("\n%s", dump_useful_thread_info());
 	logs::listener::sync_all();

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5484,17 +5484,56 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 	{
 		usz index = umax;
 
-		ppu_log.notice("Executing %u symbol resolvers", jit_mod.symbol_resolvers.size());
 
-		for (auto& sim : jit_mod.symbol_resolvers)
+#ifdef __APPLE__
+		named_thread sym_worker("PPU Symbol Resolver", [&]()
 		{
-			index++;
+			// jit_compiler::get() may write to executable memory (relocations)
+			pthread_jit_write_protect_np(false);
+#else
+		{
+#endif
+			if (is_first)
+			{
+				ppu_log.notice("Resolving %u symbol resolver functions", jit_mod.symbol_resolvers.size());
 
-			sim = ensure(!is_first ? sim : reinterpret_cast<void(*)(u8*, u64)>(jits[index]->get("__resolve_symbols")));
-			sim(vm::g_exec_addr, info.segs[0].addr);
+				for (auto& sim : jit_mod.symbol_resolvers)
+				{
+					index++;
 
-			ppu_log.notice("Executed symbol resolver #%u", index);
+					ensure(!sim);
+					sim = ensure(reinterpret_cast<void(*)(u8*, u64)>(jits[index]->get("__resolve_symbols")));
+
+					ppu_log.notice("Resolved symbol resolver function #%u", index);
+				}
+			}
+
+			ppu_log.notice("Executing %u symbol resolvers", jit_mod.symbol_resolvers.size());
+
+#ifdef __APPLE__
+			// Virtual memory mapped by MAP_JIT cannot be executed until pthread_jit_write_protect_np(true)
+			pthread_jit_write_protect_np(true);
+#endif
+
+			index = umax;
+
+			for (auto& sim : jit_mod.symbol_resolvers)
+			{
+				index++;
+
+				ensure(sim);
+				sim(vm::g_exec_addr, info.segs[0].addr);
+
+				ppu_log.notice("Executed symbol resolver #%u", index);
+			}
+
+#ifndef __APPLE__
 		}
+#else
+		});
+
+		sym_worker();
+#endif
 	}
 
 	// Find a BLR-only function in order to copy it to all BLRs (some games need it)

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5448,17 +5448,56 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 	{
 		usz index = umax;
 
-		ppu_log.notice("Executing %u symbol resolvers", jit_mod.symbol_resolvers.size());
 
-		for (auto& sim : jit_mod.symbol_resolvers)
+#ifdef __APPLE__
+		named_thread sym_worker("PPU Symbol Resolver", [&]()
 		{
-			index++;
+			// jit_compiler::get() may write to executable memory (relocations)
+			pthread_jit_write_protect_np(false);
+#else
+		{
+#endif
+			if (is_first)
+			{
+				ppu_log.notice("Resolving %u symbol resolver functions", jit_mod.symbol_resolvers.size());
 
-			sim = ensure(!is_first ? sim : reinterpret_cast<void(*)(u8*, u64)>(jits[index]->get("__resolve_symbols")));
-			sim(vm::g_exec_addr, info.segs[0].addr);
+				for (auto& sim : jit_mod.symbol_resolvers)
+				{
+					index++;
 
-			ppu_log.notice("Executed symbol resolver #%u", index);
+					ensure(!sim);
+					sim = ensure(reinterpret_cast<void(*)(u8*, u64)>(jits[index]->get("__resolve_symbols")));
+
+					ppu_log.notice("Resolved symbol resolver function #%u", index);
+				}
+			}
+
+			ppu_log.notice("Executing %u symbol resolvers", jit_mod.symbol_resolvers.size());
+
+#ifdef __APPLE__
+			// Virtual memory mapped by MAP_JIT cannot be executed until pthread_jit_write_protect_np(true)
+			pthread_jit_write_protect_np(true);
+#endif
+
+			index = umax;
+
+			for (auto& sim : jit_mod.symbol_resolvers)
+			{
+				index++;
+
+				ensure(sim);
+				sim(vm::g_exec_addr, info.segs[0].addr);
+
+				ppu_log.notice("Executed symbol resolver #%u", index);
+			}
+
+#ifndef __APPLE__
 		}
+#else
+		});
+
+		sym_worker();
+#endif
 	}
 
 	// Find a BLR-only function in order to copy it to all BLRs (some games need it)

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4473,6 +4473,16 @@ extern void ppu_initialize()
 
 bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_size)
 {
+	ppu_log.notice("Entering ppu_initialize(const ppu_module&..)");
+
+	struct log_guard
+	{
+		~log_guard() noexcept
+		{
+			ppu_log.notice("Leaving ppu_initialize(const ppu_module&..)");
+		}
+	} _log_guard;
+
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::llvm)
 	{
 		if (check_only || vm::base(info.segs[0].addr) != info.segs[0].ptr)
@@ -5367,6 +5377,8 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 
 		usz mod_index = umax;
 
+		ppu_log.notice("Loading %u modules", link_workload.size());
+
 		for (const auto& [obj_name, is_compiled] : link_workload)
 		{
 			mod_index++;
@@ -5395,7 +5407,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 
 			if (!is_compiled)
 			{
-				ppu_log.success("LLVM: Loaded module %s", obj_name);
+				ppu_log.success("LLVM: Loaded module #%u %s", mod_index, obj_name);
 			}
 		}
 	}
@@ -5436,12 +5448,16 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 	{
 		usz index = umax;
 
+		ppu_log.notice("Executing %u symbol resolvers", jit_mod.symbol_resolvers.size());
+
 		for (auto& sim : jit_mod.symbol_resolvers)
 		{
 			index++;
 
 			sim = ensure(!is_first ? sim : reinterpret_cast<void(*)(u8*, u64)>(jits[index]->get("__resolve_symbols")));
 			sim(vm::g_exec_addr, info.segs[0].addr);
+
+			ppu_log.notice("Executed symbol resolver #%u", index);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4488,6 +4488,16 @@ extern void ppu_initialize()
 
 bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_size)
 {
+	ppu_log.notice("Entering ppu_initialize(const ppu_module&..)");
+
+	struct log_guard
+	{
+		~log_guard() noexcept
+		{
+			ppu_log.notice("Leaving ppu_initialize(const ppu_module&..)");
+		}
+	} _log_guard;
+
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::llvm)
 	{
 		if (check_only || vm::base(info.segs[0].addr) != info.segs[0].ptr)
@@ -5403,6 +5413,8 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 
 		usz mod_index = umax;
 
+		ppu_log.notice("Loading %u modules", link_workload.size());
+
 		for (const auto& [obj_name, is_compiled] : link_workload)
 		{
 			mod_index++;
@@ -5431,7 +5443,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 
 			if (!is_compiled)
 			{
-				ppu_log.success("LLVM: Loaded module %s", obj_name);
+				ppu_log.success("LLVM: Loaded module #%u %s", mod_index, obj_name);
 			}
 		}
 	}
@@ -5472,12 +5484,16 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 	{
 		usz index = umax;
 
+		ppu_log.notice("Executing %u symbol resolvers", jit_mod.symbol_resolvers.size());
+
 		for (auto& sim : jit_mod.symbol_resolvers)
 		{
 			index++;
 
 			sim = ensure(!is_first ? sim : reinterpret_cast<void(*)(u8*, u64)>(jits[index]->get("__resolve_symbols")));
 			sim(vm::g_exec_addr, info.segs[0].addr);
+
+			ppu_log.notice("Executed symbol resolver #%u", index);
 		}
 	}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2175,18 +2175,12 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::lle_call:
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-#endif
 			const vm::ptr<u32> opd(arg < 32 ? vm::cast(gpr[arg]) : vm::cast(arg));
 			cmd_pop(), fast_call(opd[0], opd[1]);
 			break;
 		}
 		case ppu_cmd::entry_call:
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-#endif
 			cmd_pop(), fast_call(entry_func.addr, entry_func.rtoc, true);
 			break;
 		}
@@ -2197,9 +2191,6 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::opd_call:
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-#endif
 			const ppu_func_opd_t opd = cmd_get(1).as<ppu_func_opd_t>();
 			cmd_pop(1), fast_call(opd.addr, opd.rtoc);
 			break;
@@ -2218,9 +2209,6 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::initialize:
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(false);
-#endif
 			cmd_pop();
 
 			ppu_initialize();
@@ -2232,9 +2220,6 @@ void ppu_thread::cpu_task()
 
 			spu_cache::initialize();
 
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-#endif
 #ifdef ARCH_ARM64
 			// Flush all cache lines after potentially writing executable code
 			asm("ISB");
@@ -2381,6 +2366,11 @@ void ppu_thread::cpu_wait(bs_t<cpu_flag> old)
 
 void ppu_thread::exec_task()
 {
+#ifdef __APPLE__
+	// Ensure correct state before executing JIT code
+	pthread_jit_write_protect_np(true);
+#endif
+
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::_static)
 	{
 		// HVContext push to allow recursion. This happens with guest callback invocations.
@@ -2462,9 +2452,6 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 	syscall_history.data.resize(g_cfg.core.ppu_call_history ? syscall_history_max_size : 1);
 	syscall_history.count_debug_arguments = static_cast<u32>(g_cfg.core.ppu_call_history ? std::size(syscall_history.data[0].args) : 0);
 
-#ifdef __APPLE__
-	pthread_jit_write_protect_np(true);
-#endif
 #ifdef ARCH_ARM64
 	// Flush all cache lines after potentially writing executable code
 	asm("ISB");
@@ -4008,9 +3995,8 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 
 	named_thread_group workers("SPRX Worker ", std::min<u32>(software_thread_limit, cpu_thread_limit), [&]
 	{
-#ifdef __APPLE__
-		pthread_jit_write_protect_np(false);
-#endif
+		jit_write_guard jit_guard;
+
 		// Set low priority
 		thread_ctrl::scoped_priority low_prio(-1);
 		u32 inc_fdone = 1;
@@ -4236,9 +4222,6 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 			return;
 		}
 
-#ifdef __APPLE__
-		pthread_jit_write_protect_np(false);
-#endif
 		// Set low priority
 		thread_ctrl::scoped_priority low_prio(-1);
 
@@ -4617,6 +4600,8 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 		progress_dialog.emplace(get_localized_string(localized_string_id::PROGRESS_DIALOG_LOADING_PPU_MODULES));
 	}
 
+	jit_write_guard jit_guard;
+
 	// Permanently loaded compiled PPU modules (name -> data)
 	jit_module& jit_mod = g_fxo->get<jit_module_manager>().get(cache_path + "_" + std::to_string(std::bit_cast<usz>(info.segs[0].ptr)));
 
@@ -4797,9 +4782,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 		// Try to make the code fit in 16 bytes, may fail and fallback
 		if (*full_sample && abs_diff(*full_sample, reinterpret_cast<u64>(jit_runtime::peek(true) + 3 * 4)) < (128u << 20))
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(false);
-#endif
 			u8* code = jit_runtime::alloc(12, 4, true);
 			code_ptr = reinterpret_cast<u64>(code);
 
@@ -4913,6 +4895,11 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 			c.br(call_target);
 #endif
 		}, runtime.get(), true);
+
+#ifdef __APPLE__
+		// Restore write-protection state (modified by build_function_asm)
+		pthread_jit_write_protect_np(false);
+#endif
 
 		// Full sample may exist already, but is very far away
 		// So in this case, a new sample is written
@@ -5307,9 +5294,8 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				// Set low priority
 				thread_ctrl::scoped_priority low_prio(-1);
 
-	#ifdef __APPLE__
-				pthread_jit_write_protect_np(false);
-	#endif
+				jit_write_guard jit_guard;
+
 				for (u32 i = (*work_cv)++; i < workload.size(); i = (*work_cv)++, (*work_done)++, g_progr_pdone++)
 				{
 					if (cpu ? cpu->state.all_of(cpu_flag::exit) : Emu.IsStopped())
@@ -5332,10 +5318,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				}
 
 				core_lock.unlock();
-
-	#ifdef __APPLE__
-				pthread_jit_write_protect_np(true);
-	#endif
 			}
 		};
 
@@ -5487,10 +5469,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 		}
 	}
 
-#ifdef __APPLE__
-	// Symbol resolver is in JIT mem, so we must enable execution
-	pthread_jit_write_protect_np(true);
-#endif
 	{
 		usz index = umax;
 
@@ -5502,11 +5480,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 			sim(vm::g_exec_addr, info.segs[0].addr);
 		}
 	}
-
-#ifdef __APPLE__
-	// Symbol resolver is in JIT mem, so we must enable execution
-	pthread_jit_write_protect_np(false);
-#endif
 
 	// Find a BLR-only function in order to copy it to all BLRs (some games need it)
 	for (const auto& func : info.get_funcs())

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2174,18 +2174,12 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::lle_call:
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-#endif
 			const vm::ptr<u32> opd(arg < 32 ? vm::cast(gpr[arg]) : vm::cast(arg));
 			cmd_pop(), fast_call(opd[0], opd[1]);
 			break;
 		}
 		case ppu_cmd::entry_call:
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-#endif
 			cmd_pop(), fast_call(entry_func.addr, entry_func.rtoc, true);
 			break;
 		}
@@ -2196,9 +2190,6 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::opd_call:
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-#endif
 			const ppu_func_opd_t opd = cmd_get(1).as<ppu_func_opd_t>();
 			cmd_pop(1), fast_call(opd.addr, opd.rtoc);
 			break;
@@ -2217,9 +2208,6 @@ void ppu_thread::cpu_task()
 		}
 		case ppu_cmd::initialize:
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(false);
-#endif
 			cmd_pop();
 
 			ppu_initialize();
@@ -2231,9 +2219,6 @@ void ppu_thread::cpu_task()
 
 			spu_cache::initialize();
 
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-#endif
 #ifdef ARCH_ARM64
 			// Flush all cache lines after potentially writing executable code
 			asm("ISB");
@@ -2380,6 +2365,11 @@ void ppu_thread::cpu_wait(bs_t<cpu_flag> old)
 
 void ppu_thread::exec_task()
 {
+#ifdef __APPLE__
+	// Ensure correct state before executing JIT code
+	pthread_jit_write_protect_np(true);
+#endif
+
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::_static)
 	{
 		// HVContext push to allow recursion. This happens with guest callback invocations.
@@ -2461,9 +2451,6 @@ ppu_thread::ppu_thread(const ppu_thread_params& param, std::string_view name, u3
 	syscall_history.data.resize(g_cfg.core.ppu_call_history ? syscall_history_max_size : 1);
 	syscall_history.count_debug_arguments = static_cast<u32>(g_cfg.core.ppu_call_history ? std::size(syscall_history.data[0].args) : 0);
 
-#ifdef __APPLE__
-	pthread_jit_write_protect_np(true);
-#endif
 #ifdef ARCH_ARM64
 	// Flush all cache lines after potentially writing executable code
 	asm("ISB");
@@ -3993,9 +3980,8 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 
 	named_thread_group workers("SPRX Worker ", std::min<u32>(software_thread_limit, cpu_thread_limit), [&]
 	{
-#ifdef __APPLE__
-		pthread_jit_write_protect_np(false);
-#endif
+		jit_write_guard jit_guard;
+
 		// Set low priority
 		thread_ctrl::scoped_priority low_prio(-1);
 		u32 inc_fdone = 1;
@@ -4221,9 +4207,6 @@ extern void ppu_precompile(std::vector<std::string>& dir_queue, std::vector<ppu_
 			return;
 		}
 
-#ifdef __APPLE__
-		pthread_jit_write_protect_np(false);
-#endif
 		// Set low priority
 		thread_ctrl::scoped_priority low_prio(-1);
 
@@ -4602,6 +4585,8 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 		progress_dialog.emplace(get_localized_string(localized_string_id::PROGRESS_DIALOG_LOADING_PPU_MODULES));
 	}
 
+	jit_write_guard jit_guard;
+
 	// Permanently loaded compiled PPU modules (name -> data)
 	jit_module& jit_mod = g_fxo->get<jit_module_manager>().get(cache_path + "_" + std::to_string(std::bit_cast<usz>(info.segs[0].ptr)));
 
@@ -4785,9 +4770,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 		// Try to make the code fit in 16 bytes, may fail and fallback
 		if (*full_sample && abs_diff(*full_sample, reinterpret_cast<u64>(jit_runtime::peek(true) + 3 * 4)) < (128u << 20))
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(false);
-#endif
 			u8* code = jit_runtime::alloc(12, 4, true);
 			code_ptr = reinterpret_cast<u64>(code);
 
@@ -4901,6 +4883,11 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 			c.br(call_target);
 #endif
 		}, runtime.get(), true);
+
+#ifdef __APPLE__
+		// Restore write-protection state (modified by build_function_asm)
+		pthread_jit_write_protect_np(false);
+#endif
 
 		// Full sample may exist already, but is very far away
 		// So in this case, a new sample is written
@@ -5288,9 +5275,8 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				// Set low priority
 				thread_ctrl::scoped_priority low_prio(-1);
 
-	#ifdef __APPLE__
-				pthread_jit_write_protect_np(false);
-	#endif
+				jit_write_guard jit_guard;
+
 				for (u32 i = work_cv++; i < workload.size(); i = work_cv++, g_progr_pdone++)
 				{
 					if (cpu ? cpu->state.all_of(cpu_flag::exit) : Emu.IsStopped())
@@ -5447,10 +5433,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 		}
 	}
 
-#ifdef __APPLE__
-	// Symbol resolver is in JIT mem, so we must enable execution
-	pthread_jit_write_protect_np(true);
-#endif
 	{
 		usz index = umax;
 
@@ -5462,11 +5444,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 			sim(vm::g_exec_addr, info.segs[0].addr);
 		}
 	}
-
-#ifdef __APPLE__
-	// Symbol resolver is in JIT mem, so we must enable execution
-	pthread_jit_write_protect_np(false);
-#endif
 
 	// Find a BLR-only function in order to copy it to all BLRs (some games need it)
 	for (const auto& func : info.get_funcs())

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -119,9 +119,7 @@ static void ghc_cpp_trampoline(u64 fn_target, native_asm& c, auto& args)
 
 DECLARE(spu_runtime::tr_dispatch) = []
 {
-#ifdef __APPLE__
-	pthread_jit_write_protect_np(false);
-#endif
+	jit_write_guard jit_guard;
 #if defined(ARCH_X64)
 	// Generate a special trampoline to spu_recompiler_base::dispatch with pause instruction
 	u8* const trptr = jit_runtime::alloc(32, 16);
@@ -149,6 +147,7 @@ DECLARE(spu_runtime::tr_dispatch) = []
 
 DECLARE(spu_runtime::tr_branch) = []
 {
+	jit_write_guard jit_guard;
 #if defined(ARCH_X64)
 	// Generate a trampoline to spu_recompiler_base::branch
 	u8* const trptr = jit_runtime::alloc(32, 16);
@@ -174,6 +173,7 @@ DECLARE(spu_runtime::tr_branch) = []
 
 DECLARE(spu_runtime::tr_interpreter) = []
 {
+	jit_write_guard jit_guard;
 #if defined(ARCH_X64)
 	u8* const trptr = jit_runtime::alloc(32, 16);
 	u8* raw = move_args_ghc_to_native(trptr);
@@ -195,6 +195,8 @@ DECLARE(spu_runtime::tr_interpreter) = []
 
 DECLARE(spu_runtime::g_dispatcher) = []
 {
+	jit_write_guard jit_guard;
+
 	// Allocate 2^20 positions in data area
 	const auto ptr = reinterpret_cast<std::remove_const_t<decltype(spu_runtime::g_dispatcher)>>(jit_runtime::alloc(sizeof(*g_dispatcher), 64, false));
 
@@ -208,6 +210,8 @@ DECLARE(spu_runtime::g_dispatcher) = []
 
 DECLARE(spu_runtime::tr_all) = []
 {
+	jit_write_guard jit_guard;
+
 #if defined(ARCH_X64)
 	u8* const trptr = jit_runtime::alloc(32, 16);
 	u8* raw = trptr;
@@ -732,6 +736,8 @@ void spu_cache::add(const spu_program& func)
 
 void spu_cache::initialize(bool build_existing_cache)
 {
+	jit_write_guard jit_guard;
+
 	spu_runtime::g_interpreter = spu_runtime::g_gateway;
 
 	if (g_cfg.core.spu_decoder == spu_decoder_type::_static || g_cfg.core.spu_decoder == spu_decoder_type::dynamic)
@@ -862,15 +868,7 @@ void spu_cache::initialize(bool build_existing_cache)
 		// every exit path (return, exception, etc.). Leaving a worker
 		// in write mode at teardown can leave per-thread state
 		// inconsistent on AArch64.
-		pthread_jit_write_protect_np(false);
-
-		struct jit_write_guard
-		{
-			~jit_write_guard()
-			{
-				pthread_jit_write_protect_np(true);
-			}
-		} _jit_guard;
+		jit_write_guard jit_guard;
 #endif
 		// Set low priority
 		thread_ctrl::scoped_priority low_prio(-1);
@@ -2096,6 +2094,9 @@ void spu_recompiler_base::dispatch(spu_thread& spu, void*, u8* rip)
 		return;
 	}
 
+#if defined(__APPLE__)
+	pthread_jit_write_protect_np(false);
+#endif
 	const auto func = spu.jit->compile(spu.jit->analyse(spu._ptr<u32>(0), spu.pc));
 
 	if (!func)

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -207,9 +207,7 @@ static void ghc_cpp_trampoline(u64 fn_target, native_asm& c, auto& args)
 
 DECLARE(spu_runtime::tr_dispatch) = []
 {
-#ifdef __APPLE__
-	pthread_jit_write_protect_np(false);
-#endif
+	jit_write_guard jit_guard;
 #if defined(ARCH_X64)
 	// Generate a special trampoline to spu_recompiler_base::dispatch with pause instruction
 	u8* const trptr = jit_runtime::alloc(32, 16);
@@ -237,6 +235,7 @@ DECLARE(spu_runtime::tr_dispatch) = []
 
 DECLARE(spu_runtime::tr_branch) = []
 {
+	jit_write_guard jit_guard;
 #if defined(ARCH_X64)
 	// Generate a trampoline to spu_recompiler_base::branch
 	u8* const trptr = jit_runtime::alloc(32, 16);
@@ -262,6 +261,7 @@ DECLARE(spu_runtime::tr_branch) = []
 
 DECLARE(spu_runtime::tr_interpreter) = []
 {
+	jit_write_guard jit_guard;
 #if defined(ARCH_X64)
 	u8* const trptr = jit_runtime::alloc(32, 16);
 	u8* raw = move_args_ghc_to_native(trptr);
@@ -283,6 +283,8 @@ DECLARE(spu_runtime::tr_interpreter) = []
 
 DECLARE(spu_runtime::g_dispatcher) = []
 {
+	jit_write_guard jit_guard;
+
 	// Allocate 2^20 positions in data area
 	const auto ptr = reinterpret_cast<std::remove_const_t<decltype(spu_runtime::g_dispatcher)>>(jit_runtime::alloc(sizeof(*g_dispatcher), 64, false));
 
@@ -296,6 +298,8 @@ DECLARE(spu_runtime::g_dispatcher) = []
 
 DECLARE(spu_runtime::tr_all) = []
 {
+	jit_write_guard jit_guard;
+
 #if defined(ARCH_X64)
 	u8* const trptr = jit_runtime::alloc(32, 16);
 	u8* raw = trptr;
@@ -834,6 +838,8 @@ void spu_cache::add(const spu_program& func)
 
 void spu_cache::initialize(bool build_existing_cache)
 {
+	jit_write_guard jit_guard;
+
 	spu_runtime::g_interpreter = spu_runtime::g_gateway;
 
 	if (g_cfg.core.spu_decoder == spu_decoder_type::_static || g_cfg.core.spu_decoder == spu_decoder_type::dynamic)
@@ -964,15 +970,7 @@ void spu_cache::initialize(bool build_existing_cache)
 		// every exit path (return, exception, etc.). Leaving a worker
 		// in write mode at teardown can leave per-thread state
 		// inconsistent on AArch64.
-		pthread_jit_write_protect_np(false);
-
-		struct jit_write_guard
-		{
-			~jit_write_guard()
-			{
-				pthread_jit_write_protect_np(true);
-			}
-		} _jit_guard;
+		jit_write_guard jit_guard;
 #endif
 		// Set low priority
 		thread_ctrl::scoped_priority low_prio(-1);
@@ -2207,6 +2205,9 @@ void spu_recompiler_base::dispatch(spu_thread& spu, void*, u8* rip)
 		return;
 	}
 
+#if defined(__APPLE__)
+	pthread_jit_write_protect_np(false);
+#endif
 	auto program = spu.jit->analyse(spu._ptr<u32>(0), spu.pc);
 #ifdef ARCH_ARM64
 	const auto func = compile_spu_llvm_with_retry(spu.jit, program);

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1252,16 +1252,8 @@ extern void ppu_execute_syscall(ppu_thread& ppu, u64 code)
 
 		if (const auto func = g_ppu_syscall_table[code].first)
 		{
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(false);
-#endif
 			func(ppu, {}, vm::_ptr<u32>(ppu.cia), nullptr);
 			ppu_log.trace("Syscall '%s' (%llu) finished, r3=0x%llx", ppu_syscall_code(code), code, ppu.gpr[3]);
-
-#ifdef __APPLE__
-			pthread_jit_write_protect_np(true);
-			// No need to flush cache lines after a syscall, since we didn't generate any code.
-#endif
 			return;
 		}
 	}

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -30,7 +30,7 @@ namespace vm
 	{
 		for (u64 addr = reinterpret_cast<u64>(_addr) + 0x100000000; addr < 0x8000'0000'0000; addr += 0x100000000)
 		{
-			if (auto ptr = utils::memory_reserve(size, reinterpret_cast<void*>(addr), is_memory_mapping))
+			if (auto ptr = utils::memory_reserve(size, reinterpret_cast<void*>(addr), is_memory_mapping, false))
 			{
 				return static_cast<u8*>(ptr);
 			}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3890,6 +3890,11 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 					tty_buffer.resize(tty_read_fd.read_at(m_tty_file_init_pos, tty_buffer.data(), tty_buffer.size()));
 					tty_read_fd.close();
 
+					if (!tty_buffer.empty() && std::isspace(tty_buffer.back()))
+					{
+						tty_buffer.resize(tty_buffer.find_last_not_of(" \f\n\r\t\v"sv) + 1);
+					}
+
 					if (!tty_buffer.empty())
 					{
 						// Mark start and end very clearly with RPCS3 put in it
@@ -3923,6 +3928,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 						std::string_view to_log = not_logged;
 						to_log = to_log.substr(0, 0x8000);
 						to_log = to_log.substr(0, utils::add_saturate<usz>(to_log.rfind("\n========== SPU BLOCK"sv), 1));
+						to_log = to_log.substr(0, utils::add_saturate<usz>(to_log.find_last_of("\n"sv), 1));
 						to_remove = to_log.size();
 
 						std::string new_log(to_log);
@@ -3975,6 +3981,11 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 
 							out_added += text_append.size();
 							iter = index + 1;
+						}
+
+						if (!new_log.empty() && std::isspace(new_log.back()))
+						{
+							new_log.resize(new_log.find_last_not_of(" \f\n\r\t\v"sv) + 1);
 						}
 
 						// Cannot log it all at once due to technical reasons, split it to 8MB at maximum of whole functions

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1847,7 +1847,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 
 				struct jit_write_guard
 				{
-					~jit_write_guard()
+					~jit_write_guard() noexcept
 					{
 						pthread_jit_write_protect_np(true);
 					}

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1893,7 +1893,7 @@ game_boot_result Emulator::Load(const std::string& title_id, bool is_disc_patch,
 
 				struct jit_write_guard
 				{
-					~jit_write_guard()
+					~jit_write_guard() noexcept
 					{
 						pthread_jit_write_protect_np(true);
 					}

--- a/rpcs3/util/vm.hpp
+++ b/rpcs3/util/vm.hpp
@@ -44,10 +44,15 @@ namespace utils
 	void memory_commit(void* pointer, usz size, protection prot = protection::rw);
 
 	// Decommit all memory committed via commit_page_memory.
-	void memory_decommit(void* pointer, usz size);
+	void memory_decommit(void* pointer, usz size, bool can_be_jit = false);
 
 	// Decommit all memory and commit it again.
-	void memory_reset(void* pointer, usz size, protection prot = protection::rw);
+	void memory_reset(void* pointer, usz size, protection prot = protection::rw, bool can_be_jit = false);
+
+	inline void memory_reset(void* pointer, usz size, bool can_be_jit = false)
+	{
+		return memory_reset(pointer, size, protection::rw, can_be_jit);
+	}
 
 	// Free memory after reserved by memory_reserve, should specify original size
 	void memory_release(void* pointer, usz size);

--- a/rpcs3/util/vm.hpp
+++ b/rpcs3/util/vm.hpp
@@ -26,11 +26,15 @@ namespace utils
 		rx, // Read + execute
 	};
 
-	/**
-	* Reserve `size` bytes of virtual memory and returns it.
-	* The memory should be committed before usage.
-	*/
-	void* memory_reserve(usz size, void* use_addr = nullptr, bool is_memory_mapping = false);
+	// Reserve `size` bytes of virtual memory and returns it.
+	// The memory should be committed before usage.
+	void* memory_reserve(usz size, void* use_addr, bool is_memory_mapping = false, bool can_be_jit = false);
+
+	// Non-fixed address memory_reserve usage
+	inline void* memory_reserve(usz size, bool can_be_jit = false)
+	{
+		return memory_reserve(size, nullptr, false, can_be_jit);
+	}
 
 	/**
 	* Commit `size` bytes of virtual memory starting at pointer.

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -222,7 +222,7 @@ namespace utils
 		return _prot;
 	}
 
-	void* memory_reserve(usz size, void* use_addr, [[maybe_unused]] bool is_memory_mapping)
+	void* memory_reserve(usz size, void* use_addr, [[maybe_unused]] bool is_memory_mapping, [[maybe_unused]] bool can_be_jit)
 	{
 #ifdef _WIN32
 		if (is_memory_mapping && has_win10_memory_mapping_api())
@@ -251,15 +251,15 @@ namespace utils
 			size += 0x10000;
 		}
 
-#ifdef __APPLE__
-#ifdef ARCH_ARM64
 		// Memory mapping regions will be replaced by file-backed MAP_FIXED mappings
 		// (via shm::map), which is incompatible with MAP_JIT. Only use MAP_JIT for
 		// non-mapping regions that need JIT executable support.
-		const int jit_flag = is_memory_mapping ? 0 : MAP_JIT;
+#ifdef __APPLE__
+		const int jit_flag = is_memory_mapping || !can_be_jit ? 0 : MAP_JIT;
+#ifdef ARCH_ARM64
 		auto ptr = ::mmap(use_addr, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE | jit_flag | c_map_noreserve, -1, 0);
 #else
-		auto ptr = ::mmap(use_addr, size, PROT_NONE, MAP_ANON | MAP_PRIVATE | MAP_JIT | c_map_noreserve, -1, 0);
+		auto ptr = ::mmap(use_addr, size, PROT_NONE, MAP_ANON | MAP_PRIVATE | jit_flag | c_map_noreserve, -1, 0);
 #endif
 #else
 		auto ptr = ::mmap(use_addr, size, PROT_NONE, MAP_ANON | MAP_PRIVATE | c_map_noreserve, -1, 0);

--- a/rpcs3/util/vm_native.cpp
+++ b/rpcs3/util/vm_native.cpp
@@ -335,7 +335,7 @@ namespace utils
 #endif
 	}
 
-	void memory_decommit(void* pointer, usz size)
+	void memory_decommit(void* pointer, usz size, [[maybe_unused]] bool can_be_jit)
 	{
 		if (!size)
 		{
@@ -352,7 +352,7 @@ namespace utils
 		// The Xcode manpage says the pointer is a hint and the OS will try to map at the hint location
 		// so this isn't completely undefined behavior.
 		ensure(::munmap(pointer, size) != -1);
-		ensure(::mmap(pointer, size, PROT_NONE,  MAP_ANON | MAP_PRIVATE | MAP_JIT, -1, 0) == pointer);
+		ensure(::mmap(pointer, size, PROT_NONE,  MAP_ANON | MAP_PRIVATE | (can_be_jit ? MAP_JIT : 0), -1, 0) == pointer);
 #else
 		ensure(::mmap(pointer, size, PROT_NONE, MAP_FIXED | MAP_ANON | MAP_PRIVATE | c_map_noreserve, -1, 0) != reinterpret_cast<void*>(uptr{umax}));
 #endif
@@ -368,7 +368,7 @@ namespace utils
 #endif
 	}
 
-	void memory_reset(void* pointer, usz size, protection prot)
+	void memory_reset(void* pointer, usz size, protection prot, [[maybe_unused]] bool can_be_jit)
 	{
 		if (!size)
 		{
@@ -382,7 +382,7 @@ namespace utils
 		const u64 ptr64 = reinterpret_cast<u64>(pointer);
 #if defined(__APPLE__) && defined(ARCH_ARM64)
 		ensure(::munmap(pointer, size) != -1);
-		ensure(::mmap(pointer, size, +prot,  MAP_ANON | MAP_PRIVATE | MAP_JIT, -1, 0) == pointer);
+		ensure(::mmap(pointer, size, +prot,  MAP_ANON | MAP_PRIVATE | (can_be_jit ? MAP_JIT : 0), -1, 0) == pointer);
 #else
 		ensure(::mmap(pointer, size, +prot, MAP_FIXED | MAP_ANON | MAP_PRIVATE, -1, 0) != reinterpret_cast<void*>(uptr{umax}));
 #endif


### PR DESCRIPTION
* Make MAP_JIT an optional flag for memory region reservations, fixing write segfaults to otherwise writable data such as vm::g_exec_addr.
* Optimize PPU syscalls a bit on ARM64.
* Restore write protection after `build_function_asm`, allowing use from anywhere in PPU & SPU code.
* Ensure correct write-protection state right in `ppu_thread::exec_task()` which the last point before JIT code execution. Ensuring correct state from HLE callbacks. (not mandated by PPU commands)
* Added recovery method in signal_handler for all possible cases where write-protection status mismatches the expected state, this fixes stuff if external modules change the state.

This, as it turned out, fixes VSH on Apple ARM64. 🎉

Fixes https://github.com/RPCS3/rpcs3/issues/16081
