### PR TITLE
[macOS] Update runners to OS 15, raise minimum deployment target accordingly

### DIFF
--- a/.ci/build-mac.sh
+++ b/.ci/build-mac.sh
@@ -13,31 +13,18 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
 export HOMEBREW_NO_ENV_HINTS=1
 export HOMEBREW_NO_INSTALL_CLEANUP=1
-brew update
 brew install -f --overwrite --quiet ccache "llvm@$LLVM_COMPILER_VER"
 brew link -f --overwrite --quiet "llvm@$LLVM_COMPILER_VER"
-if [ "$AARCH64" -eq 1 ]; then
-  brew install -f --overwrite --quiet googletest opencv@4 sdl3 vulkan-headers vulkan-loader molten-vk
-  brew unlink --quiet ffmpeg fmt qtbase qtsvg qtdeclarative protobuf || true
-else
-  arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  arch -x86_64 /usr/local/bin/brew install -f --overwrite --quiet python@3.14 opencv@4 "llvm@$LLVM_COMPILER_VER" sdl3 vulkan-headers vulkan-loader molten-vk
-  arch -x86_64 /usr/local/bin/brew unlink  --quiet ffmpeg qtbase qtsvg qtdeclarative protobuf || true
-fi
+brew install -f --overwrite --quiet googletest opencv@4 sdl3 vulkan-headers vulkan-loader molten-vk
+brew unlink --quiet ffmpeg fmt qtbase qtsvg qtdeclarative protobuf || true
 
 export CXX=clang++
 export CC=clang
 
 export BREW_PATH;
-if [ "$AARCH64" -eq 1 ]; then
-  BREW_PATH="$(brew --prefix)"
-  export BREW_BIN="/opt/homebrew/bin"
-  export BREW_SBIN="/opt/homebrew/sbin"
-else
-  BREW_PATH="$("/usr/local/bin/brew" --prefix)"
-  export BREW_BIN="/usr/local/bin"
-  export BREW_SBIN="/usr/local/sbin"
-fi
+BREW_PATH="$(brew --prefix)"
+export BREW_BIN="$BREW_PATH/bin"
+export BREW_SBIN="$BREW_PATH/sbin"
 
 export WORKDIR;
 WORKDIR="$(pwd)"
@@ -68,7 +55,7 @@ ditto "/tmp/Qt/$QT_VER" "qt-downloader/$QT_VER"
 export Qt6_DIR="$WORKDIR/qt-downloader/$QT_VER/clang_64/lib/cmake/Qt$QT_VER_MAIN"
 export SDL3_DIR="$BREW_PATH/opt/sdl3/lib/cmake/SDL3"
 
-export PATH="/opt/homebrew/opt/llvm@$LLVM_COMPILER_VER/bin:$PATH"
+export PATH="$BREW_PATH/opt/llvm@$LLVM_COMPILER_VER/bin:$PATH"
 export LDFLAGS="-L$BREW_PATH/opt/llvm@$LLVM_COMPILER_VER/lib/c++ -L$BREW_PATH/opt/llvm@$LLVM_COMPILER_VER/lib/unwind -lunwind"
 
 export VULKAN_SDK
@@ -82,12 +69,13 @@ LLVM_DIR="$BREW_PATH/opt/llvm@$LLVM_COMPILER_VER"
 git submodule -q update --init --depth=1 --jobs=8 $(awk '/path/ && !/llvm/ && !/opencv/ && !/SDL/ && !/feralinteractive/ { print $3 }' .gitmodules)
 
 mkdir build && cd build || exit 1
+# The below should be uncommented once bugs with Qt 6 QListWidgets when using the OS 26 visual style are resolved.
+# sudo xcode-select -switch /Applications/Xcode_26.3.app/Contents/Developer
 
-if [ "$AARCH64" -eq 1 ]; then
 cmake .. \
     -DBUILD_RPCS3_TESTS="${RUN_UNIT_TESTS}" \
     -DRUN_RPCS3_TESTS="${RUN_UNIT_TESTS}" \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=14.4 \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
     -DCMAKE_OSX_SYSROOT="$(xcrun --sdk macosx --show-sdk-path)" \
     -DMACOSX_BUNDLE_SHORT_VERSION_STRING="${COMM_TAG}" \
     -DMACOSX_BUNDLE_BUNDLE_VERSION="${COMM_COUNT}" \
@@ -102,31 +90,8 @@ cmake .. \
     -DUSE_SYSTEM_SDL=ON \
     -DUSE_SYSTEM_OPENCV=ON \
     -G Ninja
