### PR TITLE
Do not append install dir for content type theme PKGs

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -807,7 +807,7 @@ bool package_reader::set_install_path()
 	}
 
 	// TODO: Verify whether other content types require appending title ID
-	//Added theme content type not require appending title ID
+	// Append title ID depending on content type
 	if (m_metadata.content_type != PKG_CONTENT_TYPE_THEME && m_metadata.content_type != PKG_CONTENT_TYPE_LICENSE)
 		dir += m_install_dir + '/';
 

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -807,7 +807,8 @@ bool package_reader::set_install_path()
 	}
 
 	// TODO: Verify whether other content types require appending title ID
-	if (m_metadata.content_type != PKG_CONTENT_TYPE_LICENSE)
+	//Added theme content type not require appending title ID
+	if (m_metadata.content_type != PKG_CONTENT_TYPE_THEME && m_metadata.content_type != PKG_CONTENT_TYPE_LICENSE)
 		dir += m_install_dir + '/';
 
 	// If false, an existing directory is being overwritten: cannot cancel the operation


### PR DESCRIPTION
Retail PS3 firmware installs theme PKGs directly into /dev_hdd0/theme/ without creating or appending an additional Title ID/install directory.

RPCS3 currently appends m_install_dir for PKG_CONTENT_TYPE_THEME, causing themes installed to not be recognized unless moved out of their title ID folder.