### PR TITLE
[TESTERS NEEDED] Fix freeze on Accurate PPU 128 Reservation

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -3260,30 +3260,28 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 			//auto& cline_data = vm::_ref<spu_rdata_t>(addr);
 
 			data += 0;
-			auto range_lock = vm::alloc_range_lock();
-			bool success = false;
+			rsx::reservation_lock rsx_lock(addr, 128);
+
+			auto& super_data = *vm::get_super_ptr<spu_rdata_t>(addr);
+			const bool success = [&]()
 			{
-				rsx::reservation_lock rsx_lock(addr, 128);
+				// Full lock (heavyweight): must be the global exclusive lock.
+				// A per-slot range lock does not exclude other exclusive lock holders (the drain loop
+				// skips g_range_lock_bits[1]), and dropping cpu_flag::wait/memory at the end of the
+				// ctor would then break the PPU suspension another writer_lock is relying on.
+				// TODO: vm::check_addr
+				vm::writer_lock lock(addr);
 
-				auto& super_data = *vm::get_super_ptr<spu_rdata_t>(addr);
-				success = [&]()
+				if (cmp_rdata(ppu.rdata, super_data))
 				{
-					// Full lock (heavyweight)
-					// TODO: vm::check_addr
-					vm::writer_lock lock(addr, range_lock);
+					data.release(new_data);
+					res += 64;
+					return true;
+				}
 
-					if (cmp_rdata(ppu.rdata, super_data))
-					{
-						data.release(new_data);
-						res += 64;
-						return true;
-					}
-
-					res -= 64;
-					return false;
-				}();
-			}
-			vm::free_range_lock(range_lock);
+				res -= 64;
+				return false;
+			}();
 
 			return success;
 		}

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -522,7 +522,10 @@ namespace vm
 			}
 		}
 
-		if (range_lock)
+		// Note: the exclusive (full) lock is also required to suspend PPU threads, otherwise
+		// callers such as vm::reservation_op and do_cell_atomic_128_store (called outside of SPU threads)
+		// would perform their non-atomic 128-byte stores without stopping the PPUs first
+		if (range_lock || addr >= 0x10000)
 		{
 			perf_meter<"SUSPEND"_u64> perf0;
 


### PR DESCRIPTION
**AI Disclosure:**
- Primary target of the PR is to identify the regressing code (reporting the PR and and possibly the regressing commit when possible) so it can help main developers to provide a correct fix in case the one provided by AI is not fully applicable.
- Comments on the code provided by AI are not initially removed just to provide main developers a description of the changes. Comments will be removed/changed as per indication from main developers during the review
- Analysis made by Opus 5
- Testers needed on #15373 and #15410

</br>

Fix regression introduced by the PR https://github.com/RPCS3/rpcs3/pull/15364). The regression was introduced in commit [vm: Fix writer lock leak](https://github.com/RPCS3/rpcs3/pull/15364/commits/37dc40277f25e3e35058bf76687d12e17fabc5fc).

This PR should fix that regression.

</br>

(to be tested) probably fixes #15410
(to be tested) probably fixes #15373

</br>

**NOTE:** marking the PR as draft for review from elad335

</br>

### AI Summary

**The bug**

Introduced by 8588b2b11 "vm: Fix writer lock leak" (2024-03-27), the only commit in the given range that touches the code path gated by Accurate PPU 128 Reservations.

That commit legitimately fixed a lock leak (acquire path and destructor disagreed on which lock had been taken), but in doing so it changed two other semantics:

1. vm.cpp — the gate for the "suspend all PPU threads" phase went from if (addr >= 0x10000) to if (range_lock). Callers passing no range lock (vm::reservation_op,
  do_cell_atomic_128_store outside SPU threads) silently lost the stop-the-world, despite performing non-atomic 128-byte stores.
2. PPUThread.cpp — the PPU 128-byte stdcx path was switched from the global exclusive lock to a per-slot range lock.

Change 2 is what freezes the game. Per-slot exclusive locks do not exclude each other — the drain loop explicitly skips slots already marked exclusive (to_clear & ~get_range_lock_bits(true)). So:

- An SPU in do_putllc enters its writer_lock suspend phase and, for every PPU that already has cpu_flag::wait, skips setting cpu_flag::memory.
- A PPU entering its accurate stdcx sets cpu_flag::wait in the lock constructor — so the SPU sees it as parked and moves on without marking it.
- The PPU then acquires its own slot immediately (previously it would have blocked, holding wait the whole time), and at the and of the constructor does state -= cpu_flag::memory + cpu_flag::wait — it unparks itself and returns to guest code.
- The SPU's second wait loop now waits for that PPU forever: nothing will ever set cpu_flag::memory on it. If the PPU is spinning in guest code on the value the SPU is about to write, it's a hard deadlock, with the SPU still holding the reservation lock and its bit in g_range_lock_bits[1].

With the option Disabled the PPU never takes a range-lock-based writer_lock during guest execution, so the window doesn't exist — matching the reported symptom.

</br>

**The fix**

Two files, restoring pre-8588b2b11 semantics while keeping the actual leak fix (the acquire gate if (!range_lock) is untouched, so acquire and destructor stay coherent):

- rpcs3/Emu/Memory/vm.cpp:528 — suspend gate becomes range_lock || addr >= 0x10000, restoring the stop-the-world for vm::reservation_op and for do_cell_atomic_128_store called outside SPU threads.
- rpcs3/Emu/Cell/PPUThread.cpp:3262 — the 128-byte path goes back to the global vm::writer_lock lock(addr); alloc_range_lock/free_range_lock removed (they also burned one of the 63 slots on every stdcx).

</br>

**Performance**

The only cost is the performance overhead that existed before March 2024 (global serialization of PPU 128-byte atomics, PPU suspension in cellSpurs HLE reservation ops, and dcbz only when Accurate Cache Line Stores is on) — worth an A/B benchmark, but not a behavioral regression.
  