### PR TITLE
Use opengl renderer in game window title

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -149,6 +149,9 @@ void GLGSRender::on_init_thread()
 	rsx_log.success("GL VERSION: %s", reinterpret_cast<const char*>(glGetString(GL_VERSION)));
 	rsx_log.success("GLSL VERSION: %s", reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION)));
 
+	// Update frame title after GL was initialized in order to show the proper GPU
+	m_frame->update_title();
+
 	const auto& gl_caps = gl::get_driver_caps();
 
 	std::vector<std::string> exception_reasons;

--- a/rpcs3/Emu/RSX/GL/glutils/capabilities.cpp
+++ b/rpcs3/Emu/RSX/GL/glutils/capabilities.cpp
@@ -167,4 +167,14 @@ namespace gl
 
 		initialized = true;
 	}
+
+	const std::string get_device_name()
+	{
+		if (const char* renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER)))
+		{
+			return renderer;
+		}
+
+		return "OpenGL GPU";
+	}
 }

--- a/rpcs3/Emu/RSX/GL/glutils/capabilities.h
+++ b/rpcs3/Emu/RSX/GL/glutils/capabilities.h
@@ -58,4 +58,5 @@ namespace gl
 	};
 
 	const capabilities& get_driver_caps();
+	const std::string get_device_name();
 }

--- a/rpcs3/Emu/RSX/GSFrameBase.h
+++ b/rpcs3/Emu/RSX/GSFrameBase.h
@@ -33,4 +33,6 @@ public:
 	virtual bool can_consume_frame() const = 0;
 	virtual void present_frame(std::vector<u8>&& data, u32 pitch, u32 width, u32 height, bool is_bgra) const = 0;
 	virtual void take_screenshot(std::vector<u8>&& sshot_data, u32 sshot_width, u32 sshot_height, bool is_bgra) = 0;
+
+	virtual void update_title(double fps = 0.0) = 0;
 };

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -175,13 +175,19 @@ namespace rsx
 				return;
 			}
 
+			rsx_log.notice("display_manager::start_audio: path='%s'", audio_path);
+
 			m_audio_player = std::make_unique<audio_player>(audio_path);
 			m_audio_player->set_active(true);
 		}
 
 		void display_manager::stop_audio()
 		{
-			m_audio_player.reset();
+			if (m_audio_player)
+			{
+				rsx_log.notice("display_manager::stop_audio");
+				m_audio_player.reset();
+			}
 		}
 
 		void display_manager::on_overlay_activated(const std::shared_ptr<overlay>& /*item*/)

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -765,7 +765,7 @@ namespace rsx
 		ar(stereo_enabled, format, aspect, resolution_id, scanline_pitch, gamma, resolution_x, resolution_y, state, scan_mode);
 	}
 
-	void thread::capture_frame(const std::string& name)
+	void thread::capture_frame(const std::string& name) const
 	{
 		frame_trace_data::draw_state draw_state{};
 
@@ -843,7 +843,7 @@ namespace rsx
 
 		if (capture_current_frame)
 		{
-			u32 element_count = rsx::method_registers.current_draw_clause.get_elements_count();
+			const u32 element_count = rsx::method_registers.current_draw_clause.get_elements_count();
 			capture_frame(fmt::format("Draw %s %d", rsx::method_registers.current_draw_clause.primitive, element_count));
 		}
 	}

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -218,7 +218,7 @@ namespace rsx
 
 		surface_scaling_config_t resolution_scaling_config{};
 
-		void capture_frame(const std::string& name);
+		void capture_frame(const std::string& name) const;
 		const backend_configuration& get_backend_config() const { return backend_config; }
 
 		const draw_command_processor* draw_processor() const { return &m_draw_processor; }

--- a/rpcs3/Emu/title.cpp
+++ b/rpcs3/Emu/title.cpp
@@ -3,6 +3,11 @@
 #include "rpcs3_version.h"
 
 #include "util/sysinfo.hpp"
+#include "Emu/system_config.h"
+
+#if !(defined(__ANDROID__) || defined(__APPLE__))
+#include "Emu/RSX/GL/glutils/capabilities.h"
+#endif
 
 namespace rpcs3
 {
@@ -68,7 +73,22 @@ namespace rpcs3
 				}
 				case 'G':
 				{
-					title_string += title_data.vulkan_adapter;
+					switch (g_cfg.video.renderer.get())
+					{
+					case video_renderer::null:
+						title_string += "null";
+						break;
+					case video_renderer::opengl:
+#if !(defined(__ANDROID__) || defined(__APPLE__))
+						title_string += gl::get_device_name();
+#else
+						title_string += "OpenGL GPU";
+#endif
+						break;
+					case video_renderer::vulkan:
+						title_string += title_data.vulkan_adapter;
+						break;
+					}
 					break;
 				}
 				case 'C':

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -830,17 +830,7 @@ void gs_frame::flip(draw_context_t /*context*/, bool /*skip_frame*/)
 
 	if (fps_t.GetElapsedTimeInSec() >= 0.5)
 	{
-		std::string new_title = Emu.GetFormattedTitle(m_frames / fps_t.GetElapsedTimeInSec());
-
-		if (new_title != m_window_title)
-		{
-			m_window_title = new_title;
-
-			Emu.CallFromMainThread([this, title = std::move(new_title)]()
-			{
-				setTitle(QString::fromStdString(title));
-			});
-		}
+		update_title(m_frames / fps_t.GetElapsedTimeInSec());
 
 		m_frames = 0;
 		fps_t.Start();
@@ -1128,6 +1118,21 @@ void gs_frame::take_screenshot(std::vector<u8>&& data, u32 sshot_width, u32 ssho
 		},
 		std::move(data))
 		.detach();
+}
+
+void gs_frame::update_title(double fps)
+{
+	std::string new_title = Emu.GetFormattedTitle(fps);
+
+	if (new_title != m_window_title)
+	{
+		m_window_title = new_title;
+
+		Emu.CallFromMainThread([this, title = std::move(new_title)]()
+		{
+			setTitle(QString::fromStdString(title));
+		});
+	}
 }
 
 void gs_frame::mouseDoubleClickEvent(QMouseEvent* ev)

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -82,6 +82,8 @@ public:
 	void present_frame(std::vector<u8>&& data, u32 pitch, u32 width, u32 height, bool is_bgra) const override;
 	void take_screenshot(std::vector<u8>&& data, u32 sshot_width, u32 sshot_height, bool is_bgra) override;
 
+	void update_title(double fps = 0.0) override;
+
 protected:
 	video_renderer m_renderer;
 


### PR DESCRIPTION
- Use opengl renderer in game window title

This only works after the OpenGl context was created.
So it might only be visible after a tiny delay.
If there's no OpenGl context present, I simply show "OpenGL GPU".

fixes #18892