### PR TITLE
LLVM: Improve v128 constant extraction

### DIFF
--- a/rpcs3/Emu/CPU/CPUTranslator.cpp
+++ b/rpcs3/Emu/CPU/CPUTranslator.cpp
@@ -317,6 +317,9 @@ llvm::Value* cpu_translator::bitcast(llvm::Value* val, llvm::Type* type, std::so
 template <>
 std::pair<bool, v128> cpu_translator::get_const_vector<v128>(llvm::Value* c, u32 _pos, u32 _line)
 {
+	// Bitcasts do not matter
+	c = peek_through_bitcasts(c);
+
 	v128 result{};
 
 	if (!llvm::isa<llvm::Constant>(c))


### PR DESCRIPTION
Peek through bitcasts when reading vector constant values, they are very common in SPU LLVM. (because SPU has one GPR set for all uses)
Allows existing SPU LLVM and PPU LLVM optimizations to detect more cases. 
 