### PR TITLE
Fix DLC installation

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -255,7 +255,27 @@ bool package_reader::read_metadata()
 			if (packet.size == sizeof(m_metadata.package_type))
 			{
 				archive_read(&m_metadata.package_type, sizeof(m_metadata.package_type));
+
+				std::vector<std::string> package_flags;
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_0x01)             package_flags.push_back("0x01");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_EBOOT)            package_flags.push_back("EBOOT");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_REQUIRE_LICENSE)  package_flags.push_back("REQUIRE_LICENSE");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_HDD_MC)           package_flags.push_back("HDD_MC");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_PATCH)            package_flags.push_back("PATCH");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_0x20)             package_flags.push_back("0x20");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_RENAME_DIRECTORY) package_flags.push_back("RENAME_DIRECTORY");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_EDAT)             package_flags.push_back("EDAT");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_0x100)            package_flags.push_back("0x100");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_EMULATOR)         package_flags.push_back("EMULATOR");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_VSH_MODULE)       package_flags.push_back("VSH_MODULE");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_DISC_BOUND)       package_flags.push_back("DISC_BOUND");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_UNKNOWN)          package_flags.push_back("UNKNOWN");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_PS_VITA_CARD)     package_flags.push_back("PS_VITA_CARD");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_PS_VITA_NON_GAME) package_flags.push_back("PS_VITA_NON_GAME");
+				if (m_metadata.package_type & pkg_flag::PKG_FLAG_0x8000)           package_flags.push_back("0x8000");
+
 				pkg_log.notice("Metadata: Package Type = 0x%x = %d", m_metadata.package_type, m_metadata.package_type);
+				pkg_log.notice("Metadata: Package Flags = %s", package_flags.empty() ? "{}" : fmt::merge(package_flags, ", "));
 				continue;
 			}
 			else
@@ -732,6 +752,12 @@ package_install_result package_reader::check_target_app_version() const
 
 	if (target_app_ver.empty())
 	{
+		if (!(m_metadata.package_type & pkg_flag::PKG_FLAG_PATCH))
+		{
+			// This should be a DLC. Let's allow DLCs even with smaller APP_VER.
+			return {package_install_result::error_type::no_error};
+		}
+
 		// This is most likely the first patch. Let's make sure its version is high enough for the installed game.
 
 		const double new_version = std::strtod(app_ver.data(), &ev1);

--- a/rpcs3/Crypto/unpkg.h
+++ b/rpcs3/Crypto/unpkg.h
@@ -42,7 +42,7 @@ enum : u32
 	PKG_FILE_ENTRY_KNOWN_BITS     = 0xff | PKG_FILE_ENTRY_PSP | PKG_FILE_ENTRY_OVERWRITE,
 };
 
-enum : u32
+enum pkg_content_type : u32
 {
 	PKG_CONTENT_TYPE_UNKNOWN_1      = 0x01, // ?
 	PKG_CONTENT_TYPE_UNKNOWN_2      = 0x02, // ?
@@ -63,18 +63,39 @@ enum : u32
 	PKG_CONTENT_TYPE_VMC            = 0x11, // VMC
 	PKG_CONTENT_TYPE_PS2_CLASSIC    = 0x12, // ?PS2Classic? Seen on PS2 classic
 	PKG_CONTENT_TYPE_UNKNOWN_5      = 0x13, // ?
-	PKG_CONTENT_TYPE_PSP_REMASTERED = 0x14, // ?
+	PKG_CONTENT_TYPE_PSP_REMASTERED = 0x14, // PSP Remastered
 	PKG_CONTENT_TYPE_PSP2_GD        = 0x15, // PSVita Game Data
 	PKG_CONTENT_TYPE_PSP2_AC        = 0x16, // PSVita Additional Content
 	PKG_CONTENT_TYPE_PSP2_LA        = 0x17, // PSVita LiveArea
-	PKG_CONTENT_TYPE_PSM_1          = 0x18, // PSVita PSM ?
+	PKG_CONTENT_TYPE_PSM            = 0x18, // PSVita PSM
 	PKG_CONTENT_TYPE_WT             = 0x19, // Web TV ?
-	PKG_CONTENT_TYPE_UNKNOWN_6      = 0x1A, // ?
-	PKG_CONTENT_TYPE_UNKNOWN_7      = 0x1B, // ?
-	PKG_CONTENT_TYPE_UNKNOWN_8      = 0x1C, // ?
-	PKG_CONTENT_TYPE_PSM_2          = 0x1D, // PSVita PSM ?
-	PKG_CONTENT_TYPE_UNKNOWN_9      = 0x1E, // ?
+	PKG_CONTENT_TYPE_PS4_GD         = 0x1A, // PS4 GameData
+	PKG_CONTENT_TYPE_PS4_AC         = 0x1B, // PS4 Additional Content
+	PKG_CONTENT_TYPE_PS4_AL         = 0x1C, // PS4 Additional License
+	PKG_CONTENT_TYPE_PSM_UNITY      = 0x1D, // PSVita PSM for Unity
+	PKG_CONTENT_TYPE_PS4_DP         = 0x1E, // PS4 Delta patch
 	PKG_CONTENT_TYPE_PSP2_THEME     = 0x1F, // PSVita Theme
+	PKG_CONTENT_TYPE_PS5_GAME_DATA  = 0x20, // PS5 GameData
+};
+
+enum pkg_flag : u32
+{
+	PKG_FLAG_0x01              = 0x01,
+	PKG_FLAG_EBOOT             = 0x02,
+	PKG_FLAG_REQUIRE_LICENSE   = 0x04,
+	PKG_FLAG_HDD_MC            = 0x08,
+	PKG_FLAG_PATCH             = 0x10,
+	PKG_FLAG_0x20              = 0x20,
+	PKG_FLAG_RENAME_DIRECTORY  = 0x40,
+	PKG_FLAG_EDAT              = 0x80,
+	PKG_FLAG_0x100             = 0x100,
+	PKG_FLAG_EMULATOR          = 0x200,
+	PKG_FLAG_VSH_MODULE        = 0x400,
+	PKG_FLAG_DISC_BOUND        = 0x800,
+	PKG_FLAG_UNKNOWN           = 0x1000,
+	PKG_FLAG_PS_VITA_CARD      = 0x2000,
+	PKG_FLAG_PS_VITA_NON_GAME  = 0x4000,
+	PKG_FLAG_0x8000            = 0x8000,
 };
 
 // Structs
