### PR TITLE
PPU: enable LLVM EarlyCSE on ARM64

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5684,10 +5684,8 @@ static void ppu_initialize2(jit_compiler& jit, const ppu_module<lv2_obj>& module
 				// Translate
 				if ([[maybe_unused]] const auto func = translator.Translate(mod_func))
 				{
-#ifdef ARCH_X64 // TODO
 					// Run optimization passes
 					fpm.run(*func, fam);
-#endif // ARCH_X64
 				}
 				else
 				{
@@ -5702,10 +5700,8 @@ static void ppu_initialize2(jit_compiler& jit, const ppu_module<lv2_obj>& module
 		{
 			if ([[maybe_unused]] const auto func = translator.GetSymbolResolver(module_part))
 			{
-#ifdef ARCH_X64 // TODO
 				// Run optimization passes
 				fpm.run(*func, fam);
-#endif // ARCH_X64
 			}
 			else
 			{


### PR DESCRIPTION
AI DISCLOSURE
I used GitHub Copilot in Codespaces to help find an ARM64 issue in the PPU LLVM pipeline.

From that review, the problem appeared to be that a generic LLVM function pass was only being executed for x64, even though the ARM64 specific PPU transform path was already present.

Evidence for the ARM64 path already existing:

In [PPUTranslator.cpp:42], the ARM64 build creates and registers the AArch64 GHC frame preservation pass.
In [PPUTranslator.cpp:321], translated PPU functions already call run_transforms before returning.
In [CPUTranslator.cpp:545], run_transforms executes the registered translator passes.
In [PPUThread.cpp:5653], the LLVM FunctionPassManager is created and EarlyCSEPass is added.
In [PPUThread.cpp:5688] and [PPUThread.cpp:5704], that pass manager now runs for translated PPU functions and the symbol resolver without the previous x64-only guard.
Based on that, this PR re-enables an existing LLVM cleanup pass for ARM64 rather than introducing a new ARM64 translation path.

Expected impact:

May reduce redundant work in generated PPU IR on ARM64
May slightly improve PPU compilation or game loading time on ARM64
Full runtime verification is still needed