### PR TITLE
Fix non-numerical numpad keys input binding

### DIFF
--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -1011,7 +1011,7 @@ int keyboard_pad_handler::native_scan_code_from_string([[maybe_unused]] const st
 	if (key == "Num+8" || key == "Num+Up") return 72;
 	if (key == "Num+9" || key == "Num+PgUp") return 73;
 	if (key == "Num+," || key == "Num+Del") return 83;
-	if (key == "Num+/") return 309;
+	if (key == "Num+/") return 57397;
 	if (key == "Num+*") return 55;
 	if (key == "Num+-") return 74;
 	if (key == "Num++") return 78;
@@ -1049,7 +1049,7 @@ std::string keyboard_pad_handler::native_scan_code_to_string(int native_scan_cod
 	case 72: return "Num+8"; // Also "Num+Up" depending on numlock
 	case 73: return "Num+9"; // Also "Num+PgUp" depending on numlock
 	case 83: return "Num+,"; // Also "Num+Del" depending on numlock
-	case 309: return "Num+/";
+	case 57397: return "Num+/";
 	case 55: return "Num+*";
 	case 74: return "Num+-";
 	case 78: return "Num++";

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -829,21 +829,7 @@ QStringList keyboard_pad_handler::GetKeyNames(const QKeyEvent* keyEvent)
 	if (keyEvent->modifiers() & Qt::KeypadModifier)
 	{
 		list.append("Num"); // helper object, not used as actual key
-
-		// Qt does not produce "Num+X" for numpad operator keys (/, *, -, +, ,) — it just outputs
-		// the bare character. Add explicit "Num+X" names so the is_num_key filter can distinguish
-		// them from the equivalent regular keyboard keys during binding and gameplay lookup.
-		switch (keyEvent->key())
-		{
-		case Qt::Key_Slash:    list.append("Num+/"); break;
-		case Qt::Key_Asterisk: list.append("Num+*"); break;
-		case Qt::Key_Minus:    list.append("Num+-"); break;
-		case Qt::Key_Plus:     list.append("Num++"); break;
-		case Qt::Key_Comma:    list.append("Num+,"); break;
-		default:
-			list.append(QKeySequence(keyEvent->key() | Qt::KeypadModifier).toString(QKeySequence::NativeText));
-			break;
-		}
+		list.append(QKeySequence(keyEvent->key() | Qt::KeypadModifier).toString(QKeySequence::NativeText));
 	}
 
 	// Handle special cases
@@ -904,20 +890,6 @@ std::string keyboard_pad_handler::GetKeyName(const QKeyEvent* keyEvent, bool wit
 	case Qt::Key_Down: return "↓";
 #endif
 	default:
-		// For numpad operator keys, Qt does not produce a "Num+X" name via QKeySequence even with
-		// KeypadModifier set. Return the explicit name so bindings are saved/matched correctly.
-		if (keyEvent->modifiers() & Qt::KeypadModifier)
-		{
-			switch (keyEvent->key())
-			{
-			case Qt::Key_Slash:    return "Num+/";
-			case Qt::Key_Asterisk: return "Num+*";
-			case Qt::Key_Minus:    return "Num+-";
-			case Qt::Key_Plus:     return "Num++";
-			case Qt::Key_Comma:    return "Num+,";
-			default: break;
-			}
-		}
 		break;
 	}
 

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -870,13 +870,7 @@ QStringList keyboard_pad_handler::GetKeyNames(const QKeyEvent* keyEvent)
 		list.append("Meta");
 		break;
 	default:
-		// If this is a numpad key that already has a proper "Num+X" name from native_scan_code_to_string,
-		// skip appending the bare key name (e.g. "/", "*", "-", "+", ",") to avoid it being used
-		// instead of the numpad-specific name during input binding and gameplay lookup.
-		if (!(keyEvent->modifiers() & Qt::KeypadModifier) || native_scan_code_to_string(keyEvent->nativeScanCode()).empty())
-		{
-			list.append(QKeySequence(keyEvent->key()).toString(QKeySequence::NativeText));
-		}
+		list.append(QKeySequence(keyEvent->key()).toString(QKeySequence::NativeText));
 		break;
 	}
 

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -835,11 +835,11 @@ QStringList keyboard_pad_handler::GetKeyNames(const QKeyEvent* keyEvent)
 		// them from the equivalent regular keyboard keys during binding and gameplay lookup.
 		switch (keyEvent->key())
 		{
-		case Qt::Key_Slash:    list.append("Num+/");     break;
-		case Qt::Key_Asterisk: list.append("Num+*");     break;
-		case Qt::Key_Minus:    list.append("Num+-");     break;
-		case Qt::Key_Plus:     list.append("Num++");     break;
-		case Qt::Key_Comma:    list.append("Num+,");     break;
+		case Qt::Key_Slash:    list.append("Num+/"); break;
+		case Qt::Key_Asterisk: list.append("Num+*"); break;
+		case Qt::Key_Minus:    list.append("Num+-"); break;
+		case Qt::Key_Plus:     list.append("Num++"); break;
+		case Qt::Key_Comma:    list.append("Num+,"); break;
 		default:
 			list.append(QKeySequence(keyEvent->key() | Qt::KeypadModifier).toString(QKeySequence::NativeText));
 			break;

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -829,7 +829,21 @@ QStringList keyboard_pad_handler::GetKeyNames(const QKeyEvent* keyEvent)
 	if (keyEvent->modifiers() & Qt::KeypadModifier)
 	{
 		list.append("Num"); // helper object, not used as actual key
-		list.append(QKeySequence(keyEvent->key() | Qt::KeypadModifier).toString(QKeySequence::NativeText));
+
+		// Qt does not produce "Num+X" for numpad operator keys (/, *, -, +, ,) — it just outputs
+		// the bare character. Add explicit "Num+X" names so the is_num_key filter can distinguish
+		// them from the equivalent regular keyboard keys during binding and gameplay lookup.
+		switch (keyEvent->key())
+		{
+		case Qt::Key_Slash:    list.append("Num+/");     break;
+		case Qt::Key_Asterisk: list.append("Num+*");     break;
+		case Qt::Key_Minus:    list.append("Num+-");     break;
+		case Qt::Key_Plus:     list.append("Num++");     break;
+		case Qt::Key_Comma:    list.append("Num+,");     break;
+		default:
+			list.append(QKeySequence(keyEvent->key() | Qt::KeypadModifier).toString(QKeySequence::NativeText));
+			break;
+		}
 	}
 
 	// Handle special cases
@@ -856,7 +870,13 @@ QStringList keyboard_pad_handler::GetKeyNames(const QKeyEvent* keyEvent)
 		list.append("Meta");
 		break;
 	default:
-		list.append(QKeySequence(keyEvent->key()).toString(QKeySequence::NativeText));
+		// If this is a numpad key that already has a proper "Num+X" name from native_scan_code_to_string,
+		// skip appending the bare key name (e.g. "/", "*", "-", "+", ",") to avoid it being used
+		// instead of the numpad-specific name during input binding and gameplay lookup.
+		if (!(keyEvent->modifiers() & Qt::KeypadModifier) || native_scan_code_to_string(keyEvent->nativeScanCode()).empty())
+		{
+			list.append(QKeySequence(keyEvent->key()).toString(QKeySequence::NativeText));
+		}
 		break;
 	}
 
@@ -890,6 +910,20 @@ std::string keyboard_pad_handler::GetKeyName(const QKeyEvent* keyEvent, bool wit
 	case Qt::Key_Down: return "↓";
 #endif
 	default:
+		// For numpad operator keys, Qt does not produce a "Num+X" name via QKeySequence even with
+		// KeypadModifier set. Return the explicit name so bindings are saved/matched correctly.
+		if (keyEvent->modifiers() & Qt::KeypadModifier)
+		{
+			switch (keyEvent->key())
+			{
+			case Qt::Key_Slash:    return "Num+/";
+			case Qt::Key_Asterisk: return "Num+*";
+			case Qt::Key_Minus:    return "Num+-";
+			case Qt::Key_Plus:     return "Num++";
+			case Qt::Key_Comma:    return "Num+,";
+			default: break;
+			}
+		}
 		break;
 	}
 

--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -983,7 +983,7 @@ int keyboard_pad_handler::native_scan_code_from_string([[maybe_unused]] const st
 	if (key == "Num+8" || key == "Num+Up") return 72;
 	if (key == "Num+9" || key == "Num+PgUp") return 73;
 	if (key == "Num+," || key == "Num+Del") return 83;
-	if (key == "Num+/") return 57397;
+	if (key == "Num+/") return 309;
 	if (key == "Num+*") return 55;
 	if (key == "Num+-") return 74;
 	if (key == "Num++") return 78;
@@ -1021,11 +1021,13 @@ std::string keyboard_pad_handler::native_scan_code_to_string(int native_scan_cod
 	case 72: return "Num+8"; // Also "Num+Up" depending on numlock
 	case 73: return "Num+9"; // Also "Num+PgUp" depending on numlock
 	case 83: return "Num+,"; // Also "Num+Del" depending on numlock
+	case 309: return "Num+/";
 	case 57397: return "Num+/";
 	case 55: return "Num+*";
 	case 74: return "Num+-";
 	case 78: return "Num++";
 	case 284: return "Num+Enter";
+	case 57372: return "Num+Enter";
 #else
 	// TODO
 #endif


### PR DESCRIPTION
Unlike the numerical numpad keys, the numpad operator keys ("/", "*", "-", "+", ",") cannot be bound correctly. When bound, they are detected and matched with their main keyboard equivalents instead, causing broken input detection for these particular keys.

The root cause is that Qt's "QKeySequence::toString()" does not prefix operator keys with "Num+" even when "Qt::KeypadModifier" is set, it only does this for the digit keys. As a result, these keys were being stored and matched as just "/", "*", etc., indistinguishable from their main keyboard counterparts. Fixes have been applied in keyboard_pad_handler.cpp to handle these cases correctly.
