### PR TITLE
Remove duplicated code in VKShaderInterpreter.cpp

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -148,11 +148,6 @@ namespace vk
 			vk_prog->binding_table.cbuf_location = location++;
 		}
 
-		if (vk::emulate_conditional_rendering())
-		{
-			vk_prog->binding_table.cr_pred_buffer_location = location++;
-		}
-
 		// Return next index
 		return location;
 	}


### PR DESCRIPTION
Remove a duplicated code creating an unused slot (e.g. 0,1,2,3,4,5,7)