### PR TITLE
[SPU] Optimize CLZ on targets without AVX512

### DIFF
--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -3343,12 +3343,33 @@ void spu_recompiler::HGT(spu_opcode_t op)
 
 void spu_recompiler::CLZ(spu_opcode_t op)
 {
+	const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+		
 	if (utils::has_avx512())
 	{
-		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
 		const XmmLink& vt = XmmAlloc();
 		c->vplzcntd(vt, va);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
+		return;
+	}
+	
+	if (utils::has_sse41())
+	{
+		// Use signed conversion to float, as exponent is ilog2
+		// Fixup "negative" cases by overwriting with zero
+		const u32 exp_bias = 127;
+
+		const XmmLink& vf = XmmAlloc();
+		const XmmLink& v1 = XmmAlloc();
+		c->cvtdq2ps(vf, va); // only correct with round-towards-zero
+		c->psrld(vf, 23);
+		c->movdqa(v1, XmmConst(v128::from32p(exp_bias - 1)));
+		c->psignd(v1, va);	// conditional zeroing
+		c->paddd(v1, XmmConst(v128::from32p(32))); 
+		c->psubd(v1, vf);	// (x==0)? 32 : 31 - (exponent - exp_bias)
+		c->pxor(vf, vf);
+		c->blendvps(v1, vf, va);
+		c->movdqa(SPU_OFF_128(gpr, op.rt), v1);
 		return;
 	}
 

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -3354,8 +3354,8 @@ void spu_recompiler::CLZ(spu_opcode_t op)
 	}
 
 	// Use signed conversion to float, as exponent is ilog2
-	// Fixup "negative" cases by overwriting with zero
-	const u32 exp_bias = 127;
+	// "Negative" values are zeroed due to saturation subtract
+	constexpr u32 exp_bias = 127;
 
 	const XmmLink& vf = XmmAlloc();
 	const XmmLink& v1 = XmmAlloc();
@@ -3365,10 +3365,8 @@ void spu_recompiler::CLZ(spu_opcode_t op)
 	c->pcmpeqd(v1, va);
 	c->pand(v1, XmmConst(v128::from32p(32 ^ (31 + exp_bias))));
 	c->pxor(v1, XmmConst(v128::from32p(31 + exp_bias)));
