### PR TITLE
Ancient emulation bug fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -504,8 +504,10 @@ error_code cellCameraInit()
 	return CELL_OK;
 }
 
-error_code cellCameraEnd()
+error_code cellCameraEnd(ppu_thread& ppu)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellCamera.todo("cellCameraEnd()");
 
 	auto& g_camera = g_fxo->get<camera_thread>();
@@ -570,7 +572,7 @@ error_code cellCameraOpenAsync()
 	return CELL_OK;
 }
 
-error_code cellCameraOpenEx(s32 dev_num, vm::ptr<CellCameraInfoEx> info)
+error_code cellCameraOpenEx(ppu_thread& ppu, s32 dev_num, vm::ptr<CellCameraInfoEx> info)
 {
 	cellCamera.todo("cellCameraOpenEx(dev_num=%d, info=*0x%x)", dev_num, info);
 
@@ -621,6 +623,8 @@ error_code cellCameraOpenEx(s32 dev_num, vm::ptr<CellCameraInfoEx> info)
 
 	const auto vbuf_size = get_video_buffer_size(*info);
 
+	ppu.state += cpu_flag::wait;
+
 	std::lock_guard lock(g_camera.mutex);
 
 	// TODO: find out if the buffers are also checked for nullptr
@@ -666,8 +670,10 @@ error_code cellCameraOpenPost()
 	return CELL_OK;
 }
 
