### PR TITLE
fix 2nd regression on black textures in Sonic Generations

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -270,15 +270,12 @@ namespace rsx
 			bool unordered_list = false;
 
 			rsx::simple_array<sort_helper> sort_list;
-			rsx::simple_array<utils::address_range32> sort_ranges;
 			sort_list.reserve(available_slices);
-			sort_ranges.reserve(available_slices);
 
 			// Generate sorting tree if both resources are available and overlapping
 			for (u32 index = 0; index < fbos.size(); ++index)
 			{
 				const auto range = fbos[index].surface->get_memory_range();
-				sort_ranges.push_back(range);
 				sort_list.push_back({
 					.tag = fbos[index].surface->last_use_tag,
 					.list = 0,
@@ -293,7 +290,6 @@ namespace rsx
 					continue;
 
 				const auto range = local[index]->get_section_range();
-				sort_ranges.push_back(range);
 				sort_list.push_back({
 					.tag = local[index]->last_write_tag,
 					.list = 1,
@@ -307,15 +303,11 @@ namespace rsx
 				sort_list.sort(FN(x.tag < y.tag));
 			}
 
-			// Check if ordered
-			for (u32 i = 0; i < sort_list.size(); ++i)
+			// Check if ordered. NOTE: This has to run on the final iteration order, not the insertion order,
+			// otherwise the early-out below can terminate the gather before every contributing section is consumed.
+			for (u32 i = 1; i < sort_list.size(); ++i)
 			{
-				if (i == 0)
-				{
-					continue;
-				}
-
-				if (sort_ranges[i].start < sort_ranges[i - 1].end)
+				if (sort_list[i].bounds.start < sort_list[i - 1].bounds.end)
 				{
 					unordered_list = true;
 					break;
@@ -382,7 +374,12 @@ namespace rsx
 					.dst_h = dst_height
 				});
 
-				return { section_end <= slice_end, section_end >= slice_end };
+				// NOTE: Reaching the bottom of the slice does not imply the slice is covered - sections also tile horizontally.
+				// A section that lies further along in memory can still land on the same rows at a higher X offset.
+				const bool covers_slice = (section_end >= slice_end) &&
+					(section.dst_area.x == 0 && u32(section.dst_area.x + section.dst_area.width) >= u32{attr.width});
+
+				return { section_end <= slice_end, covers_slice };
 			};
 
 			auto add_local_resource = [&](auto& section, u32 address, u16 slice, bool scaling) -> std::pair<bool, bool> // [ input fully consumed, output fully covered ]
@@ -427,6 +424,10 @@ namespace rsx
 				const u16 src_w = static_cast<u16>(src_size.width);
 				const u16 height = std::min(dst_slice_end, write_section_end) - dst_y;
 
+				// NOTE: Reaching the bottom of the slice does not imply the slice is covered - sections also tile horizontally.
+				const bool covers_slice = (write_section_end >= dst_slice_end) &&
+					(dst_offset.x == 0 && (dst_offset.x + dst_size.width) >= u32{attr.width});
+
 				if (scaling)
 				{
 					// Since output is upscaled, also upscale on dst
@@ -451,7 +452,7 @@ namespace rsx
 						.dst_h = _dst_h
 					});
 
-					return { write_section_end <= dst_slice_end, write_section_end >= dst_slice_end };
+					return { write_section_end <= dst_slice_end, covers_slice };
 				}
 
 				out.push_back
@@ -470,7 +471,7 @@ namespace rsx
 					.dst_h = height
 				});
 
-				return { write_section_end <= dst_slice_end, write_section_end >= dst_slice_end };
+				return { write_section_end <= dst_slice_end, covers_slice };
 			};
 
 			u32 current_address = attr.address;


### PR DESCRIPTION
AI Disclosure: Analysis made by Opus 4.8. Regression identification and testing made by human.

Sonic Generation is currently affected by two regressions resulting in black textures.
This PR is a follow up of #19091 (fixing the first regression) to fix the second regression. The regression was introduced by commit https://github.com/RPCS3/rpcs3/pull/17676/changes/1274db46c8b63c3c5f6f753aa0743b50e56d22e6 on build 0.0.38-18319 (#17676) making some changes in `texture_cache_helpers.h`.
The issue is present only on Vulkan and not on OpenGL (but see section below **Why it was Vulkan-only** for a clarification).

This PR should properly fix that second regression.

fixes #17719

**NOTES:**
- marking the PR as draft for review from kd-11
- of the 2 applied fixes, fix 1 is visually fixing the issue. Fix 2 (unordered list) has been applied to fix an hidden bug.

### AI Summary

All bugs were introduced by 864bb9f0d —  rsx: Speed up slice gathering for large
datasets — in rsx::texture_cache_helpers::gather_texture_slices(). The commit merged three  separate gather paths into one loop and added an early break.

</br>

**Why it was Vulkan-only**

Not a Vulkan bug. vk::texture_cache::generate_atlas_from_images (VKTextureCache.cpp:840) clears the temporary atlas to black when sections_to_copy[0] doesn't fill the target; gl::texture_cache::generate_atlas_from_images (GLTextureCache.h:555) never clears, so uncovered regions keep the recycled surface's stale contents — usually the previous frame's identical data. OpenGL wasn't correct, it was just hiding the dropped sections.

</br>

**Bug 1 — root cause: the early-out ignores horizontal tiling**

`slice_complete` was `section_end >= slice_end`, i.e. Y axis only. But `get_merged_texture_memory_region` also tiles sections horizontally (`surface_store.h`:1139: `info.dst_area.x = (offset % required_pitch) / required_bpp)`.

With small render targets packed back-to-back in memory, the ranges are ascending and disjoint → `unordered_list == false`, and the first section (`dst_area.y == 0`, full height) sets `slice_complete` immediately → break. Every remaining section, which would have filled the other columns, is never copied. The commit's rationale ("they lie after this one in memory") is false: a later section can land on the same rows at a higher X.

**Fix:**
`covers_slice` now also requires `dst_area.x == 0 && dst_area.x + dst_area.width >= attr.width`, in both `add_rtt_resource` and  `add_local_resource`.

</br>

**Bug 2 — unordered_list computed from a stale array**

`sort_ranges` was filled in insertion order, but `sort_list` is re-sorted by tag when both lists are non-empty. The ordering certificate  described a different sequence from the one actually iterated.

**Fix:**
dropped `sort_ranges`, check runs on the post-sort `sort_list[i].bounds`.

</br>

### before PR https://github.com/RPCS3/rpcs3/pull/17676

<img width="3838" height="2157" alt="image" src="https://github.com/user-attachments/assets/1e0e8147-75fe-48a5-85f2-7276d48ee395" />

### since PR https://github.com/RPCS3/rpcs3/pull/17676

<img width="3838" height="2157" alt="image" src="https://github.com/user-attachments/assets/5dbfd91f-bbc5-40b1-a998-1a1a19dd3673" />

### PR #19091 + PR #19093

<img width="3838" height="2157" alt="image" src="https://github.com/user-attachments/assets/b3c86ee1-b58b-4577-b695-0412c6e020bd" />

<img width="3838" height="2157" alt="image" src="https://github.com/user-attachments/assets/46d61d4e-ba27-4b58-975b-e59e528b1a2d" />
