### PR TITLE
fix double path delimiter

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -946,7 +946,7 @@ std::string fs::strip_end_path_delimiter(const std::string& path)
 
 	if (path.empty() || not_del == umax)
 	{
-		return path;
+		return "";
 	}
 
 	return path.substr(0, not_del + 1);

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -940,6 +940,18 @@ std::string fs::get_path_if_dir(const std::string& path)
 	return path + '/';
 }
 
+std::string fs::strip_end_path_delimiter(const std::string& path)
+{
+	const auto not_del = path.find_last_not_of(delim);
+
+	if (path.empty() || not_del == umax)
+	{
+		return path;
+	}
+
+	return path.substr(0, not_del + 1);
+}
+
 bool fs::get_stat(const std::string& path, stat_t& info)
 {
 	// Ensure consistent information on failure

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -198,6 +198,9 @@ namespace fs
 	// Return "path" plus an ending delimiter (if missing) if "path" is an existing directory. Otherwise, an empty string
 	std::string get_path_if_dir(const std::string& path);
 
+	// Return "path" removing any ending delimiter (if present)
+	std::string strip_end_path_delimiter(const std::string& path);
+
 	// Get file information
 	bool get_stat(const std::string& path, stat_t& info);
 

--- a/Utilities/File.h
+++ b/Utilities/File.h
@@ -198,7 +198,7 @@ namespace fs
 	// Return "path" plus an ending delimiter (if missing) if "path" is an existing directory. Otherwise, an empty string
 	std::string get_path_if_dir(const std::string& path);
 
-	// Return "path" removing any ending delimiter (if present)
+	// Return "path" removing any ending delimiter (if present) or an empty string if the path only exists of delimiters
 	std::string strip_end_path_delimiter(const std::string& path);
 
 	// Get file information

--- a/rpcs3/CMakeLists.txt
+++ b/rpcs3/CMakeLists.txt
@@ -183,6 +183,7 @@ if(BUILD_RPCS3_TESTS)
         PRIVATE
             tests/test.cpp
             tests/test_bit_set.cpp
+            tests/test_fs.cpp
             tests/test_fmt.cpp
             tests/test_pair.cpp
             tests/test_tuple.cpp

--- a/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSaveData.cpp
@@ -1155,15 +1155,16 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			}
 		}
 
-		auto delete_save = [&]()
+		const auto delete_save = [&]()
 		{
-			strcpy_trunc(doneGet->dirName, save_entries[selected].dirName);
+			const SaveDataEntry& entry = ::at32(save_entries, selected);
+			strcpy_trunc(doneGet->dirName, entry.dirName);
 			doneGet->hddFreeSizeKB = 40 * 1024 * 1024 - 256; // Read explanation in cellHddGameCheck
 			doneGet->excResult     = CELL_OK;
 			std::memset(doneGet->reserved, 0, sizeof(doneGet->reserved));
 
-			const std::string old_path = base_dir + ".backup_" + save_entries[selected].escaped + "/";
-			const std::string del_path = base_dir + save_entries[selected].escaped + "/";
+			const std::string old_path = base_dir + ".backup_" + entry.escaped + "/";
+			const std::string del_path = base_dir + entry.escaped + "/";
 
 			const fs::dir _dir(del_path);
 			u64 size_bytes = 0;
@@ -1456,7 +1457,7 @@ static NEVER_INLINE error_code savedata_op(ppu_thread& ppu, u32 operation, u32 v
 			}
 			else
 			{
-				fmt::throw_exception("Invalid savedata selected");
+				fmt::throw_exception("Invalid savedata selected (selected=%d)", selected);
 			}
 		}
 	}

