### PR TITLE
input: fix arrow key mapping roundtrip on macOS ARM

### DIFF
--- a/rpcs3/Input/keyboard_pad_handler.cpp
+++ b/rpcs3/Input/keyboard_pad_handler.cpp
@@ -943,10 +943,10 @@ u32 keyboard_pad_handler::GetKeyCode(const QString& keyName)
 	if (keyName == "Meta") return Qt::Key_Meta;
 #ifdef __APPLE__
 	// QKeySequence doesn't work properly for the arrow keys on macOS
-	if (keyName == "Num←") return Qt::Key_Left;
-	if (keyName == "Num↑") return Qt::Key_Up;
-	if (keyName == "Num→") return Qt::Key_Right;
-	if (keyName == "Num↓") return Qt::Key_Down;
+	if (keyName == "Num←" || keyName == "←") return Qt::Key_Left;
+	if (keyName == "Num↑" || keyName == "↑") return Qt::Key_Up;
+	if (keyName == "Num→" || keyName == "→") return Qt::Key_Right;
+	if (keyName == "Num↓" || keyName == "↓") return Qt::Key_Down;
 #endif
 
 	const QKeySequence seq(keyName);


### PR DESCRIPTION
Relates to #16424

On macOS ARM, arrow keys fail to register in-game because of a name 
mismatch in keyboard_pad_handler.cpp. (Comment on Line 945 mentions the issue, just never got resolved)

GetKeyName() stores arrow keys as Unicode symbols (↑ ↓ ← →) on macOS, 
but GetKeyCode() only recognises the Num-prefixed versions (Num↑ Num↓ 
Num← Num→), so the keys silently resolve to nothing when read back.

Fix: add the plain symbol variants as valid matches in GetKeyCode().
