### PR TITLE
rsx: Clean up the shader interpreters

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
@@ -408,6 +408,13 @@ namespace gl
 			"	uvec4 fp_instructions[];\n"
 			"};\n\n";
 
+		const ::glsl::shader_properties properties
+		{
+			.domain = ::glsl::program_domain::glsl_fragment_program,
+			.require_lit_emulation = true,
+		};
+
+		::glsl::insert_glsl_legacy_function(builder, properties);
 		builder << program_common::interpreter::get_fragment_interpreter();
 		const std::string s = builder.str();
 

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
@@ -960,13 +960,13 @@ std::string FragmentProgramDecompiler::BuildCode()
 	}
 
 	OS <<
-	"#define _builtin_lit lit_legacy\n"
 	"#define _builtin_log2 log2\n"
 	"#define _builtin_normalize(x) (length(x) > 0? normalize(x) : x)\n" // HACK!! Workaround for some games that generate NaNs unless texture filtering exactly matches PS3 (BFBC)
 	"#define _builtin_sqrt(x) sqrt(abs(x))\n"
 	"#define _builtin_rcp(x) (1. / x)\n"
 	"#define _builtin_rsq(x) (1. / _builtin_sqrt(x))\n"
-	"#define _builtin_div(x, y) (x / y)\n";
+	"#define _builtin_div(x, y) (x / y)\n"
+	"#define _builtin_lerp mix\n";
 
 	if (device_props.has_low_precision_rounding)
 	{
@@ -1118,8 +1118,11 @@ bool FragmentProgramDecompiler::handle_sct_scb(u32 opcode)
 		SetDst("_builtin_lit($0)");
 		properties.has_lit_op = true;
 		return true;
-	case RSX_FP_OPCODE_LIF: SetDst("$Ty(1.0, $0.y, ($0.y > 0 ? exp2($0.w) : 0.0), 1.0)", OPFLAGS::op_extern); return true;
-	case RSX_FP_OPCODE_LRP: SetDst("$Ty($2 * (1 - $0) + $1 * $0)", OPFLAGS::skip_type_cast); return true;
+	case RSX_FP_OPCODE_LIF:
+		SetDst("_builtin_lif($0)");
+		properties.has_lit_op = true;
+		return true;
+	case RSX_FP_OPCODE_LRP: SetDst("_builtin_lerp($2, $1, $0)", OPFLAGS::skip_type_cast); return true;
 	case RSX_FP_OPCODE_LG2: SetDst("_builtin_log2($0.x).xxxx"); return true;
 	// Pack operations. See https://www.khronos.org/registry/OpenGL/extensions/NV/NV_fragment_program.txt
 	// PK2 = PK2H (2 16-bit floats)

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -734,7 +734,7 @@ void main()
 		case RSX_FP_OPCODE_PK4:
 			vrr = vec4(uintBitsToFloat(packSnorm4x8(s0))); break;
 		case RSX_FP_OPCODE_PK16:
-			vrr = vec4(uintBitsToFloat(packSnorm2x16(s0.xy))); break;
+			vrr = vec4(uintBitsToFloat(packUnorm2x16(s0.xy))); break;
 		case RSX_FP_OPCODE_PKG:
 			// Should be similar to PKB but with gamma correction, see description of PK4UBG in khronos page
 		case RSX_FP_OPCODE_PKB:
@@ -744,7 +744,7 @@ void main()
 		case RSX_FP_OPCODE_UP4:
 			vrr = unpackSnorm4x8(floatBitsToUint(s0.x)); break;
 		case RSX_FP_OPCODE_UP16:
-			vrr = unpackSnorm2x16(floatBitsToUint(s0.x)).xyxy; break;
+			vrr = unpackUnorm2x16(floatBitsToUint(s0.x)).xyxy; break;
 		case RSX_FP_OPCODE_UPG:
 			// Same as UPB with gamma correction
 		case RSX_FP_OPCODE_UPB:

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -639,11 +639,14 @@ void main()
 			case RSX_FP_OPCODE_REP:
 				if (check_cond())
 				{
-					counter = int(GET_INST_BITS(2, 2, 8) - GET_INST_BITS(2, 10, 8)) - 1; // RANGE
-					ir0 = int(GET_INST_BITS(2, 19, 8));                                  // STEP
-					counter = max(counter, 0) / max(ir0, 1);                             // ITERATIONS
-					if (counter > 0)
+					ur0 = GET_INST_BITS(2, 10, 8);                // Start
+					ur1 = GET_INST_BITS(2, 2, 8);                 // End
+					if (ur1 > ur0)
 					{
+						counter = int(ur1 - ur0 - 1);             // RANGE
+						ir0 = int(GET_INST_BITS(2, 19, 8));       // STEP
+						counter = max(counter, 0) / max(ir0, 1);  // ITERATIONS
+
 						loop_start_addr = ip + 1;
 						loop_end_addr = int(inst.words.w >> 2);
 						continue;

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -705,7 +705,7 @@ void main()
 		case RSX_FP_OPCODE_RCP:
 			vrr = (1.f / s0.xxxx); break;
 		case RSX_FP_OPCODE_RSQ:
-			vrr = inversesqrt(s0.xxxx); break;
+			vrr = inversesqrt(abs(s0.x)).xxxx; break;
 		case RSX_FP_OPCODE_EX2:
 			vrr = exp2(s0.xxxx); break;
 		case RSX_FP_OPCODE_LG2:
@@ -795,7 +795,7 @@ void main()
 				vrr = s0 / s1.xxxx; break;
 			case RSX_FP_OPCODE_DIVSQ:
 				bvr0 = bvec4(s0);
-				sr0 = inversesqrt(s1.x);
+				sr0 = inversesqrt(abs(s1.x));
 				vr0 = s0 * sr0;
 				vrr = select(s0, vr0, bvr0);
 				break;

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -609,7 +609,7 @@ void main()
 			//case RSX_FP_OPCODE_CAL:
 				// Function call not yet found in the wild for this hw class
 			case RSX_FP_OPCODE_RET:
-				inst.end = true;
+				if (check_cond()) inst.end = true;
 				continue;
 			case RSX_FP_OPCODE_IFE:
 				if (check_cond())
@@ -645,6 +645,10 @@ void main()
 				}
 				continue;
 			case RSX_FP_OPCODE_BRK:
+				if (!check_cond())
+				{
+					continue;
+				}
 				if (loop_end_addr > 0)
 				{
 					ip = loop_end_addr;

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -625,7 +625,7 @@ void main()
 				else
 				{
 					// Go to ELSE path
-					ip = int(inst.words.z >> 2);
+					ip = int(GET_INST_BITS(2, 0, 31) >> 2);
 					inst_length = 0;
 				}
 				continue;

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -719,7 +719,11 @@ void main()
 		case RSX_FP_OPCODE_SIN:
 			vrr = sin(s0.xxxx); break;
 		case RSX_FP_OPCODE_NRM:
-			vrr.xyz = normalize(s0.xyz); break;
+			vrr = normalize(s0.xyz).xyzz; break;
+		case RSX_FP_OPCODE_LIT:
+			vrr = _builtin_lit(s0); break;
+		case RSX_FP_OPCODE_LIF:
+			vrr = _builtin_lif(s0); break;
 
 #ifdef WITH_TEXTURES
 		case RSX_FP_OPCODE_TEX:
@@ -837,8 +841,6 @@ void main()
 		//Other (missing in HW)
 		//case RSX_FP_OPCODE_BEM:
 		//case RSX_FP_OPCODE_BEMLUM:
-		//case RSX_FP_OPCODE_LIT:
-		//case RSX_FP_OPCODE_LIF:
 		//case RSX_FP_OPCODE_TIMESWTEX:
 #endif
 		write_dst(vrr);

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -101,6 +101,7 @@ uint ur0, ur1;     // GP unsigned register (scalar)
 uvec4 uvr0;        // GP unsigned register (vector)
 bvec4 bvr0, bvr1;  // GP boolean register (vector)
 float sr0;         // GP scalar register
+int ir0;           // GP scalar register (scalar)
 
 vec4 vrr;          // value return (dst register)
 vec4 s0, s1, s2;   // instruction src (src0, src1, src2)
@@ -638,8 +639,9 @@ void main()
 			case RSX_FP_OPCODE_REP:
 				if (check_cond())
 				{
-					counter = int(GET_INST_BITS(2, 2, 8) - GET_INST_BITS(2, 10, 8));
-					counter /= int(GET_INST_BITS(2, 19, 8));
+					counter = int(GET_INST_BITS(2, 2, 8) - GET_INST_BITS(2, 10, 8)) - 1; // RANGE
+					ir0 = int(GET_INST_BITS(2, 19, 8));                                  // STEP
+					counter = max(counter, 0) / max(ir0, 1);                             // ITERATIONS
 					loop_start_addr = ip + 1;
 					loop_end_addr = int(inst.words.w >> 2);
 				}

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -439,17 +439,6 @@ void write_dst(const in vec4 value)
 	uvr0 = uvec4(uint(1 << 9), uint(1 << 10), uint(1 << 11), uint(1 << 12));
 	bvr0 = bvec4(uvr0 & inst.words.xxxx);
 
-	if (TEST_INST_BIT(0, 8)) // SET COND
-	{
-		ur0 = GET_INST_BITS(1, 30, 1);
-		reg_mov(cc[ur0], value, bvr0);
-	}
-
-	if (TEST_INST_BIT(0, 30)) // NO DEST
-	{
-		return;
-	}
-
 	ur1 = GET_INST_BITS(2, 28, 3);
 	sr0 = modifier_scale[ur1];
 	vr0 = value * sr0;
@@ -465,6 +454,18 @@ void write_dst(const in vec4 value)
 		vr1 = read_cond();
 		bvr1 = decode_cond(ur0, vr1);
 		bvr0 = bvec4(uvec4(bvr0) & uvec4(bvr1));
+	}
+
+	// FIXME - HWTEST: Are CC registers affected by scale and SAT modifiers?
+	if (TEST_INST_BIT(0, 8)) // SET COND
+	{
+		ur0 = GET_INST_BITS(1, 30, 1);
+		reg_mov(cc[ur0], value, bvr0);
+	}
+
+	if (TEST_INST_BIT(0, 30)) // NO DEST
+	{
+		return;
 	}
 
 	ur1 = GET_INST_BITS(0, 1, 6);

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -818,7 +818,7 @@ void main()
 			case RSX_FP_OPCODE_MAD:
 				vrr = fma(s0, s1, s2); break;
 			case RSX_FP_OPCODE_LRP:
-				vrr = mix(s1, s2, s0); break;
+				vrr = mix(s2, s1, s0); break;
 			case RSX_FP_OPCODE_DP2A:
 				vrr = dot(s0.xy, s1.xy).xxxx + s2.xxxx; break;
 			}

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -484,14 +484,18 @@ void initialize()
 	// NOTE: Register count is the number of 'full' registers that will be consumed. Hardware seems to do some renaming.
 	// NOTE: Attempting to zero-initialize all the registers will slow things to a crawl!
 
-	uint register_count = GET_BITS(shader_control, 24, 6);
-	ur0 = 0, ur1 = 0;
-	while (register_count > 0)
-	{
-		regs32[ur0++] = vr_zero;
-		regs16[ur1++] = vr_zero;
-		regs16[ur1++] = vr_zero;
-		register_count--;
+	const uint register_count = GET_BITS(shader_control, 24, 6);
+	const uint regs32_count = min(register_count, 48u);
+	const uint regs16_count = min(register_count << 1u, 48u);
+
+	ur0 = regs32_count;
+	while (ur0 > 0) {
+		regs32[--ur0] = vr_zero;
+	}
+
+	ur0 = regs16_count;
+	while (ur0 > 0) {
+		regs16[--ur0] = vr_zero;
 	}
 
 	// Fog coord

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -828,15 +828,18 @@ void main()
 				vrr = mix(s2, s1, s0); break;
 			case RSX_FP_OPCODE_DP2A:
 				vrr = dot(s0.xy, s1.xy).xxxx + s2.xxxx; break;
+			default:
+				// Fallback - just write zero
+				vrr = vr_zero;
 			}
 		}
 #if 0
