### PR TITLE
SPU LLVM: Use 128-bit SVE2 for FMS

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -207,6 +207,16 @@ void cpu_translator::initialize(llvm::LLVMContext& context, llvm::ExecutionEngin
 	{
 		m_use_dotprod = true;
 	}
+
+	if (utils::has_sve() && utils::sve_length() == 128)
+	{
+		m_use_sve_128 = true;
+	}
+
+	if (utils::has_sve2() && utils::sve_length() == 128)
+	{
+		m_use_sve2_128 = true;
+	}
 #endif
 }
 

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -3123,6 +3123,10 @@ protected:
 
 	// Allow direct TBL2/TBX2 emission.
 	bool m_use_tbl2 = true;
+
+	bool m_use_sve_128 = false;
+
+	bool m_use_sve2_128 = false;
 #else
 	// Allow FMA
 	bool m_use_fma = false;
@@ -3746,6 +3750,45 @@ template <typename T1, typename T2, typename T3>
 
 		result.value = m_ir->CreateCall(get_intrinsic<u32[4]>(llvm::Intrinsic::aarch64_neon_umull), {data0, data1});
 		return result;
+	}
+
+	llvm::Value* to_sve_vector(llvm::Value* value)
+	{
+		if (llvm::isa<llvm::ScalableVectorType>(value->getType()))
+		{
+			return value;
+		}
+
+		const auto fixed_type = llvm::cast<llvm::FixedVectorType>(value->getType());
+		const auto scalable_type = llvm::ScalableVectorType::get(fixed_type->getElementType(), fixed_type->getNumElements());
+		return m_ir->CreateInsertVector(scalable_type, llvm::UndefValue::get(scalable_type), value, m_ir->getInt64(0));
+	}
+
+	llvm::Value* from_sve_vector(llvm::Value* value, llvm::FixedVectorType* fixed_type)
+	{
+		if (value->getType() == fixed_type)
+		{
+			return value;
+		}
+
+		return m_ir->CreateExtractVector(fixed_type, value, m_ir->getInt64(0));
+	}
+
+	llvm::Value* sve_ptrue(llvm::FixedVectorType* fixed_type)
+	{
+		const auto pred_type = llvm::ScalableVectorType::get(m_ir->getInt1Ty(), fixed_type->getNumElements());
+		return m_ir->CreateIntrinsic(llvm::Intrinsic::aarch64_sve_ptrue, {pred_type}, {m_ir->getInt32(31)});
+	}
+
+	llvm::Value* sve_fnmls(llvm::Value* acc, llvm::Value* lhs, llvm::Value* rhs)
+	{
+		const auto fixed_type = llvm::cast<llvm::FixedVectorType>(acc->getType());
+		const auto vacc = to_sve_vector(acc);
+		const auto vlhs = to_sve_vector(lhs);
+		const auto vrhs = to_sve_vector(rhs);
+		const auto result = m_ir->CreateIntrinsic(llvm::Intrinsic::aarch64_sve_fnmls, {vacc->getType()}, {sve_ptrue(fixed_type), vacc, vlhs, vrhs});
+
+		return from_sve_vector(result, fixed_type);
 	}
 	
 template <typename T1, typename T2>

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -8220,10 +8220,26 @@ public:
 
 			if (g_cfg.core.spu_xfloat_accuracy == xfloat_accuracy::approximate)
 			{
+#ifdef ARCH_ARM64
+				if (m_use_sve2_128)
+				{
+					const auto ca = eval(clamp_smax(a));
+					const auto cb = eval(clamp_smax(b));
+					return value<f32[4]>(sve_fnmls(c.value, ca.value, cb.value));
+				}
+#endif
+
 				return fma32x4(clamp_smax(a), clamp_smax(b), eval(-c));
 			}
 			else
 			{
+#ifdef ARCH_ARM64
+				if (m_use_sve2_128)
+				{
+					return value<f32[4]>(sve_fnmls(c.value, a.value, b.value));
+				}
+#endif
+
 				return fma32x4(a, b, eval(-c));
 			}
 		});

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -6,6 +6,7 @@
 
 #if defined(ARCH_ARM64)
 #include "Emu/CPU/Backends/AArch64/AArch64Common.h"
+#include <arm_sve.h>
 #endif
 #ifdef _WIN32
 #include "windows.h"
@@ -458,6 +459,19 @@ bool utils::has_sve2()
 		return IsProcessorFeaturePresent(PF_ARM_SVE2_INSTRUCTIONS_AVAILABLE) != 0;
 #endif
 	}();
