### PR TITLE
Stop playing gamelist movies when the window loses focus

### DIFF
--- a/rpcs3/rpcs3qt/game_list.cpp
+++ b/rpcs3/rpcs3qt/game_list.cpp
@@ -26,7 +26,7 @@ game_list::game_list() : QTableWidget(), game_list_base()
 
 		movie_item* new_item = static_cast<movie_item*>(item(row, 0));
 
-		if (new_item)
+		if (new_item && isActiveWindow())
 		{
 			new_item->set_active(true);
 		}
@@ -157,7 +157,7 @@ void game_list::mouseMoveEvent(QMouseEvent* event)
 		{
 			m_last_hover_item->set_active(false);
 		}
-		if (new_item)
+		if (new_item && isActiveWindow())
 		{
 			new_item->set_active(true);
 		}

--- a/rpcs3/rpcs3qt/game_list.cpp
+++ b/rpcs3/rpcs3qt/game_list.cpp
@@ -35,6 +35,15 @@ game_list::game_list() : QTableWidget(), game_list_base()
 	});
 }
 
+void game_list::stop_movie()
+{
+	if (m_last_hover_item)
+	{
+		m_last_hover_item->set_active(false);
+		m_last_hover_item = nullptr;
+	}
+}
+
 void game_list::sync_header_actions(std::map<int, QAction*>& actions, std::function<bool(int)> get_visibility)
 {
 	ensure(get_visibility);

--- a/rpcs3/rpcs3qt/game_list.h
+++ b/rpcs3/rpcs3qt/game_list.h
@@ -23,6 +23,8 @@ class game_list : public QTableWidget, public game_list_base
 public:
 	game_list();
 
+	void stop_movie();
+
 	void sync_header_actions(std::map<int, QAction*>& actions, std::function<bool(int)> get_visibility);
 	void create_header_actions(std::map<int, QAction*>& actions, std::function<bool(int)> get_visibility, std::function<void(int, bool)> set_visibility);
 

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -1237,6 +1237,12 @@ void game_list_frame::ShowCustomConfigIcon(const game_info& game)
 	RepaintIcons();
 }
 
+void game_list_frame::stop_movie()
+{
+	if (m_game_list) m_game_list->stop_movie();
+	if (m_game_grid) m_game_grid->stop_movie();
+}
+
 void game_list_frame::ResizeIcons(int slider_pos)
 {
 	m_icon_size_index = slider_pos;

--- a/rpcs3/rpcs3qt/game_list_frame.h
+++ b/rpcs3/rpcs3qt/game_list_frame.h
@@ -56,10 +56,10 @@ public:
 
 	void SetShowHidden(bool show);
 
-	content_integrity* GetIsoIntegrity() const { return m_iso_integrity; }
-	content_integrity* GetPsnContentIntegrity() const { return m_psn_content_integrity; }
-	content_integrity* GetPsnDlcIntegrity() const { return m_psn_dlc_integrity; }
-	content_integrity* GetPsnUpdateIntegrity() const { return m_psn_update_integrity; }
+	content_integrity* GetIsoIntegrity() const { return ensure(m_iso_integrity); }
+	content_integrity* GetPsnContentIntegrity() const { return ensure(m_psn_content_integrity); }
+	content_integrity* GetPsnDlcIntegrity() const { return ensure(m_psn_dlc_integrity); }
+	content_integrity* GetPsnUpdateIntegrity() const { return ensure(m_psn_update_integrity); }
 	game_compatibility* GetGameCompatibility() const { return ensure(m_game_compat); }
 	config_database* GetConfigDatabase() const { return ensure(m_config_db); }
 	const std::vector<game_info>& GetGameInfo() const { return m_game_data; }
@@ -74,6 +74,8 @@ public:
 	bool IsEntryVisible(const game_info& game, bool search_fallback = false) const;
 
 	void ShowCustomConfigIcon(const game_info& game);
+
+	void stop_movie();
 
 	// Enqueue slot for refreshed signal
 	// Allowing for an individual container for each distinct use case (currently disabled and contains only one such entry)

--- a/rpcs3/rpcs3qt/game_list_grid.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid.cpp
@@ -35,6 +35,17 @@ game_list_grid::game_list_grid()
 	});
 }
 
