### PR TITLE
fix emulator crash on crashed game window closure

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -2247,12 +2247,12 @@ bool handle_access_violation(u32 addr, bool is_writing, bool is_exec, ucontext_t
 
 	if (Emu.IsStopped())
 	{
+		// Keep retrying until the page is mapped: the thread must be able to resume so it can observe cpu_flag::exit and terminate cleanly.
+		// Reporting the violation as unhandled here would escalate a guest crash into an unhandled host exception.
 		while (!hack_alloc())
 		{
 			thread_ctrl::wait_for(1000);
 		}
-
-		return false;
 	}
 
 	return true;
@@ -2301,10 +2301,11 @@ static LONG exception_handler(PEXCEPTION_POINTERS pExp) noexcept
 			is_exec = true;
 			addr = static_cast<u32>(exec64);
 		}
-		else if (const usz exec64 = (ptr - vm::g_exec_addr - vm::g_exec_addr_seg_offset); exec64 <= u32{umax})
+		else if (const usz seg_off = (ptr - vm::g_exec_addr - vm::g_exec_addr_seg_offset); seg_off <= u32{umax} / 2)
 		{
+			// Segment map holds one u16 per 4 bytes of guest code: ptr = g_exec_addr + g_exec_addr_seg_offset + (addr >> 1)
 			is_exec = true;
-			addr = static_cast<u32>(exec64);
+			addr = static_cast<u32>(seg_off * 2);
 		}
 		else 
 		{
@@ -2549,7 +2550,8 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 #endif
 
 	const u64 exec64 = (reinterpret_cast<u64>(info->si_addr) - reinterpret_cast<u64>(vm::g_exec_addr)) / 2;
-	const u64 exec64_2 = (reinterpret_cast<u64>(info->si_addr) - reinterpret_cast<u64>(vm::g_exec_addr)) - vm::g_exec_addr_seg_offset;
+	// Segment map holds one u16 per 4 bytes of guest code: si_addr = g_exec_addr + g_exec_addr_seg_offset + (addr >> 1)
+	const u64 seg_off = (reinterpret_cast<u64>(info->si_addr) - reinterpret_cast<u64>(vm::g_exec_addr)) - vm::g_exec_addr_seg_offset;
 	const auto cause = is_executing ? "executing" : is_writing ? "writing" : "reading";
 
 	if (auto [addr, ok] = vm::try_get_addr(info->si_addr); ok && !is_executing)
@@ -2568,9 +2570,9 @@ static void signal_handler(int /*sig*/, siginfo_t* info, void* uct) noexcept
 			return;
 		}
 	}
-	else if (exec64_2 < 0x100000000ull && !is_executing)
+	else if (seg_off < 0x80000000ull && !is_executing)
 	{
-		if (thread_ctrl::get_current() && handle_access_violation(static_cast<u32>(exec64_2), is_writing, true, context))
+		if (thread_ctrl::get_current() && handle_access_violation(static_cast<u32>(seg_off * 2), is_writing, true, context))
 		{
 			return;
 		}


### PR DESCRIPTION
**AI Disclosure:**
- Primary target of the PR is to identify the regressing code (reporting the PR and and possibly the regressing commit when possible) so it can help main developers to provide a correct fix in case the one provided by AI is not fully applicable.
- Comments on the code provided by AI are not initially removed just to provide main developers a description of the changes. Comments will be removed/changed as per indication from main developers during the review
- Analysis made by Opus 4.8. Regression identification and testing made by human
- Tested on issue #18536

</br>

Fix regression introduced by the PR https://github.com/RPCS3/rpcs3/pull/18395. The regression was introduced in commit [Thread.cpp: Fix game exit on access violation](https://github.com/RPCS3/rpcs3/pull/18395/commits/2d4393beaa96bdd138a9a31afc03b2fa279b7cb1).

This PR should fix that regression.

fixes #18536
(to be tested) probably fixes #18773

</br>

**NOTE:** marking the PR as draft for review from elad335

</br>

### AI Summary of the two bugs

Both originate from a single commit in the range you gave: bb3e2689d — "Thread.cpp: Fix game exit on access violation". The other ten commits are SPU LLVM reduced-loop work and are not involved.

</br>

**Bug A — a guest crash escalated into a host process crash (CONFIRMED fixed)**

**Cause.**
In the tail of handle_access_violation() (Utilities/Thread.cpp), the commit restructured `if (Emu.IsStopped() && !hack_alloc()) return false;` into an `if (Emu.IsStopped()) { retry loop; return false; }`. That moved return false out of the condition: it used to fire only when hack_alloc() failed, and now fires even when it succeeds — which is the normal case, since hack_alloc() frequently returns true at its very first vm::check_addr() probe.

**Effect.**
Returning false means "not handled": on Windows the AV skips EXCEPTION_CONTINUE_EXECUTION and reaches exception_filter() → Unhandled Win32 exception 0xC0000005 → process termination; on POSIX it falls through to sys_log.fatal("Segfault ...")
→ abort. So every guest access violation, once emulation stopped, took the whole emulator down instead of letting the guest thread resume, observe cpu_flag::exit, and terminate cleanly.

**Fix.**
Kept the retry loop introduced by the commit, removed the unconditional return false so the function returns true — restoring the pre-commit semantics.

</br>

**Bug B — wrong reverse mapping for the PPU segment map (applied, not yet exercised in-game)**

**Cause.**
The same commit added a recovery branch for faults landing in the PPU segment map, but inverted the mapping incorrectly. Ground truth is ppu_seg_ptr(addr) = g_exec_addr + g_exec_addr_seg_offset + (addr >> 1)
(PPUThread.cpp:476), with one u16 per 4 bytes of guest code, so the map spans 2 GiB. The new code computed addr = ptr - g_exec_addr - seg_offset — missing the * 2, yielding half the real guest address — and bounded the offset at
u32{umax}, i.e. 2 GiB wider than the map, which also overflows u32 once the * 2 is applied.

**Reachability.**
Verified, not assumed: the PPU gateway reads the segment map unconditionally on every thread entry (PPUThread.cpp:229-235), and LLVM-generated code reads it on indirect branches (PPUTranslator.cpp:423, :644). A cia into an unregistered range faults exactly there.

**Effect, and why fix A made it urgent.**
With the wrong address, hack_alloc() commits a segment-map page that is not the one that faulted. With fix A in place the thread resumes, re-executes the same instruction, and faults again — an infinite exception loop at 100% CPU. Fix A turned that specific case from a crash into a hang; fix B is what makes it actually recover.

**Fix.**
In both handlers: addr = seg_off * 2, bound tightened to u32{umax} / 2 (Windows) / 0x80000000ull (POSIX), exec64_2 renamed to seg_off. Branch ordering checked — the first branch covers offsets [0, 0x2'0000'0000) (the main exec map exactly), so segment-map faults fall through correctly with no overlap.

