### PR TITLE
input: optimize and improve keyboard input

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGem.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGem.cpp
@@ -2183,7 +2183,7 @@ static void ds3_input_to_ext(u32 gem_num, gem_config::gem_controller& controller
 
 	ext.status = controller.ext_status;
 
-	for (const AnalogStick& stick : pad->m_sticks_external)
+	for (const AnalogStickExternal& stick : pad->m_sticks_external)
 	{
 		switch (stick.m_offset)
 		{
@@ -2195,7 +2195,7 @@ static void ds3_input_to_ext(u32 gem_num, gem_config::gem_controller& controller
 		}
 	}
 
-	for (const Button& button : pad->m_buttons_external)
+	for (const ButtonExternal& button : pad->m_buttons_external)
 	{
 		if (!button.m_pressed)
 			continue;

--- a/rpcs3/Emu/Cell/Modules/cellPad.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPad.cpp
@@ -418,7 +418,7 @@ void pad_get_data(u32 port_no, CellPadData* data, bool get_periph_data = false)
 			}
 		};
 
-		for (const Button& button : pad->m_buttons_external)
+		for (const ButtonExternal& button : pad->m_buttons_external)
 		{
 			// here we check btns, and set pad accordingly,
 			// if something changed, set btnChanged
@@ -497,7 +497,7 @@ void pad_get_data(u32 port_no, CellPadData* data, bool get_periph_data = false)
 			}
 		}
 