--- a/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPUASMJITRecompiler.cpp
@@ -2799,32 +2799,35 @@ void spu_recompiler::FREST(spu_opcode_t op)
 void spu_recompiler::FRSQEST(spu_opcode_t op)
 {
 	const XmmLink& va = XmmGet(op.ra, XmmType::Float);
+	const XmmLink& vz = XmmAlloc();
+	const XmmLink& v1 = XmmAlloc();
 	const XmmLink& v_fraction = XmmAlloc();
 	const XmmLink& v_exponent = XmmAlloc();
 	c->movdqa(v_fraction, va);
 	c->movdqa(v_exponent, va);
 
+	// (exponent==0)? 0xFF : 190 - (exponent + 1) / 2
+	c->paddd(v_exponent, v_exponent);
+	c->pxor(vz, vz);
+	c->pavgb(v_exponent, vz);
+	c->movdqa(v1, XmmConst(v128::from32p(190 << 24)));
+	c->psubb(v1, v_exponent);
+	c->pcmpeqb(v_exponent, vz);
+	c->por(v_exponent, v1);
+	c->psrld(v_exponent, 1);
+	c->pand(v_exponent, XmmConst(v128::from32p(0xFF << 23)));
+
 	c->psrld(v_fraction, 18);
-	c->psrld(v_exponent, 23);
-
-	c->andps(v_fraction, XmmConst(v128::from32p(0x3F)));
-	c->andps(v_exponent, XmmConst(v128::from32p(0xFF)));
-
+	c->pand(v_fraction, XmmConst(v128::from32p(0x3F)));
 	const u64 fraction_lut_addr = reinterpret_cast<u64>(spu_frsqest_fraction_lut);
-	const u64 exponent_lut_addr = reinterpret_cast<u64>(spu_frsqest_exponent_lut);
 
 	c->movabs(*arg0, fraction_lut_addr);
-	c->movabs(*arg1, exponent_lut_addr);
 
 	for (u32 index = 0; index < 4; index++)
 	{
 		c->pextrd(*qw0, v_fraction, index);
 		c->mov(*qw1, asmjit::x86::dword_ptr(*arg0, *qw0, 2));
 		c->pinsrd(v_fraction, *qw1, index);
-
-		c->pextrd(*qw0, v_exponent, index);
-		c->mov(*qw1, asmjit::x86::dword_ptr(*arg1, *qw0, 2));
-		c->pinsrd(v_exponent, *qw1, index);
 	}
 
 	c->orps(v_fraction, v_exponent);

--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -128,7 +128,6 @@ class spu_llvm_recompiler : public spu_recompiler_base, public cpu_translator
 	// Global LUTs
 	llvm::GlobalVariable* m_spu_frest_fraction_lut{};
 	llvm::GlobalVariable* m_spu_frsqest_fraction_lut{};
-	llvm::GlobalVariable* m_spu_frsqest_exponent_lut{};
 
 	// Helpers (interpreter)
 	llvm::GlobalVariable* m_scale_float_to{};
@@ -1623,7 +1622,6 @@ public:
 		// LUTs for some instructions
 		m_spu_frest_fraction_lut = new llvm::GlobalVariable(*m_module, llvm::ArrayType::get(GetType<u32>(), 32), true, llvm::GlobalValue::PrivateLinkage, llvm::ConstantDataArray::get(m_context, spu_frest_fraction_lut));
 		m_spu_frsqest_fraction_lut = new llvm::GlobalVariable(*m_module, llvm::ArrayType::get(GetType<u32>(), 64), true, llvm::GlobalValue::PrivateLinkage, llvm::ConstantDataArray::get(m_context, spu_frsqest_fraction_lut));
-		m_spu_frsqest_exponent_lut = new llvm::GlobalVariable(*m_module, llvm::ArrayType::get(GetType<u32>(), 256), true, llvm::GlobalValue::PrivateLinkage, llvm::ConstantDataArray::get(m_context, spu_frsqest_exponent_lut));
 	}
 
 	virtual spu_function_t compile(spu_program&& _func) override
@@ -7529,22 +7527,23 @@ public:
 		{
 			const auto a = bitcast<u32[4]>(value<f32[4]>(ci->getOperand(0)));
 
+			// (exponent==0)? 0xFF : 190 - (exponent + 1) / 2
+			const auto a_exponent = a & splat<u32[4]>(0xFF << 23);
+			const auto h_exponent = (a_exponent + (a_exponent & splat<u32[4]>(1 << 23))) >> splat<u32[4]>(1);
+			const auto r_exponent = splat<u32[4]>(190 << 23) - h_exponent;
+			const auto final_exponent = select(a_exponent == 0, splat<u32[4]>(0xFF << 23), r_exponent);
+
 			const auto a_fraction = (a >> splat<u32[4]>(18)) & splat<u32[4]>(0x3F);
-			const auto a_exponent = (a >> splat<u32[4]>(23)) & splat<u32[4]>(0xFF);
-			value_t<u32[4]> final_result = eval(splat<u32[4]>(0));
+			value_t<u32[4]> final_fraction = eval(splat<u32[4]>(0));
 
 			for (u32 i = 0; i < 4; i++)
 			{
 				const auto eval_fraction = eval(extract(a_fraction, i));
-				const auto eval_exponent = eval(extract(a_exponent, i));
-
 				value_t<u32> r_fraction = load_const<u32>(m_spu_frsqest_fraction_lut, eval_fraction);
-				value_t<u32> r_exponent = load_const<u32>(m_spu_frsqest_exponent_lut, eval_exponent);
-
-				final_result = eval(insert(final_result, i, eval(r_fraction | r_exponent)));
+				final_fraction = eval(insert(final_fraction, i, r_fraction));
 			}
 
-			return bitcast<f32[4]>(final_result);
+			return bitcast<f32[4]>(final_fraction | final_exponent);
 		});
 
 		set_vr(op.rt, frsqest(get_vr<f32[4]>(op.ra)));
