### PR TITLE
SPU LLVM: SVE multiply optimizations (ARM)

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3790,8 +3790,81 @@ template <typename T1, typename T2, typename T3>
 
 		return from_sve_vector(result, fixed_type);
 	}
-	
-template <typename T1, typename T2>
+
+	template <typename T, typename T1, typename T2>
+	value_t<T> sve_mull(llvm::Intrinsic::ID id, T1 a, T2 b)
+	{
+		value_t<T> result;
+
+		const auto fixed_type = llvm::cast<llvm::FixedVectorType>(get_type<T>());
+		const auto scalable_type = llvm::ScalableVectorType::get(fixed_type->getElementType(), fixed_type->getNumElements());
+		const auto data0 = to_sve_vector(a.eval(m_ir));
+		const auto data1 = to_sve_vector(b.eval(m_ir));
+		const std::array<llvm::Type*, 1> types{scalable_type};
+
+		result.value = from_sve_vector(m_ir->CreateIntrinsic(id, types, {data0, data1}), fixed_type);
+		return result;
+	}
+
+	template <typename T, typename T0, typename T1, typename T2>
+	value_t<T> sve_mlal(llvm::Intrinsic::ID id, T0 acc, T1 a, T2 b)
+	{
+		value_t<T> result;
+
+		const auto fixed_type = llvm::cast<llvm::FixedVectorType>(get_type<T>());
+		const auto scalable_type = llvm::ScalableVectorType::get(fixed_type->getElementType(), fixed_type->getNumElements());
+		const auto data0 = to_sve_vector(acc.eval(m_ir));
+		const auto data1 = to_sve_vector(a.eval(m_ir));
+		const auto data2 = to_sve_vector(b.eval(m_ir));
+		const std::array<llvm::Type*, 1> types{scalable_type};
+
+		result.value = from_sve_vector(m_ir->CreateIntrinsic(id, types, {data0, data1, data2}), fixed_type);
+		return result;
+	}
+
+	template <typename T1, typename T2>
+	value_t<s32[4]> sve_smullb(T1 a, T2 b)
+	{
+		return sve_mull<s32[4]>(llvm::Intrinsic::aarch64_sve_smullb, a, b);
+	}
+
+	template <typename T1, typename T2>
+	value_t<s32[4]> sve_smullt(T1 a, T2 b)
+	{
+		return sve_mull<s32[4]>(llvm::Intrinsic::aarch64_sve_smullt, a, b);
+	}
+
+	template <typename T1, typename T2>
+	value_t<u32[4]> sve_umullb(T1 a, T2 b)
+	{
+		return sve_mull<u32[4]>(llvm::Intrinsic::aarch64_sve_umullb, a, b);
+	}
+
+	template <typename T1, typename T2>
+	value_t<u32[4]> sve_umullt(T1 a, T2 b)
+	{
+		return sve_mull<u32[4]>(llvm::Intrinsic::aarch64_sve_umullt, a, b);
+	}
+
+	template <typename T0, typename T1, typename T2>
+	value_t<s32[4]> sve_smlalb(T0 acc, T1 a, T2 b)
+	{
+		return sve_mlal<s32[4]>(llvm::Intrinsic::aarch64_sve_smlalb, acc, a, b);
+	}
+
+	template <typename T0, typename T1, typename T2>
+	value_t<s32[4]> sve_smlalt(T0 acc, T1 a, T2 b)
+	{
+		return sve_mlal<s32[4]>(llvm::Intrinsic::aarch64_sve_smlalt, acc, a, b);
+	}
+
+	template <typename T0, typename T1, typename T2>
+	value_t<u32[4]> sve_umlalt(T0 acc, T1 a, T2 b)
+	{
+		return sve_mlal<u32[4]>(llvm::Intrinsic::aarch64_sve_umlalt, acc, a, b);
+	}
+
+	template <typename T1, typename T2>
 	auto addp(T1 a, T2 b)
 	{
 		using T_vector = typename is_llvm_expr<T1>::type;

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -6265,6 +6265,15 @@ public:
 
 	void MPYHHU(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);
+
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_umullt(bitcast<u16[8]>(a), bitcast<u16[8]>(b)));
+			return;
+		}
+#endif
 		set_vr(op.rt, (get_vr(op.ra) >> 16) * (get_vr(op.rb) >> 16));
 	}
 
@@ -6295,11 +6304,29 @@ public:
 
 	void MPYHHA(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto [a, b] = get_vrs<s32[4]>(op.ra, op.rb);
+
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_smlalt(get_vr<s32[4]>(op.rt), bitcast<s16[8]>(a), bitcast<s16[8]>(b)));
+			return;
+		}
+#endif
 		set_vr(op.rt, (get_vr<s32[4]>(op.ra) >> 16) * (get_vr<s32[4]>(op.rb) >> 16) + get_vr<s32[4]>(op.rt));
 	}
 
 	void MPYHHAU(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);
