### PR TITLE
Qt: use readable strings for window visibility in gui settings

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -647,7 +647,7 @@ void gs_frame::hide_on_close()
 {
 	// Make sure not to save the hidden state, which is useless to us.
 	const Visibility current_visibility = visibility();
-	m_gui_settings->SetValue(gui::gs_visibility, current_visibility == Visibility::Hidden ? m_visibility : current_visibility, false);
+	m_gui_settings->SetValue(gui::gs_visibility, gui::visibility_to_string(current_visibility == Visibility::Hidden ? m_visibility : current_visibility), false);
 	m_gui_settings->SetValue(gui::gs_geometry, geometry(), true);
 
 	if (!g_progr_text)
@@ -718,10 +718,10 @@ void gs_frame::show()
 		{
 			setVisibility(FullScreen);
 		}
-		else if (const QVariant var = m_gui_settings->GetValue(gui::gs_visibility); var.canConvert<Visibility>())
+		else if (const QVariant var = m_gui_settings->GetValue(gui::gs_visibility); var.canConvert<QString>())
 		{
 			// Restore saved visibility from last time. Make sure not to hide the window, or the user can't access it anymore.
-			if (const Visibility visibility = var.value<Visibility>(); visibility != Visibility::Hidden)
+			if (const Visibility visibility = gui::string_to_visibility(var.value<QString>()); visibility != Visibility::Hidden)
 			{
 				setVisibility(visibility);
 			}

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -102,6 +102,45 @@ namespace gui
 	
 		fmt::throw_exception("get_trophy_game_list_column_name: Invalid column");
 	}
+
+	QString window_states_to_string(Qt::WindowStates states)
+	{
+		if (states & Qt::WindowFullScreen) return "FullScreen";
+		if (states & Qt::WindowMaximized) return "Maximized";
+		if (states & Qt::WindowMinimized) return "Minimized";
+		return "Windowed";
+	}
+
+	Qt::WindowState string_to_window_states(const QString& state)
+	{
+		const QString lower = state.toLower(); // Allow for better user experience
+		if (lower == "fullscreen") return Qt::WindowFullScreen;
+		if (lower == "maximized") return Qt::WindowMaximized;
+		if (lower == "minimized") return Qt::WindowMinimized;
+		return Qt::WindowNoState;
+	}
+
+	QString visibility_to_string(QWindow::Visibility visibility)
+	{
+		switch (visibility)
+		{
+		case QWindow::Visibility::Windowed: return "Windowed";
+		case QWindow::Visibility::Minimized: return "Minimized";
+		case QWindow::Visibility::Maximized: return "Maximized";
+		case QWindow::Visibility::FullScreen: return "FullScreen";
+		default: return "AutomaticVisibility";
+		}
+	}
+
+	QWindow::Visibility string_to_visibility(const QString& visibility)
+	{
+		const QString lower = visibility.toLower(); // Allow for better user experience
+		if (lower == "windowed") return QWindow::Visibility::Windowed;
+		if (lower == "minimized") return QWindow::Visibility::Minimized;
+		if (lower == "maximized") return QWindow::Visibility::Maximized;
+		if (lower == "fullscreen") return QWindow::Visibility::FullScreen;
+		return QWindow::Visibility::AutomaticVisibility;
+	}
 }
 
 gui_settings::gui_settings(QObject* parent) : settings(parent)

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -109,6 +109,12 @@ namespace gui
 		return q_string_pair(path, title.simplified()); // simplified() forces single line text
 	}
 
+	QString window_states_to_string(Qt::WindowStates states);
+	Qt::WindowState string_to_window_states(const QString& state);
+
+	QString visibility_to_string(QWindow::Visibility visibility);
+	QWindow::Visibility string_to_visibility(const QString& visibility);
+
 	const QString Settings          = "CurrentSettings";
 	const QString DefaultStylesheet = "default";
 	const QString NoStylesheet      = "none";
@@ -180,6 +186,7 @@ namespace gui
 	const gui_save mw_geometry         = gui_save(main_window, "geometry",         QByteArray());
 	const gui_save mw_windowState      = gui_save(main_window, "windowState",      QByteArray());
 	const gui_save mw_mwState          = gui_save(main_window, "mwState",          QByteArray());
+	const gui_save mw_visibility       = gui_save(main_window, "visibility",       window_states_to_string(Qt::WindowNoState));
 
 	const gui_save cat_hdd_game    = gui_save(game_list, "categoryVisibleHDDGame",    true);
 	const gui_save cat_disc_game   = gui_save(game_list, "categoryVisibleDiscGame",   true);
