### PR TITLE
gui: Move download database actions from game list to Manage -> Database submenu

### DIFF
--- a/rpcs3/rpcs3qt/game_list_context_menu.cpp
+++ b/rpcs3/rpcs3qt/game_list_context_menu.cpp
@@ -628,19 +628,10 @@ void game_list_context_menu::show_single_selection_context_menu(const game_info&
 			{
 				check_integrity->setEnabled(false);
 			}
-
-			QAction* download_integrity = addAction(tr("&Download Integrity Database"));
-			connect(download_integrity, &QAction::triggered, m_game_list_frame, [this]
-			{
-				ensure(m_game_list_frame->GetIsoIntegrity())->download();
-			});
 		}
 	}
 
 	QAction* check_compat = addAction(tr("&Check Game Compatibility"));
-	QAction* download_compat = addAction(tr("&Download Compatibility Database"));
-	QAction* download_config_db = addAction(tr("&Download Config Database"));
-
 	addSeparator();
 
 	// Disk usage
@@ -733,14 +724,6 @@ void game_list_context_menu::show_single_selection_context_menu(const game_info&
 	{
 		const QString link = "https://rpcs3.net/compatibility?g=" + serial;
 		QDesktopServices::openUrl(QUrl(link));
-	});
-	connect(download_compat, &QAction::triggered, m_game_list_frame, [this]
-	{
-		m_game_list_frame->GetGameCompatibility()->RequestCompatibility(true);
-	});
-	connect(download_config_db, &QAction::triggered, m_game_list_frame, [this]
-	{
-		m_game_list_frame->GetConfigDatabase()->request_config_database(true);
 	});
 	connect(rename_title, &QAction::triggered, m_game_list_frame, [this, name, serial = QString::fromStdString(serial), global_pos]
 	{
@@ -997,20 +980,6 @@ void game_list_context_menu::show_multi_selection_context_menu(const std::vector
 	connect(remove_game, &QAction::triggered, this, [this, games]()
 	{
 		m_game_list_actions->ShowRemoveGameDialog(games);
-	});
-
-	addSeparator();
-
-	QAction* download_compat = addAction(tr("&Download Compatibility Database"));
-	connect(download_compat, &QAction::triggered, m_game_list_frame, [this]
-	{
-		m_game_list_frame->GetGameCompatibility()->RequestCompatibility(true);
-	});
-
-	QAction* download_config_db = addAction(tr("&Download Config Database"));
-	connect(download_config_db, &QAction::triggered, m_game_list_frame, [this]
-	{
-		m_game_list_frame->GetConfigDatabase()->request_config_database(true);
 	});
 
 	addSeparator();

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3541,6 +3541,21 @@ void main_window::CreateConnects()
 #endif
 	});
 
+	connect(ui->downloadIntegrityDbAct, &QAction::triggered, this, [this]()
+	{
+		ensure(m_game_list_frame->GetIsoIntegrity())->download();
+	});
+
+	connect(ui->downloadCompatDbAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->GetGameCompatibility()->RequestCompatibility(true);
+	});
+
+	connect(ui->downloadConfigDbAct, &QAction::triggered, this, [this]()
+	{
+		m_game_list_frame->GetConfigDatabase()->request_config_database(true);
+	});
+
 	connect(ui->welcomeAct, &QAction::triggered, this, [this]()
 	{
 		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, true, this);

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -315,6 +315,14 @@
      <addaction name="actionManage_Dimensions_ToyPad"/>
      <addaction name="actionManage_KamenRider_RideGate"/>
     </widget>
+    <widget class="QMenu" name="menuDatabases">
+     <property name="title">
+      <string>Databases</string>
+     </property>
+     <addaction name="downloadIntegrityDbAct"/>
+     <addaction name="downloadCompatDbAct"/>
+     <addaction name="downloadConfigDbAct"/>
+    </widget>
     <addaction name="confVFSDialogAct"/>
     <addaction name="separator"/>
     <addaction name="actionManage_Users"/>
@@ -328,6 +336,7 @@
     <addaction name="separator"/>
     <addaction name="actionManage_Cheats"/>
     <addaction name="actionManage_Game_Patches"/>
+    <addaction name="menuDatabases"/>
     <addaction name="separator"/>
     <addaction name="actionManage_Screenshots"/>
    </widget>
@@ -433,9 +442,6 @@
     <addaction name="languageMenu"/>
     <addaction name="separator"/>
     <addaction name="updateAct"/>
-    <addaction name="downloadIntegrityDbAct"/>
-    <addaction name="downloadCompatDbAct"/>
-    <addaction name="downloadConfigDbAct"/>
     <addaction name="welcomeAct"/>
     <addaction name="supportAct"/>
     <addaction name="separator"/>

--- a/rpcs3/rpcs3qt/main_window.ui
+++ b/rpcs3/rpcs3qt/main_window.ui
@@ -433,6 +433,9 @@
     <addaction name="languageMenu"/>
     <addaction name="separator"/>
     <addaction name="updateAct"/>
+    <addaction name="downloadIntegrityDbAct"/>
+    <addaction name="downloadCompatDbAct"/>
+    <addaction name="downloadConfigDbAct"/>
     <addaction name="welcomeAct"/>
     <addaction name="supportAct"/>
     <addaction name="separator"/>
@@ -848,6 +851,21 @@
   <action name="updateAct">
    <property name="text">
     <string>Check for Updates</string>
+   </property>
+  </action>
+  <action name="downloadIntegrityDbAct">
+   <property name="text">
+    <string>Download Integrity Database</string>
+   </property>
+  </action>
+  <action name="downloadCompatDbAct">
+   <property name="text">
+    <string>Download Compatibility Database</string>
+   </property>
+  </action>
+  <action name="downloadConfigDbAct">
+   <property name="text">
+    <string>Download Config Database</string>
    </property>
   </action>
   <action name="welcomeAct">


### PR DESCRIPTION
Closes #18856

Moved the three download database actions from the game list context menu to Manage -> Databases submenu, since they are not related to a specific game entry.

This is how it looks now:
<img width="309" height="527" alt="image" src="https://github.com/user-attachments/assets/18672bae-d644-4bb8-9d09-94f9b4c2e462" />
<img width="379" height="364" alt="image" src="https://github.com/user-attachments/assets/f33b60be-9ea7-4486-acdd-565b1e319853" />