-		// Other
-		case RSX_FP_OPCODE_BEM:
-		case RSX_FP_OPCODE_BEMLUM:
-		case RSX_FP_OPCODE_LIT:
-		case RSX_FP_OPCODE_LIF:
-		case RSX_FP_OPCODE_TIMESWTEX:
+		//Other (missing in HW)
+		//case RSX_FP_OPCODE_BEM:
+		//case RSX_FP_OPCODE_BEMLUM:
+		//case RSX_FP_OPCODE_LIT:
+		//case RSX_FP_OPCODE_LIF:
+		//case RSX_FP_OPCODE_TIMESWTEX:
 #endif
 		write_dst(vrr);
 	}

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -618,20 +618,21 @@ void main()
 				if (check_cond()) inst.end = true;
 				continue;
 			case RSX_FP_OPCODE_IFE:
+				ur0 = GET_INST_BITS(2, 0, 31); // ELSE addr
 				if (check_cond())
 				{
-					// Go down IF path
-					if (inst.words.z < inst.words.w)
+					// We've entered the IF block. Set up an exit trap to skip the ELSE block.
+					if (ur0 < inst.words.w)                  // If ELSE address is before ENDIF address..
 					{
-						test_addr = int(inst.words.z >> 2);
-						jump_addr = int(inst.words.w >> 2);
+						test_addr = int(ur0 >> 2u);           // When we reach ELSE block...
+						jump_addr = int(inst.words.w >> 2u);  // Jump to ENDIF
 					}
 					// If simple IF..ENDIF, do nothing
 				}
 				else
 				{
-					// Go to ELSE path
-					ip = int(GET_INST_BITS(2, 0, 31) >> 2);
+					// Go to ELSE path. If ELSE is not provided, it matches ENDIF address.
+					ip = int(ur0 >> 2u);
 					inst_length = 0;
 				}
 				continue;

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -642,14 +642,17 @@ void main()
 					counter = int(GET_INST_BITS(2, 2, 8) - GET_INST_BITS(2, 10, 8)) - 1; // RANGE
 					ir0 = int(GET_INST_BITS(2, 19, 8));                                  // STEP
 					counter = max(counter, 0) / max(ir0, 1);                             // ITERATIONS
