### PR TITLE
fix double path delimiter

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -923,7 +923,10 @@ void fmt::trim_back(std::string& source, std::string_view values)
 	const usz index = source.find_last_not_of(values);
 
 	if (index == source.npos)
+	{
+		source.clear();
 		return;
+	}
 
 	source.resize(index + 1);
 }

--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -921,6 +921,10 @@ std::string_view fmt::trim_front_sv(std::string_view source, std::string_view va
 void fmt::trim_back(std::string& source, std::string_view values)
 {
 	const usz index = source.find_last_not_of(values);
+
+	if (index == source.npos)
+		return;
+
 	source.resize(index + 1);
 }
 

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -4276,9 +4276,11 @@ std::set<std::string> Emulator::GetGameDirs() const
 	return dirs;
 }
 
-u32 Emulator::AddGamesFromDir(const std::string& path)
+u32 Emulator::AddGamesFromDir(std::string path)
 {
 	u32 games_added = 0;
+
+	fmt::trim_back(path, fs::delim);
 
 	m_games_config.set_save_on_dirty(false);
 
@@ -4313,7 +4315,7 @@ u32 Emulator::AddGamesFromDir(const std::string& path)
 					continue;
 				}
 
-				const std::string dir_path = path + '/' + dir_entry.name;
+				const std::string dir_path = path + "/" + dir_entry.name;
 
 				if (!dir_entry.is_directory && !is_iso_file(dir_path))
 				{
@@ -4349,8 +4351,10 @@ u32 Emulator::AddGamesFromDir(const std::string& path)
 	return games_added;
 }
 
-game_boot_result Emulator::AddGame(const std::string& path)
+game_boot_result Emulator::AddGame(std::string path)
 {
+	fmt::trim_back(path, fs::delim);
+
 	// Handle files directly
 	if (!fs::is_dir(path) || fs::get_optical_raw_device(path))
 	{
@@ -4396,8 +4400,10 @@ game_boot_result Emulator::AddGame(const std::string& path)
 	return result;
 }
 
-game_boot_result Emulator::AddGameToYml(const std::string& path)
+game_boot_result Emulator::AddGameToYml(std::string path)
 {
+	fmt::trim_back(path, fs::delim);
+
 	// Detect boot location
 	const auto is_invalid_path = [this](std::string_view path, std::string_view dir) -> game_boot_result
 	{

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -489,9 +489,9 @@ public:
 	void ConfigurePPUCache() const;
 
 	std::set<std::string> GetGameDirs() const;
-	u32 AddGamesFromDir(const std::string& path);
-	game_boot_result AddGame(const std::string& path);
-	game_boot_result AddGameToYml(const std::string& path);
+	u32 AddGamesFromDir(std::string path);
+	game_boot_result AddGame(std::string path);
+	game_boot_result AddGameToYml(std::string path);
 	u32 RemoveGamesFromDir(const std::string& games_dir, const std::vector<std::string>& serials_to_remove_from_yml = {}, bool save_on_disk = true);
 	u32 RemoveGames(const std::vector<std::string>& title_id_list, bool save_on_disk = true);
 	game_boot_result RemoveGameFromYml(const std::string& title_id);


### PR DESCRIPTION
A cosmetic fix. It removes a double delimiter at the end of a path in `games.yml` when using `VFS games` path.

fixes #18726
