### PR TITLE
SPU: arm64 reservation wait via WFE monitor (fixes GoW3 / #16484-class freeze on Apple Silicon)

### DIFF
--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -4355,10 +4355,20 @@ bool spu_thread::process_mfc_cmd()
 									}
 								}
 								else
-#endif
 								{
 									busy_wait(300);
 								}
+#elif defined(ARCH_ARM64)
+									// arm64 has no UMWAIT/MWAITX. Use the WFE exclusive-monitor wait (the arm64
+									// analogue of __mwaitx): sleep the core on the reservation timestamp word and
+									// wake on the PUTLLC store, instead of a blind unobserving busy_wait. Mirrors
+									// the X64 __mwaitx comparison args (reservation_acquire vs the snapshot rtime).
+									utils::spin_on_cacheline_once(vm::reservation_acquire(addr), +rtime, 100);
+#else
+								{
+									busy_wait(300);
+								}
+#endif
 
 								if (getllar_spin_count == 3)
 								{
@@ -5725,10 +5735,20 @@ s64 spu_thread::get_ch_value(u32 ch)
 					}
 				}
 				else
-#endif
 				{
 					busy_wait(300);
 				}
+#elif defined(ARCH_ARM64)
+					// arm64 has no UMWAIT/MWAITX. Use the WFE exclusive-monitor wait (the arm64
+					// analogue of __mwaitx): sleep the core on the reservation timestamp word and
+					// wake on the PUTLLC store, instead of a blind unobserving busy_wait. Mirrors
+					// the X64 __mwaitx comparison args (reservation_acquire vs the snapshot rtime).
+					utils::spin_on_cacheline_once(vm::reservation_acquire(raddr), +rtime, 100);
+#else
+				{
+					busy_wait(300);
+				}
+#endif
 
 				// Check other reservations in other threads
 				lv2_obj::notify_all();


### PR DESCRIPTION
## What

On arm64 the SPU `GETLLAR` re-poll and `RdEventStat` reservation busy-wait branches fall through to a blind `busy_wait(300)`. On x86 these branches use a hardware monitor (`__tpause`/`__mwaitx`) that sleeps on the reservation cache line and wakes the instant a `PUTLLC` writes it — arm64 had no equivalent here, so the SPU spins hot, observing nothing.

This uses the existing `utils::spin_on_cacheline_once()` (LDAXR + WFE — the arm64 analogue of `__mwaitx`, already used on arm64 in `nv406e.cpp`) on the arm64 leg of both branches, mirroring the x86 `__mwaitx` comparison arguments (`vm::reservation_acquire(addr)` vs the snapshot `rtime`). The x86 path is preprocessor-gated and byte-for-byte unchanged.

## Why

On Apple Silicon the blind spin pegs the SPU/PPU reservation loops at ~99% CPU and starves the SPURS producer/consumer handshake on machines with few P-cores, so SPURS-driven titles hang shortly after the intro. God of War III (`BCES00510`) is the canonical case (#17640); it's the "works on x64, broken on arm64" shape of #16484.

A freeze capture on a base M4 Mac mini (`thread backtrace all`) shows the four `BigCellSpursKernel` SPUs cycling the `RdEventStat` busy branch while the main PPU hot-spins a guest poll loop and the syscall counters climb with zero guest progress — a livelock, not a lost wakeup.

## Testing

- Base **M4 Mac mini** (`Mac16,10`), macOS 26.5.1, built from `master`.
- **Before:** GoW3 (`BCES00510`) freezes on a black screen seconds after the intro, every boot, on default settings.
- **After:** GoW3 boots past the freeze into stable gameplay (~30–60 FPS) on **default settings** — no `SPU loop detection` workaround needed. The previously-pegged reservation spinners now WFE-sleep and CPU redistributes to real work.

## Notes / scope

- The arm64 WFE path relies on the periodic WFE event stream as a wake backstop (same assumption as the existing `nv406e.cpp` arm64 caller; enabled by default on Apple Silicon/XNU). Post-wake re-validation is the existing `rtime`/`cmp_rdata` check, so spurious/coalesced wakes only cost a re-poll.
- Verified on GoW3 on one Apple Silicon machine; testing on other arm64 hosts and other #16484 titles is very welcome.

Refs #17640, #16484
