### PR TITLE
Fix vm::writer_lock deadlock-inducing usage on PPU

### DIFF
--- a/Utilities/Thread.cpp
+++ b/Utilities/Thread.cpp
@@ -1964,8 +1964,15 @@ bool handle_access_violation(u32 addr, bool is_writing, bool is_exec, ucontext_t
 	// Hack: allocate memory in case the emulator is stopping
 	const auto hack_alloc = [&]()
 	{
+		const bool added_flag = cpu && !cpu->state.test_and_set(cpu_flag::wait);
+
 		if (vm::check_addr(addr, required_page_perms))
 		{
+			if (added_flag)
+			{
+				cpu->check_state();
+			}
+
 			return true;
 		}
 
@@ -1973,6 +1980,11 @@ bool handle_access_violation(u32 addr, bool is_writing, bool is_exec, ucontext_t
 
 		if (!area)
 		{
+			if (added_flag)
+			{
+				cpu->check_state();
+			}
+
 			return false;
 		}
 
@@ -1993,6 +2005,11 @@ bool handle_access_violation(u32 addr, bool is_writing, bool is_exec, ucontext_t
 			{
 				ppu_register_range(addr & -0x10000, 0x10000);
 			}
+			
+			if (added_flag)
+			{
+				cpu->check_state();
+			}
 
 			g_tls_access_violation_recovered = addr;
 			return true;
@@ -2007,10 +2024,20 @@ bool handle_access_violation(u32 addr, bool is_writing, bool is_exec, ucontext_t
 				ppu_register_range(addr & -0x10000, 0x10000);
 			}
 
+			if (added_flag)
+			{
+				cpu->check_state();
+			}
+
 			g_tls_access_violation_recovered = addr;
 			return true;
 		}
 
+		if (added_flag)
+		{
+			cpu->check_state();
+		}
+	
 		return false;
 	};
 

--- a/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellSpurs.cpp
@@ -2483,6 +2483,9 @@ s32 _spurs::add_workload(ppu_thread& ppu, vm::ptr<CellSpurs> spurs, vm::ptr<u32>
 
 	u32 res_wkl;
 	const auto wkl = &spurs->wklInfo(wnum);
+
+	ppu.state += cpu_flag::wait;
+
 	vm::reservation_op(ppu, vm::unsafe_ptr_cast<spurs_wkl_state_op>(spurs.ptr(&CellSpurs::wklState1)), [&](spurs_wkl_state_op& op)
 	{
 		const u32 mask = op.wklMskB & ~(0x80000000u >> wnum);
@@ -2566,6 +2569,8 @@ s32 cellSpursShutdownWorkload(ppu_thread& ppu, vm::ptr<CellSpurs> spurs, u32 wid
 
 	if (spurs->exception)
 		return CELL_SPURS_POLICY_MODULE_ERROR_STAT;
+
+	ppu.state += cpu_flag::wait;
 
 	bool send_event;
 	s32 rc, old_state;
@@ -3094,6 +3099,8 @@ s32 _cellSpursWorkloadFlagReceiver(ppu_thread& ppu, vm::ptr<CellSpurs> spurs, u3
 
 	s32 res = CELL_OK;
 
+	ppu.state += cpu_flag::wait;
+
 	vm::reservation_op(ppu, vm::unsafe_ptr_cast<wklFlagOp>(spurs), [&](wklFlagOp& val)
 	{
 		if (is_set)
@@ -3342,6 +3349,8 @@ s32 cellSpursEventFlagSet(ppu_thread& ppu, vm::ptr<CellSpursEventFlag> eventFlag
 	u16  pendingRecv;
 	u16  pendingRecvTaskEvents[16];
 
+	ppu.state += cpu_flag::wait;
+
 	vm::reservation_op(ppu, vm::unsafe_ptr_cast<CellSpursEventFlag_x00>(eventFlag), [bits, &send, &ppuWaitSlot, &ppuEvents, &pendingRecv, &pendingRecvTaskEvents](CellSpursEventFlag_x00& eventFlag)
 	{
 		send        = false;
@@ -3406,6 +3415,8 @@ s32 cellSpursEventFlagSet(ppu_thread& ppu, vm::ptr<CellSpursEventFlag> eventFlag
 
 		//eventFlagControl = ((u64)events << 48) | ((u64)spuTaskPendingRecv << 32) | ((u64)ppuWaitMask << 16) | ((u64)ppuWaitSlotAndMode << 8) | (u64)ppuPendingRecv;
 	});
+
+	static_cast<void>(ppu.test_stopped());
 
 	if (send)
 	{
@@ -4257,6 +4268,8 @@ s32 _cellSpursSendSignal(ppu_thread& ppu, vm::ptr<CellSpursTaskset> taskset, u32
 
 	int signal;
 
+	ppu.state += cpu_flag::wait;
+
 	vm::reservation_op(ppu, vm::unsafe_ptr_cast<spurs_taskset_signal_op>(taskset), [&](spurs_taskset_signal_op& op)
 	{
 		const u32 signalled = op.signalled[taskId / 32];
@@ -4291,6 +4304,8 @@ s32 _cellSpursSendSignal(ppu_thread& ppu, vm::ptr<CellSpursTaskset> taskset, u32
 	case 1:
 	{
 		auto spurs = +taskset->spurs;
+
+		static_cast<void>(ppu.test_stopped());
 
 		ppu_execute<&cellSpursSendWorkloadSignal>(ppu, spurs, +taskset->wid);
 		auto rc = ppu_execute<&cellSpursWakeUp>(ppu, spurs);
@@ -5146,6 +5161,8 @@ s32 cellSpursJobGuardNotify(ppu_thread& ppu, vm::ptr<CellSpursJobGuard> jobGuard
 	u32 allow_jobchain_run = 0; // Affects cellSpursJobChainRun execution
 	u32 old = 0;
 
+	ppu.state += cpu_flag::wait;
+
 	const bool ok = vm::reservation_op(ppu, vm::unsafe_ptr_cast<CellSpursJobGuard_x00>(jobGuard), [&](CellSpursJobGuard_x00& jg)
 	{
 		allow_jobchain_run = jg.zero;
@@ -5169,6 +5186,8 @@ s32 cellSpursJobGuardNotify(ppu_thread& ppu, vm::ptr<CellSpursJobGuard> jobGuard
 	{
 		return CELL_OK;
 	}
+
+	static_cast<void>(ppu.test_stopped());
 
 	auto jobChain = +jobGuard->jobChain;
 
@@ -5309,6 +5328,8 @@ s32 cellSpursAddUrgentCommand(ppu_thread& ppu, vm::ptr<CellSpursJobChain> jobCha
 		return CELL_SPURS_JOB_ERROR_INVAL;
 
 	s32 result = CELL_OK;
+
+	ppu.state += cpu_flag::wait;
 
 	vm::reservation_op(ppu, vm::unsafe_ptr_cast<CellSpursJobChain_x00>(jobChain), [&](CellSpursJobChain_x00& jch)
 	{

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5151,7 +5151,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				_reserved_for_backwards_compatibility,
 				accurate_cache_line_stores,
 				reservations_128_byte,
-				greedy_mode,
+				_reserved_for_backwards_compatibility_2,
 				accurate_sat,
 				accurate_fpcc,
 				accurate_vnan,
@@ -5176,8 +5176,6 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				settings += ppu_settings::accurate_cache_line_stores;
 			if (g_cfg.core.ppu_128_reservations_loop_max_length)
 				settings += ppu_settings::reservations_128_byte;
-			if (g_cfg.core.ppu_llvm_greedy_mode)
-				settings += ppu_settings::greedy_mode;
 			if (has_mfvscr && g_cfg.core.ppu_set_sat_bit)
 				settings += ppu_settings::accurate_sat;
 			if (g_cfg.core.ppu_set_fpcc)

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -1291,6 +1291,8 @@ extern bool ppu_patch(u32 addr, u32 value)
 		return false;
 	}
 
+	ensure(!cpu_thread::get_current());
+
 	vm::writer_lock rlock;
 
 	if (!vm::check_addr(addr))
@@ -3263,6 +3265,7 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 			auto range_lock = vm::alloc_range_lock();
 			bool success = false;
 			{
+				ppu.state += cpu_flag::wait; // for vm::writer_lock
 				rsx::reservation_lock rsx_lock(addr, 128);
 
 				auto& super_data = *vm::get_super_ptr<spu_rdata_t>(addr);
@@ -3285,6 +3288,7 @@ static bool ppu_store_reservation(ppu_thread& ppu, u32 addr, u64 reg_value)
 			}
 			vm::free_range_lock(range_lock);
 
+			static_cast<void>(ppu.test_stopped());
 			return success;
 		}
 

--- a/rpcs3/Emu/Cell/SPUThread.cpp
+++ b/rpcs3/Emu/Cell/SPUThread.cpp
@@ -3670,6 +3670,13 @@ void do_cell_atomic_128_store(u32 addr, const void* to_write)
 
 			// Hard lock
 			auto spu = cpu ? cpu->try_get<spu_thread>() : nullptr;
+
+			if (!spu && cpu)
+			{
+				// For vm::writer_lock
+				cpu->state += cpu_flag::wait;
+			}
+
 			vm::writer_lock lock(addr, spu ? spu->range_lock : nullptr);
 			mov_rdata(sdata, *static_cast<const spu_rdata_t*>(to_write));
 			vm::reservation_acquire(addr) += 32;

--- a/rpcs3/Emu/Cell/lv2/sys_dbg.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_dbg.cpp
@@ -28,6 +28,7 @@ error_code sys_dbg_read_process_memory(s32 pid, u32 address, u32 size, vm::ptr<v
 		return CELL_LV2DBG_ERROR_DEINVALIDARGUMENTS;
 	}
 
+	ensure(cpu_thread::get_current())->state += cpu_flag::wait;
 	vm::writer_lock lock;
 
 	// Check if data destination is writable
@@ -74,6 +75,7 @@ error_code sys_dbg_write_process_memory(s32 pid, u32 address, u32 size, vm::cptr
 		return CELL_EFAULT;
 	}
 
+	ensure(cpu_thread::get_current())->state += cpu_flag::wait;
 	vm::writer_lock lock;
 
 	// Again

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -255,8 +255,10 @@ CellError process_is_spu_lock_line_reservation_address(u32 addr, u64 flags)
 	return {};
 }
 
-error_code sys_process_is_spu_lock_line_reservation_address(u32 addr, u64 flags)
+error_code sys_process_is_spu_lock_line_reservation_address(ppu_thread& ppu, u32 addr, u64 flags)
 {
+	ppu.state += cpu_flag::wait;
+
 	sys_process.warning("sys_process_is_spu_lock_line_reservation_address(addr=0x%x, flags=0x%llx)", addr, flags);
 
 	if (auto err = process_is_spu_lock_line_reservation_address(addr, flags))

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -98,6 +98,8 @@ struct ps3_process_info_t
 
 extern ps3_process_info_t  g_ps3_process_info;
 
+class ppu_thread;
+
 // Auxiliary functions
 s32 process_getpid();
 s32 process_get_sdk_version(u32 pid, s32& ver);
@@ -115,7 +117,7 @@ error_code sys_process_get_id2(u32 object, vm::ptr<u32> buffer, u32 size, vm::pt
 error_code _sys_process_get_paramsfo(vm::ptr<char> buffer);
 error_code sys_process_get_sdk_version(u32 pid, vm::ptr<s32> version);
 error_code sys_process_get_status(u64 unk);
-error_code sys_process_is_spu_lock_line_reservation_address(u32 addr, u64 flags);
+error_code sys_process_is_spu_lock_line_reservation_address(ppu_thread& ppu, u32 addr, u64 flags);
 error_code sys_process_kill(u32 pid);
 error_code sys_process_wait_for_child(u32 pid, vm::ptr<u32> status, u64 unk);
 error_code sys_process_wait_for_child2(u64 unk1, u64 unk2, u64 unk3, u64 unk4, u64 unk5, u64 unk6);

--- a/rpcs3/Emu/Memory/vm.cpp
+++ b/rpcs3/Emu/Memory/vm.cpp
@@ -414,20 +414,6 @@ namespace vm
 		}
 	}
 
-	void passive_unlock(cpu_thread& cpu)
-	{
-		if (auto& ptr = g_tls_locked)
-		{
-			ptr->release(nullptr);
-			ptr = nullptr;
-
-			if (cpu.state & cpu_flag::memory)
-			{
-				cpu.state -= cpu_flag::memory;
-			}
-		}
-	}
-
 	bool temporary_unlock(cpu_thread& cpu) noexcept
 	{
 		bs_t<cpu_flag> add_state = cpu_flag::wait;
@@ -436,6 +422,8 @@ namespace vm
 		{
 			add_state += cpu_flag::memory;
 		}
+
+		g_tls_locked = nullptr;
 
 		if (add_state - cpu.state)
 		{
@@ -462,20 +450,19 @@ namespace vm
 	writer_lock::writer_lock(u32 const addr, atomic_t<u64, 128>* range_lock, u32 const size, u64 const flags) noexcept
 		: range_lock(range_lock)
 	{
-		cpu_thread* cpu{};
-
-		if (g_tls_locked)
+		if (cpu_thread* cpu = cpu_thread::get_current(); cpu && cpu->get_class() == thread_class::ppu)
 		{
-			cpu = get_current_cpu_thread();
-			AUDIT(cpu);
-
-			if (*g_tls_locked != cpu || cpu->state & cpu_flag::wait)
+			// cpu_flag::wait must be added by the caller
+			// We cannot manage it internally within vm::writer_lock
+			// Because in doing that, cpu_thread::check_state() needs to be called
+			// Which may not be suitable for the code that writer_lock is used at
+			if (!(cpu->state & cpu_flag::wait))
 			{
-				cpu = nullptr;
-			}
-			else
-			{
-				cpu->state += cpu_flag::wait;
+				// If lock is not set than it is technically fine, though a bit odd for usage
+				if (g_tls_locked)
+				{
+					fmt::throw_exception("vm::writer_lock is being used without cpu_flag::wait set by the caller!\nPlease report to the developers.");
+				}
 			}
 		}
 
@@ -602,11 +589,6 @@ namespace vm
 					}
 				}
 			}
-		}
-
-		if (cpu)
-		{
-			cpu->state -= cpu_flag::memory + cpu_flag::wait;
 		}
 	}
 

--- a/rpcs3/Emu/Memory/vm_locking.h
+++ b/rpcs3/Emu/Memory/vm_locking.h
@@ -82,9 +82,6 @@ namespace vm
 	// Release it
 	void free_range_lock(atomic_t<u64, 128>*) noexcept;
 
-	// Unregister reader
-	void passive_unlock(cpu_thread& cpu);
-
 	// Optimization (set cpu_flag::memory)
 	bool temporary_unlock(cpu_thread& cpu) noexcept;
 	void temporary_unlock() noexcept;

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -21,7 +21,6 @@ struct cfg_root : cfg::node
 		cfg::_bool llvm_logs{ this, "Save LLVM logs" };
 		cfg::string llvm_cpu{ this, "Use LLVM CPU" };
 		cfg::_int<0, 1024> llvm_threads{ this, "Max LLVM Compile Threads", 0 };
-		cfg::_bool ppu_llvm_greedy_mode{ this, "PPU LLVM Greedy Mode", false, false };
 		cfg::_bool llvm_precompilation{ this, "LLVM Precompilation", true };
 		cfg::_enum<thread_scheduler_mode> thread_scheduler{this, "Thread Scheduler Mode", thread_scheduler_mode::os};
 		cfg::_bool set_daz_and_ftz{ this, "Set DAZ and FTZ", false };


### PR DESCRIPTION
This affects the following:
* Using "Accurate PPU 128 Reservation" setting: experiences this race condition often.
* The syscall `sys_process_is_spu_lock_line_reservation_address`, being called a handful of times (once per cellSpurs SPU context creation). The statistical margins that would caused hanging on default settings were very low but never zero.

Fixes https://github.com/RPCS3/rpcs3/issues/15410
Fixes https://github.com/RPCS3/rpcs3/issues/15373
Closes #19127 (fixes the core issue that the pull request is trying to work around)

## The race condition:
When using `vm::writer_lock` on PPU, the PPU must signify that it is in a controlled execution environment by raising `cpu_flag::wait` flag. This allows the SPUs to see it and not wait indefinitely for the PPU to enter such controlled state.
Now, when the PPU returns to normal execution, it must remove `cpu_flag::wait` by calling `cpu_thread::check_state()`. It cannot remove it by itself! See https://github.com/RPCS3/rpcs3/blob/d509eb86645401f34da2c3593c96fbf5f0e1fa77/rpcs3/Emu/Memory/vm.cpp#L609 where the bug lies, this is an ancient bug. By calling `cpu_thread::check_state()` the PPU re-syncronizes with SPUs about its exeuction state, but this was not being done.

# The bugfix
Calling `cpu_thread::check_state()` optionally inside `vm::writer_lock` is a possible but risky solution, because `cpu_thread::check_state()` may halt thread execution where it may not be desireable such as in a `std::lock_guard` scope. The better alternative would be, delegating `cpu_flag::wait` state management back to the caller by assertion. See https://github.com/RPCS3/rpcs3/blob/e4cc9b79723bb412bf807325a24a15dd35274534/rpcs3/Emu/Memory/vm.cpp#L464


