### PR TITLE
[System] Fix restart-loops upon restart-then-quit

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -4068,8 +4068,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 			if (after_kill_callback)
 			{
 				// Make after_kill_callback empty before call
-				const auto callback = std::move(after_kill_callback);
-				callback();
+				std::exchange(after_kill_callback, nullptr)();
 			}
 		});
 	}));
@@ -4125,7 +4124,7 @@ game_boot_result Emulator::Restart(bool graceful, bool reset_path)
 	else
 	{
 		// Execute and empty the callback
-		::as_rvalue(std::move(Emu.after_kill_callback))();
+		std::exchange(Emu.after_kill_callback, nullptr)();
 	}
 
 	return game_boot_result::no_errors;

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -4068,7 +4068,7 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 			if (after_kill_callback)
 			{
 				// Make after_kill_callback empty before call
-				std::exchange(after_kill_callback, nullptr)();
+				std::exchange(ensure(after_kill_callback), nullptr)();
 			}
 		});
 	}));
@@ -4124,7 +4124,7 @@ game_boot_result Emulator::Restart(bool graceful, bool reset_path)
 	else
 	{
 		// Execute and empty the callback
-		std::exchange(Emu.after_kill_callback, nullptr)();
+		std::exchange(ensure(Emu.after_kill_callback), nullptr)();
 	}
 
 	return game_boot_result::no_errors;


### PR DESCRIPTION
I observed under macOS (although the bug seems platform agnostic to me) that when restarting a game, then subsequently quitting it, I'd get stuck in a 'restart loop' where the game would restart upon completely shutting down, and this would repeat every time I tried to close the game until I gave up & force quit RPCS3. Seems like for whatever reason, the use of std::move didn't actually guarantee that after_kill_callback got nuked if at all, so all I've done is take a hammer to the fucker and manually set it to nullptr after being called.