### PR TITLE
SPU LLVM: Optimize SPU multiplies for ARM

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3720,6 +3720,30 @@ template <typename T1, typename T2, typename T3>
 		result.value = m_ir->CreateCall(get_intrinsic<u32[4], u8[16]>(llvm::Intrinsic::aarch64_neon_sdot), {data0, data1, data2});
 		return result;
 	}
+
+	template <typename T1, typename T2>
+	value_t<s32[4]> smull(T1 a, T2 b)
+	{
+		value_t<s32[4]> result;
+
+		const auto data0 = a.eval(m_ir);
+		const auto data1 = b.eval(m_ir);
+
+		result.value = m_ir->CreateCall(get_intrinsic<s32[4]>(llvm::Intrinsic::aarch64_neon_smull), {data0, data1});
+		return result;
+	}
+
+	template <typename T1, typename T2>
+	value_t<u32[4]> umull(T1 a, T2 b)
+	{
+		value_t<u32[4]> result;
+
+		const auto data0 = a.eval(m_ir);
+		const auto data1 = b.eval(m_ir);
+
+		result.value = m_ir->CreateCall(get_intrinsic<u32[4]>(llvm::Intrinsic::aarch64_neon_umull), {data0, data1});
+		return result;
+	}
 	
 template <typename T1, typename T2>
 	auto addp(T1 a, T2 b)

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -6218,7 +6218,12 @@ public:
 
 	void MPY(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto [a, b] = get_vrs<s32[4]>(op.ra, op.rb);
+		set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)));
+#else
 		set_vr(op.rt, (get_vr<s32[4]>(op.ra) << 16 >> 16) * (get_vr<s32[4]>(op.rb) << 16 >> 16));
+#endif
 	}
 
 	void MPYH(spu_opcode_t op)
@@ -6233,7 +6238,12 @@ public:
 
 	void MPYS(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto [a, b] = get_vrs<s32[4]>(op.ra, op.rb);
+		set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)) >> 16);
+#else
 		set_vr(op.rt, (get_vr<s32[4]>(op.ra) << 16 >> 16) * (get_vr<s32[4]>(op.rb) << 16 >> 16) >> 16);
+#endif
 	}
 
 	void CEQH(spu_opcode_t op)
@@ -6243,7 +6253,12 @@ public:
 
 	void MPYU(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);
+		set_vr(op.rt, umull(zshuffle(bitcast<u16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<u16[8]>(b), 0, 2, 4, 6)));
+#else
 		set_vr(op.rt, mpyu(get_vr(op.ra), get_vr(op.rb)));
+#endif
 	}
 
 	void CEQB(spu_opcode_t op)
@@ -6385,12 +6400,20 @@ public:
 
 	void MPYI(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(get_vr<s32[4]>(op.ra)), 0, 2, 4, 6), get_imm<s16[4]>(op.si10)));
+#else
 		set_vr(op.rt, (get_vr<s32[4]>(op.ra) << 16 >> 16) * get_imm<s32[4]>(op.si10));
+#endif
 	}
 
 	void MPYUI(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		set_vr(op.rt, umull(zshuffle(bitcast<u16[8]>(get_vr<u32[4]>(op.ra)), 0, 2, 4, 6), get_imm<u16[4]>(op.si10)));
+#else
 		set_vr(op.rt, (get_vr(op.ra) << 16 >> 16) * (get_imm(op.si10) & 0xffff));
+#endif
 	}
 
 	void CEQI(spu_opcode_t op)
@@ -6904,7 +6927,12 @@ public:
 
 	void MPYA(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto [a, b] = get_vrs<s32[4]>(op.ra, op.rb);
+		set_vr(op.rt4, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)) + get_vr<s32[4]>(op.rc));
+#else
 		set_vr(op.rt4, (get_vr<s32[4]>(op.ra) << 16 >> 16) * (get_vr<s32[4]>(op.rb) << 16 >> 16) + get_vr<s32[4]>(op.rc));
+#endif
 	}
 
 	void FSCRRD(spu_opcode_t op) //


### PR DESCRIPTION
All SPU multiply instructions are 16b * 16b. ARM Neon has 16 bit multiply instructions, but require the bits to be in specific parts of the register to be used, so it's not entirely idomatic, but 2 instructions to pack bits, and 1 instruction to multiply is better than the older approach that used 32b * 32b.

Saves 2 instructions in MPY, 1 instruction in MPYU, 2 instructions in MPYS, 2 instructions in MPYA, 1 instruction in MPYI, and 2 instructions in MPYUI.

