### PR TITLE
Fix value assignment in iota16

### DIFF
--- a/rpcs3/Emu/RSX/Common/BufferUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/BufferUtils.cpp
@@ -470,7 +470,7 @@ namespace
 		for (; (i + step) <= count; i += step, vec_ptr++)
 		{
 			_mm_stream_si128(vec_ptr, values);
-			_mm_add_epi16(values,  vec_step);
+			values = _mm_add_epi16(values,  vec_step);
 		}
 #endif
 		for (; i < count; ++i)


### PR DESCRIPTION
iota16() discarded the _mm_add_epi16 result, so `values` never advanced and every 8-element block was written as 0..7 instead of a rising sequence