+void game_list_grid::stop_movie()
+{
+	for (flow_widget_item* flow_item : items())
+	{
+		if (game_list_grid_item* item = static_cast<game_list_grid_item*>(flow_item))
+		{
+			item->set_active(false);
+		}
+	}
+}
+
 void game_list_grid::clear_list()
 {
 	clear();
@@ -145,6 +156,9 @@ void game_list_grid::populate(
 	QApplication::processEvents();
 
 	select_items(selected_items);
+
+	// Prevent playing unwanted movie
+	stop_movie();
 }
 
 void game_list_grid::repaint_icons(std::vector<game_info>& game_data, const QColor& icon_color, const QSize& icon_size, qreal device_pixel_ratio)

--- a/rpcs3/rpcs3qt/game_list_grid.h
+++ b/rpcs3/rpcs3qt/game_list_grid.h
@@ -12,6 +12,8 @@ class game_list_grid : public flow_widget, public game_list_base
 public:
 	explicit game_list_grid();
 
+	void stop_movie();
+
 	void clear_list() override;
 
 	void populate(

--- a/rpcs3/rpcs3qt/game_list_grid_item.cpp
+++ b/rpcs3/rpcs3qt/game_list_grid_item.cpp
@@ -74,7 +74,8 @@ bool game_list_grid_item::event(QEvent* event)
 	switch (event->type())
 	{
 	case QEvent::HoverEnter:
-		set_active(true);
+		if (isActiveWindow())
+			set_active(true);
 		break;
 	case QEvent::HoverLeave:
 	case QEvent::FocusOut:

--- a/rpcs3/rpcs3qt/game_list_table.cpp
+++ b/rpcs3/rpcs3qt/game_list_table.cpp
@@ -424,6 +424,9 @@ void game_list_table::populate(
 		}
 	}
 	Q_EMIT itemSelectionChanged();
+
+	// Prevent playing unwanted movie
+	stop_movie();
 }
 
 void game_list_table::repaint_icons(std::vector<game_info>& game_data, const QColor& icon_color, const QSize& icon_size, qreal device_pixel_ratio)

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -4100,6 +4100,19 @@ void main_window::closeEvent(QCloseEvent* closeEvent)
 	Emu.Quit(true);
 }
 
+void main_window::changeEvent(QEvent* event)
+{
+	if (event->type() == QEvent::ActivationChange)
+	{
+		if (m_game_list_frame && !isActiveWindow())
+		{
+			m_game_list_frame->stop_movie();
+		}
+	}
+
+	QMainWindow::changeEvent(event);
+}
+
 /**
 Add valid disc games to gamelist (games.yml)
 @param paths = dir paths to scan for game

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -3543,10 +3543,10 @@ void main_window::CreateConnects()
 
 	connect(ui->downloadIntegrityDbAct, &QAction::triggered, this, [this]()
 	{
-		ensure(m_game_list_frame->GetIsoIntegrity())->download();
-		ensure(m_game_list_frame->GetPsnContentIntegrity())->download();
-		ensure(m_game_list_frame->GetPsnDlcIntegrity())->download();
-		ensure(m_game_list_frame->GetPsnUpdateIntegrity())->download();
+		m_game_list_frame->GetIsoIntegrity()->download();
+		m_game_list_frame->GetPsnContentIntegrity()->download();
+		m_game_list_frame->GetPsnDlcIntegrity()->download();
+		m_game_list_frame->GetPsnUpdateIntegrity()->download();
 	});
 
 	connect(ui->downloadCompatDbAct, &QAction::triggered, this, [this]()

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -126,6 +126,7 @@ private Q_SLOTS:
 
 protected:
 	void closeEvent(QCloseEvent *event) override;
+	void changeEvent(QEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 	void dropEvent(QDropEvent* event) override;
 	void dragEnterEvent(QDragEnterEvent* event) override;


### PR DESCRIPTION
- Don't play movie unless the parent window is active
- Prevent playing movies directly after a refresh
- Stop movies when the main window gets inactive

Now I remember why I did not like this new currentCellChanged feature...

probably fixes #18894