<details> <summary> Before</summary>
<code>

    0000000000003770 <spu_MPY>:
    3770:	2a1803e9 	mov	w9, w24
    3774:	d3437ec8 	ubfx	x8, x22, #3, #29
    3778:	110012b5 	add	w21, w21, #0x4
    377c:	8a090108 	and	x8, x8, x9
    3780:	3ce86b20 	ldr	q0, [x25, x8]
    3784:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3788:	8a090108 	and	x8, x8, x9
    378c:	3ce86b21 	ldr	q1, [x25, x8]
    3790:	531c6ec8 	lsl	w8, w22, #4
    3794:	8a090108 	and	x8, x8, x9
    3798:	4f305400 	shl	v0.4s, v0.4s, #16
    379c:	4f305421 	shl	v1.4s, v1.4s, #16
    37a0:	4f300400 	sshr	v0.4s, v0.4s, #16
    37a4:	4f300421 	sshr	v1.4s, v1.4s, #16
    37a8:	4ea19c00 	mul	v0.4s, v0.4s, v1.4s
    37ac:	3ca86b20 	str	q0, [x25, x8]
    37b0:	d65f03c0 	ret
    37b4:	97fff213 	bl	0 <spu_ret>
    37b8:	d65f03c0 	ret
    37bc:	d503201f 	nop
    
    0000000000003970 <spu_MPYU>:
    3970:	2a1803e9 	mov	w9, w24
    3974:	d3437ec8 	ubfx	x8, x22, #3, #29
    3978:	6f01e662 	movi	v2.2d, #0xffff0000ffff
    397c:	110012b5 	add	w21, w21, #0x4
    3980:	8a090108 	and	x8, x8, x9
    3984:	3ce86b20 	ldr	q0, [x25, x8]
    3988:	d34a7ec8 	ubfx	x8, x22, #10, #22
    398c:	8a090108 	and	x8, x8, x9
    3990:	4e221c00 	and	v0.16b, v0.16b, v2.16b
    3994:	3ce86b21 	ldr	q1, [x25, x8]
    3998:	531c6ec8 	lsl	w8, w22, #4
    399c:	8a090108 	and	x8, x8, x9
    39a0:	4e221c21 	and	v1.16b, v1.16b, v2.16b
    39a4:	4ea19c00 	mul	v0.4s, v0.4s, v1.4s
    39a8:	3ca86b20 	str	q0, [x25, x8]
    39ac:	d65f03c0 	ret
    39b0:	97fff194 	bl	0 <spu_ret>
    39b4:	d65f03c0 	ret
    39b8:	d503201f 	nop
    39bc:	d503201f 	nop
    
    0000000000003860 <spu_MPYS>:
    3860:	2a1803e9 	mov	w9, w24
    3864:	d3437ec8 	ubfx	x8, x22, #3, #29
    3868:	110012b5 	add	w21, w21, #0x4
    386c:	8a090108 	and	x8, x8, x9
    3870:	3ce86b20 	ldr	q0, [x25, x8]
    3874:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3878:	8a090108 	and	x8, x8, x9
    387c:	3ce86b21 	ldr	q1, [x25, x8]
    3880:	531c6ec8 	lsl	w8, w22, #4
    3884:	8a090108 	and	x8, x8, x9
    3888:	4f305400 	shl	v0.4s, v0.4s, #16
    388c:	4f305421 	shl	v1.4s, v1.4s, #16
    3890:	4f300400 	sshr	v0.4s, v0.4s, #16
    3894:	4f300421 	sshr	v1.4s, v1.4s, #16
    3898:	4ea19c00 	mul	v0.4s, v0.4s, v1.4s
    389c:	4f300400 	sshr	v0.4s, v0.4s, #16
    38a0:	3ca86b20 	str	q0, [x25, x8]
    38a4:	d65f03c0 	ret
    38a8:	97fff1d6 	bl	0 <spu_ret>
    38ac:	d65f03c0 	ret
    
    0000000000003d50 <spu_MPYA>:
    3d50:	2a1803e9 	mov	w9, w24
    3d54:	d3437ec8 	ubfx	x8, x22, #3, #29
    3d58:	110012b5 	add	w21, w21, #0x4
    3d5c:	8a090108 	and	x8, x8, x9
    3d60:	3ce86b20 	ldr	q0, [x25, x8]
    3d64:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3d68:	8a090108 	and	x8, x8, x9
    3d6c:	3ce86b21 	ldr	q1, [x25, x8]
    3d70:	531c6ec8 	lsl	w8, w22, #4
    3d74:	8a090108 	and	x8, x8, x9
    3d78:	3ce86b22 	ldr	q2, [x25, x8]
    3d7c:	d3517ec8 	ubfx	x8, x22, #17, #15
    3d80:	8a090108 	and	x8, x8, x9
    3d84:	4f305400 	shl	v0.4s, v0.4s, #16
    3d88:	4f305421 	shl	v1.4s, v1.4s, #16
    3d8c:	4f300400 	sshr	v0.4s, v0.4s, #16
    3d90:	4f300421 	sshr	v1.4s, v1.4s, #16
    3d94:	4ea19402 	mla	v2.4s, v0.4s, v1.4s
    3d98:	3ca86b22 	str	q2, [x25, x8]
    3d9c:	d65f03c0 	ret
    3da0:	97fff098 	bl	0 <spu_ret>
    3da4:	d65f03c0 	ret
    3da8:	d503201f 	nop
    3dac:	d503201f 	nop

</code>
</details>