-					loop_start_addr = ip + 1;
-					loop_end_addr = int(inst.words.w >> 2);
+					if (counter > 0)
+					{
+						loop_start_addr = ip + 1;
+						loop_end_addr = int(inst.words.w >> 2);
+						continue;
+					}
 				}
-				else
-				{
-					ip = int(inst.words.w >> 2);
-					inst_length = 0;
-				}
+
+				// Failed cond check or 0 iterations encoded
+				ip = int(inst.words.w >> 2);
+				inst_length = 0;
 				continue;
 			case RSX_FP_OPCODE_BRK:
 				if (!check_cond())

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/FragmentInterpreter.glsl
@@ -461,7 +461,7 @@ void write_dst(const in vec4 value)
 	if (TEST_INST_BIT(0, 8)) // SET COND
 	{
 		ur0 = GET_INST_BITS(1, 30, 1);
-		reg_mov(cc[ur0], value, bvr0);
+		reg_mov(cc[ur0], vr0, bvr0);
 	}
 
 	if (TEST_INST_BIT(0, 30)) // NO DEST

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -495,7 +495,7 @@ void main()
 
 			case RSX_SCA_OPCODE_BRA:
 				// Jump by address register
-				if (dynamic_branch()) current_instruction = int(read_addr_reg().x);
+				if (dynamic_branch()) current_instruction = int(read_addr_reg().x - base_address);
 				continue;
 			case RSX_SCA_OPCODE_BRI:
 				// Jump immediate

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -558,6 +558,7 @@ void main()
 				// Call by boolean mask
 				if (static_branch())
 				{
+					if (stack_ptr == MAX_STACK_DEPTH) return;
 					callstack[stack_ptr] = current_instruction;
 					stack_ptr++;
 					current_instruction = branch_addr();

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -443,7 +443,7 @@ void main()
 
 		if (vec_opcode == RSX_VEC_OPCODE_ARL)
 		{
-			a[d0.dst_tmp] = ivec4(read_src(0));
+			a[d0.dst_tmp & 0x1u] = ivec4(read_src(0));
 		}
 		else if (vec_opcode != RSX_VEC_OPCODE_NOP)
 		{

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -241,7 +241,7 @@ void write_sca(in float value)
 	{
 		if (!d0.vec_result)
 		{
-			reg_mov(dest[d3.dst], vec4(value), d3.sca_mask);
+			reg_mov(dest[d3.dst & 0xFu], vec4(value), d3.sca_mask);
 		}
 		else
 		{
@@ -274,9 +274,9 @@ void write_vec(in vec4 value)
 	}
 	else
 	{
-		if (d0.vec_result && d3.dst < 16)
+		if (d0.vec_result)
 		{
-			reg_mov(dest[d3.dst], value, write_mask);
+			reg_mov(dest[d3.dst & 0xFu], value, write_mask);
 		}
 
 		if (d0.dst_tmp != 0x3f)

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -230,7 +230,7 @@ vec4 get_cond()
 	return shuffle(cc[d0.cond_reg_sel_1], d0.swizzle);
 }
 
-void write_sca(in float value)
+void write_sca(in vec4 value)
 {
 	if (d0.saturate)
 	{
@@ -241,16 +241,16 @@ void write_sca(in float value)
 	{
 		if (!d0.vec_result)
 		{
-			reg_mov(dest[d3.dst & 0xFu], vec4(value), d3.sca_mask);
+			reg_mov(dest[d3.dst & 0xFu], value, d3.sca_mask);
 		}
 		else
 		{
-			reg_mov(cc[d0.cond_reg_sel_1], vec4(value), d3.sca_mask);
+			reg_mov(cc[d0.cond_reg_sel_1], value, d3.sca_mask);
 		}
 	}
 	else
 	{
-		reg_mov(temp[d3.sca_dst_tmp], vec4(value), d3.sca_mask);
+		reg_mov(temp[d3.sca_dst_tmp], value, d3.sca_mask);
 	}
 }
 
@@ -476,7 +476,13 @@ void main()
 			write_vec(value);
 		}
 
-		if (sca_opcode != RSX_SCA_OPCODE_NOP)
+		if (sca_opcode == RSX_SCA_OPCODE_LIT)
+		{
+			// Ridiculously hacky instruction. It is a vector opcode, not scalar
+			// TODO: More HWTEST
+			write_sca(_builtin_lit(read_src(2)));
+		}
+		else if (sca_opcode != RSX_SCA_OPCODE_NOP)
 		{
 			float value = read_src(2).x;
 			switch (sca_opcode)
@@ -487,7 +493,6 @@ void main()
 			case RSX_SCA_OPCODE_RSQ: value = 1.0 / sqrt(value); break;
 			case RSX_SCA_OPCODE_EXP: value = exp(value); break;
 			case RSX_SCA_OPCODE_LOG: value = log(value); break;
-			//case RSX_SCA_OPCODE_LIT: value = lit_legacy(value); break;
 			case RSX_SCA_OPCODE_LG2: value = log2(value); break;
 			case RSX_SCA_OPCODE_EX2: value = exp2(value); break;
 			case RSX_SCA_OPCODE_SIN: value = sin(value); break;
@@ -541,7 +546,7 @@ void main()
 			//case RSX_SCA_OPCODE_POP:
 			}
 
-			write_sca(value);
+			write_sca(vec4(value));
 		}
 	}
 

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -308,9 +308,10 @@ ivec4 read_addr_reg()
 
 int branch_addr()
 {
-	uint addr_h = GET_BITS(instr.z, 0, 6);
-	uint addr_l = GET_BITS(instr.w, 29, 3);
-	return int((addr_h << 3) + addr_l);
+	const uint addr_2 = GET_BITS(instr.x, 23, 1);        // Allows indexing beyond 512 instructions. Some games push upto 544 instructions on CEX firmware.
+	const uint addr_1 = GET_BITS(instr.z, 0, 6);
+	const uint addr_0 = GET_BITS(instr.w, 29, 3);
+	return int((addr_2 << 9) + (addr_1 << 3) + addr_0);  // NOTE: Encoded jump addresses are already rebased by the VP analyser pass.
 }
 
 bool static_branch()
@@ -412,11 +413,11 @@ void main()
 
 	int callstack[8];
 	int stack_ptr = 0;
-	int current_instruction = 0;
+	int current_instruction = int(entry - base_address);
 
 	d3.end = false;
 
-	while (current_instruction < 512)
+	while (current_instruction >= 0 && current_instruction < 544) // NOTE: CEX can hold upto 544 instructions
 	{
 		if (d3.end)
 		{

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -505,7 +505,7 @@ void main()
 				// Call immediate
 				if (dynamic_branch())
 				{
-					callstack[stack_ptr] = current_instruction;
+					callstack[stack_ptr] = current_instruction; // Already incremented, points to next
 					stack_ptr++;
 					current_instruction = branch_addr();
 				}
@@ -518,8 +518,7 @@ void main()
 				if (dynamic_branch())
 				{
 					if (stack_ptr == 0) return;
-					current_instruction = callstack[stack_ptr];
-					stack_ptr--;
+					current_instruction = callstack[--stack_ptr];
 				}
 				continue;
 			case RSX_SCA_OPCODE_BRB:

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -237,21 +237,29 @@ void write_sca(in vec4 value)
 		value = clamp(value, 0, 1);
 	}
 
-	if (d3.sca_dst_tmp == 0x3f)
+	const bool write_out_reg = !d0.vec_result;
+	const bool write_gpr_reg = d3.sca_dst_tmp != 0x3f;
+
+	// NOTE: SCA does not support double register writes.
+	if (write_gpr_reg)
 	{
-		if (!d0.vec_result)
-		{
-			reg_mov(dest[d3.dst & 0xFu], value, d3.sca_mask);
-		}
-		else
-		{
-			reg_mov(cc[d0.cond_reg_sel_1], value, d3.sca_mask);
-		}
-	}
-	else
-	{
+		// Write to GPR. Most likely scenario.
 		reg_mov(temp[d3.sca_dst_tmp], value, d3.sca_mask);
+		return;
 	}
+
+	if (write_out_reg)
+	{
+		if (d3.dst < 16)
+		{
+			reg_mov(dest[d3.dst], value, d3.sca_mask);
+		}
+
+		return;
+	}
+
+	// Not writing to temp or out register. Update CC
+	reg_mov(cc[d0.cond_reg_sel_1], value, d3.sca_mask);
 }
 
 void write_vec(in vec4 value)
@@ -268,22 +276,32 @@ void write_vec(in vec4 value)
 		write_mask = bvec4(uvec4(write_mask) & uvec4(mask));
 	}
 
