### PR TITLE
macOS: DJ Hero Turntable support (deck buttons, passthrough conflict)

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_usbd.cpp
@@ -391,6 +391,17 @@ void usb_handler_thread::perform_scan()
 				&& desc.idProduct >= entry.id_product_min
 				&& desc.idProduct <= entry.id_product_max)
 			{
+#ifdef __APPLE__
+				// On macOS, libusb cannot claim HID interfaces, so passing through a real
+				// controller that also has an emulated implementation yields a non-functional
+				// device and silently overrides the user's emulated-device setting (the emulated
+				// setup below only fills slots not already passed through). Prefer the emulated
+				// implementation whenever the user has enabled it. (e.g. DJ Hero Turntable)
+				if (entry.make_instance && entry.max_device_count && entry.max_device_count() > 0)
+				{
+					continue;
+				}
+#endif
 				sys_usbd.success("Found device: %s", std::basic_string(entry.device_name));
 				libusb_ref_device(dev);
 				std::shared_ptr<usb_device_passthrough> usb_dev = std::make_shared<usb_device_passthrough>(dev, desc, get_new_location());

--- a/rpcs3/Input/sdl_pad_handler.cpp
+++ b/rpcs3/Input/sdl_pad_handler.cpp
@@ -341,7 +341,13 @@ SDLDevice::sdl_info sdl_pad_handler::get_sdl_info(SDL_JoystickID id)
 			const int num_axes = SDL_GetNumJoystickAxes(joystick);
 			const int num_buttons = SDL_GetNumJoystickButtons(joystick);
 
-			info.is_ds3_with_pressure_buttons = num_axes == 16 && num_buttons == 11;
+			// The DJ Hero Turntable (VID 0x12BA, PID 0x0140) coincidentally matches the
+			// DS3 axis/button counts (16 axes, 11 buttons) but is NOT a pressure-sensitive
+			// DS3. Routing its face buttons through the pressure axes drops the green (Cross)
+			// and blue (Square) deck buttons, so exclude it and read its buttons digitally.
+			const bool is_dj_hero_turntable = info.vid == 0x12BA && info.pid == 0x0140;
+
+			info.is_ds3_with_pressure_buttons = num_axes == 16 && num_buttons == 11 && !is_dj_hero_turntable;
 
 			sdl_log.notice("DS3 device %d has %d axis and %d buttons (has_pressure_buttons=%d)", id, num_axes, num_buttons, info.is_ds3_with_pressure_buttons);
 


### PR DESCRIPTION
## macOS: make the DJ Hero Turntable fully usable

This scopes two fixes for DJ Hero Turntable support on macOS. Both are independent; maintainers can take either.

> **Update:** Per review, the redundant SDL vid/pid lookup is removed (now uses the existing `info.vid`/`info.pid`), and ~~the crossfader/effects commit has been dropped~~ — the new `motion_x`/`motion_y` turntable config (cffd02b) is the proper way to map those, so the hardcoded version is obsolete. PR is now the two commits below.

### 1. Deck buttons dropped — `Input/SDL` *(not guarded; safe on all platforms)*
The turntable reports 16 axes + 11 buttons, which matches the heuristic for a *pressure-sensitive DualShock 3*. That routes its deck buttons through the DS3 pressure axes instead of reading them digitally, silently dropping the **green (Cross)** and **blue (Square)** buttons. Fix excludes this specific VID/PID from the pressure path. It only touches one device that is never a real pressure-DS3, so it's safe everywhere — it was simply found on macOS.

### 2. Emulated device displaced by a dead passthrough — `sys_usbd` *(`__APPLE__`)*
libusb can't claim HID interfaces on macOS, so a real controller that's also emulated gets passed through as a **non-functional** device — and because the emulated-device setup only fills slots *not* already passed through, it **silently overrides the user's emulated-controller setting**. The game then binds the dead passthrough device and reports no controller. Fix: on macOS, skip passthrough for a device when the user has enabled its emulation. *(This may also explain the Windows/Linux real-turntable failures in #12767.)*

### ~~3. Crossfader/effects are dead — `Io/Turntable`~~ *(dropped)*
~~SDL's DS3 mapping reports the crossfader and effects dial on the DS3 accelerometer X/Y fields, not as stick axes, so the emulated-turntable config's stick mapping never moves them.~~ **Superseded by the `motion_x`/`motion_y` turntable config added in cffd02b** — map the crossfader/effects to a motion axis there instead.

## Two non-code gotchas (for users, not in this PR)
- **Game shows "You must use a DJ Hero Turntable Controller" / no in-game detection** even with the emulated turntable enabled: `cellPadLddRegisterController` fails with `CELL_PAD_ERROR_TOO_MANY_DEVICES` when **all pad slots are occupied** — the LDD turntable needs a free slot. Configure only the player(s) you need and leave the rest `Null`.
- DJ Hero 2 also checks for a **microphone** (Settings → Audio → Microphone Type).

## For #17710 (open, Windows/Linux — same symptoms)
The reporter there sees "DJ Hero turntable" device class → no in-game inputs, "PS3 Controller" → menus only. Worth checking whether their log shows the same root cause before assuming a code regression:
1. Grep the log for `cellPadLddRegisterController` — if it's `CELL_PAD_ERROR_TOO_MANY_DEVICES`, it's the **free-slot** issue above (config, not code).
2. Confirm `Emulating device: DJ Hero Turntable` (emulated) vs `Found device:` (passthrough) — if a real turntable is connected, commit #2's logic is relevant.
3. Leave only Player 1 configured and retry.

## Notes
- Commit #2 is `__APPLE__`-scoped; #1 is platform-agnostic and safe.
- Built/tested from `master` via `.ci/build-mac.sh` (Qt 6.11.1, LLVM 21); validated against DJ Hero (BLES00602) and DJ Hero 2 (BLES00896).
- Related: #17710, #12767, #15073, #9111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
