### PR TITLE
Force a supported video renderer if the selected renderer is unsupported

### DIFF
--- a/Utilities/Config.h
+++ b/Utilities/Config.h
@@ -717,6 +717,11 @@ namespace cfg
 			m_value = std::string(value);
 			return true;
 		}
+
+		void set(std::string_view value)
+		{
+			m_value = std::string(value);
+		}
 	};
 
 	// Simple set entry (TODO: template for various types)

--- a/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicSelectionContext.cpp
@@ -301,7 +301,7 @@ u32 music_selection_context::step_track(bool next)
 			{
 				// We are at the end of the playlist.
 				cellMusicSelectionContext.notice("step_track: No more tracks to play in playlist...");
-				current_track = playlist.size() - 1; // NOTE: We could use size instead of size - 1 to allow to use PREV to play the last track again.
+				current_track = ::size32(playlist) - 1; // NOTE: We could use size instead of size - 1 to allow to use PREV to play the last track again.
 				return umax;
 			}
 		}
@@ -312,7 +312,6 @@ u32 music_selection_context::step_track(bool next)
 			{
 				// We are at the start of the playlist.
 				cellMusicSelectionContext.notice("step_track: No more tracks to play in playlist...");
-				current_track = umax;
 				return umax;
 			}
 
@@ -337,7 +336,7 @@ u32 music_selection_context::step_track(bool next)
 			// Play the previous track. Start with the last track if we reached the start of the playlist.
 			if (current_track == 0)
 			{
-				current_track = ::narrow<u32>(playlist.size() - 1);
+				current_track = ::size32(playlist) - 1;
 			}
 			else
 			{

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -121,7 +121,8 @@ namespace rsx
 }
 
 Emulator::Emulator() noexcept
-	: m_default_renderer(video_renderer::null)
+	: m_supported_renderers({video_renderer::null})
+	, m_default_renderer(video_renderer::null)
 {
 	s_emulator_available = true;
 }
@@ -301,6 +302,15 @@ static void fixup_settings(const psf::registry* _psf)
 		{
 			sys_log.warning("The music handler '%s' is currently not supported in headless mode and will therefore be set to '%s'.", g_cfg.audio.music.get(), music_handler::null);
 			g_cfg.audio.music.set(music_handler::null);
+		}
+	}
+	else
+	{
+		// Make sure we have a valid renderer
+		if (!Emu.GetSupportedRenderers().contains(g_cfg.video.renderer.get()))
+		{
+			sys_log.warning("The video renderer '%s' is not supported on this device and will therefore be set to '%s'.", g_cfg.video.renderer.get(), Emu.GetDefaultRenderer());
+			g_cfg.video.renderer.set(Emu.GetDefaultRenderer());
 		}
 	}
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -279,9 +279,32 @@ void init_fxo_for_exec(utils::serial* ar, bool full = false)
 	}
 }
 
