### PR TITLE
Add OpenCV 5 Support

### DIFF
--- a/rpcs3/Input/ps_move_tracker.cpp
+++ b/rpcs3/Input/ps_move_tracker.cpp
@@ -7,6 +7,12 @@
 
 #ifdef HAVE_OPENCV
 #include <opencv2/photo.hpp>
+
+// OpenCV 5.x moved some functions to this header
+#if __has_include(<opencv2/geometry.hpp>)
+#include <opencv2/geometry.hpp>
+#endif
+
 #endif
 
 LOG_CHANNEL(ps_move);


### PR DESCRIPTION
Arch Linux has updated it's OpenCV package to 5, which has a new header file that we need to include.

Patch blatantly stolen from Arch Linux user rubin55: https://aur.archlinux.org/packages/rpcs3-git#comment-1077557