-	if (d0.dst_tmp == 0x3f && !d0.vec_result)
+	if (d0.dst_tmp != 0x3f)
 	{
-		reg_mov(cc[d0.cond_reg_sel_1], value, write_mask);
-	}
-	else
-	{
-		if (d0.vec_result)
+		// GPR write
+		reg_mov(temp[d0.dst_tmp], value, write_mask);
+
+		if (!d0.vec_result)
 		{
-			reg_mov(dest[d3.dst & 0xFu], value, write_mask);
+			return;
 		}
 
-		if (d0.dst_tmp != 0x3f)
-		{
-			reg_mov(temp[d0.dst_tmp], value, write_mask);
-		}
+		// Fallthrough - VEC engine allows double write to one output register and one GPR
 	}
+
+	if (d0.vec_result)
+	{
+		if (d3.dst < 16)
+		{
+			reg_mov(dest[d3.dst], value, write_mask);
+		}
+
+		return;
+	}
+
+	// Writes to neither GPR nor OUT reg. Update CC
+	reg_mov(cc[d0.cond_reg_sel_1], value, write_mask);
+
 }
 
 void write_output(const in int oid, const in int mask_bit)

--- a/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLInterpreter/VertexInterpreter.glsl
@@ -62,6 +62,8 @@ layout(location=0) out vec4 dest[16];
 
 #define reg_mov(d, s, m) d = mix(d, s, m)
 