-error_code cellCameraClose(s32 dev_num)
+error_code cellCameraClose(ppu_thread& ppu, s32 dev_num)
 {
+	ppu.state += cpu_flag::wait;
+
 	cellCamera.notice("cellCameraClose(dev_num=%d)", dev_num);
 
 	if (error_code error = check_init_and_open(dev_num))

--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -700,14 +700,19 @@ error_code cellCameraClose(ppu_thread& ppu, s32 dev_num)
 	if (g_camera.info.buffer)
 	{
 		vm::dealloc(g_camera.info.buffer.addr(), vm::main);
+		g_camera.info.buffer = vm::null;
 	}
+
 	if (g_camera.info.pbuf[0])
 	{
 		vm::dealloc(g_camera.info.pbuf[0].addr(), vm::main);
+		g_camera.info.pbuf[0] = vm::null;
 	}
+
 	if (g_camera.info.pbuf[1])
 	{
 		vm::dealloc(g_camera.info.pbuf[1].addr(), vm::main);
+		g_camera.info.pbuf[1] = vm::null;
 	}
 
 	g_camera.close_camera();
@@ -1847,14 +1852,19 @@ void camera_context::reset_state()
 	if (info.buffer)
 	{
 		vm::dealloc(info.buffer.addr(), vm::main);
+		info.buffer = vm::null;
 	}
+
 	if (info.pbuf[0])
 	{
 		vm::dealloc(info.pbuf[0].addr(), vm::main);
+		info.pbuf[0] = vm::null;
 	}
+
 	if (info.pbuf[1])
 	{
 		vm::dealloc(info.pbuf[1].addr(), vm::main);
+		info.pbuf[1] = vm::null;
 	}
 
 	std::scoped_lock lock(mutex_notify_data_map);

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "Emu/System.h"
 #include "Emu/Cell/PPUModule.h"
+#include "Emu/Cell/Modules/sysPrxForUser.h"
 #include "Emu/Io/interception.h"
 #include "Emu/Io/Keyboard.h"
 #include "Emu/IdManager.h"
@@ -310,14 +311,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 				sysutil_register_cb([&, length = i, string_to_send = std::move(string_to_send)](ppu_thread& cb_ppu) -> s32
 				{
-					cb_ppu.state += cpu_flag::wait;
-
-					vm::var<u16[], vm::page_allocator<>> string_var(CELL_OSKDIALOG_STRING_SIZE, string_to_send.data());
-
-					if (cb_ppu.check_state())
-					{
-						return 0;
-					}
+					vm::var<u16[], vm::hle_malloc_allocator> string_var(CELL_OSKDIALOG_STRING_SIZE, string_to_send.data());
 
 					const u32 return_value = ccb(cb_ppu, string_var.begin(), static_cast<s32>(length));
 					cellOskDialog.warning("osk_confirm_callback return_value=%d", return_value);
@@ -512,7 +506,7 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 			// Prepare callback variables
 			vm::var<CellOskDialogKeyMessage> keyMessage(key_message);
 			vm::var<u32> action(CELL_OSKDIALOG_CHANGE_NO_EVENT);
-			vm::var<u16[], vm::page_allocator<>> pActionInfo(::narrow<u32>(string_to_send.size()), string_to_send.data());
+			vm::var<u16[], vm::hle_malloc_allocator> pActionInfo(::narrow<u32>(string_to_send.size()), string_to_send.data());
 
 			// Create helpers for logging
 			std::u16string utf16_string(reinterpret_cast<const char16_t*>(string_to_send.data()), string_to_send.size());

--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -310,7 +310,14 @@ error_code cellOskDialogLoadAsync(u32 container, vm::ptr<CellOskDialogParam> dia
 
 				sysutil_register_cb([&, length = i, string_to_send = std::move(string_to_send)](ppu_thread& cb_ppu) -> s32
 				{
+					cb_ppu.state += cpu_flag::wait;
+
 					vm::var<u16[], vm::page_allocator<>> string_var(CELL_OSKDIALOG_STRING_SIZE, string_to_send.data());
+
+					if (cb_ppu.check_state())
+					{
+						return 0;
+					}
 
 					const u32 return_value = ccb(cb_ppu, string_var.begin(), static_cast<s32>(length));
 					cellOskDialog.warning("osk_confirm_callback return_value=%d", return_value);

--- a/rpcs3/Emu/Cell/Modules/sys_game_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_game_.cpp
@@ -76,7 +76,11 @@ static void put_exitspawn(vm::ptr<void> out, vm::cptr<char> path, u32 argc, vm::
 
 static void exitspawn(ppu_thread& ppu, vm::cptr<char> path, vm::cpptr<char> argv, vm::cpptr<char> envp, u32 data, u32 data_size, s32 prio, u64 _flags)
 {
+	ppu.state += cpu_flag::wait;
+
 	sys_mutex_lock(ppu, *g_ppu_exit_mutex, 0);
+
+	ppu.state += cpu_flag::wait;
 
 	u32 arg_count = 0;
 	u32 env_count = 0;
@@ -105,6 +109,8 @@ static void exitspawn(ppu_thread& ppu, vm::cptr<char> path, vm::cpptr<char> argv
 		// TODO (process atexit)
 		return _sys_process_exit(ppu, CELL_ENOMEM, 0, 0);
 	}
+
+	static_cast<void>(ppu.check_state());
 
 	put_exitspawn(vm::cast(alloc_addr + 0x30), path, arg_count, argv, env_count, envp);
 

--- a/rpcs3/Emu/Cell/Modules/sys_libc_.cpp
+++ b/rpcs3/Emu/Cell/Modules/sys_libc_.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "Emu/Cell/lv2/sys_tty.h"
 #include "Emu/Cell/PPUModule.h"
+#include "Emu/Cell/PPUFunction.h"
 #include "Utilities/cfmt.h"
 
 LOG_CHANNEL(sysPrxForUser);
@@ -367,27 +368,50 @@ vm::cptr<char> _sys_strrchr(vm::cptr<char> str, char ch)
 	return res;
 }
 
-u32 _sys_malloc(u32 size)
+u32 _sys_malloc(ppu_thread& ppu, u32 size)
 {
+	ppu.state += cpu_flag::wait;
+
 	sysPrxForUser.warning("_sys_malloc(size=0x%x)", size);
 
-	return vm::alloc(size, vm::main);
+	const u32 res = vm::alloc(size, vm::main);
+	ppu.check_state();
+	return res;
 }
 
-u32 _sys_memalign(u32 align, u32 size)
+u32 _sys_memalign(ppu_thread& ppu, u32 align, u32 size)
 {
+	ppu.state += cpu_flag::wait;
+
 	sysPrxForUser.warning("_sys_memalign(align=0x%x, size=0x%x)", align, size);
 
-	return vm::alloc(size, vm::main, std::max<u32>(align, 0x10000));
+	const u32 res = vm::alloc(size, vm::main, std::max<u32>(align, 0x10000));
+	ppu.check_state();
+	return res;
 }
 
-error_code _sys_free(u32 addr)
+void _sys_free(ppu_thread& ppu, u32 addr)
 {
+	ppu.state += cpu_flag::wait;
+
 	sysPrxForUser.warning("_sys_free(addr=0x%x)", addr);
 
 	vm::dealloc(addr, vm::main);
 
-	return CELL_OK;
+	ppu.check_state();
+}
+
+std::pair<vm::addr_t, u32> vm::hle_malloc_allocator::alloc(u32 size, u32 align)
+{
+	const auto ppu = ensure(cpu_thread::get_current<ppu_thread>());
+	const u32 addr = vm::cast(ppu_execute<&_sys_memalign>(*ppu, align, size));
+	return { vm::cast(addr), addr ? size : 0 };
+}
+
+void vm::hle_malloc_allocator::dealloc(u32 addr, u32 size) noexcept
+{
+	const auto ppu = ensure(cpu_thread::get_current<ppu_thread>());
+	ppu_execute<&_sys_free>(*ppu, addr);
 }
 
 s32 _sys_snprintf(ppu_thread& ppu, vm::ptr<char> dst, u32 count, vm::cptr<char> fmt, ppu_va_args_t va_args)

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -985,9 +985,18 @@ enum CellSpursJobError : u32;
 enum CellSyncError : u32;
 
 enum CellGameError : u32;
+enum CellSysutilError : u32;
+enum CellSaveDataError : u32;
 enum CellGameDataError : u32;
-enum CellDiscGameError : u32;
 enum CellHddGameError : u32;
+enum CellDiscGameError : u32;
+
+enum CellCameraError : u32;
+enum CellGemError : u32;
+
+enum CellKbError : u32;
+enum CellPadError : u32;
+enum CellMouseError : u32;
 
 enum SceNpTrophyError : u32;
 enum SceNpError : u32;
@@ -1013,15 +1022,24 @@ const std::map<u64, void(*)(std::string&, u64)> s_error_codes_formatting_by_type
 	formatter_of<0x80410A00, CellSpursJobError>,
 
 	formatter_of<0x8002cb00, CellGameError>,
+	formatter_of<0x8002b100, CellSysutilError>,
+	formatter_of<0x8002b400, CellSaveDataError>,
 	formatter_of<0x8002b600, CellGameDataError>,
-	formatter_of<0x8002bd00, CellDiscGameError>,
 	formatter_of<0x8002ba00, CellHddGameError>,
+	formatter_of<0x8002bd00, CellDiscGameError>,
+
+	formatter_of<0x80140800, CellCameraError>,
+	formatter_of<0x80121800, CellGemError>,
+
+	formatter_of<0x80121000, CellKbError>,
+	formatter_of<0x80121100, CellPadError>,
+	formatter_of<0x80121200, CellMouseError>,
 
 	formatter_of<0x80022900, SceNpTrophyError>,
 	formatter_of<0x80029500, SceNpError>,
 };
 
-template<>
+template <>
 void fmt_class_string<CellError>::format(std::string& out, u64 arg)
 {
 	// Test if can be formatted by this formatter
@@ -1034,8 +1052,12 @@ void fmt_class_string<CellError>::format(std::string& out, u64 arg)
 
 		if (upper == s_error_codes_formatting_by_type.begin())
 		{
-			// Format as unknown by another enum formatter
-			upper->second(out, arg);
+			// Format as unknown
+			format_enum(out, arg, [](auto error)
+			{
+				return unknown;
+			});
+
 			return;
 		}
 

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -833,8 +833,8 @@ const std::array<std::pair<ppu_intrp_func_t, std::string_view>, 1024> g_ppu_sysc
 	NULL_FUNC(sys_ss_get_cache_of_analog_sunset_flag),      //860 (0x35C)  AUTHID
 	NULL_FUNC(sys_ss_protected_file_db),                    //861  ROOT
 	BIND_SYSC(sys_ss_virtual_trm_manager),                  //862  ROOT
-	BIND_SYSC(sys_ss_update_manager),                       //863  ROOT
-	NULL_FUNC(sys_ss_sec_hw_framework),                     //864  DBG
+	BIND_SYSC(sys_ss_update_manager),                       //863 (0x35F) ROOT
+	NULL_FUNC(sys_ss_sec_hw_framework),                     //864 (0x360) DBG
 	BIND_SYSC(sys_ss_random_number_generator),              //865 (0x361)
 	BIND_SYSC(sys_ss_secure_rtc),                           //866  ROOT
 	BIND_SYSC(sys_ss_appliance_info_manager),               //867  ROOT

--- a/rpcs3/Emu/Cell/lv2/lv2.cpp
+++ b/rpcs3/Emu/Cell/lv2/lv2.cpp
@@ -1117,6 +1117,12 @@ void fmt_class_string<CellError>::format(std::string& out, u64 arg)
 	});
 }
 
+template <>
+void fmt_class_string<error_code>::format(std::string& out, u64 arg)
+{
+	fmt_class_string<CellError>::format(out, arg);
+}
+
 stx::init_lock acquire_lock(stx::init_mutex& mtx, ppu_thread* ppu)
 {
 	if (!ppu)

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include "Emu/Cell/ErrorCodes.h"
+#include "Emu/Cell/PPUThread.h"
 #include "Emu/Memory/vm_ptr.h"
 #include "Emu/VFS.h"
 #include "Emu/IdManager.h"
@@ -20,7 +21,7 @@ extern void ppu_finalize(const ppu_module<lv2_obj>& info, bool force_mem_release
 
 LOG_CHANNEL(sys_overlay);
 
-static error_code overlay_load_module(vm::ptr<u32> ovlmid, const std::string& vpath, u64 /*flags*/, vm::ptr<u32> entry, fs::file src = {}, s64 file_offset = 0)
+static error_code overlay_load_module(ppu_thread& /*for wait flag reminder*/, vm::ptr<u32> ovlmid, const std::string& vpath, u64 /*flags*/, vm::ptr<u32> entry, fs::file src = {}, s64 file_offset = 0)
 {
 	if (!src)
 	{
@@ -126,8 +127,10 @@ void lv2_overlay::save(utils::serial& ar)
 	ar(vpath, offset);
 }
 
-error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry)
+error_code sys_overlay_load_module(ppu_thread& ppu, vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry)
 {
+	ppu.state += cpu_flag::wait;
+
 	sys_overlay.warning("sys_overlay_load_module(ovlmid=*0x%x, path=%s, flags=0x%x, entry=*0x%x)", ovlmid, path, flags, entry);
 
 	if (!g_ps3_process_info.ppc_seg)
@@ -141,11 +144,13 @@ error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path, u64
 		return CELL_EFAULT;
 	}
 
-	return overlay_load_module(ovlmid, path.get_ptr(), flags, entry);
+	return overlay_load_module(ppu, ovlmid, path.get_ptr(), flags, entry);
 }
 
-error_code sys_overlay_load_module_by_fd(vm::ptr<u32> ovlmid, u32 fd, u64 offset, u64 flags, vm::ptr<u32> entry)
+error_code sys_overlay_load_module_by_fd(ppu_thread& ppu, vm::ptr<u32> ovlmid, u32 fd, u64 offset, u64 flags, vm::ptr<u32> entry)
 {
+	ppu.state += cpu_flag::wait;
+
 	sys_overlay.warning("sys_overlay_load_module_by_fd(ovlmid=*0x%x, fd=%d, offset=0x%llx, flags=0x%x, entry=*0x%x)", ovlmid, fd, offset, flags, entry);
 
 	if (!g_ps3_process_info.ppc_seg)
@@ -173,11 +178,13 @@ error_code sys_overlay_load_module_by_fd(vm::ptr<u32> ovlmid, u32 fd, u64 offset
 		return CELL_EBADF;
 	}
 
-	return overlay_load_module(ovlmid, offset ? fmt::format("%s_x%x", file->name.data(), offset) : file->name.data(), flags, entry, lv2_file::make_view(file, offset), offset);
+	return overlay_load_module(ppu, ovlmid, offset ? fmt::format("%s_x%x", file->name.data(), offset) : file->name.data(), flags, entry, lv2_file::make_view(file, offset), offset);
 }
 
-error_code sys_overlay_unload_module(u32 ovlmid)
+error_code sys_overlay_unload_module(ppu_thread& ppu, u32 ovlmid)
 {
+	ppu.state += cpu_flag::wait;
+
 	sys_overlay.warning("sys_overlay_unload_module(ovlmid=0x%x)", ovlmid);
 
 	if (!g_ps3_process_info.ppc_seg)

--- a/rpcs3/Emu/Cell/lv2/sys_overlay.h
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.h
@@ -17,9 +17,9 @@ struct lv2_overlay final : ppu_module<lv2_obj>
 	void save(utils::serial& ar);
 };
 
-error_code sys_overlay_load_module(vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry);
-error_code sys_overlay_load_module_by_fd(vm::ptr<u32> ovlmid, u32 fd, u64 offset, u64 flags, vm::ptr<u32> entry);
-error_code sys_overlay_unload_module(u32 ovlmid);
+error_code sys_overlay_load_module(ppu_thread& ppu, vm::ptr<u32> ovlmid, vm::cptr<char> path, u64 flags, vm::ptr<u32> entry);
+error_code sys_overlay_load_module_by_fd(ppu_thread& ppu, vm::ptr<u32> ovlmid, u32 fd, u64 offset, u64 flags, vm::ptr<u32> entry);
+error_code sys_overlay_unload_module(ppu_thread& ppu, u32 ovlmid);
 //error_code sys_overlay_get_module_list(sys_pid_t pid, usz ovlmids_num, sys_overlay_t * ovlmids, usz * num_of_modules);
 //error_code sys_overlay_get_module_info(sys_pid_t pid, sys_overlay_t ovlmid, sys_overlay_module_info_t * info);
 //error_code sys_overlay_get_module_info2(sys_pid_t pid, sys_overlay_t ovlmid, sys_overlay_module_info2_t * info);//

--- a/rpcs3/Emu/Cell/lv2/sys_ss.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.cpp
@@ -4,6 +4,7 @@
 #include "sys_process.h"
 #include "Emu/IdManager.h"
 #include "Emu/Cell/timers.hpp"
+#include "Emu/Cell/PPUThread.h"
 #include "Emu/system_config.h"
 #include "util/sysinfo.hpp"
 
@@ -18,7 +19,7 @@
 
 struct lv2_update_manager
 {
-	lv2_update_manager()
+	lv2_update_manager() noexcept
 	{
 		std::string version_str = utils::get_firmware_version();
 
@@ -357,7 +358,7 @@ error_code sys_ss_get_boot_device(vm::ptr<u64> dev)
 	return CELL_OK;
 }
 
-error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64 a5, u64 a6)
+error_code sys_ss_update_manager(ppu_thread& ppu, u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64 a5, u64 a6)
 {
 	sys_ss.notice("sys_ss_update_manager(pkg=0x%x, a1=0x%x, a2=0x%x, a3=0x%x, a4=0x%x, a5=0x%x, a6=0x%x)", pkg_id, a1, a2, a3, a4, a5, a6);
 
@@ -428,20 +429,29 @@ error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64
 	}
 	case 0x600B:
 	{
+		ppu.state += cpu_flag::wait;
+
 		// read eeprom
 		const auto offset = ::narrow<u32>(a1);
 		const auto value_ptr = ::narrow<u32>(a2);
 
 		if (!value_ptr)
+		{
 			return CELL_EFAULT;
+		}
 
-		std::shared_lock shared_lock(update_manager.eeprom_mutex);
+		u8 value_out = 0xFF; // 0xFF if not set
+		{
+			std::shared_lock shared_lock(update_manager.eeprom_mutex);
 
-		if (const auto iterator = update_manager.eeprom_map.find(offset); iterator != update_manager.eeprom_map.end())
-			vm::write8(value_ptr, iterator->second);
-		else
-			vm::write8(value_ptr, 0xFF); // 0xFF if not set
+			if (const auto iterator = update_manager.eeprom_map.find(offset); iterator != update_manager.eeprom_map.end())
+			{
+				value_out = iterator->second;
+			}
+		}
 
+		static_cast<void>(ppu.test_stopped());
+		vm::write8(value_ptr, value_out);
 		break;
 	}
 	case 0x600C:
@@ -450,6 +460,7 @@ error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64
 		const auto offset = ::narrow<u32>(a1);
 		const auto value = ::narrow<u8>(a2);
 
+		ppu.state += cpu_flag::wait;
 		std::unique_lock unique_lock(update_manager.eeprom_mutex);
 
 		if (value != 0xFF)
@@ -473,7 +484,9 @@ error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64
 		if (!addr_ptr)
 			return CELL_EFAULT;
 
+		ppu.state += cpu_flag::wait;
 		const auto addr = update_manager.allocate(size);
+		static_cast<void>(ppu.test_stopped());
 
 		if (!addr)
 			return CELL_ENOMEM;
@@ -487,6 +500,7 @@ error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64
 		// release buffer
 		const auto addr = ::narrow<u32>(a1);
 
+		ppu.state += cpu_flag::wait;
 		if (!update_manager.deallocate(addr))
 			return CELL_ENOMEM;
 
@@ -519,7 +533,9 @@ error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64
 		if (!addr_ptr)
 			return CELL_EFAULT;
 
+		ppu.state += cpu_flag::wait;
 		const auto addr = update_manager.allocate(size);
+		static_cast<void>(ppu.test_stopped());
 
 		if (!addr)
 			return CELL_ENOMEM;

--- a/rpcs3/Emu/Cell/lv2/sys_ss.h
+++ b/rpcs3/Emu/Cell/lv2/sys_ss.h
@@ -28,6 +28,6 @@ error_code sys_ss_get_cache_of_product_mode(vm::ptr<u8> ptr);
 error_code sys_ss_secure_rtc(u64 cmd, u64 a2, u64 a3, u64 a4);
 error_code sys_ss_get_cache_of_flash_ext_flag(vm::ptr<u64> flag);
 error_code sys_ss_get_boot_device(vm::ptr<u64> dev);
-error_code sys_ss_update_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64 a5, u64 a6);
+error_code sys_ss_update_manager(ppu_thread& ppu, u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4, u64 a5, u64 a6);
 error_code sys_ss_virtual_trm_manager(u64 pkg_id, u64 a1, u64 a2, u64 a3, u64 a4);
 error_code sys_ss_individual_info_manager(u64 pkg_id, u64 a2, vm::ptr<u64> out_size, u64 a4, u64 a5, u64 a6);

--- a/rpcs3/Emu/Memory/vm_var.h
+++ b/rpcs3/Emu/Memory/vm_var.h
@@ -20,6 +20,13 @@ namespace vm
 		}
 	};
 
+	struct hle_malloc_allocator
+	{
+		// Defined externally
+		static std::pair<vm::addr_t, u32> alloc(u32 size, u32 align);
+		static void dealloc(u32 addr, u32 size) noexcept;
+	};
+
 	template <typename T>
 	struct stack_allocator
 	{


### PR DESCRIPTION
Fix bugs that were revealed by #19132 
https://github.com/RPCS3/rpcs3/blob/e4cc9b79723bb412bf807325a24a15dd35274534/rpcs3/Emu/Memory/vm.cpp#L464

These bugs, hit the assert because they are using `vm::writer_lock` without setting `cpu_flag::wait` beforehand.

Affected RPCS3 code locations: (the list may grow)

* `sys_overlay_load_module` and `sys_overlay_load_module_by_fd`
* `cellOskDialogLoadAsync`
* `cellCameraOpenEx`and `cellCameraClose`
* `sys_ss_update_manager`

Luckily these functions are also called a handful of times per game startup, so the bug did not manifest itself under normal conditions. (unless you were statistically extremely unfortunate)

For `sys_overlay_load_module_by_fd` and `sys_overlay_load_module` there is more that benefits from this fix:
`cpu_flag::wait` not only allows proper `vm::writer_lock` use, but singfinies the SPUs that the PPU is in a controlled execution state and that the SPUs do not need to spinlock waiting for the PPU. This means a great CPU usage reduction (during level loading) and improved loading times for Metal Gear Solid 4 (the sole user of these syscalls) by preventing the SPUs from spinlocking while the PPU loads the overlay modules. (which is a slow process)


**Please inform me of more assertions, each is different and needs special handling.**

## Additional bugfixes (that were discovered during debugging)

* Fix memory leak in `cellCameraClose` (use after free): `cellCameraOpenEx` already dealloacted `pbuf`, but this was not updated by the internal structure and caused `cellCameraEnd` to call `vm::dealloc` on the same addresses again. This can lead to `cellCameraEnd` to deallocate memory that is not related to `cellCamera` at all!
* `sys_ss_update_manager`: Fix VM write in lock guard scope, fixing potential deadlocks inside AV handler.
* `_sys_free` return type is void and not integer.