### PR TITLE
rsx: Fix inverted branch hints in FIFO command fetch

### DIFF
--- a/rpcs3/Emu/RSX/RSXFIFO.cpp
+++ b/rpcs3/Emu/RSX/RSXFIFO.cpp
@@ -23,6 +23,8 @@ namespace rsx
 	namespace FIFO
 	{
 		FIFO_control::FIFO_control(::rsx::thread* pctrl)
+			: m_fifo_mode(g_cfg.core.rsx_fifo_accuracy.get())
+			, m_atomic_fetch(m_fifo_mode != rsx_fifo_mode::fast)
 		{
 			m_thread = pctrl;
 			m_ctrl = pctrl->ctrl;
@@ -128,8 +130,8 @@ namespace rsx
 				}
 
 				// Atomic FIFO debug options
-				const bool force_cache_fill = g_cfg.core.rsx_fifo_accuracy == rsx_fifo_mode::atomic_ordered;
-				const bool strict_fetch_ordering = g_cfg.core.rsx_fifo_accuracy >= rsx_fifo_mode::atomic_ordered;
+				const bool force_cache_fill = m_fifo_mode == rsx_fifo_mode::atomic_ordered;
+				const bool strict_fetch_ordering = m_fifo_mode >= rsx_fifo_mode::atomic_ordered;
 
 				rsx::reservation_lock<true, 1> rsx_lock(addr1, m_cache_size, true);
 				const auto src = vm::_ptr<spu_rdata_t>(addr1);
@@ -231,7 +233,7 @@ namespace rsx
 				return {};
 			}
 
-			if (g_cfg.core.rsx_fifo_accuracy)
+			if (m_atomic_fetch)
 			{
 				// Return a pointer to the cache storage with confined access
 				const u32 cache_offset_in_words = (m_internal_get - m_cache_addr) / 4;
@@ -275,7 +277,7 @@ namespace rsx
 				bool ok{};
 				u32 arg = 0;
 
-				if (g_cfg.core.rsx_fifo_accuracy) [[ unlikely ]]
+				if (m_atomic_fetch) [[ likely ]]
 				{
 					std::tie(ok, arg) = fetch_u32(m_internal_get + 4);
 
@@ -365,7 +367,7 @@ namespace rsx
 				m_memwatch_cmp = 0;
 			}
 
-			if (!g_cfg.core.rsx_fifo_accuracy) [[ likely ]]
+			if (!m_atomic_fetch) [[ unlikely ]]
 			{
 				const u32 put = read_put();
 
@@ -434,7 +436,7 @@ namespace rsx
 				m_remaining_commands = count - 1;
 			}
 
-			if (g_cfg.core.rsx_fifo_accuracy)
+			if (m_atomic_fetch)
 			{
 				m_internal_get += 4;
 

--- a/rpcs3/Emu/RSX/RSXFIFO.h
+++ b/rpcs3/Emu/RSX/RSXFIFO.h
@@ -2,6 +2,7 @@
 
 #include "util/types.hpp"
 #include "Emu/RSX/gcm_enums.h"
+#include "Emu/system_config_types.h"
 
 #include <span>
 
@@ -142,6 +143,9 @@ namespace rsx
 			u32 m_remaining_commands = 0;
 			u32 m_args_ptr = 0;
 			u32 m_cmd = ~0u;
+
+			const rsx_fifo_mode m_fifo_mode;
+			const bool m_atomic_fetch;
 
 			u32 m_cache_addr = 0;
 			u32 m_cache_size = 0;


### PR DESCRIPTION
## Summary

The branch hints guarding the FIFO fetch path in `RSXFIFO.cpp` still point at the *old* default FIFO accuracy mode. On a default config, every user currently takes the path marked `[[unlikely]]` and skips the one marked `[[likely]]`.

This PR swaps the two stale hints and, while in the same code, resolves the accuracy setting once at construction instead of re-reading the config node on every FIFO command.

No functional change — the hints only affect code layout, and the cached setting is not a dynamic one.

## The problem

67f7119717fae25b8b2ecc5469c5fb5db45af1b6 ("Make RSX FIFO Atomic fetching default") switched the default from `rsx_fifo_mode::fast` to `rsx_fifo_mode::atomic`. It touched three files: the config declaration and two Qt settings files. The branch hints in `RSXFIFO.cpp` were never updated.

The setting is tested through `fifo_setting::operator bool()` (`system_config.h`):

```cpp
explicit operator bool() const
{
    return get() != rsx_fifo_mode::fast;
}
```

With the shipped default of `atomic`, this evaluates to **true**. So the two hints are now backwards:

```cpp
// read_unsafe() — the taken path is marked cold
if (g_cfg.core.rsx_fifo_accuracy) [[ unlikely ]]

// read() — the skipped path is marked hot
if (!g_cfg.core.rsx_fifo_accuracy) [[ likely ]]
```

## Why it matters

`read_unsafe()` is called once per FIFO command from the `run_FIFO()` loop:

```cpp
while (fifo_ctrl->read_unsafe(command));
```

This is the hottest loop on the RSX thread. With the hint inverted, the compiler moves the `fetch_u32()` path into the cold section and is discouraged from inlining it there, so the actually-taken path pays extra jumps and worse I-cache locality. Swapping the hints restores the intended layout for the shipped default.

## Second change: cache the accuracy setting

`g_cfg.core.rsx_fifo_accuracy` was read in six places inside `FIFO_control`, including per-command paths. Each read is a `seq_cst` atomic load, which also acts as a compiler barrier — it prevents hoisting the check out of the read loop and blocks CSE.

The config node is **not** declared dynamic:

```cpp
fifo_setting rsx_fifo_accuracy{this, "RSX FIFO Fetch Accuracy", rsx_fifo_mode::atomic };
```

and `FIFO_control` is rebuilt by `thread::on_task()` on every boot, so resolving it once in the constructor is behaviourally identical. Two `const` members replace the repeated loads:

```cpp
const rsx_fifo_mode m_fifo_mode;
const bool m_atomic_fetch;
```

`FIFO_control` is only ever created via `std::make_unique` and never copied or assigned, so the `const` members are safe.

The reads outside `FIFO_control` (`rsx_methods.cpp`, `RSXThread.cpp`) are left alone — they are not on a per-command path.

## Testing

Being upfront about what was and was not verified:

- **Not built.** I could not compile the tree locally, so I am relying on CI to validate the build across platforms. Happy to fix anything it turns up.
- The new constructs (`const` `enum class` member initialised from `get()`, a `const bool` derived from it in the same init-list, and the relational `enum class` comparisons) were validated in an isolated TU mirroring `fifo_setting`, compiled with `-std=c++23 -O2 -Wall -Wextra -Werror=reorder -Werror=uninitialized`. It confirms that with the `atomic` default the newly-`[[likely]]` branch is the taken one, and produces no warnings.
- **Not benchmarked.** I do not have FPS numbers.

## Expected impact

Modest and hard to isolate — this is a code-layout fix plus one removed atomic load per FIFO command, so any gain is confined to the RSX thread and only visible where that thread is the bottleneck. I would not expect it to show up clearly on a frame counter.

The reason I think it is worth merging regardless is that it is a **maintenance fix, not a speculative optimisation**: the hints assert something about the default config that stopped being true when the default changed, and right now they assert the opposite of reality.
