### PR TITLE
rsx: Fix swapped width/height in NV309E_SET_FORMAT decoder

### DIFF
--- a/rpcs3/Emu/RSX/rsx_decode.h
+++ b/rpcs3/Emu/RSX/rsx_decode.h
@@ -3775,12 +3775,12 @@ struct registers_decoder<NV309E_SET_FORMAT>
 
 		u8 sw_height_log2() const
 		{
-			return bf_decoder<16, 8>(value);
+			return bf_decoder<24, 8>(value);
 		}
 
 		u8 sw_width_log2() const
 		{
-			return bf_decoder<24, 8>(value);
+			return bf_decoder<16, 8>(value);
 		}
 	};
 


### PR DESCRIPTION
Width and height were swapped in the NV309E_SET_FORMAT register decoder, causing incorrect surface dimensions to be reported.

AI disclosure: ChatGPT used for PR description text only.