### PR TITLE
Fix exit after headless installation

### DIFF
--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -606,7 +606,7 @@ void tar_object::save_directory(const std::string& target_path, utils::serial& a
 		ar.breathe();
 	};
 
-	fs::stat_t stat{};
+	fs::dir_entry stat{};
 
 	if (src_dir_pos == umax)
 	{
@@ -642,14 +642,14 @@ void tar_object::save_directory(const std::string& target_path, utils::serial& a
 			// Optimization: avoid saving to list if this is not an evaluation call
 			if (is_null)
 			{
-				static_cast<fs::stat_t&>(entries.emplace_back()) = stat;
+				entries.push_back(stat);
 				entries.back().name = target_path;
 			}
 		}
 		else
 		{
 			stat = entries.back();
-			save_header(stat, entries.back().name);
+			save_header(stat, stat.name);
 		}
 
 		if (stat.is_directory)
@@ -694,11 +694,7 @@ void tar_object::save_directory(const std::string& target_path, utils::serial& a
 		}
 		else
 		{
-			fs::dir_entry entry{};
-			entry.name = target_path;
-			static_cast<fs::stat_t&>(entry) = stat;
-
-			save_file(entry, entry.name);
+			save_file(stat, target_path);
 		}
 
 		ar.breathe();

--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -855,6 +855,11 @@ int run_rpcs3(int argc, char** argv)
 
 	parser.process(app->arguments());
 
+	for (const auto& opt : parser.optionNames())
+	{
+		sys_log.notice("Option passed via command line: %s %s", opt, parser.value(opt));
+	}
+
 	// Don't start up the full rpcs3 gui if we just want the version or help.
 	if (parser.isSet(version_option) || parser.isSet(help_option))
 		return 0;
@@ -1182,12 +1187,9 @@ int run_rpcs3(int argc, char** argv)
 			{
 				main_window::InstallPackages(nullptr, {parser.value(installpkg_option)});
 			}
-		}
-	}
 
-	for (const auto& opt : parser.optionNames())
-	{
-		sys_log.notice("Option passed via command line: %s %s", opt, parser.value(opt));
+			return 0;
+		}
 	}
 
 	if (parser.isSet(arg_savestate))


### PR DESCRIPTION
- Gracefully exit after headless installation.
- Move parser option logging before parser usage
- Fix object slicing warning in tar_object::save_directory