### PR TITLE
Fix infinite ensure recursion in debug builds

### DIFF
--- a/rpcs3/util/emu_utils.cpp
+++ b/rpcs3/util/emu_utils.cpp
@@ -42,6 +42,10 @@ std::shared_ptr<CPUDisAsm> make_disasm(const cpu_thread* cpu, shared_ptr<cpu_thr
 	default: return result;
 	}
 
-	result->set_cpu_handle(std::move(handle));
+	if (handle || cpu->get_class() != thread_class::rsx)
+	{
+		result->set_cpu_handle(std::move(handle));
+	}
+
 	return result;
 }


### PR DESCRIPTION
- Fix infinite ensure recursion in debug builds.
Any triggered exception will trigger make_disasm, which - when called with an rsx thread - will not have a handle.
This means the AUDIT in set_cpu_handle triggers another exception and thusly creates an infinite recursion.