### PR TITLE
Use more std::string_view (Part 3)

### DIFF
--- a/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.h
+++ b/rpcs3/Emu/CPU/Backends/AArch64/AArch64JIT.h
@@ -45,7 +45,7 @@ namespace aarch64
             bool use_stack_frames = true;      // Allocate a stack frame for each function. The gateway can alternatively manage a global stack to use as scratch.
             bool optimize = true;              // Optimize instructions when possible. Set to false when debugging.
             u32 hypervisor_context_offset = 0; // Offset within the "thread" object where we can find the hypervisor context (registers configured at gateway).
-            std::function<bool(const std::string&)> exclusion_callback;    // [Optional] Callback run on each function before transform. Return "true" to exclude from frame processing.
+            std::function<bool(std::string_view)> exclusion_callback;      // [Optional] Callback run on each function before transform. Return "true" to exclude from frame processing.
             std::vector<std::pair<std::string, gpr>> base_register_lookup; // [Optional] Function lookup table to determine the location of the "thread" context.
             std::vector<std::string> faux_function_list;                   // [Optional] List of faux block names to treat as untrusted - typically fake functions representing codecaves.
         };

--- a/rpcs3/Emu/Cell/Modules/cellMusicExport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellMusicExport.cpp
@@ -72,7 +72,7 @@ struct music_export
 };
 
 
-bool check_music_path(const std::string& file_path)
+bool check_music_path(std::string_view file_path)
 {
 	if (file_path.size() >= CELL_MUSIC_EXPORT_UTIL_HDD_PATH_MAX)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellPhotoExport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellPhotoExport.cpp
@@ -74,7 +74,7 @@ struct photo_export
 };
 
 
