### PR TITLE
Fix 1st regression on black textures in Sonic Generations

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOpsInternal.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOpsInternal.glsl
@@ -58,12 +58,12 @@ vec4 sampleTexture2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 coords, const i
 		    const vec3 weights = compute2x2DownsampleWeights(normalized_coords.x, uv_step.x, actual_step.x);
 
 		    const vec4 sample4 = texelFetch2DMS(tex, clamp_bounds, sample_count, icoords, ivec2(2, 0));    // Further bottom right
-		    a = fma(sample0, weights.xxxx, sample1 * weights.y) + (sample4 * weights.z);     // Weighted sum
+		    a = fma(sample0, weights.xxxx, sample1 * weights.y) + (sample4 * weights.z);                   // Weighted sum
 
 		    if (!no_filter.y)
 		    {
 		        const vec4 sample5 = texelFetch2DMS(tex, clamp_bounds, sample_count, icoords, ivec2(2, 1));    // Further top right
-		        b = fma(sample2, weights.xxxx, sample3 * weights.y) + (sample5 * weights.z);     // Weighted sum
+		        b = fma(sample2, weights.xxxx, sample3 * weights.y) + (sample5 * weights.z);                   // Weighted sum
 		    }
 		}
 		else if (actual_step.x < uv_step.x)

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOpsInternal.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOpsInternal.glsl
@@ -5,7 +5,14 @@ vec4 texelFetch2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 sample_count, cons
 	const vec2 aa_coords = floor(resolve_coords / sample_count);               // AA coords = real_coords / sample_count
 	const vec2 sample_loc = fma(aa_coords, -sample_count, resolve_coords);     // Sample ID = real_coords % sample_count
 	const float sample_index = fma(sample_loc.y, sample_count.y, sample_loc.x);
-	return texelFetch(tex, ivec2(aa_coords), int(sample_index));
+
+	// texelFetch has no hardware clamping: an out-of-range texel or sample index returns 0 (black).
+	// This happens at the right/bottom edges (the +1/+2 downsample offsets overshoot) and when the
+	// bound image has fewer samples than the reconstruction assumes. Clamp to valid ranges so we
+	// return a real (edge) texel instead of a black one.
+	const ivec2 clamped_coords = clamp(ivec2(aa_coords), ivec2(0), textureSize(tex) - ivec2(1));
+	const int clamped_sample = clamp(int(sample_index), 0, textureSamples(tex) - 1);
+	return texelFetch(tex, clamped_coords, clamped_sample);
 }
 
 vec4 sampleTexture2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 coords, const in sampler_info tex_params)

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOpsInternal.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOpsInternal.glsl
@@ -1,7 +1,7 @@
 R"(
 vec4 texelFetch2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 sample_count, const in ivec2 icoords, const in ivec2 offset)
 {
-	const vec2 resolve_coords = vec2(icoords + offset);
+	const vec2 resolve_coords = vec2(clamp(icoords + offset, ivec2(0), textureSize(tex) - ivec2(1)));
 	const vec2 aa_coords = floor(resolve_coords / sample_count);               // AA coords = real_coords / sample_count
 	const vec2 sample_loc = fma(aa_coords, -sample_count, resolve_coords);     // Sample ID = real_coords % sample_count
 	const float sample_index = fma(sample_loc.y, sample_count.y, sample_loc.x);

--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOpsInternal.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentTextureMSAAOpsInternal.glsl
@@ -1,18 +1,13 @@
 R"(
-vec4 texelFetch2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 sample_count, const in ivec2 icoords, const in ivec2 offset)
+vec4 texelFetch2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in ivec2 clamp_bounds, const in vec2 sample_count, const in ivec2 icoords, const in ivec2 offset)
 {
-	const vec2 resolve_coords = vec2(clamp(icoords + offset, ivec2(0), textureSize(tex) - ivec2(1)));
-	const vec2 aa_coords = floor(resolve_coords / sample_count);               // AA coords = real_coords / sample_count
-	const vec2 sample_loc = fma(aa_coords, -sample_count, resolve_coords);     // Sample ID = real_coords % sample_count
+	const vec2 resolve_coords = vec2(clamp(icoords + offset, ivec2(0), clamp_bounds)); // Clamp to edge. Input offset is always zero or positive.
+	const vec2 aa_coords = floor(resolve_coords / sample_count);                       // AA coords = real_coords / sample_count
+	const vec2 sample_loc = fma(aa_coords, -sample_count, resolve_coords);             // Sample ID = real_coords % sample_count
 	const float sample_index = fma(sample_loc.y, sample_count.y, sample_loc.x);
 
-	// texelFetch has no hardware clamping: an out-of-range texel or sample index returns 0 (black).
-	// This happens at the right/bottom edges (the +1/+2 downsample offsets overshoot) and when the
-	// bound image has fewer samples than the reconstruction assumes. Clamp to valid ranges so we
-	// return a real (edge) texel instead of a black one.
-	const ivec2 clamped_coords = clamp(ivec2(aa_coords), ivec2(0), textureSize(tex) - ivec2(1));
-	const int clamped_sample = clamp(int(sample_index), 0, textureSamples(tex) - 1);
-	return texelFetch(tex, clamped_coords, clamped_sample);
+	// TODO: Hack. Filtering will break when sampling sub-pixel sample ids in wrap mode.
+	return texelFetch(tex, ivec2(aa_coords), int(sample_index));
 }
 
 vec4 sampleTexture2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 coords, const in sampler_info tex_params)
