### PR TITLE
rsxfp/interpreter - Implement missing texture functionality

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -1703,6 +1703,48 @@ namespace rsx
 		}
 	}
 
+	rsx::surface_color_format get_compatible_surface_color_format(u32 gcm_format)
+	{
+		switch (gcm_format)
+		{
+		case CELL_GCM_TEXTURE_R5G6B5:
+			return rsx::surface_color_format::r5g6b5;
+		case CELL_GCM_TEXTURE_A8R8G8B8:
+			return rsx::surface_color_format::a8b8g8r8;
+		case CELL_GCM_TEXTURE_W16_Z16_Y16_X16_FLOAT:
+			return rsx::surface_color_format::w16z16y16x16;
+		case CELL_GCM_TEXTURE_W32_Z32_Y32_X32_FLOAT:
+			return rsx::surface_color_format::w32z32y32x32;
+		case CELL_GCM_TEXTURE_A1R5G5B5:
+			return rsx::surface_color_format::x1r5g5b5_o1r5g5b5;
+		case CELL_GCM_TEXTURE_B8:
+			return rsx::surface_color_format::b8;
+		case CELL_GCM_TEXTURE_G8B8:
+			return rsx::surface_color_format::g8b8;
+		case CELL_GCM_TEXTURE_X32_FLOAT:
+			return rsx::surface_color_format::x32;
+		default:
+			fmt::throw_exception("Unhandled surface format 0x%x", gcm_format);
+		}
+	}
+
+	rsx::surface_depth_format2 get_compatible_surface_depth_format(u32 gcm_format)
+	{
+		switch (gcm_format)
+		{
+		case RSX_FORMAT_CLASS_DEPTH16_UNORM:
+			return rsx::surface_depth_format2::z16_uint;
+		case RSX_FORMAT_CLASS_DEPTH24_UNORM_X8_PACK32:
+			return rsx::surface_depth_format2::z24s8_uint;
+		case RSX_FORMAT_CLASS_DEPTH16_FLOAT:
+			return rsx::surface_depth_format2::z16_float;
+		case RSX_FORMAT_CLASS_DEPTH24_FLOAT_X8_PACK32:
+			return rsx::surface_depth_format2::z24s8_float;
+		default:
+			fmt::throw_exception("Invalid depth format 0x%x", gcm_format);
+		}
+	}
+
 	u32 get_max_depth_value(rsx::surface_depth_format2 format)
 	{
 		return get_format_block_size_in_bytes(format) == 2 ? 0xFFFF : 0xFFFFFF;

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -284,6 +284,21 @@ namespace rsx
 		usz alignment;
 	};
 
+	struct image_section_attributes_t
+	{
+		u32 address;
+		u32 gcm_format;
+		u32 pitch;
+		u16 width;
+		u16 height;
+		u16 depth;
+		u16 mipmaps;
+		u16 slice_h;
+		u8  bpp;
+		bool swizzled;
+		bool edge_clamped;
+	};
+
 	/**
 	* Get size to store texture in a linear fashion.
 	* Storage is assumed to use a rowPitchAlignment boundary for every row of texture.
@@ -349,6 +364,9 @@ namespace rsx
 	 */
 	std::pair<u32, bool> get_compatible_gcm_format(rsx::surface_color_format format);
 	std::pair<u32, bool> get_compatible_gcm_format(rsx::surface_depth_format2 format);
+
+	rsx::surface_color_format get_compatible_surface_color_format(u32 gcm_format);
+	rsx::surface_depth_format2 get_compatible_surface_depth_format(u32 gcm_format);
 
 	format_class classify_format(rsx::surface_depth_format2 format);
 	format_class classify_format(u32 gcm_format);

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1709,7 +1709,8 @@ namespace rsx
 					if (found_desc.external_handle != desc.external_handle ||
 						found_desc.op != desc.op ||
 						found_desc.x != desc.x || found_desc.y != desc.y ||
-						found_desc.width != desc.width || found_desc.height != desc.height)
+						found_desc.width != desc.width || found_desc.height != desc.height ||
+						found_desc.gcm_format != desc.gcm_format)
 						continue;
 
 					if (desc.op == deferred_request_command::copy_image_dynamic)

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -46,21 +46,6 @@ namespace rsx
 		blit_image_static,        // Variant of the copy command that does scaling instead of copying
 	};
 