-bool check_photo_path(const std::string& file_path)
+bool check_photo_path(std::string_view file_path)
 {
 	if (file_path.size() >= CELL_PHOTO_EXPORT_UTIL_HDD_PATH_MAX)
 	{

--- a/rpcs3/Emu/Cell/Modules/cellSsl.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSsl.cpp
@@ -75,7 +75,7 @@ error_code cellSslGetMemoryInfo()
 	return CELL_OK;
 }
 
-std::string getCert(const std::string& certPath, const int certID, const bool isNormalCert)
+std::string getCert(std::string_view certPath, const int certID, const bool isNormalCert)
 {
 	int newID = certID;
 

--- a/rpcs3/Emu/Cell/Modules/cellVideoExport.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellVideoExport.cpp
@@ -76,7 +76,7 @@ struct video_export
 };
 
 
-bool check_movie_path(const std::string& file_path)
+bool check_movie_path(std::string_view file_path)
 {
 	if (file_path.size() >= CELL_VIDEO_EXPORT_UTIL_HDD_PATH_MAX)
 	{

--- a/rpcs3/Emu/GDB.cpp
+++ b/rpcs3/Emu/GDB.cpp
@@ -102,7 +102,7 @@ std::string u32_to_padded_hex(u32 value)
 template <typename T>
 T hex_to(std::string_view val)
 {
-	T result;
+	T result {};
 	auto [ptr, err] = std::from_chars(val.data(), val.data() + val.size(), result, 16);
 	if (err != std::errc())
 	{
@@ -361,7 +361,7 @@ void gdb_thread::ack(bool accepted)
 	send_char(accepted ? '+' : '-');
 }
 
-void gdb_thread::send_cmd(const std::string& cmd)
+void gdb_thread::send_cmd(std::string_view cmd)
 {
 	u8 checksum = 0;
 	std::string buf;
@@ -376,7 +376,7 @@ void gdb_thread::send_cmd(const std::string& cmd)
 	send(buf.c_str(), static_cast<int>(buf.length()));
 }
 
-bool gdb_thread::send_cmd_ack(const std::string& cmd)
+bool gdb_thread::send_cmd_ack(std::string_view cmd)
 {
 	while (true)
 	{
@@ -465,7 +465,7 @@ std::string gdb_thread::get_reg(ppu_thread* thread, u32 rid)
 	}
 }
 
-bool gdb_thread::set_reg(ppu_thread* thread, u32 rid, const std::string& value)
+bool gdb_thread::set_reg(ppu_thread* thread, u32 rid, std::string_view value)
 {
 	switch (rid)
 	{

--- a/rpcs3/Emu/GDB.h
+++ b/rpcs3/Emu/GDB.h
@@ -44,10 +44,10 @@ class gdb_thread
 	//acknowledge packet, either as accepted or declined
 	void ack(bool accepted);
 	//sends command body cmd to client
-	void send_cmd(const std::string& cmd);
+	void send_cmd(std::string_view cmd);
 	//sends command to client until receives positive acknowledgement
 	//returns false in case some error happened, and command wasn't sent
-	bool send_cmd_ack(const std::string& cmd);
+	bool send_cmd_ack(std::string_view cmd);
 	//appends encoded char c to string str, and returns checksum. encoded byte can occupy 2 bytes
 	static u8 append_encoded_char(char c, std::string& str);
 	//convert u8 to 2 byte hexademical representation
@@ -57,7 +57,7 @@ class gdb_thread
 	//returns register value as hex string by register id (in gdb), in case of wrong id returns empty string
 	static std::string get_reg(ppu_thread* thread, u32 rid);
 	//sets register value to hex string by register id (in gdb), in case of wrong id returns false
-	static bool set_reg(ppu_thread* thread, u32 rid, const std::string& value);
+	static bool set_reg(ppu_thread* thread, u32 rid, std::string_view value);
 	//returns size of register with id rid in bytes, zero if invalid rid is provided
 	static u32 get_reg_size(ppu_thread* thread, u32 rid);
 	//send reason of stop, returns false if sending response failed

--- a/rpcs3/Emu/NP/ip_address.cpp
+++ b/rpcs3/Emu/NP/ip_address.cpp
@@ -66,7 +66,7 @@ namespace np
 		return sockaddr_ipv6;
 	}
 
-	u32 register_ip(const std::string& ip_bytes)
+	u32 register_ip(std::string_view ip_bytes)
 	{
 		if (ip_bytes.size() == 4)
 		{

--- a/rpcs3/Emu/NP/ip_address.h
+++ b/rpcs3/Emu/NP/ip_address.h
@@ -66,7 +66,7 @@ namespace np
 		std::vector<std::array<u8, 16>> ipv4_to_ipv6;
 	};
 
-	u32 register_ip(const std::string& ip_bytes);
+	u32 register_ip(std::string_view ip_bytes);
 
 	enum class IPV6_SUPPORT : u8
 	{

--- a/rpcs3/Emu/NP/np_handler.cpp
+++ b/rpcs3/Emu/NP/np_handler.cpp
@@ -1303,7 +1303,7 @@ namespace np
 		}
 	}
 
-	bool np_handler::error_and_disconnect(const std::string& error_msg)
+	bool np_handler::error_and_disconnect(std::string_view error_msg)
 	{
 		rpcn_log.error("%s", error_msg);
 		rpcn.reset();

--- a/rpcs3/Emu/NP/np_handler.h
+++ b/rpcs3/Emu/NP/np_handler.h
@@ -267,7 +267,7 @@ namespace np
 		error_code abort_request(u32 req_id);
 
 		// For signaling
-		void req_sign_infos(const std::string& npid, u32 conn_id);
+		void req_sign_infos(std::string_view npid, u32 conn_id);
 
 		// For UPNP
 		void upnp_add_port_mapping(u16 internal_port, std::string_view protocol);
@@ -297,7 +297,7 @@ namespace np
 		// Various generic helpers
 		bool discover_ip_address();
 		bool discover_ether_address();
-		bool error_and_disconnect(const std::string& error_msg);
+		bool error_and_disconnect(std::string_view error_msg);
 
 		// Notification handlers
 		void notif_user_joined_room(vec_stream& noti);

--- a/rpcs3/Emu/NP/np_requests.cpp
+++ b/rpcs3/Emu/NP/np_requests.cpp
@@ -814,7 +814,7 @@ namespace np
 		cb_info_opt->queue_callback(req_id, 0, error_code, 0);
 	}
 
-	void np_handler::req_sign_infos(const std::string& npid, u32 conn_id)
+	void np_handler::req_sign_infos(std::string_view npid, u32 conn_id)
 	{
 		const u32 req_id = get_req_id(REQUEST_ID_HIGH::MISC);
 		{

--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -967,7 +967,7 @@ namespace rpcn
 		server_info_received = false;
 	}
 
-	bool rpcn_client::connect(const std::string& host)
+	bool rpcn_client::connect(std::string_view host)
 	{
 		rpcn_log.warning("connect: Attempting to connect");
 
@@ -1172,7 +1172,7 @@ namespace rpcn
 		return true;
 	}
 
-	bool rpcn_client::login(const std::string& npid, const std::string& password, const std::string& token)
+	bool rpcn_client::login(std::string_view npid, std::string_view password, std::string_view token)
 	{
 		if (npid.empty())
 		{
@@ -1338,7 +1338,7 @@ namespace rpcn
 		return error;
 	}
 
-	ErrorType rpcn_client::resend_token(const std::string& npid, const std::string& password)
+	ErrorType rpcn_client::resend_token(std::string_view npid, std::string_view password)
 	{
 		if (authentified)
 		{
@@ -1469,7 +1469,7 @@ namespace rpcn
 		return error;
 	}
 
-	std::optional<ErrorType> rpcn_client::add_friend(const std::string& friend_username)
+	std::optional<ErrorType> rpcn_client::add_friend(std::string_view friend_username)
 	{
 		std::vector<u8> data;
 		std::copy(friend_username.begin(), friend_username.end(), std::back_inserter(data));
@@ -1494,7 +1494,7 @@ namespace rpcn
 		return error;
 	}
 
-	bool rpcn_client::remove_friend(const std::string& friend_username)
+	bool rpcn_client::remove_friend(std::string_view friend_username)
 	{
 		std::vector<u8> data;
 		std::copy(friend_username.begin(), friend_username.end(), std::back_inserter(data));
@@ -2159,7 +2159,7 @@ namespace rpcn
 		return forge_request_with_com_id(serialized, communication_id, CommandType::SendRoomMessage, req_id);
 	}
 
-	bool rpcn_client::req_sign_infos(u32 req_id, const std::string& npid)
+	bool rpcn_client::req_sign_infos(u32 req_id, std::string_view npid)
 	{
 		std::vector<u8> data;
 		std::copy(npid.begin(), npid.end(), std::back_inserter(data));
@@ -2168,7 +2168,7 @@ namespace rpcn
 		return forge_send(CommandType::RequestSignalingInfos, req_id, data);
 	}
 
-	bool rpcn_client::req_ticket(u32 req_id, const std::string& service_id, const std::vector<u8>& cookie)
+	bool rpcn_client::req_ticket(u32 req_id, std::string_view service_id, const std::vector<u8>& cookie)
 	{
 		std::vector<u8> data;
 		std::copy(service_id.begin(), service_id.end(), std::back_inserter(data));
@@ -2859,7 +2859,7 @@ namespace rpcn
 		memcpy(data.data(), com_id_str.data(), COMMUNICATION_ID_SIZE);
 	}
 
-	bool rpcn_client::forge_request_with_com_id(const std::string& serialized_data, const SceNpCommunicationId& com_id, CommandType command, u64 packet_id)
+	bool rpcn_client::forge_request_with_com_id(std::string_view serialized_data, const SceNpCommunicationId& com_id, CommandType command, u64 packet_id)
 	{
 		const usz bufsize = serialized_data.size();
 		std::vector<u8> data(COMMUNICATION_ID_SIZE + sizeof(u32) + bufsize);
@@ -2872,7 +2872,7 @@ namespace rpcn
 		return forge_send(command, packet_id, data);
 	}
 
-	bool rpcn_client::forge_request_with_data(const std::string& serialized_data, CommandType command, u64 packet_id)
+	bool rpcn_client::forge_request_with_data(std::string_view serialized_data, CommandType command, u64 packet_id)
 	{
 		const usz bufsize = serialized_data.size();
 		std::vector<u8> data(sizeof(u32) + bufsize);
@@ -2897,14 +2897,14 @@ namespace rpcn
 		return packet;
 	}
 
-	bool rpcn_client::error_and_disconnect(const std::string& error_msg)
+	bool rpcn_client::error_and_disconnect(std::string_view error_msg)
 	{
 		connected = false;
 		rpcn_log.error("%s", error_msg);
 		return false;
 	}
 
-	bool rpcn_client::error_and_disconnect_notice(const std::string& error_msg)
+	bool rpcn_client::error_and_disconnect_notice(std::string_view error_msg)
 	{
 		connected = false;
 		rpcn_log.notice("%s", error_msg);

--- a/rpcs3/Emu/NP/rpcn_client.h
+++ b/rpcs3/Emu/NP/rpcn_client.h
@@ -166,7 +166,7 @@ public:
 			vec.push_back(*(reinterpret_cast<u8*>(&value) + index));
 		}
 	}
-	void insert_string(const std::string& str) const
+	void insert_string(std::string_view str) const
 	{
 		std::copy(str.begin(), str.end(), std::back_inserter(vec));
 		vec.push_back(0);
@@ -277,8 +277,8 @@ namespace rpcn
 		bool send_packet(const std::vector<u8>& packet);
 
 	private:
-		bool connect(const std::string& host);
-		bool login(const std::string& npid, const std::string& password, const std::string& token);
+		bool connect(std::string_view host);
+		bool login(std::string_view npid, std::string_view password, std::string_view token);
 		void disconnect();
 
 	public:
@@ -297,12 +297,12 @@ namespace rpcn
 		void remove_friend_cb(friend_cb_func, void* cb_param);
 
 		ErrorType create_user(std::string_view npid, std::string_view password, std::string_view online_name, std::string_view avatar_url, std::string_view email);
-		ErrorType resend_token(const std::string& npid, const std::string& password);
+		ErrorType resend_token(std::string_view npid, std::string_view password);
 		ErrorType send_reset_token(std::string_view npid, std::string_view email);
 		ErrorType reset_password(std::string_view npid, std::string_view token, std::string_view password);
 		ErrorType delete_account();
-		std::optional<ErrorType> add_friend(const std::string& friend_username);
-		bool remove_friend(const std::string& friend_username);
+		std::optional<ErrorType> add_friend(std::string_view friend_username);
+		bool remove_friend(std::string_view friend_username);
 
 		u32 get_num_friends() const;
 		u32 get_num_blocks() const;
@@ -346,8 +346,8 @@ namespace rpcn
 		bool set_userinfo(u32 req_id, const SceNpCommunicationId& communication_id, const SceNpMatching2SetUserInfoRequest* req);
 		bool ping_room_owner(u32 req_id, const SceNpCommunicationId& communication_id, u64 room_id);
 		bool send_room_message(u32 req_id, const SceNpCommunicationId& communication_id, const SceNpMatching2SendRoomMessageRequest* req);
-		bool req_sign_infos(u32 req_id, const std::string& npid);
-		bool req_ticket(u32 req_id, const std::string& service_id, const std::vector<u8>& cookie);
+		bool req_sign_infos(u32 req_id, std::string_view npid);
+		bool req_ticket(u32 req_id, std::string_view service_id, const std::vector<u8>& cookie);
 		bool send_message(const message_data& msg_data, const std::set<std::string>& npids);
 		bool get_board_infos(u32 req_id, const SceNpCommunicationId& communication_id, SceNpScoreBoardId board_id);
 		bool record_score(u32 req_id, const SceNpCommunicationId& communication_id, SceNpScoreBoardId board_id, SceNpScorePcId char_id, SceNpScoreValue score, const std::optional<std::string> comment, const std::optional<std::vector<u8>> score_data);
@@ -396,12 +396,12 @@ namespace rpcn
 
 		std::vector<u8> forge_request(rpcn::CommandType command, u64 packet_id, const std::vector<u8>& data) const;
 		bool forge_send(rpcn::CommandType command, u64 packet_id, const std::vector<u8>& data);
-		bool forge_request_with_com_id(const std::string& serialized_data, const SceNpCommunicationId& com_id, CommandType command, u64 packet_id);
-		bool forge_request_with_data(const std::string& serialized_data, CommandType command, u64 packet_id);
+		bool forge_request_with_com_id(std::string_view serialized_data, const SceNpCommunicationId& com_id, CommandType command, u64 packet_id);
+		bool forge_request_with_data(std::string_view serialized_data, CommandType command, u64 packet_id);
 		bool forge_send_reply(rpcn::CommandType command, u64 packet_id, const std::vector<u8>& data, std::vector<u8>& reply_data);
 
-		bool error_and_disconnect(const std::string& error_mgs);
-		bool error_and_disconnect_notice(const std::string& error_msg);
+		bool error_and_disconnect(std::string_view error_mgs);
+		bool error_and_disconnect_notice(std::string_view error_msg);
 
 		std::string get_wolfssl_error(WOLFSSL* wssl, int error) const;
 

--- a/rpcs3/Emu/NP/upnp_handler.cpp
+++ b/rpcs3/Emu/NP/upnp_handler.cpp
@@ -119,13 +119,14 @@ void upnp_handler::add_port_redir(const std::string& addr, u16 internal_port, st
 	if (!m_active)
 		return;
 
+	const std::string protocol_str(protocol);
+
 	std::lock_guard lock(m_mutex);
 
-	if (m_bindings[std::string(protocol)].contains(internal_port))
+	if (m_bindings[protocol_str].contains(internal_port))
 		return;
 
 	const std::string internal_port_str = fmt::format("%d", internal_port);
-	const std::string protocol_str(protocol);
 	const u32 max_port = std::min(static_cast<u32>(internal_port) + 100, 0xFFFFu);
 	int res = 0;
 

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -21,7 +21,7 @@ std::string GLFragmentDecompilerThread::getFunction(FUNCTION f)
 	return glsl::getFunctionImpl(f);
 }
 
-std::string GLFragmentDecompilerThread::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1)
+std::string GLFragmentDecompilerThread::compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1)
 {
 	return glsl::compareFunctionImpl(f, Op0, Op1);
 }

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.h
@@ -34,8 +34,8 @@ public:
 protected:
 	std::string getFloatTypeName(usz elementCount) override;
 	std::string getHalfTypeName(usz elementCount) override;
-	std::string getFunction(FUNCTION) override;
-	std::string compareFunction(COMPARE, const std::string&, const std::string&) override;
+	std::string getFunction(FUNCTION f) override;
+	std::string compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1) override;
 
 	void insertHeader(std::stringstream &OS) override;
 	void insertInputs(std::stringstream &OS) override;

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -21,12 +21,12 @@ std::string GLVertexDecompilerThread::getFunction(FUNCTION f)
 	return glsl::getFunctionImpl(f);
 }
 
-std::string GLVertexDecompilerThread::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1, bool scalar)
+std::string GLVertexDecompilerThread::compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1, bool scalar)
 {
 	return glsl::compareFunctionImpl(f, Op0, Op1, scalar);
 }
 
-void GLVertexDecompilerThread::insertHeader(std::stringstream &OS)
+void GLVertexDecompilerThread::insertHeader(std::stringstream& OS)
 {
 	OS <<
 		"#version 430\n"
@@ -162,7 +162,7 @@ void GLVertexDecompilerThread::insertOutputs(std::stringstream& OS, const std::v
 	}
 }
 
-void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
+void GLVertexDecompilerThread::insertMainStart(std::stringstream& OS)
 {
 	const auto& dev_caps = gl::get_driver_caps();
 
@@ -236,7 +236,7 @@ void GLVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	}
 }
 
-void GLVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
+void GLVertexDecompilerThread::insertMainEnd(std::stringstream& OS)
 {
 	OS << "}\n\n";
 

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.h
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.h
@@ -26,20 +26,20 @@ struct GLVertexDecompilerThread : public VertexProgramDecompiler
 protected:
 	std::string getFloatTypeName(usz elementCount) override;
 	std::string getIntTypeName(usz elementCount) override;
-	std::string getFunction(FUNCTION) override;
-	std::string compareFunction(COMPARE, const std::string&, const std::string&, bool scalar) override;
+	std::string getFunction(FUNCTION f) override;
+	std::string compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1, bool scalar) override;
 
-	void insertHeader(std::stringstream &OS) override;
-	void insertInputs(std::stringstream &OS, const std::vector<ParamType> &inputs) override;
-	void insertConstants(std::stringstream &OS, const std::vector<ParamType> &constants) override;
-	void insertOutputs(std::stringstream &OS, const std::vector<ParamType> &outputs) override;
-	void insertMainStart(std::stringstream &OS) override;
-	void insertMainEnd(std::stringstream &OS) override;
+	void insertHeader(std::stringstream& OS) override;
+	void insertInputs(std::stringstream& OS, const std::vector<ParamType>& inputs) override;
+	void insertConstants(std::stringstream& OS, const std::vector<ParamType>& constants) override;
+	void insertOutputs(std::stringstream& OS, const std::vector<ParamType>& outputs) override;
+	void insertMainStart(std::stringstream& OS) override;
+	void insertMainEnd(std::stringstream& OS) override;
 
 	const RSXVertexProgram &rsx_vertex_program;
 	std::unordered_map<std::string, int> input_locations;
 public:
-	GLVertexDecompilerThread(const RSXVertexProgram &prog, std::string& shader, ParamArray&)
+	GLVertexDecompilerThread(const RSXVertexProgram& prog, std::string& shader, ParamArray&)
 		: VertexProgramDecompiler(prog)
 		, m_shader(shader)
 		, rsx_vertex_program(prog)

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.h
@@ -111,33 +111,33 @@ protected:
 	/** returns string calling function where arguments are passed via
 	 * $0 $1 $2 substring.
 	 */
-	virtual std::string getFunction(FUNCTION) = 0;
+	virtual std::string getFunction(FUNCTION f) = 0;
 
 	/** returns string calling comparison function on 2 args passed as strings.
 	 */
-	virtual std::string compareFunction(COMPARE, const std::string &, const std::string &) = 0;
+	virtual std::string compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1) = 0;
 
 	/** Insert header of shader file (eg #version, "system constants"...)
 	 */
