### PR TITLE
Add "Enable Mouse-based Gyro" setting to I/O config

### DIFF
--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -295,6 +295,7 @@ struct cfg_root : cfg::node
 		cfg::_bool lock_overlay_input_to_player_one{this, "Lock overlay input to player one", false, true};
 		cfg::string midi_devices{this, "Emulated Midi devices", "Keyboardßßß@@@Keyboardßßß@@@Keyboardßßß@@@"};
 		cfg::_bool load_sdl_mappings{ this, "Load SDL GameController Mappings", true };
+		cfg::_bool mouse_based_gyro_enabled{ this, "Mouse-based gyro enabled", false, true };
 		cfg::_bool pad_debug_overlay{ this, "IO Debug overlay", false, true };
 		cfg::_bool mouse_debug_overlay{ this, "Mouse Debug overlay", false, true };
 		cfg::uint<1, 180> fake_move_rotation_cone_h{ this, "Fake Move Rotation Cone", 10, true };

--- a/rpcs3/Input/mouse_gyro_handler.cpp
+++ b/rpcs3/Input/mouse_gyro_handler.cpp
@@ -26,6 +26,12 @@ bool mouse_gyro_handler::toggle_enabled()
 	return m_enabled;
 }
 
+void mouse_gyro_handler::set_enabled(bool enabled)
+{
+	m_enabled = enabled;
+	clear();
+}
+
 void mouse_gyro_handler::set_gyro_active()
 {
 	gui_log.notice("Mouse-based gyro activated");

--- a/rpcs3/Input/mouse_gyro_handler.h
+++ b/rpcs3/Input/mouse_gyro_handler.h
@@ -13,6 +13,7 @@ class mouse_gyro_handler
 public:
 	void clear();
 	bool toggle_enabled();
+	void set_enabled(bool enabled);
 
 	void handle_event(QEvent* ev, const QWindow& win);
 	void apply_gyro(const std::shared_ptr<Pad>& pad);

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -83,6 +83,7 @@ void pad_thread::Init()
 
 	// Reset mouse-based gyro state
 	m_mouse_gyro.clear();
+	m_mouse_gyro.set_enabled(g_cfg.io.mouse_based_gyro_enabled.get());
 
 	// Cache old settings if possible
 	std::array<pad_setting, CELL_PAD_MAX_PORT_NUM> pad_settings;

--- a/rpcs3/Input/pad_thread.cpp
+++ b/rpcs3/Input/pad_thread.cpp
@@ -82,7 +82,6 @@ void pad_thread::Init()
 	std::lock_guard lock(pad::g_pad_mutex);
 
 	// Reset mouse-based gyro state
-	m_mouse_gyro.clear();
 	m_mouse_gyro.set_enabled(g_cfg.io.mouse_based_gyro_enabled.get());
 
 	// Cache old settings if possible

--- a/rpcs3/rpcs3qt/emu_settings_type.cpp
+++ b/rpcs3/rpcs3qt/emu_settings_type.cpp
@@ -186,6 +186,7 @@ const std::map<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::GHLtar,                  get_cfg_location(local_cfg.io.ghltar) },
 	{ emu_settings_type::MidiDevices,             get_cfg_location(local_cfg.io.midi_devices) },
 	{ emu_settings_type::SDLMappings,             get_cfg_location(local_cfg.io.load_sdl_mappings) },
+	{ emu_settings_type::MouseBasedGyro,          get_cfg_location(local_cfg.io.mouse_based_gyro_enabled) },
 	{ emu_settings_type::IoDebugOverlay,          get_cfg_location(local_cfg.io.pad_debug_overlay) },
 	{ emu_settings_type::MouseDebugOverlay,       get_cfg_location(local_cfg.io.mouse_debug_overlay) },
 

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -178,6 +178,7 @@ enum class emu_settings_type
 	GHLtar,
 	MidiDevices,
 	SDLMappings,
+	MouseBasedGyro,
 	IoDebugOverlay,
 	MouseDebugOverlay,
 

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1243,6 +1243,9 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	ui->loadSdlMappings->setVisible(false);
 #endif
 
+	m_emu_settings->EnhanceCheckBox(ui->mouseBasedGyroBox, emu_settings_type::MouseBasedGyro);
+	SubscribeTooltip(ui->mouseBasedGyroBox, tooltips.settings.mouse_based_gyro);
+
 #ifndef _WIN32
 	// Remove raw mouse handler
 	remove_item(ui->mouseHandlerBox, static_cast<int>(mouse_handler::raw), static_cast<int>(g_cfg.io.mouse.def));

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -1842,6 +1842,13 @@
               </widget>
              </item>
              <item>
+              <widget class="QCheckBox" name="mouseBasedGyroBox">
+               <property name="text">
+                <string>Enable Mouse-based Gyro</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <spacer name="verticalSpacerIoAdditionalSettings">
                <property name="orientation">
                 <enum>Qt::Orientation::Vertical</enum>

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -255,6 +255,7 @@ public:
 		const QString show_move_cursor  = tr("Shows the raw position of the PS Move input.\nThis can be very helpful during calibration screens.");
 		const QString midi_devices      = tr("Select up to 3 emulated MIDI devices and their types.");
 		const QString sdl_mappings      = tr("Loads the SDL GameController database for improved gamepad compatibility. Only used in the SDL pad handler.");
+		const QString mouse_based_gyro  = tr("Enables mouse-based gyro emulation at game startup. It can also be toggled at any time with the associated hotkey.\nHold the right mouse button to activate gyro input: moving the mouse maps to the X and Z motion axes, and the scroll wheel maps to the Y axis. Release the button to reset the motion values.");
 
 		const QString lock_overlay_input_to_player_one  = tr("Locks the native overlay input to the first player.");
 


### PR DESCRIPTION
This is a continuation of my work on #18113.

Addresses issue #18197.

Adds a new checkbox in the I/O settings tab that enables mouse-based gyro emulation at game startup, making the feature more discoverable to users.