@@ -349,6 +370,7 @@ public:
 
 	bool is_valid() const { return m_is_valid; }
 	const PKGHeader& get_header() const { return m_header; }
+	const PKGMetaData& get_metadata() const { return m_metadata; }
 	package_install_result check_target_app_version() const;
 	static package_install_result extract_data(std::deque<package_reader>& readers, std::deque<std::string>& bootable_paths);
 	const psf::registry& get_psf() const { return m_psf; }
@@ -358,7 +380,7 @@ public:
 
 	void abort_extract();
 
-	fs::file &file()
+	fs::file& file()
 	{
 		return m_file;
 	}

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -300,15 +300,13 @@ compat::package_info game_compatibility::GetPkgInfo(const QString& pkg_path, con
 		if (info.category == "GD")
 		{
 			// For now let's assume that PS3 Game Data packages are always updates or DLC.
-			// Update packages always seem to have an APP_VER, so let's say it's a DLC otherwise.
-			// Ideally this would simply be the package content type, but I am too lazy to implement this right now.
-			if (info.version.isEmpty())
+			if (reader.get_metadata().package_type & pkg_flag::PKG_FLAG_PATCH)
 			{
-				info.type = compat::package_type::dlc;
+				info.type = compat::package_type::update;
 			}
 			else
 			{
-				info.type = compat::package_type::update;
+				info.type = compat::package_type::dlc;
 			}
 		}
 	}

--- a/rpcs3/rpcs3qt/game_compatibility.cpp
+++ b/rpcs3/rpcs3qt/game_compatibility.cpp
@@ -1,4 +1,5 @@
 #include "game_compatibility.h"
+#include "gui_application.h"
 #include "gui_settings.h"
 #include "downloader.h"
 #include "localized.h"
@@ -268,12 +269,13 @@ compat::package_info game_compatibility::GetPkgInfo(const QString& pkg_path, con
 
 	const psf::registry& psf = reader.get_psf();
 
-	// TODO: localization of title and changelog
-	const std::string title_key     = "TITLE";
-	const std::string changelog_key = "paramhip";
+	const std::string localized_title_key = fmt::format("TITLE_%02d", gui_application::get_language_id());
+	const std::string localized_changelog_key = fmt::format("paramhip_%02d", gui_application::get_language_id());
+
+	std::string_view localized_title = psf::get_string(psf, localized_title_key);
 
 	info.path     = pkg_path;
-	info.title    = QString::fromStdString(std::string(psf::get_string(psf, title_key))); // Let's read this from the psf first
+	info.title    = QString::fromStdString(std::string(localized_title.empty() ? psf::get_string(psf, "TITLE") : localized_title));
 	info.title_id = QString::fromStdString(std::string(psf::get_string(psf, "TITLE_ID")));
 	info.category = QString::fromStdString(std::string(psf::get_string(psf, "CATEGORY")));
 	info.version  = QString::fromStdString(std::string(psf::get_string(psf, "APP_VER")));
@@ -327,12 +329,12 @@ compat::package_info game_compatibility::GetPkgInfo(const QString& pkg_path, con
 			{
 				if (info.version.toStdString() == package.version)
 				{
-					if (const std::string localized_title = package.get_title(title_key); !localized_title.empty())
+					if (const std::string localized_title = package.get_title(localized_title_key); !localized_title.empty())
 					{
 						info.title = QString::fromStdString(localized_title);
 					}
 
-					if (const std::string localized_changelog = package.get_changelog(changelog_key); !localized_changelog.empty())
+					if (const std::string localized_changelog = package.get_changelog(localized_changelog_key); !localized_changelog.empty())
 					{
 						info.changelog = QString::fromStdString(localized_changelog);
 					}

--- a/rpcs3/rpcs3qt/game_compatibility.h
+++ b/rpcs3/rpcs3qt/game_compatibility.h
@@ -35,7 +35,7 @@ namespace compat
 		std::vector<pkg_changelog> changelogs;
 		std::vector<pkg_title> titles;
 
-		std::string get_changelog(const std::string& type) const
+		std::string get_changelog(std::string_view type) const
 		{
 			if (const auto it = std::find_if(changelogs.cbegin(), changelogs.cend(), [type](const pkg_changelog& cl) { return cl.type == type; });
 				it != changelogs.cend())
@@ -50,7 +50,7 @@ namespace compat
 			return "";
 		}
 
-		std::string get_title(const std::string& type) const
+		std::string get_title(std::string_view type) const
 		{
 			if (const auto it = std::find_if(titles.cbegin(), titles.cend(), [type](const pkg_title& t) { return t.type == type; });
 				it != titles.cend())


### PR DESCRIPTION
- Use localization for title and changelog of packages if possible
- Identify patches/DLC based on package_type instead of APP_VER
- Always allow to install DLC if it has no TARGET_APP_VER

fixes https://github.com/RPCS3/rpcs3/issues/19069