### PR TITLE
cellAudio: fix _mxr000 surmixer event-queue key constant

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -1662,7 +1662,7 @@ error_code AudioSetNotifyEventQueue(ppu_thread& ppu, u64 key, u32 iFlags)
 	lv2_sleep(20, &ppu);
 
 	// Dirty hack for sound: confirm the creation of _mxr000 event queue by _cellsurMixerMain thread
-	constexpr u64 c_mxr000 = 0x8000cafe0246030;
+	constexpr u64 c_mxr000 = 0x8000cafe02460300;
 
 	if (key == c_mxr000 || key == 0)
 	{


### PR DESCRIPTION
The "Dirty hack for sound" in `AudioSetNotifyEventQueue()` is gated on a named constant `c_mxr000` that is supposed to equal the IPC key of the `_mxr000` event queue created by a game's `_cellsurMixerMain` thread (`0x8000cafe02460300`, used by SEGA AM2 / CRI `cellSurMixer` titles such as Virtua Fighter 5 FS).

When the inline literal was refactored into the named constant in 730badd37 (*"cellAudio: Move and partially fix _mxr000 hack"*) a trailing hex digit was dropped — `0x8000cafe0246030` instead of `0x8000cafe02460300` (the value the original 2018 hack in cc0d7c598 used). As a result `key == c_mxr000` never matches and `lv2_event_queue::find(c_mxr000)` looks up the wrong key, so the surmixer-queue serialization path has been effectively dead for every `_mxr000` CRI game since.

This restores the correct 16-digit key so the gate and lookup match the queue the game actually creates.

Note: this corrects a real latent bug but does not by itself resolve the broader cellSurMixer init issues some of these titles have.