-else
-cmake .. \
-    -DBUILD_RPCS3_TESTS=OFF \
-    -DRUN_RPCS3_TESTS=OFF \
-    -DCMAKE_OSX_ARCHITECTURES=x86_64 \
-    -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
-    -DCMAKE_TOOLCHAIN_FILE=buildfiles/cmake/TCDarwinX86_64.cmake \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=14.4 \
-    -DCMAKE_OSX_SYSROOT="$(xcrun --sdk macosx --show-sdk-path)" \
-    -DMACOSX_BUNDLE_SHORT_VERSION_STRING="${COMM_TAG}" \
-    -DMACOSX_BUNDLE_BUNDLE_VERSION="${COMM_COUNT}"\
-    -DSTATIC_LINK_LLVM=ON \
-    -DUSE_SDL=ON \
-    -DUSE_DISCORD_RPC=ON \
-    -DUSE_AUDIOUNIT=ON \
-    -DUSE_SYSTEM_FFMPEG=OFF \
-    -DUSE_NATIVE_INSTRUCTIONS=OFF \
-    -DUSE_PRECOMPILED_HEADERS=OFF \
-    -DUSE_SYSTEM_MVK=ON \
-    -DUSE_SYSTEM_SDL=ON \
-    -DUSE_SYSTEM_OPENCV=ON \
-    -G Ninja
-fi
 
-ninja; build_status=$?;
+ninja -j4; build_status=$?;
 
 cd ..
 

--- a/.ci/deploy-mac.sh
+++ b/.ci/deploy-mac.sh
@@ -7,7 +7,6 @@ cd bin
 git clone --revision=a075e5e417f87675ea3137b7365f3e5a99608d72 https://github.com/KhronosGroup/MoltenVK.git
 cd MoltenVK
 ./fetchDependencies --macos
-sudo xcode-select -switch /Applications/Xcode_16.2.app/Contents/Developer
 make macos MVK_USE_METAL_PRIVATE_API=1
 cd ../
 
@@ -84,7 +83,7 @@ echo "[InternetShortcut]" > Quickstart.url
 echo "URL=https://rpcs3.net/quickstart" >> Quickstart.url
 echo "IconIndex=0" >> Quickstart.url
 
-if [ "$AARCH64" -eq 1 ]; then
+if [ "$(arch)" = "arm64" ]; then
   ARCHIVE_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v${LVER}_macos_aarch64.7z"
 else
   ARCHIVE_FILEPATH="$BUILD_ARTIFACTSTAGINGDIRECTORY/rpcs3-v${LVER}_macos.7z"

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -123,15 +123,15 @@ jobs:
       matrix:
         include:
           - name: Intel
-            AARCH64: 0
+            runs-on: macos-15-intel
             UPLOAD_COMMIT_HASH: 51ae32f468089a8169aaf1567de355ff4a3e0842
             UPLOAD_REPO_FULL_NAME: rpcs3/rpcs3-binaries-mac
           - name: Apple Silicon
-            AARCH64: 1
+            runs-on: macos-15
             UPLOAD_COMMIT_HASH: 8e21bdbc40711a3fccd18fbf17b742348b0f4281
             UPLOAD_REPO_FULL_NAME: rpcs3/rpcs3-binaries-mac-arm64
     name: RPCS3 Mac ${{ matrix.name }} 
-    runs-on: macos-14
+    runs-on: ${{ matrix.runs-on }} 
     env:
       CCACHE_DIR: /tmp/ccache_dir
       QT_VER: '6.11.1'
@@ -140,8 +140,7 @@ jobs:
       RELEASE_MESSAGE: ../GitHubReleaseMessage.txt
       UPLOAD_COMMIT_HASH: ${{ matrix.UPLOAD_COMMIT_HASH }}
       UPLOAD_REPO_FULL_NAME: ${{ matrix.UPLOAD_REPO_FULL_NAME }}
-      AARCH64: ${{ matrix.AARCH64 }}
-      RUN_UNIT_TESTS: github.event_name == 'pull_request' && 'ON' || 'OFF'
+      RUN_UNIT_TESTS: ${{ matrix.name == 'Apple Silicon' && (github.event_name == 'pull_request' && 'ON') || 'OFF' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@main

--- a/rpcs3/rpcs3.plist.in
+++ b/rpcs3/rpcs3.plist.in
@@ -31,7 +31,7 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>14.4</string>
+	<string>15.0</string>
 	<key>NSCameraUsageDescription</key>
 	<string>The camera will be used for PlayStation Eye emulation</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
This change accounts for the impending deprecation of Github's OS 14 runners, moves Intel builds to GH's own Intel runner (enabling much of the CI scripts to be cleaned up) and also enables some future changes, such as building with Xcode 26.3's SDK to get Liquid Glass control & window styling, this also removes one blocker for future KosmicKrisp builds (#17902) as they won't need to use a different runner version to mainline builds and will also be able to build with Xcode 26.3's SDK (needed as KK now requires Metal 4 support).
 
Currently I've had to comment out the actual line that makes RPCS3 build against SDK 26 due to some bugs Qt has with the Liquid Glass visual style (QListWidget is broken in specific, checkboxes don't draw at all, breaking some settings views and the patch manager) so the PR will only raise builds to SDK 15 instead, I'll file a separate PR for building against SDK 26 if/when Qt fixes their stuff.

(One other notable consequence of building with SDK 15 or above I thought was worth mentioning is that certain ARM timestamp frequency registers (CNTFRQ_EL0, CNTVCT_EL0) now return a frequency of 1Ghz on M3+ instead of 24Mhz (for older SDKs or for SDK 15+ on M2 and older), as per https://developer.apple.com/documentation/macos-release-notes/macos-15-release-notes#Platform.)