<details> <summary> After</summary>
<code>

    0000000000003d50 <spu_MPY>:
    3d50:	2a1803e9 	mov	w9, w24
    3d54:	d3437ec8 	ubfx	x8, x22, #3, #29
    3d58:	110012b5 	add	w21, w21, #0x4
    3d5c:	8a090108 	and	x8, x8, x9
    3d60:	3ce86b20 	ldr	q0, [x25, x8]
    3d64:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3d68:	8a090108 	and	x8, x8, x9
    3d6c:	3ce86b21 	ldr	q1, [x25, x8]
    3d70:	531c6ec8 	lsl	w8, w22, #4
    3d74:	8a090108 	and	x8, x8, x9
    3d78:	3ce86b22 	ldr	q2, [x25, x8]
    3d7c:	d3517ec8 	ubfx	x8, x22, #17, #15
    3d80:	8a090108 	and	x8, x8, x9
    3d84:	0e612800 	xtn	v0.4h, v0.4s
    3d88:	0e612821 	xtn	v1.4h, v1.4s
    3d8c:	0e618002 	smlal	v2.4s, v0.4h, v1.4h
    3d90:	3ca86b22 	str	q2, [x25, x8]
    3d94:	d65f03c0 	ret
    3d98:	97fff09a 	bl	0 <spu_ret>
    3d9c:	d65f03c0 	ret

    0000000000003970 <spu_MPYU>:
    3970:	2a1803e9 	mov	w9, w24
    3974:	d3437ec8 	ubfx	x8, x22, #3, #29
    3978:	110012b5 	add	w21, w21, #0x4
    397c:	8a090108 	and	x8, x8, x9
    3980:	3ce86b20 	ldr	q0, [x25, x8]
    3984:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3988:	8a090108 	and	x8, x8, x9
    398c:	3ce86b21 	ldr	q1, [x25, x8]
    3990:	531c6ec8 	lsl	w8, w22, #4
    3994:	8a090108 	and	x8, x8, x9
    3998:	0e612800 	xtn	v0.4h, v0.4s
    399c:	0e612821 	xtn	v1.4h, v1.4s
    39a0:	2e61c000 	umull	v0.4s, v0.4h, v1.4h
    39a4:	3ca86b20 	str	q0, [x25, x8]
    39a8:	d65f03c0 	ret
    39ac:	97fff195 	bl	0 <spu_ret>
    39b0:	d65f03c0 	ret
    39b4:	d503201f 	nop
    39b8:	d503201f 	nop
    39bc:	d503201f 	nop
    
    0000000000003860 <spu_MPYS>:
    3860:	2a1803e9 	mov	w9, w24
    3864:	d3437ec8 	ubfx	x8, x22, #3, #29
    3868:	110012b5 	add	w21, w21, #0x4
    386c:	8a090108 	and	x8, x8, x9
    3870:	3ce86b20 	ldr	q0, [x25, x8]
    3874:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3878:	8a090108 	and	x8, x8, x9
    387c:	3ce86b21 	ldr	q1, [x25, x8]
    3880:	531c6ec8 	lsl	w8, w22, #4
    3884:	8a090108 	and	x8, x8, x9
    3888:	0e612800 	xtn	v0.4h, v0.4s
    388c:	0e612821 	xtn	v1.4h, v1.4s
    3890:	0e61c000 	smull	v0.4s, v0.4h, v1.4h
    3894:	4f300400 	sshr	v0.4s, v0.4s, #16
    3898:	3ca86b20 	str	q0, [x25, x8]
    389c:	d65f03c0 	ret
    38a0:	97fff1d8 	bl	0 <spu_ret>
    38a4:	d65f03c0 	ret
    38a8:	d503201f 	nop
    
    0000000000003d50 <spu_MPYA>:
    3d50:	2a1803e9 	mov	w9, w24
    3d54:	d3437ec8 	ubfx	x8, x22, #3, #29
    3d58:	110012b5 	add	w21, w21, #0x4
    3d5c:	8a090108 	and	x8, x8, x9
    3d60:	3ce86b20 	ldr	q0, [x25, x8]
    3d64:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3d68:	8a090108 	and	x8, x8, x9
    3d6c:	3ce86b21 	ldr	q1, [x25, x8]
    3d70:	531c6ec8 	lsl	w8, w22, #4
    3d74:	8a090108 	and	x8, x8, x9
    3d78:	3ce86b22 	ldr	q2, [x25, x8]
    3d7c:	d3517ec8 	ubfx	x8, x22, #17, #15
    3d80:	8a090108 	and	x8, x8, x9
    3d84:	4f305400 	shl	v0.4s, v0.4s, #16
    3d88:	4f305421 	shl	v1.4s, v1.4s, #16
    3d8c:	4f300400 	sshr	v0.4s, v0.4s, #16
    3d90:	4f300421 	sshr	v1.4s, v1.4s, #16
    3d94:	4ea19402 	mla	v2.4s, v0.4s, v1.4s
    3d98:	3ca86b22 	str	q2, [x25, x8]
    3d9c:	d65f03c0 	ret
    3da0:	97fff098 	bl	0 <spu_ret>
    3da4:	d65f03c0 	ret
    3da8:	d503201f 	nop
    3dac:	d503201f 	nop
</code>
</details>