@@ -272,7 +279,7 @@ namespace gui
 	const gui_save gs_hideMouseIdle     = gui_save(gs_frame, "hideMouseOnIdle",       false);
 	const gui_save gs_hideMouseIdleTime = gui_save(gs_frame, "hideMouseOnIdleTime",   2000);
 	const gui_save gs_geometry          = gui_save(gs_frame, "geometry",              QRect());
-	const gui_save gs_visibility        = gui_save(gs_frame, "visibility",            QWindow::Visibility::AutomaticVisibility);
+	const gui_save gs_visibility        = gui_save(gs_frame, "visibility",            visibility_to_string(QWindow::Visibility::AutomaticVisibility));
 
 	const gui_save ss_icon_color      = gui_save(trophy, "icon_color",    gl_icon_color);
 	const gui_save ss_game_icon_size  = gui_save(trophy, "game_icon_size",  25);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -1923,6 +1923,7 @@ void main_window::DecryptSPRXLibraries()
 void main_window::SaveWindowState() const
 {
 	// Save gui settings
+	m_gui_settings->SetValue(gui::mw_visibility, gui::window_states_to_string(windowState()), false);
 	m_gui_settings->SetValue(gui::mw_geometry, saveGeometry(), false);
 	m_gui_settings->SetValue(gui::mw_windowState, saveState(), false);
 
@@ -1999,14 +2000,7 @@ void main_window::RepaintToolBarIcons()
 		ui->sysPauseAct->setIcon(m_icon_play);
 	}
 
-	if (isFullScreen())
-	{
-		ui->toolbar_fullscreen->setIcon(m_icon_fullscreen_off);
-	}
-	else
-	{
-		ui->toolbar_fullscreen->setIcon(m_icon_fullscreen_on);
-	}
+	ui->toolbar_fullscreen->setIcon(isFullScreen() ? m_icon_fullscreen_off : m_icon_fullscreen_on);
 
 	const QColor& new_color = new_colors[QIcon::Normal];
 	ui->sizeSlider->setStyleSheet(ui->sizeSlider->styleSheet().append("QSlider::handle:horizontal{ background: rgba(%1, %2, %3, %4); }")
@@ -3941,6 +3935,10 @@ void main_window::ConfigureGuiFromSettings()
 
 	// Gamelist
 	m_game_list_frame->LoadSettings();
+
+	// Restore saved visibility from last time.
+	setWindowState(gui::string_to_window_states(m_gui_settings->GetValue(gui::mw_visibility).toString()));
+	ui->toolbar_fullscreen->setIcon(isFullScreen() ? m_icon_fullscreen_off : m_icon_fullscreen_on);
 }
 
 void main_window::SetIconSizeActions(int idx) const
@@ -4060,7 +4058,7 @@ void main_window::CreateFirmwareCache()
 	}
 }
 
-void main_window::mouseDoubleClickEvent(QMouseEvent *event)
+void main_window::mouseDoubleClickEvent(QMouseEvent* event)
 {
 	if (isFullScreen())
 	{

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -125,9 +125,9 @@ private Q_SLOTS:
 	void update_gui_pad_thread();
 
 protected:
-	void closeEvent(QCloseEvent *event) override;
-	void changeEvent(QEvent *event) override;
-	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	void closeEvent(QCloseEvent* event) override;
+	void changeEvent(QEvent* event) override;
+	void mouseDoubleClickEvent(QMouseEvent* event) override;
 	void dropEvent(QDropEvent* event) override;
 	void dragEnterEvent(QDragEnterEvent* event) override;
 	void dragMoveEvent(QDragMoveEvent* event) override;
@@ -184,7 +184,7 @@ private:
 	QActionGroup* m_category_visible_act_group = nullptr;
 
 	// Dockable widget frames
-	QMainWindow *m_mw = nullptr;
+	QMainWindow* m_mw = nullptr;
 	log_frame* m_log_frame = nullptr;
 	debugger_frame* m_debugger_frame = nullptr;
 	game_list_frame* m_game_list_frame = nullptr;


### PR DESCRIPTION
- Add humanly readable gui setting for main window visibility
- Use humanly readable gui setting for game window visibility
- Allowed values (case insensitive):
  - Windowed
  - Minimized
  - Maximized
  - FullScreen
  - AutomaticVisibility (only for game window)

Example:

[main_window]
visibility=FullScreen

[GSFrame]
visibility=Maximized


fixes #17482