+#define MAX_STACK_DEPTH 8
+
 struct D0
 {
     uint addr_swz;
@@ -429,7 +431,7 @@ void main()
 		dest[i] = vec4(0., 0., 0., 1.);
 	}
 
-	int callstack[8];
+	int callstack[MAX_STACK_DEPTH];
 	int stack_ptr = 0;
 	int current_instruction = int(entry - base_address);
 
@@ -528,6 +530,7 @@ void main()
 				// Call immediate
 				if (dynamic_branch())
 				{
+					if (stack_ptr == MAX_STACK_DEPTH) return;
 					callstack[stack_ptr] = current_instruction; // Already incremented, points to next
 					stack_ptr++;
 					current_instruction = branch_addr();

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXProgramCommon.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXProgramCommon.glsl
@@ -12,15 +12,30 @@ R"(
 #define CMP_FIXUP(a) (a)
 #endif
 
+#define _builtin_approx_pow(a, b) exp2((b) * log2(a))
+
 #ifdef _ENABLE_LIT_EMULATION
-vec4 lit_legacy(const in vec4 val)
+// LIT is well documented in NV extension documents. See https://registry.khronos.org/OpenGL/extensions/NV/NV_vertex_program.txt
+// In RSXFP the LIT instruction is unimplemented in hw. In it's place we have LIF and full LIT is emulated using at least 3 instructions.
+vec4 _builtin_lit(const in vec4 values)
 {
-	vec4 clamped_val = vec4(max(val.xy, vec2(0.)), val.zw);
-	return vec4(
-		1.,
-		clamped_val.x,
-		exp2(clamped_val.w * log2(max(clamped_val.y, 0.0000000001))) * sign(clamped_val.x),
-		1.);
+    vec4 t = vec4(max(values.xy, 0.f), values.zw);
+    return vec4(1.f,
+        t.x,
+        t.x > 0.f ? _builtin_approx_pow(max(t.y, 1e-10), t.w) : 0.f,
+        1.f);
+}
+
+// LIT d, t on RSXFP becomes:
+// t.xy = max(t.xy, 0)
+// t.w = t.w * log2(t.y)
+// LIF d, t
+vec4 _builtin_lif(const in vec4 t)
+{
+    return vec4(1.f,
+        t.y,
+        t.y > 0.f ? exp2(t.w) : 0.f,
+        1.f);
 }
 #endif
 

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXProgramCommon.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXProgramCommon.glsl
@@ -19,10 +19,11 @@ R"(
 // In RSXFP the LIT instruction is unimplemented in hw. In it's place we have LIF and full LIT is emulated using at least 3 instructions.
 vec4 _builtin_lit(const in vec4 values)
 {
-    vec4 t = vec4(max(values.xy, 0.f), values.zw);
+    // We clamp t.y to 1e-10 to avoid NaN in approx_pow when y=0 and w=0. This matches the spec's pow(x, 0) == 1 requirement.
+    vec4 t = vec4(max(values.xy, vec2(0.f, 1e-10)), values.zw);
     return vec4(1.f,
         t.x,
-        t.x > 0.f ? _builtin_approx_pow(max(t.y, 1e-10), t.w) : 0.f,
+        t.x > 0.f ? _builtin_approx_pow(t.y, t.w) : 0.f,
         1.f);
 }
 

--- a/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/VertexProgramDecompiler.cpp
@@ -660,7 +660,7 @@ std::string VertexProgramDecompiler::Decompile()
 		case RSX_SCA_OPCODE_EXP: SetDSTSca("exp($s)"); break;
 		case RSX_SCA_OPCODE_LOG: SetDSTSca("log($s)"); break;
 		case RSX_SCA_OPCODE_LIT:
-			SetDSTSca("lit_legacy($s)");
+			SetDSTSca("_builtin_lit($s)");
 			properties.has_lit_op = true;
 			break;
 		case RSX_SCA_OPCODE_BRA:

--- a/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/VK/VKShaderInterpreter.cpp
@@ -285,10 +285,11 @@ namespace vk
 			}
 		}
 