-// Some settings are not allowed in certain PPU decoders
+// Some settings are not allowed with certain conditions
 static void fixup_settings(const psf::registry* _psf)
 {
+	// Disable some incompatible settings in headless mode
+	if (Emu.IsHeadless())
+	{
+		if (g_cfg.video.renderer != video_renderer::null)
+		{
+			sys_log.warning("The video renderer '%s' is currently not supported in headless mode and will therefore be set to '%s'.", g_cfg.video.renderer.get(), video_renderer::null);
+			g_cfg.video.renderer.set(video_renderer::null);
+		}
+
+		if (g_cfg.io.camera == camera_handler::qt)
+		{
+			sys_log.warning("The camera handler '%s' is currently not supported in headless mode and will therefore be set to '%s'.", g_cfg.io.camera.get(), camera_handler::null);
+			g_cfg.io.camera.set(camera_handler::null);
+		}
+
+		if (g_cfg.audio.music == music_handler::qt)
+		{
+			sys_log.warning("The music handler '%s' is currently not supported in headless mode and will therefore be set to '%s'.", g_cfg.audio.music.get(), music_handler::null);
+			g_cfg.audio.music.set(music_handler::null);
+		}
+	}
+
+	// Some settings are not allowed in certain PPU decoders
 	if (g_cfg.core.ppu_decoder != ppu_decoder_type::_static)
 	{
 		if (g_cfg.core.ppu_use_nj_bit)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -475,11 +475,11 @@ void Emulator::Init()
 	g_cfg.name.clear();
 
 	// Not all renderers are known at compile time, so set a provided default if possible
-	if (m_default_renderer == video_renderer::vulkan && !m_default_graphics_adapter.empty())
-	{
-		g_cfg.video.renderer.set(m_default_renderer);
-		g_cfg.video.vk.adapter.from_string(m_default_graphics_adapter);
-	}
+	// TODO: Also initialize render_creator in headless mode
+	ensure(m_supported_renderers.contains(m_default_renderer));
+	ensure(!(m_default_renderer == video_renderer::vulkan && m_default_graphics_adapter.empty()));
+	g_cfg.video.renderer.set(m_default_renderer);
+	g_cfg.video.vk.adapter.set(m_default_graphics_adapter);
 
 	g_cfg_defaults = g_cfg.to_string();
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -475,7 +475,6 @@ void Emulator::Init()
 	g_cfg.name.clear();
 
 	// Not all renderers are known at compile time, so set a provided default if possible
-	// TODO: Also initialize render_creator in headless mode
 	ensure(m_supported_renderers.contains(m_default_renderer));
 	ensure(!(m_default_renderer == video_renderer::vulkan && m_default_graphics_adapter.empty()));
 	g_cfg.video.renderer.set(m_default_renderer);

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -172,6 +172,7 @@ class Emulator final
 
 	bool m_continuous_mode = false;
 	bool m_has_gui = true;
+	bool m_headless = false;
 	bool m_add_database_config = false;
 
 	bool m_state_inspection_savestate = false;
@@ -471,6 +472,9 @@ public:
 
 	bool HasGui() const { return m_has_gui; }
 	void SetHasGui(bool has_gui) { m_has_gui = has_gui; }
+
+	bool IsHeadless() const { return m_headless; }
+	void SetHeadless(bool headless) { m_headless = headless; }
 
 	void SetDefaultRenderer(video_renderer renderer) { m_default_renderer = renderer; }
 	void SetDefaultGraphicsAdapter(std::string adapter) { m_default_graphics_adapter = std::move(adapter); }

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -142,6 +142,7 @@ class Emulator final
 
 	games_config m_games_config;
 
+	std::set<video_renderer> m_supported_renderers;
 	video_renderer m_default_renderer;
 	std::string m_default_graphics_adapter;
 
@@ -476,6 +477,10 @@ public:
 	bool IsHeadless() const { return m_headless; }
 	void SetHeadless(bool headless) { m_headless = headless; }
 
+	const std::set<video_renderer>& GetSupportedRenderers() const { return m_supported_renderers; }
+	void SetSupportedRenderers(std::set<video_renderer> renderers) { m_supported_renderers = std::move(renderers); }
+
+	video_renderer GetDefaultRenderer() const { return m_default_renderer; }
 	void SetDefaultRenderer(video_renderer renderer) { m_default_renderer = renderer; }
 	void SetDefaultGraphicsAdapter(std::string adapter) { m_default_graphics_adapter = std::move(adapter); }
 

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -24,7 +24,7 @@ headless_application::headless_application(int& argc, char** argv) : QCoreApplic
 bool headless_application::Init()
 {
 	// Force init the emulator
-	InitializeEmulator(m_active_user.empty() ? "00000001" : m_active_user, false);
+	InitializeEmulator(m_active_user.empty() ? "00000001" : m_active_user, false, true);
 
 	// Create callbacks from the emulator, which reference the handlers.
 	InitializeCallbacks();

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -45,6 +45,7 @@
 #include <thread>
 
 LOG_CHANNEL(sys_log, "SYS");
+LOG_CHANNEL(cfg_log, "CFG");
 
 namespace audio
 {
@@ -59,6 +60,36 @@ namespace rsx::overlays
 }
 
 extern void qt_events_aware_op(int repeat_duration_ms, std::function<bool()> wrapped_op);
+
+main_application::main_application()
+	: m_render_creator(std::make_shared<render_creator>())
+{
+	std::set<video_renderer> supported_renderers;
+	supported_renderers.insert(video_renderer::null);
+
+	if (m_render_creator->OpenGL.supported)
+	{
+		supported_renderers.insert(video_renderer::opengl);
+	}
+
+	// Make Vulkan default setting if it is supported
+	if (m_render_creator->Vulkan.supported && !m_render_creator->Vulkan.adapters.empty())
+	{
+		const std::string adapter = ::at32(m_render_creator->Vulkan.adapters, 0).toStdString();
+		cfg_log.notice("Setting the default renderer to Vulkan. Default GPU: '%s'", adapter);
+		Emu.SetDefaultRenderer(video_renderer::vulkan);
+		Emu.SetDefaultGraphicsAdapter(adapter);
+
+		supported_renderers.insert(video_renderer::vulkan);
+	}
+	else if (m_render_creator->OpenGL.supported)
+	{
+		cfg_log.notice("Setting the default renderer to OpenGl");
+		Emu.SetDefaultRenderer(video_renderer::opengl);
+	}
+
+	Emu.SetSupportedRenderers(supported_renderers);
+}
 
 /** Emu.Init() wrapper for user management */
 void main_application::InitializeEmulator(const std::string& user, bool show_gui, bool headless)

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -61,9 +61,10 @@ namespace rsx::overlays
 extern void qt_events_aware_op(int repeat_duration_ms, std::function<bool()> wrapped_op);
 
 /** Emu.Init() wrapper for user management */
-void main_application::InitializeEmulator(const std::string& user, bool show_gui)
+void main_application::InitializeEmulator(const std::string& user, bool show_gui, bool headless)
 {
 	Emu.SetHasGui(show_gui);
+	Emu.SetHeadless(headless);
 	Emu.SetUsr(user);
 	Emu.Init();
 

--- a/rpcs3/main_application.h
+++ b/rpcs3/main_application.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "rpcs3qt/render_creator.h"
+
 #include <string>
 #include <QThread>
 
@@ -9,6 +11,8 @@ class gs_frame;
 class main_application
 {
 public:
+	main_application();
+
 	virtual bool Init() = 0;
 
 	static void InitializeEmulator(const std::string& user, bool show_gui, bool headless);
@@ -25,6 +29,7 @@ protected:
 
 	EmuCallbacks CreateCallbacks();
 
+	std::shared_ptr<render_creator> m_render_creator;
 	std::string m_active_user;
 	gs_frame* m_game_window = nullptr;
 };

--- a/rpcs3/main_application.h
+++ b/rpcs3/main_application.h
@@ -11,7 +11,7 @@ class main_application
 public:
 	virtual bool Init() = 0;
 
-	static void InitializeEmulator(const std::string& user, bool show_gui);
+	static void InitializeEmulator(const std::string& user, bool show_gui, bool headless);
 
 	void SetActiveUser(const std::string& user)
 	{

--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -425,9 +425,6 @@
     <ClCompile Include="QTGeneratedFiles\Debug\moc_register_editor_dialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="QTGeneratedFiles\Debug\moc_render_creator.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-    </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Debug\moc_clans_settings_dialog.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -735,9 +732,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_register_editor_dialog.cpp">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="QTGeneratedFiles\Release\moc_render_creator.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="QTGeneratedFiles\Release\moc_clans_settings_dialog.cpp">
@@ -1471,16 +1465,7 @@
     </CustomBuild>
     <ClInclude Include="rpcs3qt\custom_tree_widget.h" />
     <ClInclude Include="rpcs3qt\emu_settings_type.h" />
-    <CustomBuild Include="rpcs3qt\render_creator.h">
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtCore" "-I.\debug" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtConcurrent"</Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Moc%27ing %(Identity)...</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions) "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtConcurrent"</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>
-    </CustomBuild>
+    <ClInclude Include="rpcs3qt\render_creator.h" />
     <ClInclude Include="rpcs3qt\flow_layout.h" />
     <CustomBuild Include="rpcs3qt\flow_widget.h">
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Moc%27ing %(Identity)...</Message>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -858,12 +858,6 @@
     <ClCompile Include="rpcs3qt\render_creator.cpp">
       <Filter>Gui\settings</Filter>
     </ClCompile>
-    <ClCompile Include="QTGeneratedFiles\Debug\moc_render_creator.cpp">
-      <Filter>Generated Files\Debug</Filter>
-    </ClCompile>
-    <ClCompile Include="QTGeneratedFiles\Release\moc_render_creator.cpp">
-      <Filter>Generated Files\Release</Filter>
-    </ClCompile>
     <ClCompile Include="rpcs3qt\config_adapter.cpp">
       <Filter>Gui\settings</Filter>
     </ClCompile>

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -118,6 +118,11 @@ bool emu_settings::Init()
 
 		supported_renderers.insert(video_renderer::vulkan);
 	}
+	else if (m_render_creator->OpenGL.supported)
+	{
+		cfg_log.notice("Setting the default renderer to OpenGl");
+		Emu.SetDefaultRenderer(video_renderer::opengl);
+	}
 
 	Emu.SetSupportedRenderers(supported_renderers);
 

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -100,21 +100,28 @@ bool emu_settings::Init()
 {
 	m_render_creator = new render_creator(this);
 
-	if (m_render_creator->abort_requested)
+	std::set<video_renderer> supported_renderers;
+	supported_renderers.insert(video_renderer::null);
+
+	if (m_render_creator->OpenGL.supported)
 	{
-		return false;
+		supported_renderers.insert(video_renderer::opengl);
 	}
 
 	// Make Vulkan default setting if it is supported
-	if (m_render_creator->Vulkan.supported && !m_render_creator->Vulkan.adapters.empty())
+	if (!m_render_creator->abort_requested && m_render_creator->Vulkan.supported && !m_render_creator->Vulkan.adapters.empty())
 	{
 		const std::string adapter = ::at32(m_render_creator->Vulkan.adapters, 0).toStdString();
 		cfg_log.notice("Setting the default renderer to Vulkan. Default GPU: '%s'", adapter);
 		Emu.SetDefaultRenderer(video_renderer::vulkan);
 		Emu.SetDefaultGraphicsAdapter(adapter);
+
+		supported_renderers.insert(video_renderer::vulkan);
 	}
 
-	return true;
+	Emu.SetSupportedRenderers(supported_renderers);
+
+	return !m_render_creator->abort_requested;
 }
 
 void emu_settings::LoadSettings(const std::string& title_id, bool create_config_from_global, const std::string& db_config)

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -91,42 +91,10 @@ namespace
 	}
 }
 
-emu_settings::emu_settings()
+emu_settings::emu_settings(std::shared_ptr<render_creator> r_creator)
 	: QObject()
+	, m_render_creator(ensure(r_creator))
 {
-}
-
-bool emu_settings::Init()
-{
-	m_render_creator = new render_creator(this);
-
-	std::set<video_renderer> supported_renderers;
-	supported_renderers.insert(video_renderer::null);
-
-	if (m_render_creator->OpenGL.supported)
-	{
-		supported_renderers.insert(video_renderer::opengl);
-	}
-
-	// Make Vulkan default setting if it is supported
-	if (!m_render_creator->abort_requested && m_render_creator->Vulkan.supported && !m_render_creator->Vulkan.adapters.empty())
-	{
-		const std::string adapter = ::at32(m_render_creator->Vulkan.adapters, 0).toStdString();
-		cfg_log.notice("Setting the default renderer to Vulkan. Default GPU: '%s'", adapter);
-		Emu.SetDefaultRenderer(video_renderer::vulkan);
-		Emu.SetDefaultGraphicsAdapter(adapter);
-
-		supported_renderers.insert(video_renderer::vulkan);
-	}
-	else if (m_render_creator->OpenGL.supported)
-	{
-		cfg_log.notice("Setting the default renderer to OpenGl");
-		Emu.SetDefaultRenderer(video_renderer::opengl);
-	}
-
-	Emu.SetSupportedRenderers(supported_renderers);
-
-	return !m_render_creator->abort_requested;
 }
 
 void emu_settings::LoadSettings(const std::string& title_id, bool create_config_from_global, const std::string& db_config)

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -35,9 +35,7 @@ public:
 	/** Creates a settings object which reads in the config.yml file at rpcs3/bin/%path%/config.yml
 	* Settings are only written when SaveSettings is called.
 	*/
-	emu_settings();
-
-	bool Init();
+	emu_settings(std::shared_ptr<render_creator> r_creator);
 
 	/** Connects a combo box with the target settings type*/
 	void EnhanceComboBox(QComboBox* combobox, emu_settings_type type, bool is_ranged = false, bool use_max = false, int max = 0, bool sorted = false, bool strict = true);
@@ -94,7 +92,7 @@ public:
 	emu_settings_type FindSettingsType(const cfg::_base* node) const;
 
 	/** Gets all the renderer info for gpu settings.*/
-	render_creator* m_render_creator = nullptr;
+	std::shared_ptr<render_creator> m_render_creator;
 
 	/** Gets a list of all the microphones available.*/
 	microphone_creator m_microphone_creator;

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -152,7 +152,7 @@ bool gui_application::Init()
 	}
 
 	// Force init the emulator
