### PR TITLE
gui: Remove close button from Game List dock widget

### DIFF
--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3568,6 +3568,7 @@ void main_window::CreateDockWindows()
 	m_mw->setContextMenuPolicy(Qt::PreventContextMenu);
 
 	m_game_list_frame = new game_list_frame(m_gui_settings, m_emu_settings, m_persistent_settings, m_mw);
+	m_game_list_frame->setFeatures(m_game_list_frame->features() & ~QDockWidget::DockWidgetClosable);
 	m_debugger_frame = new debugger_frame(m_gui_settings, m_mw);
 	m_log_frame = new log_frame(m_gui_settings, m_mw);
 


### PR DESCRIPTION
## Summary

Removes the close button from the Game List dock widget to prevent users from accidentally closing it and not knowing how to get it back.

## Problem

As described in #18518, many users mistakenly click the close button on the Game List widget and then complain they can't see their games anymore. This is a common UX pain point.

## Fix

Disable the `DockWidgetClosable` feature on the game list dock widget:
```cpp
m_game_list_frame->setFeatures(m_game_list_frame->features() & ~QDockWidget::DockWidgetClosable);
```

The game list visibility can still be toggled via **View > View Game List** menu action, which is the intended mechanism.

Fixes #18518