### PR TITLE
Fix: get_known_bits fix

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -618,7 +618,7 @@ llvm::KnownBits cpu_translator::get_known_bits_fallback(llvm::Value* value)
 
 	if (!type->isVectorTy())
 	{
-		if (const auto it = llvm::dyn_cast<llvm::IntegerType>(type))
+		if (llvm::isa<llvm::IntegerType>(type))
 		{
 			if (auto bin_inst = llvm::dyn_cast<llvm::BinaryOperator>(value))
 			{
@@ -660,20 +660,7 @@ llvm::KnownBits cpu_translator::get_known_bits_fallback(llvm::Value* value)
 		return llvm::KnownBits(type->getScalarSizeInBits());
 	}
 
-	const auto cv = llvm::dyn_cast<llvm::ConstantDataVector>(value);
-
-	if (!cv)
-	{
-		if (llvm::isa<llvm::ConstantAggregateZero>(value))
-		{
-			llvm::KnownBits ret(type->getScalarSizeInBits());
-			ret.Zero.setAllBits();
-			return ret;
-		}
-	}
-
 	const auto original_value = peek_through_bitcasts(value);
-	const auto original_type = original_value->getType();
 
 	auto bin_inst = llvm::dyn_cast<llvm::BinaryOperator>(original_value);
 
@@ -696,31 +683,40 @@ llvm::KnownBits cpu_translator::get_known_bits_fallback(llvm::Value* value)
 
 	ensure(ok);
 
-	llvm::APInt dest{};
+	llvm::APInt all_lanes{};
+	llvm::APInt any_lanes{};
 
 	auto combine_bits = [&](const auto& array, u32 size)
 	{
-		auto first = +array[0];
+		auto all = +array[0];
+		auto any = +array[0];
 
-		for (u32 i = 0; i < size; i++)
+		for (u32 i = 1; i < size; i++)
 		{
-			first &= +array[i];
+			all &= +array[i];
+			any |= +array[i];
 		}
 
-		return first;
+		return std::make_pair(all, any);
 	};
 
 	if (type->getScalarType()->isIntegerTy(8))
 	{
-		dest = llvm::APInt(8, combine_bits(v128_const._u8, 16));
+		const auto [all, any] = combine_bits(v128_const._u8, 16);
+		all_lanes = llvm::APInt(8, all);
+		any_lanes = llvm::APInt(8, any);
 	}
 	else if (type->getScalarType()->isIntegerTy(16))
 	{
-		dest = llvm::APInt(16, combine_bits(v128_const._u16, 8));
+		const auto [all, any] = combine_bits(v128_const._u16, 8);
+		all_lanes = llvm::APInt(16, all);
+		any_lanes = llvm::APInt(16, any);
 	}
 	else if (type->getScalarType()->isIntegerTy(32))
 	{
-		dest = llvm::APInt(32, combine_bits(v128_const._u32, 4));
+		const auto [all, any] = combine_bits(v128_const._u32, 4);
+		all_lanes = llvm::APInt(32, all);
+		any_lanes = llvm::APInt(32, any);
 	}
 	else // if (type->getScalarType()->isIntegerTy(64))
 	{
@@ -730,14 +726,14 @@ llvm::KnownBits cpu_translator::get_known_bits_fallback(llvm::Value* value)
 	if (bin_inst->getOpcode() == llvm::Instruction::Or)
 	{
 		llvm::KnownBits ret(type->getScalarSizeInBits());
-		ret.One = dest;
+		ret.One = all_lanes;
 		return ret;
 	}
 
 	if (bin_inst->getOpcode() == llvm::Instruction::And)
 	{
 		llvm::KnownBits ret(type->getScalarSizeInBits());
-		ret.Zero = dest;
+		ret.Zero = any_lanes;
 		ret.Zero.flipAllBits();
 		return ret;
 	}

--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -610,4 +610,138 @@ void cpu_translator::erase_stores(llvm::ArrayRef<llvm::Value*> args)
 	}
 }
 
+llvm::KnownBits cpu_translator::get_known_bits_fallback(llvm::Value* value)
+{
+	// TODO: Improve it - add support for integer addition/subtraction and more stuff
+
+	const auto type = value->getType();
+
+	if (!type->isVectorTy())
+	{
+		if (const auto it = llvm::dyn_cast<llvm::IntegerType>(type))
+		{
+			if (auto bin_inst = llvm::dyn_cast<llvm::BinaryOperator>(value))
+			{
+				llvm::Value* lhs = ensure(bin_inst->getOperand(0));
+				llvm::Value* rhs = ensure(bin_inst->getOperand(1));
+
+				llvm::ConstantInt* constant_value = llvm::dyn_cast<llvm::ConstantInt>(rhs) ? llvm::dyn_cast<llvm::ConstantInt>(rhs) : llvm::dyn_cast<llvm::ConstantInt>(lhs);
+
+				if (!constant_value)
+				{
+					return llvm::KnownBits(type->getScalarSizeInBits());
+				}
+
+				if (bin_inst->getOpcode() == llvm::Instruction::Or)
+				{
+					llvm::KnownBits ret(type->getScalarSizeInBits());
+					ret.One = constant_value->getValue();
+					return ret;
+				}
+
+				if (bin_inst->getOpcode() == llvm::Instruction::And)
+				{
+					llvm::KnownBits ret(type->getScalarSizeInBits());
+					ret.Zero = constant_value->getValue();
+					ret.Zero.flipAllBits();
+					return ret;
+				}
+
+				return llvm::KnownBits(type->getScalarSizeInBits());
+			}
+		}
+
+		fmt::throw_exception("Bad KnownBits type: i%ux", type->getScalarSizeInBits());
+	}
+
+	if (auto v = llvm::cast<llvm::FixedVectorType>(type); v->getScalarSizeInBits() * v->getNumElements() != 128)
+	{
+		// Unsupported
+		return llvm::KnownBits(type->getScalarSizeInBits());
+	}
+
+	const auto cv = llvm::dyn_cast<llvm::ConstantDataVector>(value);
+
+	if (!cv)
+	{
+		if (llvm::isa<llvm::ConstantAggregateZero>(value))
+		{
+			llvm::KnownBits ret(type->getScalarSizeInBits());
+			ret.Zero.setAllBits();
+			return ret;
+		}
+	}
+
+	const auto original_value = peek_through_bitcasts(value);
+	const auto original_type = original_value->getType();
+
+	auto bin_inst = llvm::dyn_cast<llvm::BinaryOperator>(original_value);
+
+	if (!bin_inst)
+	{
+		return llvm::KnownBits(type->getScalarSizeInBits());
+	}
+
+	llvm::Value* lhs = ensure(bin_inst->getOperand(0));
+	llvm::Value* rhs = ensure(bin_inst->getOperand(1));
+
+	llvm::Value* constant_value = llvm::dyn_cast<llvm::ConstantDataVector>(rhs) ? llvm::dyn_cast<llvm::ConstantDataVector>(rhs) : llvm::dyn_cast<llvm::ConstantDataVector>(lhs);
+
+	if (!constant_value)
+	{
+		return llvm::KnownBits(value->getType()->getScalarSizeInBits());
+	}
+
+	const auto [ok, v128_const] = get_const_vector(constant_value, -1);
+
+	ensure(ok);
+
+	llvm::APInt dest{};
+
+	auto combine_bits = [&](const auto& array, u32 size)
+	{
+		auto first = +array[0];
+
+		for (u32 i = 0; i < size; i++)
+		{
+			first &= +array[i];
+		}
+
+		return first;
+	};
+
+	if (type->getScalarType()->isIntegerTy(8))
+	{
+		dest = llvm::APInt(8, combine_bits(v128_const._u8, 16));
+	}
+	else if (type->getScalarType()->isIntegerTy(16))
+	{
+		dest = llvm::APInt(16, combine_bits(v128_const._u16, 8));
+	}
+	else if (type->getScalarType()->isIntegerTy(32))
+	{
+		dest = llvm::APInt(32, combine_bits(v128_const._u32, 4));
+	}
+	else // if (type->getScalarType()->isIntegerTy(64))
+	{
+		return llvm::KnownBits(type->getScalarSizeInBits());
+	}
+
+	if (bin_inst->getOpcode() == llvm::Instruction::Or)
+	{
+		llvm::KnownBits ret(type->getScalarSizeInBits());
+		ret.One = dest;
+		return ret;
+	}
+
+	if (bin_inst->getOpcode() == llvm::Instruction::And)
+	{
+		llvm::KnownBits ret(type->getScalarSizeInBits());
+		ret.Zero = dest;
+		ret.Zero.flipAllBits();
+		return ret;
+	}
+
+	return llvm::KnownBits(type->getScalarSizeInBits());
+}
 #endif

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -4271,10 +4271,53 @@ template <typename T1, typename T2, typename T3>
 	template <typename T = v128>
 	llvm::Constant* make_const_vector(T, llvm::Type*, u32 = __builtin_LINE());
 
+	// IR is emitted in a single pass: phi nodes may still be missing their back-edge incoming
+	// values, so any known bits computeKnownBits derives through a phi are unsound for the
+	// final IR. Whether a phi is complete cannot be queried (the CFG edges from not-yet-emitted
+	// predecessors don't exist either), so reject every value whose bits may derive from a phi.
+	static bool is_known_bits_safe(llvm::Value* value)
+	{
+		llvm::SmallPtrSet<const llvm::Value*, 32> visited;
+		llvm::SmallVector<const llvm::Value*, 32> worklist{value};
+
+		while (!worklist.empty())
+		{
+			const llvm::Value* v = worklist.pop_back_val();
+
+			if (!visited.insert(v).second)
+			{
+				continue;
+			}
+
+			if (llvm::isa<llvm::PHINode>(v) || visited.size() > 256)
+			{
+				return false;
+			}
+
+			// Loads don't propagate operand bits; constants and arguments are leaves
+			if (auto i = llvm::dyn_cast<llvm::Instruction>(v); i && !llvm::isa<llvm::LoadInst>(i))
+			{
+				for (const llvm::Use& op : i->operands())
+				{
+					worklist.push_back(op.get());
+				}
+			}
+		}
+
+		return true;
+	}
+
 	template <typename T>
 	llvm::KnownBits get_known_bits(T a)
 	{
-		return llvm::computeKnownBits(a.eval(m_ir), m_module->getDataLayout());
+		llvm::Value* value = a.eval(m_ir);
+
+		if (!is_known_bits_safe(value))
+		{
+			return llvm::KnownBits(value->getType()->getScalarSizeInBits());
+		}
+
+		return llvm::computeKnownBits(value, m_module->getDataLayout());
 	}
 
 	template <typename T>

--- a/rpcs3/Emu/CPU/CPUTranslator.h
+++ b/rpcs3/Emu/CPU/CPUTranslator.h
@@ -4307,6 +4307,8 @@ template <typename T1, typename T2, typename T3>
 		return true;
 	}
 