-	InitializeEmulator(m_active_user, m_show_gui);
+	InitializeEmulator(m_active_user, m_show_gui, false);
 
 	// Create callbacks from the emulator, which reference the handlers.
 	InitializeCallbacks();

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -126,14 +126,34 @@ bool gui_application::Init()
 		}
 	}
 
-	m_emu_settings = std::make_shared<emu_settings>();
+	if (m_render_creator->vulkan_timed_out)
+	{
+		gui_log.error("Vulkan device enumeration timed out");
+		const auto button = QMessageBox::critical(nullptr, tr("Vulkan Check Timeout"),
+			tr("Querying for Vulkan-compatible devices is taking too long. This is usually caused by malfunctioning "
+				"graphics drivers, reinstalling them could fix the issue.\n\n"
+				"Selecting ignore starts the emulator without Vulkan support."),
+			QMessageBox::Ignore | QMessageBox::Abort, QMessageBox::Abort);
+
+		if (button != QMessageBox::Ignore)
+		{
+			return false;
+		}
+	}
+
+#ifdef __APPLE__
+	if (!m_render_creator->Vulkan.supported)
+	{
+		QMessageBox::warning(nullptr,
+							 tr("Warning"),
+							 tr("Vulkan is not supported on this Mac.\n"
+								"No graphics will be rendered."));
+	}
+#endif
+
+	m_emu_settings = std::make_shared<emu_settings>(m_render_creator);
 	m_gui_settings = std::make_shared<gui_settings>();
 	m_persistent_settings = std::make_shared<persistent_settings>();