@@ -8575,20 +8574,24 @@ public:
 			register_intrinsic("spu_rsqrte", [&](llvm::CallInst* ci)
 			{
 				const auto a = bitcast<u32[4]>(value<f32[4]>(ci->getOperand(0)));
+
+				// (exponent==0)? 0xFF : 190 - (exponent + 1) / 2
+				const auto a_exponent = a & splat<u32[4]>(0xFF << 23);
+				const auto h_exponent = (a_exponent + (a_exponent & splat<u32[4]>(1 << 23))) >> splat<u32[4]>(1);
+				const auto r_exponent = splat<u32[4]>(190 << 23) - h_exponent;
+				const auto final_exponent = select(a_exponent == 0, splat<u32[4]>(0xFF << 23), r_exponent);
+
 				const auto a_fraction = (a >> splat<u32[4]>(18)) & splat<u32[4]>(0x3F);
-				const auto a_exponent = (a >> splat<u32[4]>(23)) & splat<u32[4]>(0xFF);
-				value_t<u32[4]> b = eval(splat<u32[4]>(0));
+				value_t<u32[4]> final_fraction = eval(splat<u32[4]>(0));
 
 				for (u32 i = 0; i < 4; i++)
 				{
 					const auto eval_fraction = eval(extract(a_fraction, i));
-					const auto eval_exponent = eval(extract(a_exponent, i));
-
 					value_t<u32> r_fraction = load_const<u32>(m_spu_frsqest_fraction_lut, eval_fraction);
-					value_t<u32> r_exponent = load_const<u32>(m_spu_frsqest_exponent_lut, eval_exponent);
-
-					b = eval(insert(b, i, eval(r_fraction | r_exponent)));
+					final_fraction = eval(insert(final_fraction, i, r_fraction));
 				}
+
+				const auto b = eval(final_fraction | final_exponent);
 
 				const auto base = (b & 0x007ffc00u) << 9; // Base fraction
 				const auto ymul = (b & 0x3ff) * (a & 0x7ffff); // Step fraction * Y fraction (fixed point at 2^-32)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -4313,7 +4313,7 @@ u32 Emulator::AddGamesFromDir(const std::string& path)
 					continue;
 				}
 
-				const std::string dir_path = path + '/' + dir_entry.name;
+				const std::string dir_path = fs::strip_end_path_delimiter(path) + "/" + dir_entry.name;
 
 				if (!dir_entry.is_directory && !is_iso_file(dir_path))
 				{
@@ -4377,7 +4377,7 @@ game_boot_result Emulator::AddGame(const std::string& path)
 
 		if (entry.is_directory && std::regex_match(entry.name, std::regex("^PS3_GM[[:digit:]]{2}$")))
 		{
-			const std::string elf = path + "/" + entry.name + "/USRDIR/EBOOT.BIN";
+			const std::string elf = fs::strip_end_path_delimiter(path) + "/" + entry.name + "/USRDIR/EBOOT.BIN";
 
 			if (fs::is_file(elf))
 			{

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -397,7 +397,7 @@ void game_list_frame::Refresh(const bool from_drive, const std::vector<std::stri
 			action->setText(get_action_text(col));
 		}
 
-		const std::string games_dir = rpcs3::utils::get_games_dir();
+		const std::string games_dir = fs::strip_end_path_delimiter(rpcs3::utils::get_games_dir());
 
 		// Remove the specified and detected serials (title id) belonging to "games_dir" folder only from the game list in memory
 		// (not yet in "games.yml" file)

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -397,7 +397,7 @@ void game_list_frame::Refresh(const bool from_drive, const std::vector<std::stri
 			action->setText(get_action_text(col));
 		}
 
-		const std::string games_dir = fs::strip_end_path_delimiter(rpcs3::utils::get_games_dir());
+		const std::string games_dir = rpcs3::utils::get_games_dir();
 
 		// Remove the specified and detected serials (title id) belonging to "games_dir" folder only from the game list in memory
 		// (not yet in "games.yml" file)

--- a/rpcs3/tests/rpcs3_test.vcxproj
+++ b/rpcs3/tests/rpcs3_test.vcxproj
@@ -96,6 +96,7 @@
     <ClCompile Include="test_dmux_pamf.cpp">
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="test_fs.cpp" />
     <ClCompile Include="test_fmt.cpp" />
     <ClCompile Include="test_rsx_cfg.cpp" />
     <ClCompile Include="test_rsx_fp_asm.cpp" />


### PR DESCRIPTION
A cosmetic fix. It removes a double delimiter at the end of a path in `games.yml` when using `VFS games` path.

fixes #18726
