### PR TITLE
rsx/copypasta: Fix reversed 2-sided lighting input registers for FS stage

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -328,11 +328,12 @@ void GLFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 
 	if (m_prog.two_sided_lighting)
 	{
+		// diff_color0/spec_color0 are COL0/COL1 (o[1]/o[2], front), diff_color1/spec_color1 are BFC0/BFC1 (o[3]/o[4], back)
 		if (properties.in_register_mask & in_diff_color)
-			OS << "	vec4 diff_color = gl_FrontFacing ? diff_color1 : diff_color0;\n";
+			OS << "	vec4 diff_color = gl_FrontFacing ? diff_color0 : diff_color1;\n";
 
 		if (properties.in_register_mask & in_spec_color)
-			OS << "	vec4 spec_color = gl_FrontFacing ? spec_color1 : spec_color0;\n";
+			OS << "	vec4 spec_color = gl_FrontFacing ? spec_color0 : spec_color1;\n";
 	}
 }
 

--- a/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLFragmentProgram.cpp
@@ -328,7 +328,6 @@ void GLFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 
 	if (m_prog.two_sided_lighting)
 	{
-		// diff_color0/spec_color0 are COL0/COL1 (o[1]/o[2], front), diff_color1/spec_color1 are BFC0/BFC1 (o[3]/o[4], back)
 		if (properties.in_register_mask & in_diff_color)
 			OS << "	vec4 diff_color = gl_FrontFacing ? diff_color0 : diff_color1;\n";
 

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -464,11 +464,12 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 
 	if (m_prog.two_sided_lighting)
 	{
+		// diff_color0/spec_color0 are COL0/COL1 (o[1]/o[2], front), diff_color1/spec_color1 are BFC0/BFC1 (o[3]/o[4], back)
 		if (properties.in_register_mask & in_diff_color)
-			OS << "	vec4 diff_color = gl_FrontFacing ? diff_color1 : diff_color0;\n";
+			OS << "	vec4 diff_color = gl_FrontFacing ? diff_color0 : diff_color1;\n";
 
 		if (properties.in_register_mask & in_spec_color)
-			OS << "	vec4 spec_color = gl_FrontFacing ? spec_color1 : spec_color0;\n";
+			OS << "	vec4 spec_color = gl_FrontFacing ? spec_color0 : spec_color1;\n";
 	}
 
 	for (u16 i = 0, mask = (properties.common_access_sampler_mask | properties.shadow_sampler_mask); mask != 0; ++i, mask >>= 1)

--- a/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFragmentProgram.cpp
@@ -464,7 +464,6 @@ void VKFragmentDecompilerThread::insertMainStart(std::stringstream & OS)
 
 	if (m_prog.two_sided_lighting)
 	{
-		// diff_color0/spec_color0 are COL0/COL1 (o[1]/o[2], front), diff_color1/spec_color1 are BFC0/BFC1 (o[3]/o[4], back)
 		if (properties.in_register_mask & in_diff_color)
 			OS << "	vec4 diff_color = gl_FrontFacing ? diff_color0 : diff_color1;\n";
 


### PR DESCRIPTION
**AI Disclosure:**
- Primary target of the PR is to identify the regressing code (reporting the PR and and possibly the regressing commit when possible) so it can help main developers to provide a correct fix in case the one provided by AI is not fully applicable.
- Comments on the code provided by AI are not initially removed just to provide main developers a description of the changes. Comments will be removed/changed as per indication from main developers during the review
- Analysis made by Opus 5
- Testers needed on #18550

</br>

Fix regression introduced by the PR https://github.com/RPCS3/rpcs3/pull/6388. The regression was introduced in commit [rsx/decompiler: Restructure program register behavior](https://github.com/RPCS3/rpcs3/pull/6388/commits/2ba1692574a0d3bfd66fb0a2ec887b86f5acc625).
The regression is present on both Vulkan and OpenGL.

This PR should fix that regression.

(to be tested) probably fixes #18550

</br>

**NOTE:** marking the PR as draft for review from kd-11

</br>

### AI Summary

The fragment program's two-sided lighting selector had its operands reversed: front-facing fragments were shaded with the back colors (BFC0/BFC1) and back-facing fragments with the front colors (COL0/COL1).

```
// before
vec4 diff_color = gl_FrontFacing ? diff_color1: diff_color0;
vec4 spec_color = gl_FrontFacing ? spec_color1: spec_color0;
```

diff_color0/spec_color0 are COL0/COL1 — o[1]/o[2], the front colors. diff_color1/spec_color1 are BFC0/BFC1 — o[3]/o[4], the back colors. This follows from the attribute output bit order in gcm_enums.h:370-373 (FRONTDIFFUSE = 0, FRONTSPECULAR = 1, BACKDIFFUSE = 2, BACKSPECULAR = 3) and from the VP register tables (GLVertexProgram.cpp:126-130, VKVertexProgram.cpp:279-282), where diff_color ← dst_reg1 and diff_color1 ← dst_reg3.

</br>

**Symptom**

Reported in Miyazato Sankyoudai Naizou Sega Golf Club: the character model renders with visibly attenuated lighting — uniformly darker than it should be, with the rest of the scene unaffected. Identical on OpenGL and Vulkan.

It is worth noting that this bug does not present as light arriving from the wrong direction, which is what one would intuitively expect from a front/back swap. On a closed mesh the back faces are never visible, so what you actually see is the whole model shaded with the color the vertex program computed for the inverted normal — essentially the ambient term for a front-lit character. The result reads as "the lighting is too weak", which makes it easy to misattribute.

</br>

**Root cause and why it surfaced when it did**

The swap originates in 6e07e07cd ("GL: enable 2-sided lighting", 2016), which named dst_reg3 as front_diff_color.

It was dormant for three years because the enable predicate was inverted: front_back_color_enabled = !rsx::method_registers.two_side_light_en(), so the two-sided path was effectively never taken by a game that correctly enables
NV4097_SET_TWO_SIDE_LIGHT_EN.

3e28e4b1e ("rsx/decompiler: Restructure program register behavior") replaced this with two_sided_lighting = two_side_light_en(), which activated the path for the first time and exposed the latent swap. Bisection lands on that commit for this reason, but the defect being fixed here predates it.

</br>

**Fix**

Operands swapped in both backends, in insertMainStart — GLFragmentProgram.cpp:333,336 and VKFragmentProgram.cpp:469,472:

```
vec4 diff_color = gl_FrontFacing ? diff_color0 : diff_color1;
vec4 spec_color = gl_FrontFacing ? spec_color0 : spec_color1;
```

</br>

---
### Two related defects, for @kd-11's consideration

Both come from 3e28e4b1e and are still present in master. Neither causes the bug above, so they were deliberately left out of this change to keep the fix isolated — but both look like real behavioral regressions worth a second opinion from someone with hardware access.

</br>

**1. two_sided_lighting no longer checks that the VP actually exports back colors**

RSXThread.cpp:2180:

current_fragment_program.two_sided_lighting = m_ctx->register_state->two_side_light_en();

The pre-3e28e4b1e code gated the two-sided path on back_color_diffuse_output / back_color_specular_output, derived from vertex_attrib_output_mask. That guard was dropped.

If a game enables NV4097_SET_TWO_SIDE_LIGHT_EN but its vertex program never writes dst_reg3/dst_reg4, the FP still selects diff_color1/spec_color1, and the VP falls through to the default introduced by the same
commit at GLVertexProgram.cpp:271:

OS << "       " << i.name << " = vec4(0., 0., 0 1.);\n";   // was vec4(1.) before 3e28e4b1e

Result: back-facing geometry gets a fully black diffuse/specular term. (Note the default itself also flipped from white to black in that commit — the old value carried an Atelier Escha comment.)

Minimal restoration of the old guard:

current_fragment_program.two_sided_lighting = m_ctx->register_state->two_side_light_en() && !!(m_ctx->register_state->vertex_attrib_out put_mask() & (CELL_GCM_ATTRIB_OUTPUT_MASK_BACKDIFFUSE | CELL_GCM_ATTRIB_OUTPUT_MASK_BACKSPECULAR));

This is coarse: with only BACKDIFFUSE exported, the specular path still resolves spec_color1 to the black default. Two independent flags on RSXFragmentProgram would be exact.
Alternatively — and possibly cleaner, since it keeps VP state out of the FP cache key — the VP could emit the corresponding front register instead of vec4(0., 0., 0., 1.) when a back-color source register is unwritten. I
don't have hardware to confirm which of the two matches the RSX, so I'd rather flag it than guess.

**2. COL0/COL1 reads discard the per-source precision modifier**

FragmentProgramDecompiler.cpp:628-629:

```
case 0x01:
case 0x02:
{
    // COL0, COL1
    ret += "_saturate(" + reg_var + ")";
    precision_modifier = RSX_FP_PRECISION_REAL;
    break;
}
```

Before 3e28e4b1e these registers were read raw and still went through ClampValue(ret, precision_modifier) at the end of GetSRC with the modifier the ucode actually encodes in src1.srcN_prec_mod. Setting it to RSX_FP_PRECISION_REAL (0) now skips that call entirely, so any FIXED12 / FIXED9 / HALF clamp the program requested on a COL0/COL1 operand is silently dropped.

The commit message cites hardware testing showing these registers read back clamped to (0, 1), which justifies the _saturate itself. Two things still seem worth confirming:

- If the input is genuinely already in [0, 1],  the encoded precision modifier is mostly a  no-op and keeping it costs nothing — dropping it is a behavior change with no stated motivation.
- The _saturate is applied per-read, i.e. after interpolation, whereas hardware would clamp the vertex output before it. For values outside [0, 1] the two differ across the gradient, not only at the endpoints.