### PR TITLE
HOTFIX: JIT/AArch64: advertise +i8mm to the LLVM target machine

### DIFF
--- a/Utilities/JITLLVM.cpp
+++ b/Utilities/JITLLVM.cpp
@@ -750,6 +750,15 @@ jit_compiler::jit_compiler(const std::unordered_map<std::string, u64>& _link, co
 	else
 		attributes.push_back("-dotprod");
 
+	// The recompilers emit i8mm intrinsics (e.g. ummla) gated on utils::has_i8mm().
+	// The JIT target features must advertise i8mm too, otherwise the backend fails
+	// with "Cannot select: intrinsic %llvm.aarch64.neon.ummla" whenever the resolved
+	// -mcpu does not already imply it (e.g. the cortex-a78 fallback on Apple silicon).
+	if (utils::has_i8mm())
+		attributes.push_back("+i8mm");
+	else
+		attributes.push_back("-i8mm");
+
 	if (utils::has_sve())
 		attributes.push_back("+sve");
 	else


### PR DESCRIPTION
### Problem
On AArch64 the PPU/SPU recompilers emit i8mm intrinsics (`ummla`/`smmla`, used by the SPU `GBB`/`GBH` gather paths) gated on `utils::has_i8mm()`. The JIT's target-feature (`MAttrs`) list, however, only mirrored `dotprod`/`sha3`/`sve` from HWCAP and never advertised `i8mm`.

When the resolved `-mcpu` does not already imply i8mm (e.g. the `cortex-a78` fallback used on Apple silicon under Linux), LLVM aborts codegen on the first SPU block that uses those instructions:

```
LLVM ERROR: Cannot select: intrinsic %llvm.aarch64.neon.ummla
```

This crashes the emulator at boot — effectively every game on affected hosts.

### Fix
Mirror `i8mm` into the JIT `MAttrs` list exactly like the neighbouring features, gated on the same `utils::has_i8mm()` that gates emitting the intrinsics, so the target machine always advertises what the recompilers emit.

### Testing
Apple M2 Pro/Max, Asahi Linux (aarch64), bundled LLVM 19. Before: instant `Cannot select … ummla` crash on boot. After: games boot and run (verified with LittleBigPlanet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
