### PR TITLE
fix some flickering

### DIFF
--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -1539,7 +1539,17 @@ namespace rsx
 			}
 		}
 
-		if (depth_buffer_unused)
+		// A draw with no colour target and depth-test disabled, but with an active ZPASS occlusion
+		// query, must still rasterize against the bound depth buffer so the query produces a pixel
+		// count (e.g. the light/torch occlusion coronas in Resistance 3). Otherwise the depth buffer
+		// is dropped here, no attachment remains, the draw is discarded below ("Framebuffer setup
+		// failed") and the query returns no data - making the light flicker, which precise_zpass_count
+		// cannot mask. Keeping the resolved depth surface bound turns this into a (read-only, since
+		// depth writes are off) depth-only framebuffer, an already-supported configuration.
+		const bool keep_depth_for_query = depth_buffer_unused && color_buffer_unused && layout.zeta_address &&
+			!!method_registers.registers[NV4097_SET_ZPASS_PIXEL_COUNT_ENABLE];
+
+		if (depth_buffer_unused && !keep_depth_for_query)
 		{
 			layout.zeta_address = 0;
 		}


### PR DESCRIPTION
This PR is based on a deep and iterative analysis from new Opus 4.8 applied to the regressing PR #18019 causing flickering on some games, e.g. on some light sources in Resistance 3 as reported in #18026.
Apparently this PR fully fixes the issue in Resistance 3 for both Vulkan and OpenGL and for any zcull variant (`Precise`, `Approximate` and `Relaxed`).
Apparently the PR doesn't cause any performance drop or regression on any games I tested.
If confirmed by main developers as proper fix, hopefully it fixes some other games.

### NOTE:
In Resistance 3, flickering on light sources was always present (at least on my nvidia GTX 970, RTX 4060 and RTX 5090) with zcull set to `Precise` since that variant was added some years ago. For some reasons, the flickering was not present with variants `Approximate` and `Relaxed`. PR #18019 fixed the light through objects issue (for all three zcull variants) but introduced the flickering also for `Approximate` and `Relaxed`. All this information have been provided to Opus 4.8 and a lot of instrumented logs, rrc files have been analyzed before converging to the provided solution.

When the flickering was present, the following message was constantly present:

`·W 0:01:14.068539 {RSX [0x34e7e74]} RSX: Framebuffer setup failed. Draw calls may have been lost`

With this PR, this message is no more present