-	virtual void insertHeader(std::stringstream &OS) = 0;
+	virtual void insertHeader(std::stringstream& OS) = 0;
 	/** Insert global declaration of fragments inputs.
 	 */
-	virtual void insertInputs(std::stringstream &OS) = 0;
+	virtual void insertInputs(std::stringstream& OS) = 0;
 	/** insert global declaration of fragments outputs.
 	*/
-	virtual void insertOutputs(std::stringstream &OS) = 0;
+	virtual void insertOutputs(std::stringstream& OS) = 0;
 	/** insert declaration of shader constants.
 	*/
-	virtual void insertConstants(std::stringstream &OS) = 0;
+	virtual void insertConstants(std::stringstream& OS) = 0;
 	/** insert helper function definitions.
 	*/
-	virtual void insertGlobalFunctions(std::stringstream &OS) = 0;
+	virtual void insertGlobalFunctions(std::stringstream& OS) = 0;
 	/** insert beginning of main (signature, temporary declaration...)
 	*/
-	virtual void insertMainStart(std::stringstream &OS) = 0;
+	virtual void insertMainStart(std::stringstream& OS) = 0;
 	/** insert end of main function (return value, output copy...)
 	 */
-	virtual void insertMainEnd(std::stringstream &OS) = 0;
+	virtual void insertMainEnd(std::stringstream& OS) = 0;
 
 public:
 	enum : u16