-		for (const AnalogStick& stick : pad->m_sticks_external)
+		for (const AnalogStickExternal& stick : pad->m_sticks_external)
 		{
 			switch (stick.m_offset)
 			{

--- a/rpcs3/Emu/Io/GameTablet.cpp
+++ b/rpcs3/Emu/Io/GameTablet.cpp
@@ -200,7 +200,7 @@ void usb_device_gametablet::interrupt_transfer(u32 buf_size, u8* buf, u32 /*endp
 		const auto& pad = ::at32(pads, m_controller_index);
 		if (pad->is_connected() && !pad->is_copilot())
 		{
-			for (Button& button : pad->m_buttons_external)
+			for (ButtonExternal& button : pad->m_buttons_external)
 			{
 				if (!button.m_pressed)
 				{

--- a/rpcs3/Emu/Io/emulated_pad_config.h
+++ b/rpcs3/Emu/Io/emulated_pad_config.h
@@ -93,7 +93,7 @@ public:
 		if (!pad || pad->is_copilot())
 			return;
 
-		for (const Button& button : pad->m_buttons_external)
+		for (const ButtonExternal& button : pad->m_buttons_external)
 		{
 			if (button.m_pressed || !press_only)
 			{
@@ -104,7 +104,7 @@ public:
 			}
 		}
 
-		for (const AnalogStick& stick : pad->m_sticks_external)
+		for (const AnalogStickExternal& stick : pad->m_sticks_external)
 		{
 			if (handle_input(func, stick.m_offset, get_axis_keycode(stick.m_offset, stick.m_value), stick.m_value, true, true))
 			{

--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -441,6 +441,9 @@ struct AnalogStick
 	std::map<u32, u16> m_pressed_keys_max; // only used in keyboard_pad_handler
 	std::map<u32, u16> m_pressed_combos_min; // only used in keyboard_pad_handler
 	std::map<u32, u16> m_pressed_combos_max; // only used in keyboard_pad_handler
+	u8 m_stick_min = 0; // only used in keyboard_pad_handler
+	u8 m_stick_max = 128; // only used in keyboard_pad_handler
+	u8 m_stick_val = 128; // only used in keyboard_pad_handler
 
 	AnalogStick() {}
 	AnalogStick(u32 offset, std::vector<std::set<u32>> key_combos_min, std::vector<std::set<u32>> key_combos_max)

--- a/rpcs3/Emu/Io/pad_types.h
+++ b/rpcs3/Emu/Io/pad_types.h
@@ -421,6 +421,14 @@ struct Button
 	}
 };
 
+struct ButtonExternal
+{
+	u32 m_offset = 0;
+	u32 m_outKeyCode = 0;
+	u16 m_value    = 0;
+	bool m_pressed = false;
+};
+
 struct AnalogStick
 {
 	u32 m_offset = 0;
@@ -440,6 +448,12 @@ struct AnalogStick
 		, m_key_combos_min(std::move(key_combos_min))
 		, m_key_combos_max(std::move(key_combos_max))
 	{}
+};
+
+struct AnalogStickExternal
+{
+	u32 m_offset = 0;
+	u16 m_value = 128;
 };
 
 struct AnalogSensor
@@ -519,8 +533,8 @@ struct Pad
 	std::array<AnalogSensor, 4> m_sensors{};
 	std::array<VibrateMotor, 2> m_vibrate_motors{};
 
-	std::vector<Button> m_buttons_external;
-	std::array<AnalogStick, 4> m_sticks_external{};
+	std::vector<ButtonExternal> m_buttons_external;
+	std::array<AnalogStickExternal, 4> m_sticks_external{};
 
 	std::vector<std::shared_ptr<Pad>> copilots;
 

--- a/rpcs3/Emu/RSX/Overlays/overlays.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlays.cpp
@@ -341,7 +341,7 @@ namespace rsx
 						continue;
 					}
 
-					for (const Button& button : pad->m_buttons_external)
+					for (const ButtonExternal& button : pad->m_buttons_external)
 					{
 						pad_button button_id = pad_button::pad_button_max_enum;
 						if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL1)
@@ -418,7 +418,7 @@ namespace rsx
 							break;
 					}
 
-					for (const AnalogStick& stick : pad->m_sticks_external)
+					for (const AnalogStickExternal& stick : pad->m_sticks_external)
 					{
 						pad_button button_id = pad_button::pad_button_max_enum;
 						pad_button release_id = pad_button::pad_button_max_enum;

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -262,8 +262,8 @@ void keyboard_pad_handler::Key(const u32 code, bool pressed, u16 value)
 				const u16 actual_max_value = is_max_pressed ? MultipliedInput(255, stick_multiplier) : 255;
 				const u16 normalized_max_value = std::ceil(actual_max_value / 2.0);
 
-				m_stick_min[i] = is_min_pressed ? std::min<u8>(normalized_min_value, 128) : 0;
-				m_stick_max[i] = is_max_pressed ? std::min<int>(128 + normalized_max_value, 255) : 128;
+				stick.m_stick_min = is_min_pressed ? std::min<u8>(normalized_min_value, 128) : 0;
+				stick.m_stick_max = is_max_pressed ? std::min<int>(128 + normalized_max_value, 255) : 128;
 			}
 			else
 			{
@@ -345,25 +345,25 @@ void keyboard_pad_handler::Key(const u32 code, bool pressed, u16 value)
 				{
 					const std::pair<bool, u16> stick_value = register_new_stick_value(true);
 
-					m_stick_max[i] = stick_value.first ? std::min<int>(128 + stick_value.second, 255) : 128;
+					stick.m_stick_max = stick_value.first ? std::min<int>(128 + stick_value.second, 255) : 128;
 				}
 
 				if (is_min)
 				{
 					const std::pair<bool, u16> stick_value = register_new_stick_value(false);
 
-					m_stick_min[i] = stick_value.first ? std::min<u8>(stick_value.second, 128) : 0;
+					stick.m_stick_min = stick_value.first ? std::min<u8>(stick_value.second, 128) : 0;
 				}
 			}
 
-			m_stick_val[i] = m_stick_max[i] - m_stick_min[i];
+			stick.m_stick_val = stick.m_stick_max - stick.m_stick_min;
 
 			const f32 stick_lerp_factor = is_left_stick ? m_l_stick_lerp_factor : m_r_stick_lerp_factor;
 
 			// to get the fastest response time possible we don't wanna use any lerp with factor 1
 			if (stick_lerp_factor >= 1.0f)
 			{
-				stick.m_value = m_stick_val[i];
+				stick.m_value = stick.m_stick_val;
 			}
 		}
 	}
@@ -380,12 +380,16 @@ void keyboard_pad_handler::release_all_keys()
 			button.m_actual_value = 0;
 		}
 
-		for (usz i = 0; i < pad.m_sticks.size(); i++)
+		for (AnalogStick& stick : pad.m_sticks)
 		{
-			m_stick_min[i] = 0;
-			m_stick_max[i] = 128;
-			m_stick_val[i] = 128;
-			pad.m_sticks[i].m_value = 128;
+			stick.m_value = 128;
+			stick.m_stick_min = 0;
+			stick.m_stick_max = 128;
+			stick.m_stick_val = 128;
+			stick.m_pressed_keys_min.clear();
+			stick.m_pressed_keys_max.clear();
+			stick.m_pressed_combos_min.clear();
+			stick.m_pressed_combos_max.clear();
 		}
 	}
 
@@ -1261,11 +1265,13 @@ void keyboard_pad_handler::process()
 					// we already applied the following values on keypress if we used factor 1
 					if (stick_lerp_factor < 1.0f)
 					{
-						const f32 v0 = static_cast<f32>(pad.m_sticks[j].m_value);
-						const f32 v1 = static_cast<f32>(m_stick_val[j]);
+						AnalogStick& stick = pad.m_sticks[j];
+
+						const f32 v0 = static_cast<f32>(stick.m_value);
+						const f32 v1 = static_cast<f32>(stick.m_stick_val);
 						const f32 res = get_lerped(v0, v1, stick_lerp_factor);
 
-						pad.m_sticks[j].m_value = static_cast<u16>(res);
+						stick.m_value = static_cast<u16>(res);
 					}
 				}
 			}

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -1346,26 +1346,43 @@ void keyboard_pad_handler::process()
 
 		// Normalize and apply pad squircling
 		// Copy sticks first. We don't want to modify the raw internal values
-		std::array<AnalogStick, 4> squircled_sticks = pad_internal.m_sticks;
+		std::array<u16, 4> squircled_sticks =
+		{
+			pad_internal.m_sticks[0].m_value,
+			pad_internal.m_sticks[1].m_value,
+			pad_internal.m_sticks[2].m_value,
+			pad_internal.m_sticks[3].m_value
+		};
 
 		// Apply squircling
 		if (cfg->lpadsquircling != 0)
 		{
-			u16& lx = squircled_sticks[0].m_value;
-			u16& ly = squircled_sticks[1].m_value;
+			u16& lx = squircled_sticks[0];
+			u16& ly = squircled_sticks[1];
 
 			ConvertToSquirclePoint(lx, ly, cfg->lpadsquircling);
 		}
 
 		if (cfg->rpadsquircling != 0)
 		{
-			u16& rx = squircled_sticks[2].m_value;
-			u16& ry = squircled_sticks[3].m_value;
+			u16& rx = squircled_sticks[2];
+			u16& ry = squircled_sticks[3];
 
 			ConvertToSquirclePoint(rx, ry, cfg->rpadsquircling);
 		}
 
-		pad->m_buttons = pad_internal.m_buttons;
-		pad->m_sticks = squircled_sticks; // Don't use std::move here. We assign values lockless, so std::move can lead to segfaults.
+		for (usz j = 0; j < pad->m_buttons.size(); j++)
+		{
+			const Button& btn_internal = pad_internal.m_buttons[j];
+			Button& btn = pad->m_buttons[j];
+
+			btn.m_value = btn_internal.m_value;
+			btn.m_pressed = btn_internal.m_pressed;
+		}
+
+		for (usz j = 0; j < pad->m_sticks.size(); j++)
+		{
+			pad->m_sticks[j].m_value = squircled_sticks[j];
+		}
 	}
 }

--- a/rpcs3/Input/keyboard_pad_handler.h
+++ b/rpcs3/Input/keyboard_pad_handler.h
@@ -129,11 +129,6 @@ private:
 	u32 m_l_stick_multiplier = 100;
 	u32 m_r_stick_multiplier = 100;
 
-	static constexpr usz max_sticks = 4;
-	std::array<u8, max_sticks> m_stick_min{ 0, 0, 0, 0 };
-	std::array<u8, max_sticks> m_stick_max{ 128, 128, 128, 128 };
-	std::array<u8, max_sticks> m_stick_val{ 128, 128, 128, 128 };
-
 	// Mouse Movements
 	steady_clock::time_point m_last_mouse_move_left;
 	steady_clock::time_point m_last_mouse_move_right;

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -313,7 +313,7 @@ void pad_thread::apply_copilots()
 		for (usz i = 0; i < pad->m_buttons.size(); i++)
 		{
 			const Button& src = pad->m_buttons[i];
-			Button& dst = pad->m_buttons_external[i];
+			ButtonExternal& dst = pad->m_buttons_external[i];
 
 			dst.m_offset = src.m_offset;
 			dst.m_outKeyCode = src.m_outKeyCode;
@@ -324,7 +324,7 @@ void pad_thread::apply_copilots()
 		for (usz i = 0; i < pad->m_sticks.size(); i++)
 		{
 			const AnalogStick& src = pad->m_sticks[i];
-			AnalogStick& dst = pad->m_sticks_external[i];
+			AnalogStickExternal& dst = pad->m_sticks_external[i];
 
 			dst.m_offset = src.m_offset;
 			dst.m_value = src.m_value;
@@ -343,7 +343,7 @@ void pad_thread::apply_copilots()
 				continue;
 			}
 
-			for (Button& button : pad->m_buttons_external)
+			for (ButtonExternal& button : pad->m_buttons_external)
 			{
 				for (const Button& other : copilot->m_buttons)
 				{
@@ -366,7 +366,7 @@ void pad_thread::apply_copilots()
 		}
 
 		// Merge sticks
-		for (AnalogStick& stick : pad->m_sticks_external)
+		for (AnalogStickExternal& stick : pad->m_sticks_external)
 		{
 			f32 accumulated_value = normalize(stick.m_value);
 


### PR DESCRIPTION
- Use smaller external structs for button and stick access outside of the pad_thread
This needs less memory and hides unwanted members from client code.
- Only copy back necessary values in keyboard pad handler
Profiling has shown that copying both containers entirely took the longest.
- Move keyboard stick value buffers to pad object (instead of using one buffer for all pads)
This should improve stick input when using the keyboard for 2 players.

This resulted from a profiling session of a very simple game.
It showed that after SPU, RSX and Qt code the keyboard input processing took the "longest".
This was barely of relevance in the grand scheme of things, but popped out enough to draw my attention.
I removed the pad thread sleeps on purpose to get a better statistic, showing that copying the button and stick vectors from the internal pad object to the actual pad object was most expensive.

After these optimizations, the slowest part seems to be the squircle code.
But it's irrelevant when adding the sleep back in, since the whole keyboard input processing dropped far down in the list.