### PR TITLE
gl: Support TeraScale 1 GPUs (ATI HD 2000/3000/4000)

### DIFF
--- a/rpcs3/Emu/RSX/GL/glutils/ring_buffer.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/ring_buffer.cpp
@@ -20,7 +20,6 @@ namespace gl
 		DSA_CALL2(NamedBufferStorage, m_id, size, data, buffer_storage_flags);
 		m_memory_mapping = DSA_CALL2_RET(MapNamedBufferRange, m_id, 0, size, GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT);
 
-		ensure(m_memory_mapping != nullptr);
 		m_data_loc = 0;
 		m_size = ::narrow<u32>(size);
 		m_memory_type = memory_type::host_visible;


### PR DESCRIPTION
This one liner allows TeraScale 1 GPUs (RV770) to work with RPCS3.

Opened this hack as a draft for @kd-11 to decide what to do with it.

Note: Falling back to legacy ring buffer does not require removing this assert, however it performs much worse at around 5 FPS.

### Showcase

<img width="1280" height="748" alt="image" src="https://github.com/user-attachments/assets/88f4e7a7-0bf2-45a3-9da9-1ba26c0b1267" />

<img width="1280" height="748" alt="Screenshot_20260610_211702" src="https://github.com/user-attachments/assets/0cd25841-f54c-4a3d-8756-267dcc6618e3" />