-		[[maybe_unused]] ::glsl::shader_properties properties{};
-		properties.domain = ::glsl::program_domain::glsl_fragment_program;
-		properties.require_depth_conversion = true;
-		properties.require_wpos = true;
+		::glsl::shader_properties properties
+		{
+			.domain = ::glsl::program_domain::glsl_fragment_program,
+			.require_lit_emulation = true,
+		};
 
 		u32 len;
 		ParamArray arr;
@@ -417,6 +418,7 @@ namespace vk
 			"	uint rop_control = fs_contexts[_fs_context_offset].rop_control;\n"
 			"	float alpha_ref = fs_contexts[_fs_context_offset].alpha_ref;\n\n";
 
+		::glsl::insert_glsl_legacy_function(builder, properties);
 		builder << program_common::interpreter::get_fragment_interpreter();
 		const std::string s = builder.str();
 


### PR DESCRIPTION
Partial rewrite of the interpreters to match the reference (decompiler) code whenever possible. Many of the crashes were due to typos and recklessness. There were also many issues which were fixed on decompiler but the interpreter was never updated.

Closes https://github.com/RPCS3/rpcs3/issues/19073
Fixes https://github.com/RPCS3/rpcs3/issues/19083
Fixes https://github.com/RPCS3/rpcs3/issues/16587

Also relates to https://github.com/RPCS3/rpcs3/issues/15289