### PR TITLE
 Far Cry 3 / Buy gun crash / Improve has_flushable_data with unlocked check

### DIFF
--- a/rpcs3/Emu/RSX/Common/surface_utils.h
+++ b/rpcs3/Emu/RSX/Common/surface_utils.h
@@ -794,7 +794,16 @@ namespace rsx
 
 		bool has_flushable_data() const
 		{
-			ensure(is_locked());
+			if (!is_locked())
+			{
+				// The owning texture-cache section can remain locked while this
+				// render target's mirrored lock flag is cleared (e.g. after a
+				// surface swap/clone during render-to-texture readback, as seen
+				// in Far Cry 3's weapon-purchase screen). An unlocked surface has
+				// no GPU data pending flush to guest memory, so report none rather
+				// than asserting.
+				return false;
+			}
 			ensure(texture_cache_metadata.timestamp);
 			return (texture_cache_metadata.timestamp < last_use_tag);
 		}


### PR DESCRIPTION
With this check, Far Cry 3 doesnt crash any more when trying to buy a gun in the village's gun store in the middle of Chapter 1 after you woke up in the hut, are greeted by Dennis and introduced to the village by him.

 @rpcs3-Team: Thanks for your great work!