### PR TITLE
PPU LLVM: Optimize vector NaN handling for AVX512

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5153,6 +5153,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				accurate_vnan,
 				accurate_nj_mode,
 				contains_symbol_resolver,
+				daz_and_ftz,
 
 				__bitset_enum_max
 			};
@@ -5184,6 +5185,8 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				settings += ppu_settings::accurate_nj_mode, settings -= ppu_settings::fixup_nj_denormals, fmt::throw_exception("NJ Not implemented");
 			if (fpos >= info.get_funcs().size() || module_counter % c_moudles_per_jit == c_moudles_per_jit - 1)
 				settings += ppu_settings::contains_symbol_resolver; // Avoid invalidating all modules for this purpose
+			if (g_cfg.core.set_daz_and_ftz)
+				settings += ppu_settings::daz_and_ftz;
 
 			// Write version, hash, CPU, settings
 			fmt::append(obj_name, "v7-kusa-%s-%s-%s.obj", fmt::base57(output, 16), fmt::base57(settings), jit_compiler::cpu(g_cfg.core.llvm_cpu.to_string()));

--- a/rpcs3/Emu/Cell/PPUTranslator.cpp
+++ b/rpcs3/Emu/Cell/PPUTranslator.cpp
@@ -447,6 +447,13 @@ Function* PPUTranslator::GetSymbolResolver(const ppu_module<lv2_obj>& info)
 
 Value* PPUTranslator::VecHandleNan(Value* val)
 {
+	if (m_use_avx512 && !g_cfg.core.set_daz_and_ftz)
+	{
+		// VFIXUPIMMPS is only equivalent when DAZ is disabled.
+		// Select the canonical NaN for QNaN/SNaN and pass through every other class.
+		return vfixupimmps(value<f32[4]>(nan_vec4), value<f32[4]>(val), splat<u32[4]>(0x1111'1100), 0x10, 0xff).eval(m_ir);
+	}
+
 	const auto is_nan = m_ir->CreateFCmpUNO(val, val);
 
 	val = m_ir->CreateSelect(is_nan, nan_vec4, val);


### PR DESCRIPTION
Use VFIXUPIMMPS for VecHandleNan on AVX-512 targets.

Before
<img width="600" height="550" alt="image" src="https://github.com/user-attachments/assets/1ab4564b-e609-4b49-8c05-08ded152ae8a" />
after
<img width="600" height="550" alt="image" src="https://github.com/user-attachments/assets/5de9c842-7c74-4a0b-b3f0-fc8cbf8a6812" />
