### PR TITLE
cellMusic: Fix shuffle always producing the same order

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
@@ -362,7 +362,8 @@ u32 music_selection_context::step_track(bool next)
 		{
 			// We reached the first or last track again. Let's shuffle!
 			cellMusicSelectionContext.notice("step_track: Shuffling playlist...");
-			auto engine = std::default_random_engine{};
+			std::random_device rd;
+			auto engine = std::default_random_engine{rd()};
 			std::shuffle(std::begin(playlist), std::end(playlist), engine);
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the music shuffle in `cellMusicSelectionContext` always producing the same deterministic track order.

## Problem

The `step_track()` function used `std::default_random_engine{}` (default-constructed with a fixed seed) to shuffle the playlist. This means every time the playlist wraps around and triggers a re-shuffle, the tracks end up in the exact same order — effectively no randomness at all.

This is why users report that shuffle "plays the same song all the time" in games like Gran Turismo 5.

## Fix

Seed the random engine with `std::random_device` so each shuffle produces a genuinely different order:

```cpp
std::random_device rd;
auto engine = std::default_random_engine{rd()};
std::shuffle(std::begin(playlist), std::end(playlist), engine);
```

## Impact

Any game using `cellMusic` with `CELL_SEARCH_CONTEXTOPTION_SHUFFLE` will now get actual random playback order instead of the same deterministic sequence every time.

Fixes #18672