### PR TITLE
cellMusic: fix occasional deadlock during auto-play in playlist mode

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellMusic.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.cpp
@@ -66,6 +66,7 @@ void fmt_class_string<CellMusic2Error>::format(std::string& out, u64 arg)
 
 struct music_state
 {
+public:
 	shared_mutex mutex;
 
 	vm::ptr<void(u32 event, vm::ptr<void> param, vm::ptr<void> userData)> func{};
@@ -99,17 +100,37 @@ struct music_state
 			switch (status)
 			{
 			case music_handler_base::player_status::end_of_media:
-				// Let's just play the next song for now
-				if (current_selection_context.content_type == CELL_SEARCH_CONTENTTYPE_MUSICLIST && handler->get_state() == CELL_MUSIC_PB_STATUS_PLAY)
-				{
-					if (const error_code error = set_playback_command(CELL_MUSIC_PB_CMD_NEXT, true))
-					{
-						cellMusic.error("Failed to play next track. error=0x%x", +error);
-					}
-				}
+				// Let's just play the next song for now if we are in list mode.
+				// Due to potential main thread recursion this may cause a deadlock with the internal mutex of the handler.
+				// Let's just call it from another thread instead.
+				m_wake_up_thread = 1;
+				m_wake_up_thread.notify_one();
 				break;
 			default:
 				return;
+			}
+		});
+
+		m_thread = std::make_unique<named_thread<std::function<void()>>>("cellMusic State", [this]()
+		{
+			while (thread_ctrl::state() != thread_state::aborting)
+			{
+				while (thread_ctrl::state() != thread_state::aborting && !m_wake_up_thread)
+				{
+					thread_ctrl::wait_on(m_wake_up_thread, 0);
+				}
+				m_wake_up_thread = 0;
+
+				if (thread_ctrl::state() == thread_state::aborting)
+				{
+					return;
+				}
+
+				// Play the next song
+				if (const error_code error = set_playback_command(CELL_MUSIC_PB_CMD_NEXT_TRACK))
+				{
+					cellMusic.error("Failed to play next track. error=0x%x", +error);
+				}
 			}
 		});
 	}
@@ -118,6 +139,19 @@ struct music_state
 		: music_state()
 	{
 		save(ar);
+	}
+
+	~music_state()
+	{
+		if (m_thread)
+		{
+			auto& thread = *m_thread;
+			thread = thread_state::aborting;
+			m_wake_up_thread = 1;
+			m_wake_up_thread.notify_one();
+			thread();
+			m_thread.reset();
+		}
 	}
 
 	void save(utils::serial& ar)
@@ -135,7 +169,7 @@ struct music_state
 	}
 
 	// NOTE: This function only uses CELL_MUSIC enums. CELL_MUSIC2 enums are identical.
-	error_code set_playback_command(s32 command, bool automatic = false)
+	error_code set_playback_command(u32 command)
 	{
 		switch (command)
 		{
@@ -150,11 +184,27 @@ struct music_state
 		case CELL_MUSIC_PB_CMD_FASTREVERSE:
 		case CELL_MUSIC_PB_CMD_NEXT:
 		case CELL_MUSIC_PB_CMD_PREV:
+		case CELL_MUSIC_PB_CMD_NEXT_TRACK:
 		{
 			std::string path;
+			bool automatic = false;
 			bool no_more_tracks = false;
 			{
 				std::lock_guard lock(mtx);
+
+				// Handle auto-play of the next track in the current playlist.
+				if (command == CELL_MUSIC_PB_CMD_NEXT_TRACK)
+				{
+					// We only auto-play the next song if we are in list mode and the music is playing.
+					if (current_selection_context.content_type != CELL_SEARCH_CONTENTTYPE_MUSICLIST || handler->get_state() != CELL_MUSIC_PB_STATUS_PLAY)
+					{
+						return CELL_OK;
+					}
+
+					command = CELL_MUSIC_PB_CMD_NEXT;
+					automatic = true;
+				}
+
 				const std::vector<std::string>& playlist = current_selection_context.playlist;
 				const u32 current_track = current_selection_context.current_track;
 				u32 next_track = current_track;
@@ -208,6 +258,10 @@ struct music_state
 
 		return CELL_OK;
 	}
+
+private:
+	std::unique_ptr<named_thread<std::function<void()>>> m_thread;
+	atomic_t<u32> m_wake_up_thread{0};
 };
 
 error_code cell_music_select_contents()

--- a/rpcs3/Emu/Cell/Modules/cellMusic.h
+++ b/rpcs3/Emu/Cell/Modules/cellMusic.h
@@ -90,6 +90,8 @@ enum
 	CELL_MUSIC_PB_CMD_PREV        = 4,
 	CELL_MUSIC_PB_CMD_FASTFORWARD = 5,
 	CELL_MUSIC_PB_CMD_FASTREVERSE = 6,
+
+	CELL_MUSIC_PB_CMD_NEXT_TRACK  = 7, // RPCS3 helper for auto-play of the next track in the current playlist
 };
 
 enum

--- a/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
@@ -387,6 +387,12 @@ error_code cellMusicDecodeSetDecodeCommand(s32 command)
 		return CELL_OK;
 	});
 
