### PR TITLE
Fix some verification fails

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -657,7 +657,22 @@ namespace gl
 			const rsx::image_section_attributes_t search_desc = { .gcm_format = gcm_format, .width = width, .height = height, .depth = depth, .mipmaps = mipmaps };
 			const bool allow_dirty = (context != rsx::texture_upload_context::framebuffer_storage);
 			auto& cached = *find_cached_texture(rsx_range, search_desc, true, true, allow_dirty);
-			ensure(!cached.is_locked());
+
+			// If the section is locked, only allow proceeding if it's not an FBO-backed section.
+			// For CPU uploads we can safely deprotect so the CPU may create/upload the texture.
+			if (cached.is_locked())
+			{
+				if (context == rsx::texture_upload_context::framebuffer_storage)
+				{
+					// Framebuffer regions must stay locked here — preserve original invariant.
+					ensure(!"create_new_texture: region is locked for framebuffer_storage");
+				}
+				else
+				{
+					// Deprotect to allow CPU write / initialization.
+					cached.unprotect();
+				}
+			}
 
 			gl::viewable_image* image = nullptr;
 			if (cached.exists())

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -958,6 +958,13 @@ namespace vk
 			unspill(cmd);
 		}
 
+		// CRITICAL FIX: Ensure resolve surface exists for MSAA surfaces when transfer_read is requested
+		// This prevents crashes in get_surface(...) when resolve_surface is null after spilling
+		if (access.is_transfer() && samples() > 1 && !resolve_surface)
+		{
+			get_resolve_target_safe(cmd);
+		}
+
 		if (access == rsx::surface_access::shader_write && m_cyclic_ref_tracker.is_enabled())
 		{
 			if (current_layout == VK_IMAGE_LAYOUT_GENERAL || current_layout == VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -1013,7 +1013,22 @@ namespace vk
 		const rsx::image_section_attributes_t search_desc = { .gcm_format = gcm_format, .width = width, .height = height, .depth = section_depth, .mipmaps = mipmaps };
 		const bool allow_dirty = (context != rsx::texture_upload_context::framebuffer_storage);
 		cached_texture_section& region = *find_cached_texture(rsx_range, search_desc, true, true, allow_dirty);
-		ensure(!region.is_locked());
+
+		// If the section is locked, only allow proceeding if it's not an FBO-backed section.
+		// For CPU uploads we can safely deprotect so the CPU may create/upload the texture.
+		if (region.is_locked())
+		{
+			if (context == rsx::texture_upload_context::framebuffer_storage)
+			{
+				// Framebuffer regions must stay locked here — preserve original invariant.
+				ensure(!"create_new_texture: region is locked for framebuffer_storage");
+			}
+			else
+			{
+				// Deprotect to allow CPU write / initialization.
+				region.unprotect();
+			}
+		}
 
 		vk::viewable_image* image = nullptr;
 		if (region.exists())


### PR DESCRIPTION
Used Opus 4.7 to troubleshoot issues in #14457. Both two issues in #14457 were 100% reproducible on my env. So, I just instrumented stack traces in the code for a further deep analysis and cross checks.
Apparently the fixes provided in this PR fix the issues with no impact at all on performance.
The fix for `create_new_texture()` was also confirmed as fixing #18135.

Below just a report provided by Opus 4.7 for the verification fail on `memory_barrier()` occurring on `Vulkan` compared to the same function on `OpenGL` that apparently was not affected by the issue

```
ROOT CAUSE FOUND:
Looking at the memory_barrier implementation:
•	When access == rsx::surface_access::transfer_read, the code does NOT explicitly create/ensure a resolve surface when samples() > 1 and msaa_flags don't have require_resolve or require_unresolve set.
•	The function returns early at line 1041 (after checking flags) if old_contents.empty(), and the resolve logic only handles specific MSAA flag conditions (lines 1016-1039).
•	If a surface has been spilled/evicted and the MSAA flags don't match the expected patterns, memory_barrier(...) doesn't call get_resolve_target_safe(cmd), so resolve_surface remains nullptr.
Minimal Fix:
Add explicit resolve surface creation in memory_barrier for transfer_read access when samples > 1:
```

fixes #14457
fixes #18135