+	return g_value;
+}
+
+#if defined(_MSC_VER)
+#define sve_func
+#else
+#define sve_func __attribute__((__target__("+sve")))
+#endif
+
+// svcntb returns sve length in bytes, our function retuns length in bits
+sve_func int utils::sve_length()
+{
+	static const int g_value = static_cast<int>(svcntb() * 8);
 	return g_value;
 }
 

--- a/rpcs3/util/sysinfo.hpp
+++ b/rpcs3/util/sysinfo.hpp
@@ -64,6 +64,8 @@ namespace utils
 	bool has_sve();
 
 	bool has_sve2();
+
+	int sve_length();
 #endif
 	std::string get_cpu_brand();
 


### PR DESCRIPTION
Saves one negate instruction over baseline neon. Unfortunately, we also need to materialize the ptrue constant. But that should be free in larger blocks.

Before:
```asm
0000000000003e60 <spu_FMS>:
    3e60:	2a1803e9 	mov	w9, w24
    3e64:	d3437ec8 	ubfx	x8, x22, #3, #29
    3e68:	6f044403 	mvni	v3.4s, #0x80, lsl #16
    3e6c:	110012b5 	add	w21, w21, #0x4
    3e70:	8a090108 	and	x8, x8, x9
    3e74:	3ce86b20 	ldr	q0, [x25, x8]
    3e78:	d34a7ec8 	ubfx	x8, x22, #10, #22
    3e7c:	8a090108 	and	x8, x8, x9
    3e80:	6ea0f864 	fneg	v4.4s, v3.4s
    3e84:	3ce86b21 	ldr	q1, [x25, x8]
    3e88:	531c6ec8 	lsl	w8, w22, #4
    3e8c:	8a090108 	and	x8, x8, x9
    3e90:	3ce86b22 	ldr	q2, [x25, x8]
    3e94:	d3517ec8 	ubfx	x8, x22, #17, #15
    3e98:	8a090108 	and	x8, x8, x9
    3e9c:	6ea36c00 	umin	v0.4s, v0.4s, v3.4s
    3ea0:	6ea36c21 	umin	v1.4s, v1.4s, v3.4s
    3ea4:	4ea46c00 	smin	v0.4s, v0.4s, v4.4s
    3ea8:	4ea46c21 	smin	v1.4s, v1.4s, v4.4s
    3eac:	6ea0f842 	fneg	v2.4s, v2.4s
    3eb0:	4e20cc22 	fmla	v2.4s, v1.4s, v0.4s
    3eb4:	3ca86b22 	str	q2, [x25, x8]
    3eb8:	d65f03c0 	ret
    3ebc:	97fff051 	bl	0 <spu_ret>
    3ec0:	d65f03c0 	ret
```
After
```asm
0000000000003e40 <spu_FMS>:
    3e40:       2a1803e9        mov     w9, w24
    3e44:       d3437ec8        ubfx    x8, x22, #3, #29
    3e48:       6f044403        mvni    v3.4s, #0x80, lsl #16
    3e4c:       2598e3e0        ptrue   p0.s
    3e50:       110012b5        add     w21, w21, #0x4
    3e54:       6ea0f864        fneg    v4.4s, v3.4s
    3e58:       8a090108        and     x8, x8, x9
    3e5c:       3ce86b20        ldr     q0, [x25, x8]
    3e60:       d34a7ec8        ubfx    x8, x22, #10, #22
    3e64:       8a090108        and     x8, x8, x9
    3e68:       3ce86b21        ldr     q1, [x25, x8]
    3e6c:       531c6ec8        lsl     w8, w22, #4
    3e70:       8a090108        and     x8, x8, x9
    3e74:       3ce86b22        ldr     q2, [x25, x8]
    3e78:       d3517ec8        ubfx    x8, x22, #17, #15
    3e7c:       8a090108        and     x8, x8, x9
    3e80:       6ea36c00        umin    v0.4s, v0.4s, v3.4s
    3e84:       6ea36c21        umin    v1.4s, v1.4s, v3.4s
    3e88:       4ea46c00        smin    v0.4s, v0.4s, v4.4s
    3e8c:       4ea46c21        smin    v1.4s, v1.4s, v4.4s
    3e90:       65a16002        fnmls   z2.s, p0/m, z0.s, z1.s
    3e94:       3ca86b22        str     q2, [x25, x8]
    3e98:       d65f03c0        ret
    3e9c:       97fff059        bl      0 <spu_ret>
    3ea0:       d65f03c0        ret
```

By the way, who named this instruction? FNMLS sounds like it's negate multiply subtract, but it's actually (-c + (a*b)), or in other words, it's a really strange way to write ((a*b) - c). Essentially, it's performing the negate that the old path was doing before executing FMLA. 

P.S. I stole the SVE length code from https://github.com/RPCS3/rpcs3/pull/18789
After one is merged I'll just rebase the other one.