-	struct image_section_attributes_t
-	{
-		u32 address;
-		u32 gcm_format;
-		u32 pitch;
-		u16 width;
-		u16 height;
-		u16 depth;
-		u16 mipmaps;
-		u16 slice_h;
-		u8  bpp;
-		bool swizzled;
-		bool edge_clamped;
-	};
-
 	struct blit_op_result
 	{
 		bool succeeded = false;

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -746,12 +746,13 @@ namespace rsx
 			}
 
 			texptr->memory_barrier(cmd, rsx::surface_access::transfer_read);
+			auto format_class = rsx::classify_format(attr2.gcm_format);
 
 			if (extended_dimension == rsx::texture_dimension_extended::texture_dimension_3d)
 			{
 				return{ texptr->get_surface(rsx::surface_access::transfer_read), deferred_request_command::_3d_unwrap,
 						attr2, {},
-						texture_upload_context::framebuffer_storage, texptr->format_class(), scale,
+						texture_upload_context::framebuffer_storage, format_class, scale,
 						rsx::texture_dimension_extended::texture_dimension_3d, decoded_remap };
 			}
 
@@ -759,7 +760,7 @@ namespace rsx
 
 			return{ texptr->get_surface(rsx::surface_access::transfer_read), deferred_request_command::cubemap_unwrap,
 					attr2, {},
-					texture_upload_context::framebuffer_storage, texptr->format_class(), scale,
+					texture_upload_context::framebuffer_storage, format_class, scale,
 					rsx::texture_dimension_extended::texture_dimension_cubemap, decoded_remap };
 		}
 

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -495,6 +495,7 @@ void GLGSRender::bind_texture_env()
 	const bool is_interpreter = m_shader_interpreter.is_interpreter(m_program);
 
 	auto decay_view_for_interpreter = [&](
+		const rsx::image_section_attributes_t& attr,
 		gl::texture_cache::sampled_image_descriptor* desc,
 		gl::texture_view* base,
 		const rsx::texture_channel_remap_t& decoded_remap,
@@ -506,14 +507,31 @@ void GLGSRender::bind_texture_env()
 			return base;
 		}
 
+		if (is_redirected && desc->image_type > rsx::texture_dimension_extended::texture_dimension_2d)
+		{
+			// Cannot handle redirect on 3D or cubemap with the interpreter.
+			const auto target = gl::get_target(desc->image_type);
+			return m_null_textures[target]->get_view(rsx::default_remap_vector);
+		}
+
 		using deferred_subresource_t = gl::texture_cache::deferred_subresource;
+		auto image = static_cast<gl::viewable_image*>(base->image());
+
+		if (is_msaa)
+		{
+			// MSAA resolve
+			auto rtt = gl::as_rtt(base->image());
+			rtt->memory_barrier(cmd, rsx::surface_access::transfer_read);
+			image = rtt->get_surface(rsx::surface_access::transfer_read);
+		}
 
 		if (is_redirected)
 		{
 			// Force bitcast
 			deferred_subresource_t flatten_op{};
-			flatten_op.external_handle = base->image();
-			flatten_op.op = m_rtts.address_is_bound(desc->ref_address)
+			flatten_op.address = desc->ref_address;
+			flatten_op.external_handle = image;
+			flatten_op.op = desc->is_cyclic_reference
 				? rsx::deferred_request_command::copy_image_dynamic
 				: rsx::deferred_request_command::copy_image_static;
 			flatten_op.width = flatten_op.external_handle->width();
@@ -521,12 +539,11 @@ void GLGSRender::bind_texture_env()
 			flatten_op.depth = 1;
 			flatten_op.gcm_format = desc->format_ex.format();
 			flatten_op.remap = decoded_remap;
+			flatten_op.cache_range = utils::address_range32::start_length(desc->ref_address, attr.pitch * attr.height);
 			return m_gl_texture_cache.create_temporary_subresource(cmd, flatten_op);
 		}
 
