### PR TITLE
rpcs3: Add --no-precompile flags for PKG installation

### DIFF
--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -404,6 +404,7 @@ constexpr auto arg_updating     = "updating";
 constexpr auto arg_user_id      = "user-id";
 constexpr auto arg_installfw    = "installfw";
 constexpr auto arg_installpkg   = "installpkg";
+constexpr auto arg_pkg_no_precompile = "no-precompile";
 constexpr auto arg_savestate    = "savestate";
 constexpr auto arg_rsx_capture  = "rsx-capture";
 constexpr auto arg_timer        = "high-res-timer";
@@ -829,6 +830,7 @@ int run_rpcs3(int argc, char** argv)
 	parser.addOption(installfw_option);
 	const QCommandLineOption installpkg_option(arg_installpkg, "Forces the emulator to install this pkg file.", "path", "");
 	parser.addOption(installpkg_option);
+	parser.addOption(QCommandLineOption(arg_pkg_no_precompile, "Skip cache precompilation after PKG install."));
 	const QCommandLineOption decrypt_option(arg_decrypt, "Decrypt PS3 binaries.", "path(s)", "");
 	parser.addOption(decrypt_option);
 	const QCommandLineOption user_id_option(arg_user_id, "Start RPCS3 as this user.", "user id", "");
@@ -1180,7 +1182,7 @@ int run_rpcs3(int argc, char** argv)
 
 			if (parser.isSet(arg_installpkg))
 			{
-				main_window::InstallPackages(nullptr, {parser.value(installpkg_option)});
+				main_window::InstallPackages(nullptr, {parser.value(installpkg_option)}, false, parser.isSet(arg_pkg_no_precompile));
 			}
 		}
 	}

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -864,7 +864,7 @@ bool main_window::InstallFileInExData(const std::string& extension, const QStrin
 	return to.commit();
 }
 
-bool main_window::InstallPackages(main_window* mw, QStringList file_paths, bool from_boot)
+bool main_window::InstallPackages(main_window* mw, QStringList file_paths, bool from_boot, bool no_precompile)
 {
 	if (file_paths.isEmpty())
 	{
@@ -969,26 +969,26 @@ bool main_window::InstallPackages(main_window* mw, QStringList file_paths, bool 
 
 	if (from_boot)
 	{
-		return HandlePackageInstallation(mw, file_paths, true);
+		return HandlePackageInstallation(mw, file_paths, true, no_precompile);
 	}
 
 	// Handle further installations with a timeout. Otherwise the source explorer instance is not usable during the following file processing.
 	if (mw)
 	{
-		QTimer::singleShot(0, [mw, paths = std::move(file_paths)]()
+		QTimer::singleShot(0, [mw, paths = std::move(file_paths), no_precompile]()
 		{
-			HandlePackageInstallation(mw, paths, false);
+			HandlePackageInstallation(mw, paths, false, no_precompile);
 		});
 	}
 	else
 	{
-		return HandlePackageInstallation(nullptr, file_paths, false);
+		return HandlePackageInstallation(nullptr, file_paths, false, no_precompile);
 	}
 
 	return true;
 }
 
-bool main_window::HandlePackageInstallation(main_window* mw, QStringList file_paths, bool from_boot)
+bool main_window::HandlePackageInstallation(main_window* mw, QStringList file_paths, bool from_boot, bool no_precompile)
 {
 	if (file_paths.empty())
 	{
@@ -1043,6 +1043,7 @@ bool main_window::HandlePackageInstallation(main_window* mw, QStringList file_pa
 			}
 			packages.push_back(std::move(info));
 		}
+		precompile_caches = !no_precompile;
 	}
 
 	if (canceled || packages.empty())

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -75,7 +75,7 @@ public:
 	bool Init(bool with_cli_boot);
 	QIcon GetAppIcon() const;
 	void OnMissingFw();
-	static bool InstallPackages(main_window* mw, QStringList file_paths = {}, bool from_boot = false);
+	static bool InstallPackages(main_window* mw, QStringList file_paths = {}, bool from_boot = false, bool no_precompile = false);
 	static void InstallPup(main_window* mw, QString file_path = "");
 
 Q_SIGNALS:
@@ -145,7 +145,7 @@ private:
 	void CreateShortCuts(const std::map<std::string, QString>& paths, std::set<gui::utils::shortcut_location> locations);
 
 	static bool InstallFileInExData(const std::string& extension, const QString& path, const std::string& filename);
-	static bool HandlePackageInstallation(main_window* mw, QStringList file_paths, bool from_boot);
+	static bool HandlePackageInstallation(main_window* mw, QStringList file_paths, bool from_boot, bool no_precompile = false);
 	static void HandlePupInstallation(main_window* mw, const QString& file_path, const QString& dir_path = "");
 
 	void ExtractPup();


### PR DESCRIPTION
Patially implements #18616

## Problem

There is no way to control cache precompilation from CLI.

## Changes

Adds ```--no-precompile``` flag that allows to skip cache precompilation after PKG installation.