### PR TITLE
ci/bsd: Update FreeBSD to 14.4, use LLVM 22 while keeping clang-devel

### DIFF
--- a/.ci/install-freebsd.sh
+++ b/.ci/install-freebsd.sh
@@ -11,6 +11,9 @@ pkg info # debug
 # WITH_LLVM
 pkg install "llvm$LLVM_COMPILER_VER"
 
+# Compiler dependency (latest clang)
+pkg install "llvm-devel"
+
 # Mandatory dependencies (qtX-base is pulled via qtX-multimedia)
 pkg install git ccache cmake ninja "qt$QT_VER_MAIN-multimedia" "qt$QT_VER_MAIN-svg" glew openal-soft ffmpeg pcre2
 

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -443,10 +443,10 @@ jobs:
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       QT_VER_MAIN: '6'
-      LLVM_COMPILER_VER: '-devel'
+      LLVM_COMPILER_VER: '22'
+      LLVM_CONFIG: 'llvm-config22'
       CC: 'clang-devel'
       CXX: 'clang++-devel'
-      LLVM_CONFIG: 'llvm-config-devel'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rpcs3.yml
+++ b/.github/workflows/rpcs3.yml
@@ -469,7 +469,7 @@ jobs:
           envs: 'QT_VER_MAIN LLVM_COMPILER_VER CCACHE_DIR CC CXX LLVM_CONFIG'
           usesh: true
           copyback: false
-          release: "14.3"
+          release: "14.4"
           run: .ci/install-freebsd.sh && .ci/build-freebsd.sh
 
       - name: Save Build Ccache


### PR DESCRIPTION
- ci: Update FreeBSD CI to use 14.4
- ci: Specify LLVM22 on FreeBSD build
  - RPCS3 does not yet support building with newer LLVM
- ci: Fetch llvm-devel on FreeBSD
  - Required to have latest clang-devel