### PR TITLE
spu: Clear the MFC_LSA_offs bits higher than the limit

### DIFF
--- a/rpcs3/Emu/Cell/RawSPUThread.cpp
+++ b/rpcs3/Emu/Cell/RawSPUThread.cpp
@@ -299,13 +299,8 @@ bool spu_thread::write_reg(const u32 addr, const u32 value)
 	{
 	case MFC_LSA_offs:
 	{
-		if (value >= SPU_LS_SIZE)
-		{
-			break;
-		}
-
 		std::lock_guard lock(mfc_prxy_mtx);
-		mfc_prxy_cmd.lsa = value;
+		mfc_prxy_cmd.lsa = value & (SPU_LS_SIZE - 1);
 		mfc_prxy_write_state.lsa = true;
 		return true;
 	}


### PR DESCRIPTION
Allows BandFuse: Rock Legends to go ingame.
@Florin9doi's finding from #17994

Fixes #19036