+	//sysutil_register_cb([&dec, command](ppu_thread& ppu) -> s32
+	//{
+	//	dec.func(ppu, CELL_MUSIC_DECODE_EVENT_STATUS_NOTIFICATION, vm::addr_t(command), dec.userData);
+	//	return CELL_OK;
+	//});
+
 	return CELL_OK;
 }
 

--- a/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
@@ -90,6 +90,7 @@ struct music_decode
 		case CELL_MUSIC_DECODE_CMD_PREV:
 		{
 			decoder.stop();
+			read_pos = 0;
 
 			if (decoder.set_next_index(command == CELL_MUSIC_DECODE_CMD_NEXT) == umax)
 			{
@@ -195,9 +196,10 @@ error_code cell_music_decode_read(vm::ptr<void> buf, vm::ptr<u32> startTime, u64
 
 	if (dec.decoder.m_size == 0)
 	{
-		return CELL_MUSIC_DECODE_ERROR_NO_LPCM_DATA;
+		return { CELL_MUSIC_DECODE_ERROR_NO_LPCM_DATA, "m_size == 0" };
 	}
 
+	ensure(dec.decoder.m_size >= dec.read_pos);
 	const u64 size_left = dec.decoder.m_size - dec.read_pos;
 
 	if (dec.read_pos == 0)
@@ -229,10 +231,10 @@ error_code cell_music_decode_read(vm::ptr<void> buf, vm::ptr<u32> startTime, u64
 
 	if (size_to_read == 0)
 	{
-		return CELL_MUSIC_DECODE_ERROR_NO_LPCM_DATA; // TODO: speculative
+		return { CELL_MUSIC_DECODE_ERROR_NO_LPCM_DATA, "size_to_read == 0" }; // TODO: speculative
 	}
 
-	std::memcpy(buf.get_ptr(), &dec.decoder.data[dec.read_pos], size_to_read);
+	std::memcpy(buf.get_ptr(), &::at32(dec.decoder.data, dec.read_pos), size_to_read);
 
 	if (size_to_read < reqSize)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicDecode.cpp
@@ -74,6 +74,7 @@ struct music_decode
 			cellMusicDecode.notice("set_decode_command(START): context: %s", current_selection_context.to_string());
 
 			music_selection_context context = current_selection_context;
+			context.current_track = context.first_track;
 
 			for (usz i = 0; i < context.playlist.size(); i++)
 			{

--- a/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
@@ -287,7 +287,7 @@ u32 music_selection_context::step_track(bool next)
 		return umax;
 	}
 
-	const std::string last_track = ::at32(playlist, current_track);
+	const std::string last_track = (current_track < playlist.size()) ? playlist[current_track] : "";
 
 	switch (repeat_mode)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
@@ -267,9 +267,10 @@ void music_selection_context::set_track(std::string_view track)
 
 	for (usz i = 0; i < playlist.size(); i++)
 	{
-		cellMusicSelectionContext.error("set_track: Comparing track '%s' vs '%s'", track, playlist[i]);
+		cellMusicSelectionContext.notice("set_track: Comparing track '%s' vs '%s'", track, playlist[i]);
 		if (track.ends_with(playlist[i]))
 		{
+			cellMusicSelectionContext.notice("set_track: Found track '%s': '%s'", track, playlist[i]);
 			first_track = current_track = static_cast<u32>(i);
 			return;
 		}

--- a/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
@@ -301,7 +301,7 @@ u32 music_selection_context::step_track(bool next)
 			{
 				// We are at the end of the playlist.
 				cellMusicSelectionContext.notice("step_track: No more tracks to play in playlist...");
-				current_track = umax;
+				current_track = playlist.size() - 1; // NOTE: We could use size instead of size - 1 to allow to use PREV to play the last track again.
 				return umax;
 			}
 		}

--- a/rpcs3/util/logs.cpp
+++ b/rpcs3/util/logs.cpp
@@ -257,10 +257,8 @@ namespace logs
 		{
 			return found.first->second->enabled.observe();
 		}
-		else
-		{
-			return level::always;
-		}
+
+		return level::always;
 	}
 
 	void set_channel_levels(const std::map<std::string, logs::level, std::less<>>& map)

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -477,6 +477,8 @@ namespace utils
 
 	void audio_decoder::clear()
 	{
+		media_log.notice("audio_decoder: Clear data...");
+
 		track_fully_decoded = 0;
 		track_fully_consumed = 0;
 		has_error = false;
@@ -487,6 +489,8 @@ namespace utils
 
 	void audio_decoder::stop()
 	{
+		media_log.notice("audio_decoder: Stop decoding...");
+
 		if (m_thread)
 		{
 			auto& thread = *m_thread;
@@ -695,7 +699,7 @@ namespace utils
 					if (buffer)
 						av_freep(&buffer);
 
-					media_log.notice("audio_decoder: decoded frame_count=%d buffer_size=%d timestamp_us=%d", frame_count, buffer_size, av.audio.frame->best_effort_timestamp);
+					media_log.trace("audio_decoder: decoded frame_count=%d buffer_size=%d timestamp_us=%d", frame_count, buffer_size, av.audio.frame->best_effort_timestamp);
 				}
 			}
 		};

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -465,7 +465,7 @@ namespace utils
 		stop();
 	}
 
-	void audio_decoder::set_context(music_selection_context context)
+	void audio_decoder::set_context(music_selection_context&& context)
 	{
 		m_context = std::move(context);
 	}
@@ -714,8 +714,6 @@ namespace utils
 				return;
 			}
 
-			m_context.current_track = m_context.first_track;
-
 			if (m_context.context_option == CELL_SEARCH_CONTEXTOPTION_SHUFFLE && m_context.playlist.size() > 1)
 			{
 				// Shuffle once if necessary
@@ -740,8 +738,12 @@ namespace utils
 
 				// Let's only decode one track at a time. Wait for the consumer to finish reading the track.
 				media_log.notice("audio_decoder: waiting until track is consumed...");
-				thread_ctrl::wait_on(track_fully_consumed, 0);
-				track_fully_consumed = false;
+
+				while (thread_ctrl::state() != thread_state::aborting && !track_fully_consumed)
+				{
+					thread_ctrl::wait_on(track_fully_consumed, 0);
+				}
+				track_fully_consumed = 0;
 			}
 
 			media_log.notice("audio_decoder: finished playlist");

--- a/rpcs3/util/media_utils.h
+++ b/rpcs3/util/media_utils.h
@@ -63,7 +63,7 @@ namespace utils
 		audio_decoder();
 		~audio_decoder();
 
-		void set_context(music_selection_context context);
+		void set_context(music_selection_context&& context);
 		void set_swap_endianness(bool swapped);
 		void clear();
 		void stop();


### PR DESCRIPTION
- Fixes occasional deadlock in NFS: Hot Pursuit and NFS: Rivals when using custom music.
- Fix playlist out of bounds exception in music_selection_context::step_track.
- These bugs were introduced in #18812
- cellMusicDecode: Fix read position on prev/next track
- cellMusicDecode: Fix track selection on prev/next track