### PR TITLE
Fix triple ret interpreter bug for ARM64

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -3847,20 +3847,23 @@ public:
 							}
 							else if (!(itype & spu_itype::branch))
 							{
-								// Hack: inline ret instruction before final jmp; this is not reliable.
+								// Inline ret exits the instruction helper directly.
 #ifdef ARCH_X64
 								m_ir->CreateCall(InlineAsm::get(get_ftype<void>(), "ret", "", true, false, InlineAsm::AD_Intel));
 #else
 								m_ir->CreateCall(InlineAsm::get(get_ftype<void>(), "ret", "", true, false));
 #endif
-								fret = ret_func;
+								m_ir->CreateUnreachable();
 							}
 
-							const auto arg3 = UndefValue::get(get_type<u32>());
-							const auto _ret = m_ir->CreateCall(if_type, fret, {m_lsptr, m_thread, m_interp_pc, arg3, m_interp_table, m_interp_7f0, m_interp_regs});
-							_ret->setCallingConv(CallingConv::GHC);
-							_ret->setTailCall();
-							m_ir->CreateRetVoid();
+							if (!m_ir->GetInsertBlock()->getTerminator())
+							{
+								const auto arg3 = UndefValue::get(get_type<u32>());
+								const auto _ret = m_ir->CreateCall(if_type, fret, {m_lsptr, m_thread, m_interp_pc, arg3, m_interp_table, m_interp_7f0, m_interp_regs});
+								_ret->setCallingConv(CallingConv::GHC);
+								_ret->setTailCall();
+								m_ir->CreateRetVoid();
+							}
 						}
 
 						if (!m_ir->GetInsertBlock()->getTerminator())


### PR DESCRIPTION
the SPU interpreter on arm would produce weird code like this:

    389c:	d65f03c0 	ret
    38a0:	97fff1d8 	bl	0 <spu_ret>
    38a4:	d65f03c0 	ret
    
    <spu_ret> being this:
    0000000000000000 <spu_ret>:
       0:	d65f03c0 	ret
       4:	d503201f 	nop
       8:	d503201f 	nop
       c:	d503201f 	nop
       
Since the first ret would exit the instruction, the code after is nonsensical and unreachable.

<details> <summary> Before</summary>
<code>

    0000000000003860 <spu_MPYS>:
    3860:	2a1803e9 	mov	w9, w24
    3864:	d3437ec8 	ubfx	x8, x22, #3, #29
    3868:	110012b5 	add	w21, w21, #0x4
    386c:	8a090108 	and	x8, x8, x9
    3870:	3ce86b20 	ldr	q0, [x25, x8]
    3874:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3878:	8a090108 	and	x8, x8, x9
    387c:	3ce86b21 	ldr	q1, [x25, x8]
    3880:	531c6ec8 	lsl	w8, w22, #4
    3884:	8a090108 	and	x8, x8, x9
    3888:	0e612800 	xtn	v0.4h, v0.4s
    388c:	0e612821 	xtn	v1.4h, v1.4s
    3890:	0e61c000 	smull	v0.4s, v0.4h, v1.4h
    3894:	4f300400 	sshr	v0.4s, v0.4s, #16
    3898:	3ca86b20 	str	q0, [x25, x8]
    389c:	d65f03c0 	ret
    38a0:	97fff1d8 	bl	0 <spu_ret>
    38a4:	d65f03c0 	ret
    38a8:	d503201f 	nop
    38ac:	d503201f 	nop

</code>
</details>

<details> <summary> After</summary>
<code>

    0000000000003030 <spu_MPYS>:
    3030:	2a1803e9 	mov	w9, w24
    3034:	d3437ec8 	ubfx	x8, x22, #3, #29
    3038:	8a090108 	and	x8, x8, x9
    303c:	3ce86b20 	ldr	q0, [x25, x8]
    3040:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3044:	8a090108 	and	x8, x8, x9
    3048:	3ce86b21 	ldr	q1, [x25, x8]
    304c:	531c6ec8 	lsl	w8, w22, #4
    3050:	8a090108 	and	x8, x8, x9
    3054:	0e612800 	xtn	v0.4h, v0.4s
    3058:	0e612821 	xtn	v1.4h, v1.4s
    305c:	0e61c000 	smull	v0.4s, v0.4h, v1.4h
    3060:	4f300400 	sshr	v0.4s, v0.4s, #16
    3064:	3ca86b20 	str	q0, [x25, x8]
    3068:	d65f03c0 	ret
    306c:	d503201f 	nop

</code>
</details>