+	llvm::KnownBits get_known_bits_fallback(llvm::Value* value);
+
 	template <typename T>
 	llvm::KnownBits get_known_bits(T a)
 	{
@@ -4314,7 +4316,7 @@ template <typename T1, typename T2, typename T3>
 
 		if (!is_known_bits_safe(value))
 		{
-			return llvm::KnownBits(value->getType()->getScalarSizeInBits());
+			return get_known_bits_fallback(value);
 		}
 
 		return llvm::computeKnownBits(value, m_module->getDataLayout());


### PR DESCRIPTION
Disclosure: I did the regression bisect but the patch was designed by Fable.

This fixes LLVM 22 build but is a valid fix for old LLVM versions too.

```
  The SPU recompiler queries LLVM's analysis on IR that is still under construction. get_known_bits
  (CPUTranslator.h:4271) calls llvm::computeKnownBits during instruction emission, and the recompiler builds functions
  in one pass: loop-header phis only get their back-edge incomings after the loop body is emitted (the "Connect PHI
  nodes if necessary" code at SPULLVMRecompiler.cpp:534).

  So when SHUFB at, say, address 0x10084 is emitted inside a loop, its control register is a phi that at that moment has
  a single incoming: zeroinitializer (the preheader edge — the back-edge value is produced at a later address and
  doesn't exist yet as an SSA value). computeKnownBits on that phi answers "all bits known zero", which is unsound once
  the back edge is added.

  Why it only breaks now: the control is read as u8[16], i.e. a bitcast <4 x i32> %phi to <16 x i8> — a wide→narrow
  element bitcast. On LLVM ≤ 21, computeKnownBits could not see through that bitcast, so the bogus phi answer never
  reached the decision and the conservative path was always taken. Commit 30728eb2 teaches ValueTracking to look through
  exactly this bitcast shape (the second hunk, SubBitWidth % BitWidth == 0). It landed Aug 4 2025, right after the 21.x
  branch — matching your 21-good/22-bad boundary precisely.
```

Co-Authored with @elad335 