### PR TITLE
[FOR REVIEW] Fix a black square artifact on water effect in bioshock 2

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1976,10 +1976,16 @@ namespace rsx
 
 			if (!overlapping_locals.empty())
 			{
-				// Remove everything that is not a transfer target
-				overlapping_locals.erase_if([](const auto& e)
+				// Remove everything that is not a transfer target, and reject blit targets whose texel size
+				// differs from the requested format. Reinterpreting e.g. a 32bpp A8R8G8B8 blit result as a
+				// 64bpp FP16 texture byte-for-byte yields garbage (denormal/near-zero floats -> black squares);
+				// the stored GPU bytes are not the linear-memory bytes the game intends to reinterpret. Dropping
+				// such a section forces a normal texture upload from RSX memory, which matches hardware.
+				overlapping_locals.erase_if([&](const auto& e)
 				{
-					return e->is_dirty() || (e->get_context() != rsx::texture_upload_context::blit_engine_dst);
+					return e->is_dirty() ||
+						(e->get_context() != rsx::texture_upload_context::blit_engine_dst) ||
+						(get_format_block_size_in_bytes(e->get_gcm_format()) != attr.bpp);
 				});
 			}
 


### PR DESCRIPTION
Follow up of #17414. As reported there, that issue has been identified as a regression on Vulkan since old PR #6493, Before that PR, Vulkan was not affected by the issue while OpenGL was already affected.

fixes #17414

Used Opus 4.8 for a deep investigation, iteration and testing with instrumented logs and probes and an apparent solution was found.
No regression found on other games with the applied fix.

Below a brief recap of the analysis and fix:


Fix black square artifact on water/refraction effects (BioShock 2)

Symptom: A black square appears over water/refraction effects. Present on both OpenGL and Vulkan.

Root cause: When the game samples an FP16 texture (CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT, 8bpp) at an address that overlaps a cached blit_engine_dst section stored in a 32bpp format (CELL_GCM_TEXTURE_A8R8G8B8), fast_texture_search reuses that local section and reinterprets it byte-for-byte across the differing texel size (4→8 bpp). The 8-bit UNORM bytes reinterpreted as half-floats decode to denormal/near-zero values, so the reconstructed region renders black. The stored GPU bytes of the blit result are not the linear-memory bytes the game intends to reinterpret, so the in-place reinterpret is simply wrong here.

Fix: In fast_texture_search (rpcs3/Emu/RSX/Common/texture_cache.h), reject overlapping blit_engine_dst locals whose texel size differs from the requested format. The lookup then falls back to a normal texture upload from RSX memory, which matches hardware behavior.

Notes:
- One-line change in shared texture-cache code, so it fixes both the GL and VK backends.
- Surgical: only triggers on a genuine bpp mismatch between an FP16 request and a 32bpp blit target.