### PR TITLE
Fix recording with fallback encoders

### DIFF
--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -74,7 +74,11 @@ gs_frame::gs_frame(QScreen* screen, const QRect& geometry, const QIcon& appIcon,
 {
 	m_window_title = Emu.GetFormattedTitle(0);
 
-	if (!g_cfg_recording.load())
+	if (g_cfg_recording.load())
+	{
+		gui_log.notice("Using recording config:\n%s", g_cfg_recording.to_string());
+	}
+	else
 	{
 		gui_log.notice("Could not load recording config. Using defaults.");
 	}

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -1035,12 +1035,32 @@ namespace utils
 				return nullptr;
 			};
 
-			const AVCodec* selected_video_codec = avcodec_find_encoder_by_name(m_video_codec_name.c_str());
-			const AVCodec* selected_audio_codec = avcodec_find_encoder_by_name(m_audio_codec_name.c_str());
+			const auto get_codec = [](const std::string& name, AVCodecID fallback, bool is_video)
+			{
+				const AVCodec* codec = name.empty() ? nullptr : avcodec_find_encoder_by_name(name.c_str());
+				if (codec) return codec;
+				media_log.warning("video_encoder: avcodec_find_encoder_by_name('%s') for %s failed or name is empty. Using fallback coded %d", name, is_video ? "video" : "audio", static_cast<int>(fallback));
+				return avcodec_find_encoder(fallback);
+			};
 
-			const AVCodecID video_codec_id = selected_video_codec ? selected_video_codec->id : static_cast<AVCodecID>(m_video_codec_id);
-			const AVCodecID audio_codec_id = selected_audio_codec ? selected_audio_codec->id : static_cast<AVCodecID>(m_audio_codec_id);
-			const AVOutputFormat* out_format = find_format(video_codec_id, audio_codec_id);
+			const AVCodec* selected_video_codec = get_codec(m_video_codec_name, static_cast<AVCodecID>(m_video_codec_id), true);
+			const AVCodec* selected_audio_codec = get_codec(m_audio_codec_name, static_cast<AVCodecID>(m_audio_codec_id), false);
+
+			if (!selected_video_codec)
+			{
+				media_log.error("video_encoder: avcodec_find_encoder for video failed");
+				has_error = true;
+				return;
+			}
+
+			if (!selected_audio_codec)
+			{
+				media_log.error("video_encoder: avcodec_find_encoder for audio failed");
+				has_error = true;
+				return;
+			}
+
+			const AVOutputFormat* out_format = find_format(selected_video_codec->id, selected_audio_codec->id);
 
 			if (out_format)
 			{
@@ -1048,7 +1068,7 @@ namespace utils
 			}
 			else
 			{
-				media_log.error("video_encoder: Could not find a format for the requested video_codec '%s' (ID=%d) and audio_codec '%s' (ID=%d)", m_video_codec_name, m_video_codec_id, m_audio_codec_name, m_audio_codec_id);
+				media_log.error("video_encoder: Could not find a format for the requested video_codec '%s' (ID=%d) and audio_codec '%s' (ID=%d)", m_video_codec_name, static_cast<int>(selected_video_codec->id), m_audio_codec_name, static_cast<int>(selected_audio_codec->id));
 
 				// Fallback to some other codec
 				for (const AVCodec* video_codec : video_codecs)

--- a/rpcs3/util/media_utils.cpp
+++ b/rpcs3/util/media_utils.cpp
@@ -409,6 +409,40 @@ namespace utils
 		return best_sample_rate;
 	}
 
+	static int select_sample_format(const AVCodec* codec)
+	{
+		constexpr AVSampleFormat default_sample_format = AV_SAMPLE_FMT_FLTP;
+
+		if (!codec)
+			return default_sample_format;
+
+		const void* sample_formats = nullptr;
+		int num = 0;
+
+		if (const int err = avcodec_get_supported_config(nullptr, codec, AVCodecConfig::AV_CODEC_CONFIG_SAMPLE_FORMAT, 0, &sample_formats, &num))
+		{
+			media_log.error("select_sample_format: avcodec_get_supported_config error: %d='%s'", err, av_error_to_string(err));
+			return default_sample_format;
+		}
+
+		if (!sample_formats)
+			return default_sample_format;
+
+		int i = 0;
+		std::set<AVSampleFormat> formats;
+		for (const AVSampleFormat* sample_format = static_cast<const AVSampleFormat*>(sample_formats); sample_format && *sample_format != AV_SAMPLE_FMT_NONE && i < num; sample_format++, i++)
+		{
+			media_log.notice("select_sample_format: found sample format: '%s'", av_get_sample_fmt_name(*sample_format));
+			formats.insert(*sample_format);
+		}
+
+		if (formats.contains(AV_SAMPLE_FMT_FLT)) return AV_SAMPLE_FMT_FLT;
+		if (formats.contains(AV_SAMPLE_FMT_FLTP)) return AV_SAMPLE_FMT_FLTP;
+
+		media_log.warning("select_sample_format: using default sample format: '%s'", av_get_sample_fmt_name(default_sample_format));
+		return default_sample_format;
+	}
+
 	AVChannelLayout get_preferred_channel_layout(int channels)
 	{
 		switch (channels)
@@ -1148,13 +1182,14 @@ namespace utils
 				}
 
 				m_sample_rate = select_sample_rate(av.audio.codec);
+				m_sample_format = select_sample_format(av.audio.codec);
 
 				av.audio.context->codec_id = av.format_context->oformat->audio_codec;
 				av.audio.context->codec_type = AVMEDIA_TYPE_AUDIO;
 				av.audio.context->bit_rate = m_audio_bitrate_bps;
 				av.audio.context->sample_rate = m_sample_rate;
 				av.audio.context->time_base = {.num = 1, .den = av.audio.context->sample_rate};
-				av.audio.context->sample_fmt = AV_SAMPLE_FMT_FLTP; // AV_SAMPLE_FMT_FLT is not supported in regular AC3
+				av.audio.context->sample_fmt = static_cast<AVSampleFormat>(m_sample_format);
 				av.audio.stream->time_base = av.audio.context->time_base;
 
 				// check that the encoder supports the format
@@ -1186,7 +1221,7 @@ namespace utils
 					return;
 				}
 
-				av.audio.frame->format = AV_SAMPLE_FMT_FLTP;
+				av.audio.frame->format = static_cast<AVSampleFormat>(m_sample_format);
 				av.audio.frame->nb_samples = av.audio.context->frame_size;
 
 				if (int err = av_channel_layout_copy(&av.audio.frame->ch_layout, &av.audio.context->ch_layout); err < 0)

--- a/rpcs3/util/video_sink.h
+++ b/rpcs3/util/video_sink.h
@@ -111,6 +111,7 @@ namespace utils
 		atomic_t<bool> m_flush = false;
 		u32 m_framerate = 30;
 		u32 m_sample_rate = 48000;
+		s32 m_sample_format = -1;
 		static constexpr u32 m_samples_per_block = 256;
 	};
 }


### PR DESCRIPTION
- Log recording config
- Support FLT non-planar format
- Fix encoder fallback codec:
I forgot to add avcodec_find_encoder if no encoder was found for the configured name.
In the legacy case the configured name is empty and therefore no encoder is found.

fixes #19135