### PR TITLE
SPU LLVM: Idiomatic FSM implementation for ARM64

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -5660,22 +5660,44 @@ public:
 		}
 
 		const auto v = extract(get_vr(op.ra), 3);
+#ifdef ARCH_ARM64
+// Workaround for bad codegen via LLVM
+// More idiomatic version that compiles to 2 neon instructions
+// Remove me when addressed by upstream llvm: https://github.com/llvm/llvm-project/issues/200325 - Whatcookie
+		const auto masks = build<u32[4]>(1, 2, 4, 8);
+		const auto bits = vsplat<u32[4]>(zext<u32>(trunc<i4>(v)));
+		set_vr(op.rt, sext<s32[4]>((bits & masks) == masks));
+#else
 		const auto m = bitcast<bool[4]>(trunc<i4>(v));
 		set_vr(op.rt, sext<s32[4]>(m));
+#endif
 	}
 
 	void FSMH(spu_opcode_t op)
 	{
 		const auto v = extract(get_vr(op.ra), 3);
+#ifdef ARCH_ARM64
+		const auto masks = build<u16[8]>(1, 2, 4, 8, 16, 32, 64, 128);
+		const auto bits = vsplat<u16[8]>(zext<u16>(trunc<u8>(v)));
+		set_vr(op.rt, sext<s16[8]>((bits & masks) == masks));
+#else
 		const auto m = bitcast<bool[8]>(trunc<u8>(v));
 		set_vr(op.rt, sext<s16[8]>(m));
+#endif
 	}
 
 	void FSMB(spu_opcode_t op)
 	{
 		const auto v = extract(get_vr(op.ra), 3);
+#ifdef ARCH_ARM64
+		const auto masks = build<u8[16]>(1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128);
+		const auto bytes = bitcast<u8[16]>(vsplat<u16[8]>(trunc<u16>(v)));
+		const auto bits = zshuffle(bytes, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1);
+		set_vr(op.rt, sext<s8[16]>((bits & masks) == masks));
+#else
 		const auto m = bitcast<bool[16]>(trunc<u16>(v));
 		set_vr(op.rt, sext<s8[16]>(m));
+#endif
 	}
 
 	template <typename TA>
@@ -6336,8 +6358,15 @@ public:
 
 	void FSMBI(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
+		const auto masks = build<u8[16]>(1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128);
+		const auto bytes = bitcast<u8[16]>(vsplat<u16[8]>(get_imm<u16>(op.i16)));
+		const auto bits = zshuffle(bytes, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1);
+		set_vr(op.rt, sext<s8[16]>((bits & masks) == masks));
+#else
 		const auto m = bitcast<bool[16]>(get_imm<u16>(op.i16));
 		set_vr(op.rt, sext<s8[16]>(m));
+#endif
 	}
 
 	void IL(spu_opcode_t op)


### PR DESCRIPTION
Now compiles down to just 2 instructions on Neon, instead of falling back to scalar instructions

Before:
spu_FSMH:
        and     w8, w24, w22, lsr #3
        add     x8, x25, x8
        ldrb    w8, [x8, #12]
        sbfx    w10, w8, #0, #1
        sbfx    w9, w8, #1, #1
        fmov    s0, w10
        mov     v0.h[1], w9
        sbfx    w9, w8, #2, #1
        mov     v0.h[2], w9
        sbfx    w9, w8, #3, #1
        mov     v0.h[3], w9
        sbfx    w9, w8, #4, #1
        mov     v0.h[4], w9
        sbfx    w9, w8, #5, #1
        mov     v0.h[5], w9
        sbfx    w9, w8, #6, #1
        sbfx    w8, w8, #7, #1
        mov     v0.h[6], w9
        mov     v0.h[7], w8
        lsl     w8, w22, #4
        and     x8, x24, x8
        str     q0, [x25, x8]
        ret
        
After:
"spu_FSMH-idomatic":
        and     w8, w24, w22, lsr #3
        add     x8, x25, x8
        ldrb    w8, [x8, #12]
        dup     v0.8h, w8
        adrp    x8, .LCPI1_0
        ldr     q1, [x8, :lo12:.LCPI1_0]
        lsl     w8, w22, #4
        and     x8, x24, x8
        cmtst   v0.8h, v0.8h, v1.8h
        str     q0, [x25, x8]
        ret

We can remove this workaround when LLVM fixes this issue upstream: https://github.com/llvm/llvm-project/issues/200325