-	c->psubd(v1, vf);	// (x==0)? 32 : 31 - (exponent - exp_bias)
-	c->psrad(va, 31);
-	c->pandn(va, v1);
-	c->movdqa(SPU_OFF_128(gpr, op.rt), va);
+	c->psubusw(v1, vf);	// (x==0)? 32 : 31 - (exponent - exp_bias)
+	c->movdqa(SPU_OFF_128(gpr, op.rt), v1);
 	return;
 }
 

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -3343,44 +3343,33 @@ void spu_recompiler::HGT(spu_opcode_t op)
 
 void spu_recompiler::CLZ(spu_opcode_t op)
 {
+	const XmmLink& va = XmmGet(op.ra, XmmType::Int);
+
 	if (utils::has_avx512())
 	{
-		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
 		const XmmLink& vt = XmmAlloc();
 		c->vplzcntd(vt, va);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
 		return;
 	}
-	
-	if (utils::has_sse41())
-	{
-		// Use signed conversion to float, as exponent is ilog2
-		// Fixup "negative" cases by overwriting with zero
-		const u32 exp_bias = 127;
 
-		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
-		const XmmLink& vf = XmmAlloc();
-		const XmmLink& v1 = XmmAlloc();
-		c->cvtdq2ps(vf, va); // only correct with round-towards-zero
-		c->psrld(vf, 23);
-		c->movdqa(v1, XmmConst(v128::from32p(exp_bias - 1)));
-		c->psignd(v1, va);	// conditional zeroing
-		c->paddd(v1, XmmConst(v128::from32p(32))); 
-		c->psubd(v1, vf);	// (x==0)? 32 : 31 - (exponent - exp_bias)
-		c->pxor(vf, vf);
-		c->blendvps(v1, vf, va);
-		c->movdqa(SPU_OFF_128(gpr, op.rt), v1);
-		return;
-	}
+	// Use signed conversion to float, as exponent is ilog2
+	// Fixup "negative" cases by overwriting with zero
+	const u32 exp_bias = 127;
 
-	c->mov(qw0->r32(), 32 + 31);
-	for (u32 i = 0; i < 4; i++) // unrolled loop
-	{
-		c->bsr(*addr, SPU_OFF_32(gpr, op.ra, &v128::_u32, i));
-		c->cmovz(*addr, qw0->r32());
-		c->xor_(*addr, 31);
-		c->mov(SPU_OFF_32(gpr, op.rt, &v128::_u32, i), *addr);
-	}
+	const XmmLink& vf = XmmAlloc();
+	const XmmLink& v1 = XmmAlloc();
+	c->cvtdq2ps(vf, va); // only correct with round-towards-zero
+	c->psrld(vf, 23);
+	c->pxor(v1, v1);
+	c->pcmpeqd(v1, va);
+	c->pand(v1, XmmConst(v128::from32p(32 ^ (31 + exp_bias))));
+	c->pxor(v1, XmmConst(v128::from32p(31 + exp_bias)));
+	c->psubd(v1, vf);	// (x==0)? 32 : 31 - (exponent - exp_bias)
+	c->psrad(va, 31);
+	c->pandn(va, v1);
+	c->movdqa(SPU_OFF_128(gpr, op.rt), va);
+	return;
 }
 
 void spu_recompiler::XSWD(spu_opcode_t op)

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -3343,10 +3343,9 @@ void spu_recompiler::HGT(spu_opcode_t op)
 
 void spu_recompiler::CLZ(spu_opcode_t op)
 {
-	const XmmLink& va = XmmGet(op.ra, XmmType::Int);
-		
 	if (utils::has_avx512())
 	{
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
 		const XmmLink& vt = XmmAlloc();
 		c->vplzcntd(vt, va);
 		c->movdqa(SPU_OFF_128(gpr, op.rt), vt);
@@ -3359,6 +3358,7 @@ void spu_recompiler::CLZ(spu_opcode_t op)
 		// Fixup "negative" cases by overwriting with zero
 		const u32 exp_bias = 127;
 
+		const XmmLink& va = XmmGet(op.ra, XmmType::Int);
 		const XmmLink& vf = XmmAlloc();
 		const XmmLink& v1 = XmmAlloc();
 		c->cvtdq2ps(vf, va); // only correct with round-towards-zero

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -6329,7 +6329,30 @@ public:
 
 	void CLZ(spu_opcode_t op)
 	{
+#ifdef ARCH_ARM64
 		set_vr(op.rt, ctlz(get_vr(op.ra)));
+#else
+		if (m_use_avx512)
+		{
+			set_vr(op.rt, ctlz(get_vr(op.ra)));
+			return;
+		}
+
+		// Implement manually since LLVM can't take advantage of round-towards-zero.
+		// Helpful as when converting to a float the exponent is always floor(ilog2)
+
+		constexpr u32 exp_bias = 127;
+		value_t<f32[4]> flt;
+
+		const auto a = get_vr(op.ra);
+		flt.value = m_ir->CreateSIToFP(a.value, get_type<f32[4]>()); // only correct with round-towards-zero!
+		const auto exp = bitcast<u32[4]>(flt) >> 23;
+
+		// "Negative" values cause saturation due to float's sign bit
+		const auto offset = select(a == 0, splat<u32[4]>(32), splat<u32[4]>(exp_bias + 31));
+		const auto lzcnt = sub_sat(bitcast<u16[8]>(offset), bitcast<u16[8]>(exp));
+		set_vr(op.rt, bitcast<u32[4]>(lzcnt));
+#endif
 	}
 
 	void XSWD(spu_opcode_t op)


### PR DESCRIPTION
Codegen is currently poor on targets without AVX512. LLVM can't take advantage of the rounding mode being towards-zero (and is generally unoptimal), and ASMJIT isn't even vectorized.

This method works by converting the integer into a float and extracting the exponent to calculate `ilog2` of the input. The count can then be derived through `lzcnt = 31 - ilog2`, with the subtraction being saturating so "negative" inputs are zeroed.