@@ -201,7 +201,7 @@ public:
 	device_props;
 
 	ParamArray m_parr;
-	FragmentProgramDecompiler(const RSXFragmentProgram &prog, u32& size);
+	FragmentProgramDecompiler(const RSXFragmentProgram& prog, u32& size);
 	FragmentProgramDecompiler(const FragmentProgramDecompiler&) = delete;
 	FragmentProgramDecompiler(FragmentProgramDecompiler&&) = delete;
 	std::string Decompile();

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -73,7 +73,7 @@ namespace glsl
 		}
 	}
 
-	std::string compareFunctionImpl(COMPARE f, const std::string &Op0, const std::string &Op1, bool scalar)
+	std::string compareFunctionImpl(COMPARE f, std::string_view Op0, std::string_view Op1, bool scalar)
 	{
 		if (scalar)
 		{

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.h
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.h
@@ -71,7 +71,7 @@ namespace glsl
 
 	std::string getFloatTypeNameImpl(usz elementCount);
 	std::string getHalfTypeNameImpl(usz elementCount);
-	std::string compareFunctionImpl(COMPARE f, const std::string &Op0, const std::string &Op1, bool scalar = false);
+	std::string compareFunctionImpl(COMPARE f, std::string_view Op0, std::string_view Op1, bool scalar = false);
 	void insert_vertex_input_fetch(std::stringstream& OS, glsl_rules rules, bool glsl4_compliant=true);
 	void insert_rop_init(std::ostream& OS);
 	void insert_rop(std::ostream& OS, const shader_properties& props);

--- a/rpcs3/Emu/RSX/Program/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Program/ShaderParam.h
@@ -130,7 +130,7 @@ struct ParamType
 	{
 	}
 
-	bool HasItem(const std::string& name) const
+	bool HasItem(std::string_view name) const
 	{
 		return std::any_of(items.cbegin(), items.cend(), [&name](const auto& item)
 		{
@@ -138,7 +138,7 @@ struct ParamType
 		});
 	}
 
-	bool ReplaceOrInsert(const std::string& name, const ParamItem& item)
+	bool ReplaceOrInsert(std::string_view name, const ParamItem& item)
 	{
 		if (HasItem(name))
 		{
@@ -168,7 +168,7 @@ struct ParamArray
 {
 	std::vector<ParamType> params[PF_PARAM_COUNT];
 
-	ParamType* SearchParam(const ParamFlag &flag, const std::string& type)
+	ParamType* SearchParam(const ParamFlag& flag, std::string_view type)
 	{
 		for (auto& param : params[flag])
 		{
@@ -179,7 +179,7 @@ struct ParamArray
 		return nullptr;
 	}
 
-	bool HasParamTypeless(const ParamFlag flag, const std::string& name) const
+	bool HasParamTypeless(const ParamFlag flag, std::string_view name) const
 	{
 		const auto& p = params[flag];
 		return std::any_of(p.cbegin(), p.cend(), [&name](const auto& param)
@@ -188,7 +188,7 @@ struct ParamArray
 		});
 	}
 
-	bool HasParam(const ParamFlag flag, const std::string& type, const std::string& name)
+	bool HasParam(const ParamFlag flag, std::string_view type, std::string_view name)
 	{
 		const ParamType* t = SearchParam(flag, type);
 		return t && t->HasItem(name);

--- a/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.h
+++ b/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.h
@@ -99,35 +99,35 @@ protected:
 	/** returns string calling function where arguments are passed via
 	* $0 $1 $2 substring.
 	*/
-	virtual std::string getFunction(FUNCTION) = 0;
+	virtual std::string getFunction(FUNCTION f) = 0;
 
 	/** returns string calling comparison function on 2 args passed as strings.
 	*/
-	virtual std::string compareFunction(COMPARE, const std::string &, const std::string &, bool scalar = false) = 0;
+	virtual std::string compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1, bool scalar = false) = 0;
 
 	/** Insert header of shader file (eg #version, "system constants"...)
 	*/
-	virtual void insertHeader(std::stringstream &OS) = 0;
+	virtual void insertHeader(std::stringstream& OS) = 0;
 
 	/** Insert vertex declaration.
 	*/
-	virtual void insertInputs(std::stringstream &OS, const std::vector<ParamType> &inputs) = 0;
+	virtual void insertInputs(std::stringstream& OS, const std::vector<ParamType>& inputs) = 0;
 
 	/** insert global declaration of vertex shader outputs.
 	*/
-	virtual void insertConstants(std::stringstream &OS, const std::vector<ParamType> &constants) = 0;
+	virtual void insertConstants(std::stringstream& OS, const std::vector<ParamType>& constants) = 0;
 
 	/** insert declaration of shader constants.
 	*/
-	virtual void insertOutputs(std::stringstream &OS, const std::vector<ParamType> &outputs) = 0;
+	virtual void insertOutputs(std::stringstream& OS, const std::vector<ParamType>& outputs) = 0;
 
 	/** insert beginning of main (signature, temporary declaration...)
 	*/
-	virtual void insertMainStart(std::stringstream &OS) = 0;
+	virtual void insertMainStart(std::stringstream& OS) = 0;
 
 	/** insert end of main function (return value, output copy...)
 	*/
-	virtual void insertMainEnd(std::stringstream &OS) = 0;
+	virtual void insertMainEnd(std::stringstream& OS) = 0;
 
 public:
 	struct

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -21,7 +21,7 @@ std::string VKFragmentDecompilerThread::getFunction(FUNCTION f)
 	return glsl::getFunctionImpl(f);
 }
 
-std::string VKFragmentDecompilerThread::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1)
+std::string VKFragmentDecompilerThread::compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1)
 {
 	return glsl::compareFunctionImpl(f, Op0, Op1);
 }

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.h
@@ -37,8 +37,8 @@ public:
 protected:
 	std::string getFloatTypeName(usz elementCount) override;
 	std::string getHalfTypeName(usz elementCount) override;
-	std::string getFunction(FUNCTION) override;
-	std::string compareFunction(COMPARE, const std::string&, const std::string&) override;
+	std::string getFunction(FUNCTION f) override;
+	std::string compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1) override;
 
 	void insertHeader(std::stringstream &OS) override;
 	void insertInputs(std::stringstream &OS) override;

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.cpp
@@ -282,7 +282,7 @@ namespace vk
 			return *this;
 		}
 