+
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_umlalt(get_vr<u32[4]>(op.rt), bitcast<u16[8]>(a), bitcast<u16[8]>(b)));
+			return;
+		}
+#endif
 		set_vr(op.rt, (get_vr(op.ra) >> 16) * (get_vr(op.rb) >> 16) + get_vr(op.rt));
 	}
 
@@ -6307,7 +6334,15 @@ public:
 	{
 #ifdef ARCH_ARM64
 		const auto [a, b] = get_vrs<s32[4]>(op.ra, op.rb);
-		set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)));
+
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_smullb(bitcast<s16[8]>(a), bitcast<s16[8]>(b)));
+		}
+		else
+		{
+			set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)));
+		}
 #else
 		set_vr(op.rt, (get_vr<s32[4]>(op.ra) << 16 >> 16) * (get_vr<s32[4]>(op.rb) << 16 >> 16));
 #endif
@@ -6320,6 +6355,15 @@ public:
 
 	void MPYHH(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto [a, b] = get_vrs<s32[4]>(op.ra, op.rb);
+
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_smullt(bitcast<s16[8]>(a), bitcast<s16[8]>(b)));
+			return;
+		}
+#endif
 		set_vr(op.rt, (get_vr<s32[4]>(op.ra) >> 16) * (get_vr<s32[4]>(op.rb) >> 16));
 	}
 
@@ -6327,7 +6371,15 @@ public:
 	{
 #ifdef ARCH_ARM64
 		const auto [a, b] = get_vrs<s32[4]>(op.ra, op.rb);
-		set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)) >> 16);
+
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_smullb(bitcast<s16[8]>(a), bitcast<s16[8]>(b)) >> 16);
+		}
+		else
+		{
+			set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)) >> 16);
+		}
 #else
 		set_vr(op.rt, (get_vr<s32[4]>(op.ra) << 16 >> 16) * (get_vr<s32[4]>(op.rb) << 16 >> 16) >> 16);
 #endif
@@ -6342,7 +6394,15 @@ public:
 	{
 #ifdef ARCH_ARM64
 		const auto [a, b] = get_vrs<u32[4]>(op.ra, op.rb);
-		set_vr(op.rt, umull(zshuffle(bitcast<u16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<u16[8]>(b), 0, 2, 4, 6)));
+
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_umullb(bitcast<u16[8]>(a), bitcast<u16[8]>(b)));
+		}
+		else
+		{
+			set_vr(op.rt, umull(zshuffle(bitcast<u16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<u16[8]>(b), 0, 2, 4, 6)));
+		}
 #else
 		set_vr(op.rt, mpyu(get_vr(op.ra), get_vr(op.rb)));
 #endif
@@ -6495,7 +6555,14 @@ public:
 	void MPYI(spu_opcode_t op)
 	{
 #ifdef ARCH_ARM64
-		set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(get_vr<s32[4]>(op.ra)), 0, 2, 4, 6), get_imm<s16[4]>(op.si10)));
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_smullb(bitcast<s16[8]>(get_vr<s32[4]>(op.ra)), get_imm<s16[8]>(op.si10)));
+		}
+		else
+		{
+			set_vr(op.rt, smull(zshuffle(bitcast<s16[8]>(get_vr<s32[4]>(op.ra)), 0, 2, 4, 6), get_imm<s16[4]>(op.si10)));
+		}
 #else
 		set_vr(op.rt, (get_vr<s32[4]>(op.ra) << 16 >> 16) * get_imm<s32[4]>(op.si10));
 #endif
@@ -6504,7 +6571,14 @@ public:
 	void MPYUI(spu_opcode_t op)
 	{
 #ifdef ARCH_ARM64
-		set_vr(op.rt, umull(zshuffle(bitcast<u16[8]>(get_vr<u32[4]>(op.ra)), 0, 2, 4, 6), get_imm<u16[4]>(op.si10)));
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt, sve_umullb(bitcast<u16[8]>(get_vr<u32[4]>(op.ra)), get_imm<u16[8]>(op.si10)));
+		}
+		else
+		{
+			set_vr(op.rt, umull(zshuffle(bitcast<u16[8]>(get_vr<u32[4]>(op.ra)), 0, 2, 4, 6), get_imm<u16[4]>(op.si10)));
+		}
 #else
 		set_vr(op.rt, (get_vr(op.ra) << 16 >> 16) * (get_imm(op.si10) & 0xffff));
 #endif