@@ -21,9 +16,10 @@ vec4 sampleTexture2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 coords, const i
 	const vec2 scaled_coords = _texcoord_xform(coords, tex_params);
 	const vec2 normalized_coords = texture2DMSCoord(scaled_coords, flags);
 	const vec2 sample_count = vec2(2., textureSamples(tex) * 0.5);
-	const vec2 image_size = textureSize(tex) * sample_count;
+	const ivec2 image_size = ivec2(textureSize(tex) * sample_count);
+	const ivec2 clamp_bounds = image_size - ivec2(1);
 	const ivec2 icoords = ivec2(normalized_coords * image_size);
-	const vec4 sample0 = texelFetch2DMS(tex, sample_count, icoords, ivec2(0));
+	const vec4 sample0 = texelFetch2DMS(tex, clamp_bounds, sample_count, icoords, ivec2(0));
 
 	if (_get_bits(flags, FILTERED_MAG_BIT, 2) == 0)
 	{
@@ -42,7 +38,7 @@ vec4 sampleTexture2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 coords, const i
 
 	vec4 a, b;
 	float factor;
-	const vec4 sample2 = texelFetch2DMS(tex, sample_count, icoords, ivec2(0, 1));     // Top left
+	const vec4 sample2 = texelFetch2DMS(tex, clamp_bounds, sample_count, icoords, ivec2(0, 1));     // Top left
 
 	if (no_filter.x)
 	{
@@ -53,20 +49,20 @@ vec4 sampleTexture2DMS(in _MSAA_SAMPLER_TYPE_ tex, const in vec2 coords, const i
 	else
 	{
 		// Filter required, sample more data
-		const vec4 sample1 = texelFetch2DMS(tex, sample_count, icoords, ivec2(1, 0));     // Bottom right
-		const vec4 sample3 = texelFetch2DMS(tex, sample_count, icoords, ivec2(1, 1));     // Top right
+		const vec4 sample1 = texelFetch2DMS(tex, clamp_bounds, sample_count, icoords, ivec2(1, 0));     // Bottom right
+		const vec4 sample3 = texelFetch2DMS(tex, clamp_bounds, sample_count, icoords, ivec2(1, 1));     // Top right
 
 		if (actual_step.x > uv_step.x)
 		{
 		    // Downscale in X, centered
 		    const vec3 weights = compute2x2DownsampleWeights(normalized_coords.x, uv_step.x, actual_step.x);
 
-		    const vec4 sample4 = texelFetch2DMS(tex, sample_count, icoords, ivec2(2, 0));    // Further bottom right
+		    const vec4 sample4 = texelFetch2DMS(tex, clamp_bounds, sample_count, icoords, ivec2(2, 0));    // Further bottom right
 		    a = fma(sample0, weights.xxxx, sample1 * weights.y) + (sample4 * weights.z);     // Weighted sum
 
 		    if (!no_filter.y)
 		    {
-		        const vec4 sample5 = texelFetch2DMS(tex, sample_count, icoords, ivec2(2, 1));    // Further top right
+		        const vec4 sample5 = texelFetch2DMS(tex, clamp_bounds, sample_count, icoords, ivec2(2, 1));    // Further top right
 		        b = fma(sample2, weights.xxxx, sample3 * weights.y) + (sample5 * weights.z);     // Weighted sum
 		    }
 		}


### PR DESCRIPTION
Sonic Generation is currently affected by two regressions resulting in black textures.
The first regression I found, not tracked by any issue report, was introduced by the old PR #11665. That PR (with only one commit) reworked MSAA for Vulkan (OGL was not supporting MSAA at that time) and introduced some black textures visible on main menu on the left and right part of the screen (see screenshot below). 
That regression was also propagated to OGL when MSAA support was added on build v0.0.34-17470 (#16683) and it is still present on current build.
The issue is not present disabling MSAA (`Anti-Aliasing (MSAA)` setting set to `Disabled`).

This PR should fix that first regression.

### before PR #11665

<img width="3838" height="2157" alt="image" src="https://github.com/user-attachments/assets/ad335181-a6a3-4e79-98f3-8f91c0e60e16" />

### since PR #11665

<img width="3838" height="2155" alt="image" src="https://github.com/user-attachments/assets/82e10b9d-d7c6-4290-9a94-ac328cf99978" />

AI Disclosure: Analysis made by Opus 4.8. Regression identification and testing made by human.