### PR TITLE
Utilities: make thread priority hints actually work on Linux (nice)

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -3353,6 +3353,23 @@ void thread_ctrl::set_native_priority(int priority)
 	{
 		sig_log.error("SetThreadPriority() failed: %s", fmt::win_error{GetLastError(), nullptr});
 	}
+#elif defined(__linux__)
+	// Under the default SCHED_OTHER policy sched_priority is always 0, so adjusting it via
+	// pthread_setschedparam is a no-op on Linux — which silently defeated every scoped_priority
+	// hint in the codebase (compiler/background threads meant to yield, audio/RSX meant to be
+	// favored). SCHED_OTHER honors per-thread nice values instead, so use setpriority(). On
+	// Linux 'who == 0' targets the calling thread (per-task nice). Lowering priority (nice up)
+	// always succeeds; raising (nice down) needs CAP_SYS_NICE and is best-effort — ignore
+	// failure so unprivileged runs don't spam the log.
+	const int nice_val = priority < 0 ? std::min(19, -priority * 5)
+		: priority > 0 ? std::max(-20, -priority * 5)
+		: 0;
+
+	errno = 0;
+	if (setpriority(PRIO_PROCESS, 0, nice_val) != 0 && nice_val < 0 && errno != EACCES && errno != EPERM)
+	{
+		sig_log.error("setpriority() failed: %d", errno);
+	}
 #else
 	int policy;
 	struct sched_param param;

--- a/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUCommonRecompiler.cpp
@@ -8965,6 +8965,12 @@ struct spu_llvm_worker
 
 	void operator()()
 	{
+		// Run on-demand SPU compilation at low priority so it yields to the actively-executing
+		// PPU/SPU emulation threads. On a cold cache these workers would otherwise contend for all
+		// cores and slow down time-critical SPU init (e.g. VF5FS CRI audio) enough to miss in-game
+		// timeouts — most visible on core-limited machines (Apple silicon).
+		thread_ctrl::scoped_priority low_prio(-1);
+
 		// SPU LLVM Recompiler instance
 		std::unique_ptr<spu_recompiler_base> compiler;
 


### PR DESCRIPTION
### Problem
`thread_ctrl::set_native_priority()` adjusts `sched_priority` via `pthread_setschedparam()`. Under the default `SCHED_OTHER` policy `sched_priority` is always `0`, so on Linux the call is a **silent no-op**. Every `scoped_priority()` hint in the codebase is therefore dead on Linux:

- `low_prio(-1)` — SPU/PPU recompiler workers, shader/render setup, log writer (meant to yield)
- `high_prio(+1)` — `cellAudio`, `sys_rsxaudio`, RSX thread (meant to be favored)

All of them run at the same nice level, so the intended "background yields, latency-sensitive is favored" scheduling never happens on Linux.

### Change
Route the Linux path through per-thread `nice` (`setpriority`, `who == 0` = calling thread), which `SCHED_OTHER` honors:

- Lowering priority (nice up) always succeeds.
- Raising priority (nice down) needs `CAP_SYS_NICE` and is best-effort — `EACCES`/`EPERM` are ignored so unprivileged runs don't spam the log.

The Windows path and the generic POSIX fallback are unchanged.

Also gives the on-demand SPU LLVM compiler workers (`spu_llvm_worker`) the same `low_prio(-1)` the AOT cache builder already declares, so background compilation yields to actively-executing emulation.

### Effect
This makes the existing, intended priority design actually take effect on Linux. On core-limited machines (e.g. Apple silicon / Asahi) it noticeably reduces — though does not fully eliminate — cold-cache SPU-init timing failures where background compilation starves a time-critical SPU thread. It is a general scheduling-correctness fix, not specific to any title.