@@ -7091,7 +7165,15 @@ public:
 	{
 #ifdef ARCH_ARM64
 		const auto [a, b] = get_vrs<s32[4]>(op.ra, op.rb);
-		set_vr(op.rt4, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)) + get_vr<s32[4]>(op.rc));
+
+		if (m_use_sve2_128)
+		{
+			set_vr(op.rt4, sve_smlalb(get_vr<s32[4]>(op.rc), bitcast<s16[8]>(a), bitcast<s16[8]>(b)));
+		}
+		else
+		{
+			set_vr(op.rt4, smull(zshuffle(bitcast<s16[8]>(a), 0, 2, 4, 6), zshuffle(bitcast<s16[8]>(b), 0, 2, 4, 6)) + get_vr<s32[4]>(op.rc));
+		}
 #else
 		set_vr(op.rt4, (get_vr<s32[4]>(op.ra) << 16 >> 16) * (get_vr<s32[4]>(op.rb) << 16 >> 16) + get_vr<s32[4]>(op.rc));
 #endif

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -531,13 +531,18 @@ std::string utils::get_system_info()
 	}
 #ifdef ARCH_ARM64
 
-	if (has_neon())
+	if (!has_neon())
 	{
-		result += " | Neon";
+		fmt::throw_exception("Neon support not present");
+	}
+
+	if (has_sve())
+	{
+		fmt::append(result, " | SVE%s-%d", has_sve2() ? "2" : "", sve_length());
 	}
 	else
 	{
-		fmt::throw_exception("Neon support not present");
+		result += " | Neon";
 	}
 #else
 


### PR DESCRIPTION
Since SVE is variable length, ARM decided to take a different approach to handle the widening (16b*16b -> 32b result) multiplies. Instead of having 16 bit values packed in the bottom or top 64 bits of a 128b register, the SVE widening instructions instead refer to the top or bottom 16 bits of each 32bit element.

The great thing is that for the most part, these match the SPU multiply instructions 1:1!

For now, it's only enabled for 128b SVE implementations.

This optimization can technically work for SVE lengths greater than 128b, but existing 256b SVE implementations (and greater) run at lower IPC than neon equivalents, and using 256b SVE when unnecessary will burn extra power. All current client SVE implementations are 128b only. If something with 256b or greater SVE comes along, we can benchmark and revisit the performance.

SVE instructions require to be "scaleable vectors" in LLVM IR, so I've also added some helpers to help converting to/from scaleable vectors from fixed length vectors.

<details> <summary> Before</summary>
<code>

    0000000000003970 <spu_MPYU>:
    3970:	2a1803e9 	mov	w9, w24
    3974:	d3437ec8 	ubfx	x8, x22, #3, #29
    3978:	110012b5 	add	w21, w21, #0x4
    397c:	8a090108 	and	x8, x8, x9
    3980:	3ce86b20 	ldr	q0, [x25, x8]
    3984:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3988:	8a090108 	and	x8, x8, x9
    398c:	3ce86b21 	ldr	q1, [x25, x8]
    3990:	531c6ec8 	lsl	w8, w22, #4
    3994:	8a090108 	and	x8, x8, x9
    3998:	0e612800 	xtn	v0.4h, v0.4s
    399c:	0e612821 	xtn	v1.4h, v1.4s
    39a0:	2e61c000 	umull	v0.4s, v0.4h, v1.4h
    39a4:	3ca86b20 	str	q0, [x25, x8]
    39a8:	d65f03c0 	ret
    39ac:	97fff195 	bl	0 <spu_ret>
    39b0:	d65f03c0 	ret
    39b4:	d503201f 	nop
    39b8:	d503201f 	nop
    39bc:	d503201f 	nop

</code>
</details>

<details> <summary> After</summary>
<code>

    0000000000003910 <spu_MPYU>:
    3910:	2a1803e9 	orr	w9, wzr, w24
    3914:	d3437ec8 	ubfm	x8, x22, #3, #31
    3918:	110012b5 	add	w21, w21, #0x4
    391c:	8a090108 	and	x8, x8, x9
    3920:	3ce86b20 	ldr	q0, [x25, x8]
    3924:	d34a7ec8 	ubfm	x8, x22, #10, #31
    3928:	8a090108 	and	x8, x8, x9
    392c:	3ce86b21 	ldr	q1, [x25, x8]
    3930:	45817800 	umullb	z0.s, z0.h, z1.h
    3934:	531c6ec8 	ubfm	w8, w22, #28, #27
    3938:	8a090108 	and	x8, x8, x9
    393c:	3ca86b20 	str	q0, [x25, x8]
    3940:	d65f03c0 	ret
    3944:	97fff1af 	bl	0 <spu_ret>
    3948:	d65f03c0 	ret
    394c:	d503201f 	hint	#0x0

</code>
</details>

That's just one SIMD instruction for the majority of multiply instructions!

Also I ripped out the SVE length detection from https://github.com/RPCS3/rpcs3/pull/18422 since that's the only part that's mergeable (and needed) right now.

<img width="770" height="43" alt="image" src="https://github.com/user-attachments/assets/c450aa44-16b3-4fd6-9a44-e2e8e7a17b8a" />
