### PR TITLE
Propagate src_loc in write_to_ptr and read_from_ptr

### DIFF
--- a/Utilities/StrFmt.cpp
+++ b/Utilities/StrFmt.cpp
@@ -630,6 +630,13 @@ namespace fmt
 		thread_ctrl::emergency_exit(out);
 	}
 
+	[[noreturn]] void raw_verify_error(std::source_location loc, std::source_location propagated_loc, const char8_t* msg, usz object)
+	{
+		std::string out;
+		fmt::append(out, "%s (object: 0x%x)%s%s", msg ? msg : u8"Verification failed", object, loc, propagated_loc);
+		thread_ctrl::emergency_exit(out);
+	}
+
 	[[noreturn]] void raw_range_error(std::source_location loc, std::string_view index, usz container_size)
 	{
 		std::string out;

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -589,7 +589,7 @@ u32 ppu_read_mmio_aware_u32(u8* vm_base, u32 eal)
 	}
 
 	// Value is assumed to be swapped
-	return read_from_ptr<u32>(vm_base + eal);
+	return read_from_ptr<u32>(vm_base, eal);
 }
 
 void ppu_write_mmio_aware_u32(u8* vm_base, u32 eal, u32 value)

--- a/rpcs3/util/types.hpp
+++ b/rpcs3/util/types.hpp
@@ -941,6 +941,7 @@ using const_str = const_str_t<>;
 namespace fmt
 {
 	[[noreturn]] void raw_verify_error(std::source_location loc, const char8_t* msg, usz object);
+	[[noreturn]] void raw_verify_error(std::source_location loc, std::source_location propagated_loc, const char8_t* msg, usz object);
 	[[noreturn]] void raw_range_error(std::source_location loc, std::string_view index, usz container_size);
 	[[noreturn]] void raw_range_error(std::source_location loc, usz index, usz container_size);
 }
@@ -974,6 +975,17 @@ constexpr decltype(auto) ensure(T&& arg, const_str msg = const_str(), std::sourc
 	}
 
 	fmt::raw_verify_error(src_loc, msg, 0);
+}
+
+template <typename T>
+constexpr decltype(auto) ensure(T&& arg, std::source_location propagated_loc, const_str msg = const_str(), std::source_location src_loc = std::source_location::current()) noexcept
+{
+	if (std::forward<T>(arg)) [[likely]]
+	{
+		return std::forward<T>(arg);
+	}
+
+	fmt::raw_verify_error(src_loc, propagated_loc, msg, 0);
 }
 
 template <typename T, typename F> requires (std::is_invocable_v<F, T&&>)
@@ -1185,7 +1197,7 @@ namespace stx
 
 // Read object of type T from raw pointer, array, string, vector, or any contiguous container
 template <typename T, typename U>
-constexpr T read_from_ptr(U&& array, usz pos = 0)
+constexpr T read_from_ptr(U&& array, usz pos = 0, std::source_location src_loc = std::source_location::current())
 {
 	// TODO: ensure array element types are trivial
 	static_assert(sizeof(T) % sizeof(array[0]) == 0);
@@ -1197,7 +1209,7 @@ constexpr T read_from_ptr(U&& array, usz pos = 0)
 	{
 		if constexpr (requires { std::size(array); })
 		{
-			ensure((pos + elements_per_value) <= std::size(array));
+			ensure((pos + elements_per_value) <= std::size(array), src_loc);
 		}
 
 		std::memcpy(+buf, &array[pos], sizeof(buf));
@@ -1214,14 +1226,14 @@ constexpr T read_from_ptr(U&& array, usz pos = 0)
 }
 
 template <typename T, typename U>
-constexpr void write_to_ptr(U&& array, usz pos, const T& value)
+constexpr void write_to_ptr(U&& array, usz pos, const T& value, std::source_location src_loc = std::source_location::current())
 {
 	static_assert(sizeof(T) % sizeof(array[0]) == 0);
 	constexpr usz elements_per_value = sizeof(T) / sizeof(array[0]);
 
 	if constexpr (requires { std::size(array); })
 	{
-		ensure((pos + elements_per_value) <= std::size(array));
+		ensure((pos + elements_per_value) <= std::size(array), src_loc);
 	}
 
 	if (!std::is_constant_evaluated())
@@ -1235,14 +1247,14 @@ constexpr void write_to_ptr(U&& array, usz pos, const T& value)
 }
 
 template <typename T, typename U>
-constexpr void write_to_ptr(U&& array, const T& value)
+constexpr void write_to_ptr(U&& array, const T& value, std::source_location src_loc = std::source_location::current())
 {
 	static_assert(sizeof(T) % sizeof(array[0]) == 0);
 	constexpr usz elements_per_value = sizeof(T) / sizeof(array[0]);
 
 	if constexpr (requires { std::size(array); })
 	{
-		ensure(elements_per_value <= std::size(array));
+		ensure(elements_per_value <= std::size(array), src_loc);
 	}
 
 	if (!std::is_constant_evaluated())


### PR DESCRIPTION
Adds better location info to verification failure in write_to_ptr and read_from_ptr