-
-	if (!m_emu_settings->Init())
-	{
-		return false;
-	}
 
 	if (m_gui_settings->GetValue(gui::m_attachCommandLine).toBool())
 	{

--- a/rpcs3/rpcs3qt/render_creator.cpp
+++ b/rpcs3/rpcs3qt/render_creator.cpp
@@ -1,7 +1,5 @@
 #include "render_creator.h"
 
-#include <QMessageBox>
-
 #include "Utilities/Thread.h"
 
 #if defined(HAVE_VULKAN)
@@ -15,7 +13,7 @@
 
 LOG_CHANNEL(cfg_log, "CFG");
 
-render_creator::render_creator(QObject *parent) : QObject(parent)
+render_creator::render_creator()
 {
 #if defined(HAVE_VULKAN)
 	// Some drivers can get stuck when checking for vulkan-compatible gpus, f.ex. if they're waiting for one to get
@@ -73,21 +71,8 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 	}())
 	{
 		enum_thread.release(); // Detach thread (destructor is not called)
-
-		cfg_log.error("Vulkan device enumeration timed out");
-		const auto button = QMessageBox::critical(nullptr, tr("Vulkan Check Timeout"),
-			tr("Querying for Vulkan-compatible devices is taking too long. This is usually caused by malfunctioning "
-				"graphics drivers, reinstalling them could fix the issue.\n\n"
-				"Selecting ignore starts the emulator without Vulkan support."),
-			QMessageBox::Ignore | QMessageBox::Abort, QMessageBox::Abort);
-
-		if (button != QMessageBox::Ignore)
-		{
-			abort_requested = true;
-			return;
-		}
-
 		supports_vulkan = false;
+		vulkan_timed_out = true;
 	}
 	else
 	{
@@ -103,14 +88,6 @@ render_creator::render_creator(QObject *parent) : QObject(parent)
 
 #ifdef __APPLE__
 	OpenGL.supported = false;
-
-	if (!Vulkan.supported)
-	{
-		QMessageBox::warning(nullptr,
-							 tr("Warning"),
-							 tr("Vulkan is not supported on this Mac.\n"
-								"No graphics will be rendered."));
-	}
 #endif
 
 	renderers = { &Vulkan, &OpenGL, &NullRender };

--- a/rpcs3/rpcs3qt/render_creator.h
+++ b/rpcs3/rpcs3qt/render_creator.h
@@ -2,16 +2,13 @@
 
 #include "emu_settings_type.h"
 
-#include <QObject>
 #include <QString>
 #include <QStringList>
 
-class render_creator : public QObject
+class render_creator
 {
-	Q_OBJECT
-
 public:
-	render_creator(QObject* parent);
+	render_creator();
 
 	void update_names(const QStringList& names);
 
@@ -33,7 +30,7 @@ public:
 			, supported(supported) {}
 	};
 
-	bool abort_requested = false;
+	bool vulkan_timed_out = false;
 	bool supports_vulkan = false;
 	QStringList vulkan_adapters;
 	render_info Vulkan;

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -370,7 +370,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	//   | |__| | |    | |__| |    | | (_| | |_) |
 	//    \_____|_|     \____/     |_|\__,_|_.__/
 
-	render_creator* r_creator = m_emu_settings->m_render_creator;
+	std::shared_ptr<render_creator> r_creator = m_emu_settings->m_render_creator;
 
 	if (!r_creator)
 	{

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -365,7 +365,7 @@ void user_manager_dialog::OnUserLogin()
 	const u32 key = GetUserKey();
 	const std::string new_user = m_user_list[key].GetUserId();
 
-	main_application::InitializeEmulator(new_user, Emu.HasGui());
+	main_application::InitializeEmulator(new_user, Emu.HasGui(), Emu.IsHeadless());
 
 	m_active_user = new_user;
 	m_persistent_settings->SetValue(gui::persistent::active_user, QString::fromStdString(m_active_user));


### PR DESCRIPTION
- Set OpenGl as default renderer if vulkan is not supported.
This prevents saving Vulkan to config.yml during initial boot if not supported.
This was a regression from setting the default renderer to vulkan in system_config.h
- Initialize render_creator in main_application as non-Qt object.
This now also sets the supported renderers in headless mode.
- Force video renderer to default renderer if not supported.
- Force disable some incompatible settings in headless mode.
- cellMusic/Decode: don't set current_track to umax on prev (prevent potential OOB access).

fixes #18821