### PR TITLE
rsx: fix exception data_heap in debug builds

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/data_heap.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/data_heap.h
@@ -81,7 +81,7 @@ namespace vk
 				return { *heap, 0, VK_WHOLE_SIZE };
 			}
 
-			if (utils::address_range64::start_length(offset, range).inside(m_cached_buffer_range)) [[ likely ]]
+			if (m_cached_buffer_range.valid() && utils::address_range64::start_length(offset, range).inside(m_cached_buffer_range)) [[ likely ]]
 			{
 				return { *heap, m_cached_buffer_range.start, m_cached_buffer_range.length() };
 			}
@@ -95,6 +95,7 @@ namespace vk
 				const u64 block_addr = start_partition * aligned_window_size;
 				const u64 block_end = std::min<u64>(block_addr + aligned_window_size, size());
 				m_cached_buffer_range = utils::address_range64::start_end(block_addr, block_end - 1);
+				AUDIT(m_cached_buffer_range.valid());
 				return { *heap, m_cached_buffer_range.start, m_cached_buffer_range.length() };
 			}
 


### PR DESCRIPTION
The AUDIT in .inside() triggers whenever m_cached_buffer_range was not assigned yet.
Added another AUDIT to ensure that m_cached_buffer_range is valid after assignment.

This theoretically changes the function's behaviour.
I hope the window() function is not called with invalid parameters.
I could add another `AUDIT(offset != umax && range > 0);`