### PR TITLE
cellAudio: Fix _mxr000 event queue hack

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellAudio.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellAudio.cpp
@@ -1666,32 +1666,31 @@ error_code AudioSetNotifyEventQueue(ppu_thread& ppu, u64 key, u32 iFlags)
 
 	if (key == c_mxr000 || key == 0)
 	{
-		bool has_sur_mixer_thread = false;
-
-		for (usz count = 0; !lv2_event_queue::find(c_mxr000) && count < 100; count++)
+		const bool has_sur_mixer_thread = idm::select<named_thread<ppu_thread>>([&](u32 id, named_thread<ppu_thread>& test_ppu)
 		{
-			if (has_sur_mixer_thread || idm::select<named_thread<ppu_thread>>([&](u32 id, named_thread<ppu_thread>& test_ppu)
+			// Confirm thread existence
+			if (id == ppu.id)
 			{
-				// Confirm thread existence
-				if (id == ppu.id)
-				{
-					return false;
-				}
-
-				const auto ptr = test_ppu.ppu_tname.load();
-
-				if (!ptr)
-				{
-					return false;
-				}
-
-				return *ptr == "_cellsurMixerMain"sv;
-			}).ret)
-			{
-				has_sur_mixer_thread = true;
+				return false;
 			}
-			else
+
+			const auto ptr = test_ppu.ppu_tname.load();
+
+			if (!ptr)
 			{
+				return false;
+			}
+
+			return *ptr == "_cellsurMixerMain"sv;
+		}).ret;
+
+		bool was_mxr000_queue_found = false;
+
+		for (usz count = 0; has_sur_mixer_thread && count < 100; count++)
+		{
+			if (lv2_event_queue::find(c_mxr000))
+			{
+				was_mxr000_queue_found = true;
 				break;
 			}
 
@@ -1701,13 +1700,14 @@ error_code AudioSetNotifyEventQueue(ppu_thread& ppu, u64 key, u32 iFlags)
 				return {};
 			}
 
-			cellAudio.error("AudioSetNotifyEventQueue(): Waiting for _mxr000. x%d", count);
+			(count < 3 ? cellAudio.warning : cellAudio.error)("AudioSetNotifyEventQueue(): Waiting for _mxr000. x%d", count);
 
 			lv2_sleep(50'000, &ppu);
 		}
 
-		if (has_sur_mixer_thread && lv2_event_queue::find(c_mxr000))
+		if (key == 0 && was_mxr000_queue_found)
 		{
+			// Correct key value argument
 			key = c_mxr000;
 		}
 	}


### PR DESCRIPTION
`has_sur_mixer_thread` is not set if lv2_event_queue::find(c_mxr000) was yielding a non-null result. (race condition #2: cellSurMixer thread had just created the event queue)
I believe #18850 tried to address this bug as well actually, because in most menifistations of the race condition `key` argument is 0 instead of 0x8000cafe02460300. So when `has_sur_mixer_thread` is not set the key value is not corrected.

I believe this fixes https://github.com/RPCS3/rpcs3/issues/18852 and the audio or startup freezes of some games.
