### PR TITLE
pad settings: Fix for clearing bindings

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5486,7 +5486,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 	{
 		usz index = umax;
 
-
 #ifdef __APPLE__
 		named_thread sym_worker("PPU Symbol Resolver", [&]()
 		{

--- a/rpcs3/rpcs3qt/pad_settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.cpp
@@ -1173,13 +1173,19 @@ bool pad_settings_dialog::eventFilter(QObject* object, QEvent* event)
 {
 	switch (event->type())
 	{
+	case QEvent::MouseButtonPress:
+	{
+		// Save object on rightclick if we are not remapping a button in order to allow clearing a binding
+		m_clear_binding_object = (m_button_id == button_ids::id_pad_begin && static_cast<QMouseEvent*>(event)->button() == Qt::RightButton) ? object : nullptr;
+		break;
+	}
 	case QEvent::MouseButtonRelease:
 	{
 		// On right click clear binding if we are not remapping pad button
-		if (m_button_id == button_ids::id_pad_begin)
+		// Only allow clearing a binding if the same object was also pressed while we were not remapping
+		if (m_button_id == button_ids::id_pad_begin && static_cast<QMouseEvent*>(event)->button() == Qt::RightButton && m_clear_binding_object == object)
 		{
-			QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
-			if (const auto button = qobject_cast<QPushButton*>(object); button && button->isEnabled() && mouse_event->button() == Qt::RightButton)
+			if (const auto button = qobject_cast<QPushButton*>(object); button && button->isEnabled())
 			{
 				if (const int button_id = m_pad_buttons->id(button); m_cfg_entries.contains(button_id))
 				{
@@ -1482,6 +1488,10 @@ void pad_settings_dialog::OnPadButtonClicked(int id)
 	m_last_pos = QCursor::pos();
 
 	m_button_id = id;
+
+	// Disable clearing of a binding while we are remapping a button
+	m_clear_binding_object = nullptr;
+
 	if (auto button = m_pad_buttons->button(m_button_id))
 	{
 		button->setText(tr("[ Waiting %1 ]").arg(MAX_SECONDS));

--- a/rpcs3/rpcs3qt/pad_settings_dialog.h
+++ b/rpcs3/rpcs3qt/pad_settings_dialog.h
@@ -132,6 +132,8 @@ private:
 	std::string m_title_id;
 	std::shared_ptr<gui_settings> m_gui_settings;
 
+	QObject* m_clear_binding_object = nullptr;
+
 	// Tooltips
 	QString m_description;
 	QHash<QObject*, QString> m_descriptions;


### PR DESCRIPTION
Fix accidentally clearing a binding during remap if the same button is assigned to rightclick in the pad navigation.
Only allow clearing a binding on release if the same button was also pressed while no remapping occured.

fixes #19053