-		bool program::has_uniform(program_input_type type, const std::string& uniform_name)
+		bool program::has_uniform(program_input_type type, std::string_view uniform_name)
 		{
 			for (auto& set : m_sets)
 			{
@@ -296,7 +296,7 @@ namespace vk
 			return false;
 		}
 
-		std::pair<u32, u32> program::get_uniform_location(::glsl::program_domain domain, program_input_type type, const std::string& uniform_name)
+		std::pair<u32, u32> program::get_uniform_location(::glsl::program_domain domain, program_input_type type, std::string_view uniform_name)
 		{
 			for (unsigned i = 0; i < ::size32(m_sets); ++i)
 			{
@@ -632,7 +632,7 @@ namespace vk
 
 			std::unordered_map<u32, VkDescriptorType> descriptor_type_map;
 
-			auto descriptor_count = [](const std::string& name) -> u32
+			auto descriptor_count = [](std::string_view name) -> u32
 			{
 				const auto start = name.find_last_of("[");
 				if (start == std::string::npos)
@@ -643,8 +643,8 @@ namespace vk
 				const auto end = name.find_last_of("]");
 				ensure(end != std::string::npos && start < end, "Invalid variable name");
 
-				const std::string array_size = name.substr(start + 1, end - start - 1);
-				if (const auto count = std::atoi(array_size.c_str());
+				const std::string_view array_size = name.substr(start + 1, end - start - 1);
+				if (const auto count = std::atoi(array_size.data());
 					count > 0)
 				{
 					return count;

--- a/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramPipeline.h
@@ -221,13 +221,12 @@ namespace vk
 			program& link(bool separate_stages);
 			program& bind(const vk::command_buffer& cmd, VkPipelineBindPoint bind_point);
 
-			bool has_uniform(program_input_type type, const std::string &uniform_name);
-			std::pair<u32, u32> get_uniform_location(::glsl::program_domain domain, program_input_type type, const std::string& uniform_name);
+			bool has_uniform(program_input_type type, std::string_view uniform_name);
+			std::pair<u32, u32> get_uniform_location(::glsl::program_domain domain, program_input_type type, std::string_view uniform_name);
 
 			void bind_uniform(const VkDescriptorImageInfoEx& image_descriptor, u32 set_id, u32 binding_point);
 			void bind_uniform(const VkDescriptorBufferInfoEx& buffer_descriptor, u32 set_id, u32 binding_point);
 			void bind_uniform(const VkDescriptorBufferViewEx& buffer_view, u32 set_id, u32 binding_point);
-			void bind_uniform(const VkDescriptorBufferViewEx& buffer_view, ::glsl::program_domain domain, program_input_type type, const std::string &binding_name);
 
 			void bind_uniform_array(const std::span<const VkDescriptorImageInfoEx>& image_descriptors,u32 set_id, u32 binding_point);
 

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -21,7 +21,7 @@ std::string VKVertexDecompilerThread::getFunction(FUNCTION f)
 	return glsl::getFunctionImpl(f);
 }
 
-std::string VKVertexDecompilerThread::compareFunction(COMPARE f, const std::string &Op0, const std::string &Op1, bool scalar)
+std::string VKVertexDecompilerThread::compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1, bool scalar)
 {
 	return glsl::compareFunctionImpl(f, Op0, Op1, scalar);
 }
@@ -69,7 +69,7 @@ void VKVertexDecompilerThread::prepareBindingTable()
 	}
 }
 
-void VKVertexDecompilerThread::insertHeader(std::stringstream &OS)
+void VKVertexDecompilerThread::insertHeader(std::stringstream& OS)
 {
 	prepareBindingTable();
 
@@ -182,7 +182,7 @@ void VKVertexDecompilerThread::insertInputs(std::stringstream& OS, const std::ve
 	}
 }
 
-void VKVertexDecompilerThread::insertConstants(std::stringstream & OS, const std::vector<ParamType> & constants)
+void VKVertexDecompilerThread::insertConstants(std::stringstream& OS, const std::vector<ParamType>& constants)
 {
 	vk::glsl::program_input in
 	{
@@ -330,7 +330,7 @@ void VKVertexDecompilerThread::insertFSExport(std::stringstream& OS)
 		"}\n\n";
 }
 
-void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
+void VKVertexDecompilerThread::insertMainStart(std::stringstream& OS)
 {
 	glsl::shader_properties properties2{};
 	properties2.domain = glsl::glsl_vertex_program;
@@ -388,9 +388,9 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	OS << "{\n";
 
 	//Declare temporary registers, ignoring those mapped to outputs
-	for (const ParamType &PT : m_parr.params[PF_PARAM_NONE])
+	for (const ParamType& PT : m_parr.params[PF_PARAM_NONE])
 	{
-		for (const ParamItem &PI : PT.items)
+		for (const ParamItem& PI : PT.items)
 		{
 			if (PI.name.starts_with("dst_reg"))
 				continue;
@@ -403,9 +403,9 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 		}
 	}
 
-	for (const ParamType &PT : m_parr.params[PF_PARAM_IN])
+	for (const ParamType& PT : m_parr.params[PF_PARAM_IN])
 	{
-		for (const ParamItem &PI : PT.items)
+		for (const ParamItem& PI : PT.items)
 		{
 			OS << "	vec4 " << PI.name << "= read_location(" << std::to_string(PI.location) << ");\n";
 		}
@@ -414,7 +414,7 @@ void VKVertexDecompilerThread::insertMainStart(std::stringstream & OS)
 	OS << "\nuint xform_constants_offset = get_draw_params().xform_constants_offset;\n\n";
 }
 
-void VKVertexDecompilerThread::insertMainEnd(std::stringstream & OS)
+void VKVertexDecompilerThread::insertMainEnd(std::stringstream& OS)
 {
 	OS << "}\n\n";
 

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.h
@@ -25,21 +25,21 @@ struct VKVertexDecompilerThread : public VertexProgramDecompiler
 protected:
 	std::string getFloatTypeName(usz elementCount) override;
 	std::string getIntTypeName(usz elementCount) override;
-	std::string getFunction(FUNCTION) override;
-	std::string compareFunction(COMPARE, const std::string&, const std::string&, bool scalar) override;
+	std::string getFunction(FUNCTION f) override;
+	std::string compareFunction(COMPARE f, std::string_view Op0, std::string_view Op1, bool scalar) override;
 
-	void insertHeader(std::stringstream &OS) override;
-	void insertInputs(std::stringstream &OS, const std::vector<ParamType> &inputs) override;
-	void insertConstants(std::stringstream &OS, const std::vector<ParamType> &constants) override;
-	void insertOutputs(std::stringstream &OS, const std::vector<ParamType> &outputs) override;
-	void insertMainStart(std::stringstream &OS) override;
-	void insertMainEnd(std::stringstream &OS) override;
+	void insertHeader(std::stringstream& OS) override;
+	void insertInputs(std::stringstream& OS, const std::vector<ParamType>& inputs) override;
+	void insertConstants(std::stringstream& OS, const std::vector<ParamType>& constants) override;
+	void insertOutputs(std::stringstream& OS, const std::vector<ParamType>& outputs) override;
+	void insertMainStart(std::stringstream& OS) override;
+	void insertMainEnd(std::stringstream& OS) override;
 
 	void prepareBindingTable();
 
 	const RSXVertexProgram &rsx_vertex_program;
 public:
-	VKVertexDecompilerThread(const RSXVertexProgram &prog, std::string& shader, ParamArray&, class VKVertexProgram &dst)
+	VKVertexDecompilerThread(const RSXVertexProgram& prog, std::string& shader, ParamArray&, class VKVertexProgram& dst)
 		: VertexProgramDecompiler(prog)
 		, m_shader(shader)
 		, vk_prog(&dst)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -4843,7 +4843,7 @@ bool Emulator::IsValidSfb(const std::string& path)
 	return false;
 }
 
-void Emulator::SaveSettings(const std::string& settings, const std::string& title_id)
+void Emulator::SaveSettings(std::string_view settings, const std::string& title_id)
 {
 	std::string config_name;
 
@@ -4864,7 +4864,7 @@ void Emulator::SaveSettings(const std::string& settings, const std::string& titl
 	}
 	else
 	{
-		temp.file.write(settings.c_str(), settings.size());
+		temp.file.write(settings.data(), settings.size());
 		if (!temp.commit())
 		{
 			sys_log.error("Could not save config to %s (failed to commit) (error=%s)", config_name, fs::g_tls_error);
@@ -4875,7 +4875,7 @@ void Emulator::SaveSettings(const std::string& settings, const std::string& titl
 	if (config_name == g_cfg.name || title_id == Emu.GetTitleID())
 	{
 		// Update current config
-		if (!g_cfg.from_string({settings.c_str(), settings.size()}, !Emu.IsStopped()))
+		if (!g_cfg.from_string(settings, !Emu.IsStopped()))
 		{
 			sys_log.fatal("Failed to update configuration");
 		}

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -510,7 +510,7 @@ public:
 	static bool IsVsh();
 	static bool IsValidSfb(const std::string& path);
 
-	static void SaveSettings(const std::string& settings, const std::string& title_id);
+	static void SaveSettings(std::string_view settings, const std::string& title_id);
 };
 
 extern Emulator Emu;

--- a/rpcs3/Emu/system_utils.cpp
+++ b/rpcs3/Emu/system_utils.cpp
@@ -56,13 +56,13 @@ namespace rpcs3::utils
 		was_silenced = silenced;
 	}
 
-	u32 check_user(const std::string& user)
+	u32 check_user(std::string_view user)
 	{
 		u32 id = 0;
 
 		if (user.size() == 8)
 		{
-			std::from_chars(&user.front(), &user.back() + 1, id);
+			std::from_chars(user.data(), user.data() + user.size(), id);
 		}
 
 		return id;
@@ -583,7 +583,7 @@ namespace rpcs3::utils
 		const bool check_disc = !disc_dir.empty();
 		const bool check_hdd0 = !hdd0_dir.empty() && !check_disc;
 
-		const auto find_content = [&](const std::string& name, const std::string& extension) -> std::string
+		const auto find_content = [&](std::string_view name, std::string_view extension) -> std::string
 		{
 			// Check localized content first
 			for (bool localized : { true, false })

--- a/rpcs3/Emu/system_utils.hpp
+++ b/rpcs3/Emu/system_utils.hpp
@@ -21,7 +21,7 @@ namespace rpcs3::utils
 
 	void configure_logs(bool force_enable = false);
 
-	u32 check_user(const std::string& user);
+	u32 check_user(std::string_view user);
 
 	bool install_pkg(const std::string& path);
 

--- a/rpcs3/Emu/vfs_config.cpp
+++ b/rpcs3/Emu/vfs_config.cpp
@@ -11,9 +11,9 @@ std::string cfg_vfs::get(const cfg::string& _cfg, std::string_view emu_dir) cons
 	return get(_cfg.to_string(), _cfg.def, emu_dir);
 }
 
-std::string cfg_vfs::get(const std::string& _cfg, const std::string& def, std::string_view emu_dir) const
+std::string cfg_vfs::get(std::string_view _cfg, std::string_view def, std::string_view emu_dir) const
 {
-	std::string path = _cfg;
+	std::string path = std::string(_cfg);
 
 	// Fallback
 	if (path.empty())

--- a/rpcs3/Emu/vfs_config.h
+++ b/rpcs3/Emu/vfs_config.h
@@ -42,7 +42,7 @@ struct cfg_vfs : cfg::node
 	cfg::device_info get_device(const cfg::device_entry& _cfg, std::string_view key, std::string_view emu_dir = {}) const;
 
 private:
-	std::string get(const std::string& _cfg, const std::string& def, std::string_view emu_dir) const;
+	std::string get(std::string_view _cfg, std::string_view def, std::string_view emu_dir) const;
 	cfg::device_info get_device_info(const cfg::device_entry& _cfg, std::string_view key, std::string_view emu_dir = {}) const;
 };
 

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -568,8 +568,9 @@ void tar_object::save_directory(const std::string& target_path, utils::serial& a
 	auto save_header = [&](const fs::stat_t& stat, std::string_view name)
 	{
 		static_assert(sizeof(TARHeader) == 512);
+		ensure(src_dir_pos <= name.size());
 
-		std::string_view saved_path = name.size() == src_dir_pos ? name : name.substr(src_dir_pos);
+		std::string_view saved_path = name.size() == src_dir_pos ? std::string_view() : name.substr(src_dir_pos);
 
 		if (is_null)
 		{

--- a/rpcs3/rpcs3qt/cheat_manager.cpp
+++ b/rpcs3/rpcs3qt/cheat_manager.cpp
@@ -195,7 +195,7 @@ bool cheat_engine::erase(const std::string& game, const u32 offset)
 	return true;
 }
 
-bool cheat_engine::resolve_script(u32& final_offset, const u32 offset, const std::string& red_script)
+bool cheat_engine::resolve_script(u32& final_offset, const u32 offset, std::string_view red_script)
 {
 	enum operand
 	{
@@ -290,8 +290,11 @@ bool cheat_engine::resolve_script(u32& final_offset, const u32 offset, const std
 				cur_op = operand_sub;
 				index++;
 				break;
-			case ' ': index++; break;
-			default: log_cheat.fatal("invalid character in redirection script"); return false;
+			case ' ': index++;
+				break;
+			default:
+				log_cheat.fatal("invalid character in redirection script");
+				return false;
 			}
 		}
 	}

--- a/rpcs3/rpcs3qt/cheat_manager.h
+++ b/rpcs3/rpcs3qt/cheat_manager.h
@@ -30,7 +30,7 @@ public:
 	void save() const;
 
 	// Static functions to find/get/set values in ps3 memory
-	static bool resolve_script(u32& final_offset, const u32 offset, const std::string& red_script);
+	static bool resolve_script(u32& final_offset, const u32 offset, std::string_view red_script);
 
 	template <typename T>
 	static std::vector<u32> search(const T value, const std::vector<u32>& to_filter);

--- a/rpcs3/rpcs3qt/midi_creator.cpp
+++ b/rpcs3/rpcs3qt/midi_creator.cpp
@@ -8,7 +8,7 @@
 
 LOG_CHANNEL(cfg_log, "CFG");
 
-const auto midi_deleter = [](RtMidiWrapper* ptr) { if (ptr) rtmidi_in_free(ptr); };
+inline constexpr auto midi_deleter = [](RtMidiWrapper* ptr) { if (ptr) rtmidi_in_free(ptr); };
 using midi_ptr = std::unique_ptr<RtMidiWrapper, decltype(midi_deleter)>;
 
 std::mutex midi_creator::m_midi_init_mutex = {};

--- a/rpcs3/rpcs3qt/rpcn_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/rpcn_settings_dialog.cpp
@@ -1353,7 +1353,7 @@ rpcn_friends_dialog::~rpcn_friends_dialog()
 	}
 }
 
-bool rpcn_friends_dialog::add_friend_with_error_dialog(const std::string& friend_username)
+bool rpcn_friends_dialog::add_friend_with_error_dialog(std::string_view friend_username)
 {
 	QString err_msg;
 	const auto opt_error = m_rpcn->add_friend(friend_username);

--- a/rpcs3/rpcs3qt/rpcn_settings_dialog.h
+++ b/rpcs3/rpcs3qt/rpcn_settings_dialog.h
@@ -121,7 +121,7 @@ public:
 private:
 	void add_update_list(QListWidget* list, const QString& name, const QIcon& icon, const QVariant& data);
 	void remove_list(QListWidget* list, const QString& name);
-	bool add_friend_with_error_dialog(const std::string& friend_username);
+	bool add_friend_with_error_dialog(std::string_view friend_username);
 
 private Q_SLOTS:
 	void add_update_friend(const QString& name, bool status);

--- a/rpcs3/rpcs3qt/shortcut_utils.cpp
+++ b/rpcs3/rpcs3qt/shortcut_utils.cpp
@@ -109,7 +109,7 @@ namespace gui::utils
 		return true;
 	}
 
-	static std::string make_simple_name(const std::string& name)
+	static std::string make_simple_name(std::string_view name)
 	{
 		const std::string simple_name = QString::fromStdString(vfs::escape(name, true)).simplified().toStdString();
 		return simple_name;
@@ -227,7 +227,7 @@ namespace gui::utils
 		Microsoft::WRL::ComPtr<IShellLink> pShellLink;
 		Microsoft::WRL::ComPtr<IPersistFile> pPersistFile;
 
-		const auto cleanup = [&](bool return_value, const std::string& fail_reason) -> bool
+		const auto cleanup = [&](bool return_value, std::string_view fail_reason) -> bool
 		{
 			if (!return_value) sys_log.error("Failed to create shortcut: %s", fail_reason);
 			CoUninitialize();
@@ -611,7 +611,7 @@ namespace gui::utils
 		return result;
 	}
 
-	static void remove_shortcuts(const std::string& simple_name, [[maybe_unused]] const std::string& serial)
+	static void remove_shortcuts(std::string_view simple_name, [[maybe_unused]] const std::string& serial)
 	{
 		if (simple_name.empty() || simple_name == "." || simple_name == "..")
 		{

--- a/rpcs3/rpcs3qt/steam_utils.cpp
+++ b/rpcs3/rpcs3qt/steam_utils.cpp
@@ -520,7 +520,7 @@ namespace gui::utils
 		return !path.empty() && fs::is_dir(path);
 	}
 
-	u32 steam_shortcut::crc32(const std::string& data)
+	u32 steam_shortcut::crc32(std::string_view data)
 	{
 		u32 crc = 0xFFFFFFFF;
 
@@ -882,7 +882,7 @@ namespace gui::utils
 	}
 #endif
 
-	std::string steam_shortcut::steamid64_to_32(const std::string& steam_id)
+	std::string steam_shortcut::steamid64_to_32(std::string_view steam_id)
 	{
 		u64 id = 0;
 		if (!try_to_uint64(&id, steam_id, 0, umax))
@@ -1009,7 +1009,7 @@ namespace gui::utils
 
 		usz user_count = 0;
 
-		const auto find_user_id = [&content, &user_count](const std::string& key, const std::string& comp) -> std::string
+		const auto find_user_id = [&content, &user_count](const std::string& key, std::string_view comp) -> std::string
 		{
 			user_count = 0;
 			usz pos = 0;

--- a/rpcs3/rpcs3qt/steam_utils.h
+++ b/rpcs3/rpcs3qt/steam_utils.h
@@ -105,7 +105,7 @@ namespace gui::utils
 
 		void update_steam_input_config(const std::string& user_dir);
 
-		static u32 crc32(const std::string& data);
+		static u32 crc32(std::string_view data);
 		static u32 steam_appid(const std::string& exe, const std::string& name);
 
 		static void append(std::string& s, const std::string& val);
@@ -114,7 +114,7 @@ namespace gui::utils
 		static std::string fix_slashes(const std::string& s);
 		static std::string kv_string(const std::string& key, const std::string& value);
 		static std::string kv_int(const std::string& key, u32 value);
-		static std::string steamid64_to_32(const std::string& steam_id);
+		static std::string steamid64_to_32(std::string_view steam_id);
 		static std::string get_steam_path();
 		static std::string get_last_active_steam_user(const std::string& steam_path);
 

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -229,7 +229,7 @@ void user_manager_dialog::OnUserRemove()
 	}
 }
 
-void user_manager_dialog::GenerateUser(const std::string& user_id, const std::string& username)
+void user_manager_dialog::GenerateUser(const std::string& user_id, std::string_view username)
 {
 	ensure(rpcs3::utils::check_user(user_id) > 0);
 

--- a/rpcs3/rpcs3qt/user_manager_dialog.h
+++ b/rpcs3/rpcs3qt/user_manager_dialog.h
@@ -35,7 +35,7 @@ protected:
 private:
 	void Init();
 	void UpdateTable(bool mark_only = false);
-	static void GenerateUser(const std::string& user_id, const std::string& username);
+	static void GenerateUser(const std::string& user_id, std::string_view username);
 	static bool ValidateUsername(const QString& text_to_validate);
 
 	void ShowContextMenu(const QPoint &pos);

--- a/rpcs3/tests/test_rsx_fp_asm.cpp
+++ b/rpcs3/tests/test_rsx_fp_asm.cpp
@@ -51,7 +51,7 @@ namespace rsx::assembler
 		return nullptr;
 	};
 
-	static FlowGraph CFG_from_source(const std::string& asm_)
+	static FlowGraph CFG_from_source(std::string_view asm_)
 	{
 		auto ir = FPIR::from_source(asm_);
 


### PR DESCRIPTION
This is based on a branch I had lying around for a while now and worked on while being bored.
I thought I'd just commit the stuff before I forget about it.

- Use std::string_view in rsx code
- Use std::string_view in rpcn code
- Use std::string_view in cell modules
- Fix some midi_deleter warning