### PR TITLE
Crypto/unpkg: fix data race and short-read overflow in PKG extraction

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -148,6 +148,11 @@ bool package_reader::read_header()
 	}
 	}
 
+	// Remember every fragment's path so extract workers can each open a private
+	// handle later (see m_part_paths). The first fragment is always m_path.
+	m_part_paths.clear();
+	m_part_paths.push_back(m_path);
+
 	if (m_header.pkg_size > m_file.size())
 	{
 		// Check if multi-files pkg
@@ -183,6 +188,7 @@ bool package_reader::read_header()
 			}
 
 			cursize += add_size;
+			m_part_paths.push_back(archive_filename);
 			filelist.emplace_back(std::move(archive_file));
 		}
 
@@ -1384,6 +1390,47 @@ u64 package_reader::archive_read(void* data_ptr, const u64 num_bytes)
 
 std::span<const char> package_reader::archive_read_block(u64 offset, void* data_ptr, u64 num_bytes)
 {
+	// extract_data runs one extract_worker per hardware thread, and they all
+	// read the package through this function. A single fs::file handle is not
+	// safe to read from several threads at once, so give each thread its own
+	// handle instead of sharing m_file. The handle is rebuilt once per thread
+	// from m_part_paths (a plain file for a regular package, a gather stream for
+	// a multi-part set), which is fixed after read_header.
+	if (!m_part_paths.empty())
+	{
+		thread_local fs::file t_file;
+		thread_local const package_reader* t_owner = nullptr;
+
+		if (t_owner != this)
+		{
+			if (m_part_paths.size() == 1)
+			{
+				t_file = fs::file(m_part_paths[0]);
+			}
+			else
+			{
+				std::vector<fs::file> parts;
+				parts.reserve(m_part_paths.size());
+
+				for (const std::string& part_path : m_part_paths)
+				{
+					parts.emplace_back(part_path);
+				}
+
+				t_file = fs::make_gather(std::move(parts));
+			}
+
+			t_owner = this;
+		}
+
+		if (t_file)
+		{
+			const usz read_n = t_file.read_at(offset, data_ptr, num_bytes);
+			return {static_cast<const char*>(data_ptr), read_n};
+		}
+	}
+
+	// Fallback for reads that happen before m_part_paths is populated.
 	const usz read_n = m_file.read_at(offset, data_ptr, num_bytes);
 
 	return {static_cast<const char*>(data_ptr), read_n};

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -1509,7 +1509,17 @@ usz package_reader::decrypt(u64 offset, u64 size, const uchar* key, void* local_
 		pkg_log.error("Unknown release type (0x%x)", m_header.pkg_type);
 	}
 
-	if (blocks * 16 != size)
+	if (data_span.size() < size)
+	{
+		// Short read (fewer bytes available than requested): zero the unread
+		// tail. The bytes actually decrypted are [0, data_span.size()); the rest
+		// of the caller's buffer is defined as zero. Deriving the fill length
+		// from blocks * 16 (as the aligned case below does) underflows here:
+		// blocks comes from the short data_span, so blocks * 16 can be smaller
+		// than size, producing a huge unsigned length.
+		std::memset(out_data + data_span.size(), 0, size - data_span.size());
+	}
+	else if (blocks * 16 != size)
 	{
 		// Put NTS and other zeroes on unaligned reads
 		std::memset(out_data + size, 0, blocks * 16 - size);

--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -393,6 +393,11 @@ private:
 	std::string m_path{};
 	std::string m_install_dir{};
 	fs::file m_file{};
+	// Paths of every fragment of the package (one entry for a regular .pkg,
+	// several for a multi-part _NN.pkg set). Set once in read_header and never
+	// mutated afterwards, so extract workers can open their own file handles
+	// from it without sharing m_file across threads.
+	std::vector<std::string> m_part_paths{};
 	std::array<uchar, 16> m_dec_key{};
 
 	PKGHeader m_header{};


### PR DESCRIPTION
## Context

While I was working on an RPCS3 libretro core, I noticed that after installing some PKGs a few of the extracted files came out corrupt. At first I figured the bug was in the libretro core, but after hours of testing and adding some precise instrumentation I traced it to the package extraction code itself. The scenario that reliably exposed it was running the core under RetroArch with "Threaded Video" enabled — that puts enough extra pressure on the CPU to open the race window detailed below.

## Summary

PKG extraction (`package_reader::extract_data`) spawns one worker per hardware thread, and all workers read the package through `archive_read_block`. They share a single `fs::file` (`m_file`), which isn't safe to read from multiple threads at once. Under enough CPU contention (RetroArch's "Threaded Video" was my repro) this races, and a subset of extracted files gets written out still-encrypted (raw PKG bytes instead of the decrypted payload), so the installed title later stalls or fails while reading a corrupted asset.

This PR gives each worker its own file handle, and also fixes an unrelated unsigned-length underflow in `decrypt` on short reads.

## The data race

`fs::file::read_at` is positional (pread), so each call is fine on its own, but the workers all share the same `fs::file` object. Concurrent reads through that shared handle corrupt random entries. Because it only manifests under contention, it's non-deterministic and easy to miss in light testing — it does not reproduce single-threaded. For what it's worth, plain RPCS3 as it ships today didn't reproduce it for me, but that doesn't mean it can't happen under the right circumstances; the hazard is in the code regardless of which frontend triggers it.

### Fix

Keep extraction fully multi-threaded, but rebuild a private handle per thread inside `archive_read_block`:

- `read_header` records the path of every fragment in a new `m_part_paths` member (one entry for a regular `.pkg`, several for a multi-part `_NN.pkg` set). It is set once and never mutated afterwards.
- `archive_read_block` lazily opens a `thread_local` handle from `m_part_paths` — a plain `fs::file` for a single-part package, or `fs::make_gather` for a multi-part set — so no `fs::file` is shared across threads. A fallback to `m_file` covers any read that happens before `m_part_paths` is populated.

## Short-read overflow in `decrypt`

When the source provides fewer bytes than requested, `blocks` is derived from the short span, so `blocks * 16` can be smaller than `size`, and `memset(out_data + size, 0, blocks * 16 - size)` underflows to a huge unsigned length (heap overflow). The short-read case now zeroes exactly the unread tail `[data_span.size(), size)`; the aligned-but-unaligned-tail case is unchanged.

## Testing

I tested on Linux (Vulkan), installing and booting:

- Single-part PKG (small) — NBA JAM On Fire Edition.
- Single-part PKG larger than 4 GB (~9.5 GB) — Metal Gear Solid 3 Snake Eater HD, to exercise 64-bit offsets.
- That same large title repackaged as a 4-part `_00`–`_03.pkg` set, to exercise the multi-part `make_gather` path and reads whose offsets cross the part boundaries.

Everything installed cleanly and booted; before the fix, the large/contended installs would intermittently produce a corrupted file. I confirmed before/after by byte-comparing extracted installs of the same title.

## AI involvement disclosure

Per the project's AI use policy: AI tooling helped with root-cause investigation and with drafting the code and comments. I've reviewed and understand the change and take full ownership of it, and I ran all of the testing above myself. I also made sure it doesn't break existing behavior — it removes a real concurrency hazard in the extraction path rather than papering over a symptom.
