### PR TITLE
rsx: Fix interpreter error spam due to incorrect format lookup

### DIFF
--- a/rpcs3/Emu/RSX/RSXTexture.cpp
+++ b/rpcs3/Emu/RSX/RSXTexture.cpp
@@ -457,7 +457,7 @@ namespace rsx
 
 	image_section_attributes_t fragment_texture::attributes() const
 	{
-		const auto _format = format();
+		const auto _format = format() & ~(CELL_GCM_TEXTURE_UN | CELL_GCM_TEXTURE_LN);
 		return {
 			.address = offset(),
 			.gcm_format = _format,


### PR DESCRIPTION
Fixes "Unimplemented block size for format" spam when the shader interpreter engages.