-		// MSAA
-		auto surface = gl::as_rtt(base->image())->get_surface(rsx::surface_access::transfer_read);
-		return surface->get_view(decoded_remap, base->aspect());
+		return image->get_view(decoded_remap, base->aspect());
 	};
 
 	for (u32 textures_ref = current_fp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
@@ -540,8 +557,8 @@ void GLGSRender::bind_texture_env()
 		gl::texture_view* stencil_mirror = nullptr;
 		auto sampler_state = static_cast<gl::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
 
-		if (rsx::method_registers.fragment_textures[i].enabled() &&
-			sampler_state->validate())
+		auto& tex = rsx::method_registers.fragment_textures[i];
+		if (tex.enabled() && sampler_state->validate())
 		{
 			if (primary_view = sampler_state->image_handle; !primary_view) [[unlikely]]
 			{
@@ -569,19 +586,24 @@ void GLGSRender::bind_texture_env()
 		if (is_interpreter) [[ unlikely ]]
 		{
 			// Interpreter does not support MSAA or DEPTH->RGBA conversion a.k.a aspect redirection
-			const auto mask = (1u << i);
-			const bool is_redirected = !!(current_fragment_program.texture_state.redirected_textures & mask);
-			const bool is_msaa = !!(current_fragment_program.texture_state.multisampled_textures & mask);
 			auto view = primary_view;
-			if (is_redirected || is_msaa)
+			if (primary_view->aspect() != gl::image_aspect::color || primary_view->image()->samples() != 1)
 			{
-				view = decay_view_for_interpreter(
-					sampler_state,
-					primary_view,
-					rsx::method_registers.fragment_textures[i].decoded_remap(),
-					is_msaa,
-					is_redirected);
+				const auto mask = (1u << i);
+				const bool is_redirected = !!(current_fragment_program.texture_state.redirected_textures & mask);
+				const bool is_msaa = !!(current_fragment_program.texture_state.multisampled_textures & mask);
+				if (is_redirected || is_msaa)
+				{
+					view = decay_view_for_interpreter(
+						tex.attributes(),
+						sampler_state,
+						primary_view,
+						tex.decoded_remap(),
+						is_msaa,
+						is_redirected);
+				}
 			}
+
 			m_shader_interpreter.bind_fragment_texture(i, view->handle(), *sampler_state);
 			continue;
 		}

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -576,7 +576,15 @@ void GLGSRender::bind_texture_env()
 
 	if (is_interpreter)
 	{
-		m_shader_interpreter.flush_texture_bindings();
+		if (current_fp_metadata.referenced_textures_mask)
+		{
+			m_shader_interpreter.flush_fragment_texture_bindings();
+		}
+
+		if (current_vp_metadata.referenced_textures_mask)
+		{
+			m_shader_interpreter.flush_vertex_texture_bindings();
+		}
 	}
 
 	if (current_fragment_program.ctrl & RSX_SHADER_CONTROL_EMULATE_DEPTH_COMPARE)

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -494,6 +494,41 @@ void GLGSRender::bind_texture_env()
 	gl::command_context cmd{ gl_state };
 	const bool is_interpreter = m_shader_interpreter.is_interpreter(m_program);
 
+	auto decay_view_for_interpreter = [&](
+		gl::texture_cache::sampled_image_descriptor* desc,
+		gl::texture_view* base,
+		const rsx::texture_channel_remap_t& decoded_remap,
+		bool is_msaa,
+		bool is_redirected) -> gl::texture_view*
+	{
+		if (!is_msaa && !is_redirected)
+		{
+			return base;
+		}
+
+		using deferred_subresource_t = gl::texture_cache::deferred_subresource;
+
+		if (is_redirected)
+		{
+			// Force bitcast
+			deferred_subresource_t flatten_op{};
+			flatten_op.external_handle = base->image();
+			flatten_op.op = m_rtts.address_is_bound(desc->ref_address)
+				? rsx::deferred_request_command::copy_image_dynamic
+				: rsx::deferred_request_command::copy_image_static;
+			flatten_op.width = flatten_op.external_handle->width();
+			flatten_op.height = flatten_op.external_handle->height();
+			flatten_op.depth = 1;
+			flatten_op.gcm_format = desc->format_ex.format();
+			flatten_op.remap = decoded_remap;
+			return m_gl_texture_cache.create_temporary_subresource(cmd, flatten_op);
+		}
+
+		// MSAA
+		auto surface = gl::as_rtt(base->image())->get_surface(rsx::surface_access::transfer_read);
+		return surface->get_view(decoded_remap, base->aspect());
+	};
+
 	for (u32 textures_ref = current_fp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
 	{
 		if (!(textures_ref & 1))
@@ -533,7 +568,21 @@ void GLGSRender::bind_texture_env()
 
 		if (is_interpreter) [[ unlikely ]]
 		{
-			m_shader_interpreter.bind_fragment_texture(i, primary_view->handle(), *sampler_state);
+			// Interpreter does not support MSAA or DEPTH->RGBA conversion a.k.a aspect redirection
+			const auto mask = (1u << i);
+			const bool is_redirected = !!(current_fragment_program.texture_state.redirected_textures & mask);
+			const bool is_msaa = !!(current_fragment_program.texture_state.multisampled_textures & mask);
+			auto view = primary_view;
+			if (is_redirected || is_msaa)
+			{
+				view = decay_view_for_interpreter(
+					sampler_state,
+					primary_view,
+					rsx::method_registers.fragment_textures[i].decoded_remap(),
+					is_msaa,
+					is_redirected);
+			}
+			m_shader_interpreter.bind_fragment_texture(i, view->handle(), *sampler_state);
 			continue;
 		}
 

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.cpp
@@ -493,10 +493,15 @@ namespace gl
 		data->prog->uniforms[0] = GL_STREAM_BUFFER_START + 0;
 		data->prog->uniforms[1] = GL_STREAM_BUFFER_START + 1;
 
+		// Initialize texture bindings
 		if (compiler_options & COMPILER_OPT_ENABLE_TEXTURES)
 		{
-			// Initialize texture bindings
-			flush_texture_bindings(data->prog.get());
+			flush_fragment_texture_bindings(data->prog.get());
+		}
+
+		if (compiler_options & COMPILER_OPT_ENABLE_VTX_TEXTURES)
+		{
+			flush_vertex_texture_bindings(data->prog.get());
 		}
 
 		data->flags &= ~CACHED_PIPE_UNINITIALIZED;
@@ -525,7 +530,7 @@ namespace gl
 		}
 	}
 
-	void shader_interpreter::flush_texture_bindings(glsl::program* program)
+	void shader_interpreter::flush_fragment_texture_bindings(glsl::program* program)
 	{
 		using enum rsx::texture_dimension_extended;
 
@@ -536,9 +541,15 @@ namespace gl
 		}
 
 		const bool is_bound_interpreter = m_current_interpreter && m_current_interpreter->prog.get() == program;
-		const u32 dirty_mask = is_bound_interpreter
-			? 0xff
-			: m_texture_bindings.dirty;
+		u32 dirty_mask = m_texture_bindings.dirty;
+
+		if (is_bound_interpreter) [[ likely ]]
+		{
+			// Check if we even support textures
+			dirty_mask = (m_current_interpreter->build_compiler_options & COMPILER_OPT_ENABLE_TEXTURES)
+				? 0xff
+				: 0x0;
+		}
 
 		if (!dirty_mask)
 		{
@@ -563,5 +574,10 @@ namespace gl
 		{
 			m_texture_bindings.dirty = 0;
 		}
+	}
+
+	void shader_interpreter::flush_vertex_texture_bindings(glsl::program* program)
+	{
+		// TODO
 	}
 }

--- a/rpcs3/Emu/RSX/GL/GLShaderInterpreter.h
+++ b/rpcs3/Emu/RSX/GL/GLShaderInterpreter.h
@@ -132,7 +132,8 @@ namespace gl
 
 		// Update texture bindings based on the incoming descriptor structures
 		void bind_fragment_texture(int i, handle64_t handle, const rsx::sampled_image_descriptor_base& descriptor);
-		void flush_texture_bindings(glsl::program* program = nullptr);
+		void flush_fragment_texture_bindings(glsl::program* program = nullptr);
+		void flush_vertex_texture_bindings(glsl::program* program = nullptr);
 
 		glsl::program* get(const interpreter::program_metadata& fp_metadata, u32 vp_ctrl, u32 fp_ctrl);
 		bool is_interpreter(const glsl::program* program) const;

--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -455,6 +455,21 @@ namespace rsx
 		return registers[NV4097_SET_TEXTURE_CONTROL3 + m_index] & 0xfffff;
 	}
 
+	image_section_attributes_t fragment_texture::attributes() const
+	{
+		const auto _format = format();
+		return {
+			.address = offset(),
+			.gcm_format = _format,
+			.pitch = pitch(),
+			.width = width(),
+			.height = height(),
+			.depth = depth(),
+			.mipmaps = mipmap(),
+			.bpp = rsx::get_format_block_size_in_bytes(_format)
+		};
+	}
+
 	u32 vertex_texture::offset() const
 	{
 		return registers[NV4097_SET_VERTEX_TEXTURE_OFFSET + (m_index * 8)] & 0x7FFFFFFF;

--- a/rpcs3/Emu/RSX/RSXTexture.h
+++ b/rpcs3/Emu/RSX/RSXTexture.h
@@ -5,6 +5,7 @@
 namespace rsx
 {
 	struct texture_format_ex;
+	struct image_section_attributes_t;
 
 	class fragment_texture
 	{
@@ -85,6 +86,8 @@ namespace rsx
 
 		u16 depth() const;
 		u32 pitch() const;
+
+		image_section_attributes_t attributes() const;
 	};
 
 	class vertex_texture

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -829,6 +829,59 @@ bool VKGSRender::bind_interpreter_texture_env()
 
 	bool out_of_memory = false;
 
+	auto decay_view_for_interpreter = [&](
+		const rsx::image_section_attributes_t& attr,
+		vk::texture_cache::sampled_image_descriptor* desc,
+		vk::image_view* base,
+		const rsx::texture_channel_remap_t& decoded_remap,
+		bool is_msaa,
+		bool is_redirected) -> vk::image_view*
+	{
+		if (!is_msaa && !is_redirected)
+		{
+			return base;
+		}
+
+		if (is_redirected && desc->image_type > rsx::texture_dimension_extended::texture_dimension_2d)
+		{
+			// Cannot handle redirect on 3D or cubemap with the interpreter.
+			auto view_type = vk::get_view_type(desc->image_type);
+			return vk::null_image_view(*m_current_command_buffer, view_type);
+		}
+
+		using deferred_subresource_t = vk::texture_cache::deferred_subresource;
+		auto image = static_cast<vk::viewable_image*>(base->image());
+
+		if (is_msaa)
+		{
+			// MSAA resolve
+			auto rtt = vk::as_rtt(base->image());
+			rtt->memory_barrier(*m_current_command_buffer, rsx::surface_access::transfer_read);
+			image = rtt->get_surface(rsx::surface_access::transfer_read);
+		}
+
+		if (is_redirected)
+		{
+			// Force bitcast
+			deferred_subresource_t flatten_op{};
+			flatten_op.address = desc->ref_address;
+			flatten_op.external_handle = image;
+			flatten_op.op = desc->is_cyclic_reference
+				? rsx::deferred_request_command::copy_image_dynamic
+				: rsx::deferred_request_command::copy_image_static;
+			flatten_op.width = flatten_op.external_handle->width();
+			flatten_op.height = flatten_op.external_handle->height();
+			flatten_op.depth = 1;
+			flatten_op.gcm_format = desc->format_ex.format();
+			flatten_op.remap = decoded_remap;
+			flatten_op.cache_range = utils::address_range32::start_length(desc->ref_address, attr.pitch * attr.height);
+			return m_texture_cache.create_temporary_subresource(*m_current_command_buffer, flatten_op);
+		}
+
+		image->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		return image->get_view(decoded_remap, base->info.subresourceRange.aspectMask);
+	};
+
 	for (u32 textures_ref = current_fp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
 	{
 		if (!(textures_ref & 1))
@@ -837,8 +890,8 @@ bool VKGSRender::bind_interpreter_texture_env()
 		vk::image_view* view = nullptr;
 		auto sampler_state = static_cast<vk::texture_cache::sampled_image_descriptor*>(fs_sampler_state[i].get());
 
-		if (rsx::method_registers.fragment_textures[i].enabled() &&
-			sampler_state->validate())
+		auto& tex = rsx::method_registers.fragment_textures[i];
+		if (tex.enabled() && sampler_state->validate())
 		{
 			if (view = sampler_state->image_handle; !view)
 			{
@@ -848,18 +901,49 @@ bool VKGSRender::bind_interpreter_texture_env()
 					out_of_memory = true;
 				}
 			}
-			else
+		}
+
+		if (!view)
+		{
+			// OOM or disabled texture
+			continue;
+		}
+
+		auto primary_view = view;
+
+		// Flatten MSAA and DEPTH24S8 redirects
+		if (view->image()->samples() > 1 || view->info.subresourceRange.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT)
+		{
+			const auto mask = (1u << i);
+			const bool is_redirected = !!(current_fragment_program.texture_state.redirected_textures & mask);
+			const bool is_msaa = !!(current_fragment_program.texture_state.multisampled_textures & mask);
+			if (is_redirected || is_msaa)
 			{
-				validate_image_layout_for_read_access(*m_current_command_buffer, view, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, sampler_state);
+				view = decay_view_for_interpreter(
+					tex.attributes(),
+					sampler_state,
+					view,
+					tex.decoded_remap(),
+					is_msaa,
+					is_redirected);
+
+				if (!view)
+				{
+					// OOM
+					out_of_memory = true;
+					continue;
+				}
 			}
 		}
 
-		if (view)
+		if (primary_view == view)
 		{
-			const int offsets[] = { 0, 16, 48, 32 };
-			auto& sampled_image_info = texture_env[offsets[static_cast<u32>(sampler_state->image_type)] + i];
-			sampled_image_info = { *view, *fs_sampler_handles[i] };
+			validate_image_layout_for_read_access(*m_current_command_buffer, view, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, sampler_state);
 		}
+
+		const int offsets[] = { 0, 16, 48, 32 };
+		auto& sampled_image_info = texture_env[offsets[static_cast<u32>(sampler_state->image_type)] + i];
+		sampled_image_info = { *view, *fs_sampler_handles[i] };
 	}
 
 	m_shader_interpreter.update_fragment_textures(texture_env);


### PR DESCRIPTION
Adds support for MSAA and depth redirect sampling when using the interpreter. Vertex textures are not handled yet, that will come later.

Closes https://github.com/RPCS3/rpcs3/issues/16586
Closes https://github.com/RPCS3/rpcs3/issues/19020
