### PR TITLE
Qt: implement auto_scroll_label and use it for the settings descriptions

### DIFF
--- a/rpcs3/rpcs3.vcxproj
+++ b/rpcs3/rpcs3.vcxproj
@@ -845,6 +845,7 @@
     <ClCompile Include="rpcs3.cpp" />
     <ClCompile Include="rpcs3qt\about_dialog.cpp" />
     <ClCompile Include="rpcs3qt\anaglyph_settings_dialog.cpp" />
+    <ClCompile Include="rpcs3qt\auto_scroll_label.cpp" />
     <ClCompile Include="rpcs3qt\basic_mouse_settings_dialog.cpp" />
     <ClCompile Include="rpcs3qt\breakpoint_handler.cpp" />
     <ClCompile Include="rpcs3qt\breakpoint_list.cpp" />
@@ -1225,6 +1226,7 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp</Outputs>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(QTDIR)\bin\moc.exe"  "%(FullPath)" -o ".\QTGeneratedFiles\$(ConfigurationName)\moc_%(Filename).cpp"  -D_WINDOWS -DUNICODE -DWIN32 -DWIN64 -DWITH_DISCORD_RPC -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DNDEBUG -DQT_CONCURRENT_LIB -D%(PreprocessorDefinitions)  "-I.\..\3rdparty\wolfssl\wolfssl" "-I.\..\3rdparty\curl\curl\include" "-I.\..\3rdparty\libusb\libusb\libusb" "-I$(VULKAN_SDK)\Include" "-I$(QTDIR)\include" "-I$(QTDIR)\include\QtWidgets" "-I$(QTDIR)\include\QtGui" "-I$(QTDIR)\include\QtCore" "-I.\release" "-I.\QTGeneratedFiles\$(ConfigurationName)" "-I.\QTGeneratedFiles" "-I$(QTDIR)\include\QtConcurrent"</Command>
     </CustomBuild>
+    <ClInclude Include="rpcs3qt\auto_scroll_label.h" />
     <ClInclude Include="rpcs3qt\breakpoint_handler.h" />
     <CustomBuild Include="rpcs3qt\breakpoint_list.h">
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(QTDIR)\bin\moc.exe;%(FullPath)</AdditionalInputs>

--- a/rpcs3/rpcs3.vcxproj.filters
+++ b/rpcs3/rpcs3.vcxproj.filters
@@ -1323,6 +1323,9 @@
     <ClCompile Include="rpcs3qt\guest_memory_dumper.cpp">
       <Filter>Gui\utils</Filter>
     </ClCompile>
+    <ClCompile Include="rpcs3qt\auto_scroll_label.cpp">
+      <Filter>Gui\widgets</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Input\ds4_pad_handler.h">
@@ -1576,6 +1579,9 @@
     </ClInclude>
     <ClInclude Include="rpcs3qt\render_creator.h">
       <Filter>Gui\settings</Filter>
+    </ClInclude>
+    <ClInclude Include="rpcs3qt\auto_scroll_label.h">
+      <Filter>Gui\widgets</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/rpcs3/rpcs3qt/CMakeLists.txt
+++ b/rpcs3/rpcs3qt/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(rpcs3_ui STATIC
     about_dialog.cpp
     anaglyph_settings_dialog.cpp
     auto_pause_settings_dialog.cpp
+    auto_scroll_label.cpp
     basic_mouse_settings_dialog.cpp
     breakpoint_handler.cpp
     breakpoint_list.cpp
@@ -208,6 +209,9 @@ set_target_properties(rpcs3_ui
 # https://docs.microsoft.com/en-us/windows/win32/winsock/creating-a-basic-winsock-application
 # https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers#faster-builds-with-smaller-header-files
 target_compile_definitions(rpcs3_ui PRIVATE WIN32_LEAN_AND_MEAN)
+
+# We need to know where our custom widgets are located when compiling form files
+target_include_directories(rpcs3_ui AFTER PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(rpcs3_ui
     PUBLIC

--- a/rpcs3/rpcs3qt/auto_scroll_label.cpp
+++ b/rpcs3/rpcs3qt/auto_scroll_label.cpp
@@ -1,0 +1,93 @@
+#include "stdafx.h"
+#include "auto_scroll_label.h"
+
+#include <QPainter>
+
+auto_scroll_label::auto_scroll_label(QWidget* parent)
+	: QLabel(parent)
+{
+	connect(&m_timer, &QTimer::timeout, this, &auto_scroll_label::update_scroll);
+
+	m_timer.start(m_timer_interval);
+}
+
+void auto_scroll_label::setText(const QString& text)
+{
+	if (text == this->text()) return;
+
+	QLabel::setText(text);
+
+	update_text_height();
+	m_scroll_offset = 0;
+	m_pause_ticks = 0;
+}
+
+void auto_scroll_label::paintEvent(QPaintEvent* /*event*/)
+{
+	QPainter p(this);
+
+	p.setFont(font());
+	p.setPen(palette().windowText().color());
+	p.setClipRect(rect());
+
+	QRect r = contentsRect();
+	r.setHeight(m_text_height);
+	r.translate(0, -m_scroll_offset);
+
+	p.drawText(r, alignment() | Qt::TextWordWrap, text());
+}
+
+void auto_scroll_label::resizeEvent(QResizeEvent* event)
+{
+	QLabel::resizeEvent(event);
+	update_text_height();
+}
+
+void auto_scroll_label::update_text_height()
+{
+	const QFontMetrics fm(font());
+	const QRect r = fm.boundingRect(QRect(0, 0, contentsRect().width(), INT_MAX), alignment() | Qt::TextWordWrap, text());
+
+	m_text_height = r.height();
+}
+
+void auto_scroll_label::update_scroll()
+{
+	const int old_scroll_offset = m_scroll_offset;
+	update_scroll_offset();
+
+	if (isVisible() && m_scroll_offset != old_scroll_offset)
+	{
+		update();
+	}
+}
+
+void auto_scroll_label::update_scroll_offset()
+{
+	if (!isVisible() || m_text_height <= height())
+	{
+		m_scroll_offset = 0;
+		m_pause_ticks = 0;
+		return;
+	}
+
+	if (m_pause_ticks < m_pause_tick_count)
+	{
+		m_pause_ticks++;
+		return;
+	}
+
+	const int max_offset = m_text_height - height();
+
+	if (++m_scroll_offset >= max_offset)
+	{
+		m_pause_ticks = 0;
+
+		if (m_at_end)
+		{
+			m_scroll_offset = 0;
+		}
+
+		m_at_end = !m_at_end;
+	}
+}

--- a/rpcs3/rpcs3qt/auto_scroll_label.h
+++ b/rpcs3/rpcs3qt/auto_scroll_label.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QLabel>
+#include <QTimer>
+
+class auto_scroll_label : public QLabel
+{
+public:
+	auto_scroll_label(QWidget* parent = nullptr);
+
+	void setText(const QString& text);
+
+protected:
+	void paintEvent(QPaintEvent* event) override;
+	void resizeEvent(QResizeEvent* event) override;
+
+private slots:
+	void update_scroll();
+
+private:
+	void update_scroll_offset();
+	void update_text_height();
+
+	QTimer m_timer;
+
+	static constexpr int m_timer_interval = 30; // ms
+	static constexpr int m_pause_tick_count = 50; // ~1.5 seconds at 30 ms
+
+	int m_scroll_offset = 0;
+	int m_text_height = 0;
+	int m_pause_ticks = 0;
+	bool m_at_end = false;
+};

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -8,7 +8,9 @@
 #include <QInputDialog>
 #include <QDesktopServices>
 #include <QColorDialog>
+#include <QPlainTextEdit>
 #include <QSpinBox>
+#include <QTextDocument>
 #include <QTimer>
 #include <QScreen>
 #include <QStyleFactory>
@@ -2461,10 +2463,14 @@ void settings_dialog::open()
 	});
 }
 
-void settings_dialog::SubscribeDescription(QLabel* description)
+void settings_dialog::SubscribeDescription(QPlainTextEdit* description)
 {
-	description->setFixedHeight(description->sizeHint().height());
-	m_description_labels.push_back(std::pair<QLabel*, QString>(description, description->text()));
+	// Give the description box a static height
+	constexpr int visible_lines = 4;
+	const int margins = static_cast<int>(description->document()->documentMargin()) * 2 + description->frameWidth() * 2;
+	description->setFixedHeight(description->fontMetrics().lineSpacing() * visible_lines + margins);
+
+	m_description_views.emplace_back(description, description->toPlainText());
 }
 
 void settings_dialog::SubscribeTooltip(QObject* object, const QString& tooltip)
@@ -2497,17 +2503,17 @@ bool settings_dialog::eventFilter(QObject* object, QEvent* event)
 	{
 		const int i = ui->tab_widget_settings->currentIndex();
 
-		if (i >= 0 && static_cast<usz>(i) < m_description_labels.size())
+		if (i >= 0 && static_cast<usz>(i) < m_description_views.size())
 		{
-			if (QLabel* label = m_description_labels[i].first)
+			if (QPlainTextEdit* description = m_description_views[i].first)
 			{
 				if (event->type() == QEvent::Enter)
 				{
-					label->setText(m_descriptions[object]);
+					description->setPlainText(m_descriptions[object]);
 				}
 				else if (event->type() == QEvent::Leave)
 				{
-					label->setText(m_description_labels[i].second);
+					description->setPlainText(m_description_views[i].second);
 				}
 			}
 		}

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -8,9 +8,7 @@
 #include <QInputDialog>
 #include <QDesktopServices>
 #include <QColorDialog>
-#include <QPlainTextEdit>
 #include <QSpinBox>
-#include <QTextDocument>
 #include <QTimer>
 #include <QScreen>
 #include <QStyleFactory>
@@ -118,20 +116,8 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	// Localized tooltips
 	const Tooltips tooltips;
 
-	// Add description labels
-	SubscribeDescription(ui->description_cpu);
-	SubscribeDescription(ui->description_gpu);
-	SubscribeDescription(ui->description_audio);
-	SubscribeDescription(ui->description_io);
-	SubscribeDescription(ui->description_system);
-	SubscribeDescription(ui->description_network);
-	SubscribeDescription(ui->description_advanced);
-	SubscribeDescription(ui->description_emulator);
-	if (!game)
-	{
-		SubscribeDescription(ui->description_gui);
-	}
-	SubscribeDescription(ui->description_debug);
+	m_default_description = ui->description->text();
+	ui->description->setFixedHeight(ui->description->sizeHint().height());
 
 	if (game)
 	{
@@ -2463,16 +2449,6 @@ void settings_dialog::open()
 	});
 }
 
-void settings_dialog::SubscribeDescription(QPlainTextEdit* description)
-{
-	// Give the description box a static height
-	constexpr int visible_lines = 4;
-	const int margins = static_cast<int>(description->document()->documentMargin()) * 2 + description->frameWidth() * 2;
-	description->setFixedHeight(description->fontMetrics().lineSpacing() * visible_lines + margins);
-
-	m_description_views.emplace_back(description, description->toPlainText());
-}
-
 void settings_dialog::SubscribeTooltip(QObject* object, const QString& tooltip)
 {
 	m_descriptions[object] = tooltip;
@@ -2494,28 +2470,15 @@ bool settings_dialog::eventFilter(QObject* object, QEvent* event)
 		}
 	}
 
-	if (!m_descriptions.contains(object))
+	if (m_descriptions.contains(object))
 	{
-		return QDialog::eventFilter(object, event);
-	}
-
-	if (event->type() == QEvent::Enter || event->type() == QEvent::Leave)
-	{
-		const int i = ui->tab_widget_settings->currentIndex();
-
-		if (i >= 0 && static_cast<usz>(i) < m_description_views.size())
+		if (event->type() == QEvent::Enter)
 		{
-			if (QPlainTextEdit* description = m_description_views[i].first)
-			{
-				if (event->type() == QEvent::Enter)
-				{
-					description->setPlainText(m_descriptions[object]);
-				}
-				else if (event->type() == QEvent::Leave)
-				{
-					description->setPlainText(m_description_views[i].second);
-				}
-			}
+			ui->description->setText(m_descriptions[object]);
+		}
+		else if (event->type() == QEvent::Leave)
+		{
+			ui->description->setText(m_default_description);
 		}
 	}
 

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -4,6 +4,7 @@
 
 #include <QDialog>
 #include <QLabel>
+#include <QPlainTextEdit>
 #include <QSlider>
 
 #include <memory>
@@ -64,9 +65,9 @@ private:
 	QString m_discord_state;
 
 	// Descriptions
-	std::vector<std::pair<QLabel*, QString>> m_description_labels;
+	std::vector<std::pair<QPlainTextEdit*, QString>> m_description_views;
 	QHash<QObject*, QString> m_descriptions;
-	void SubscribeDescription(QLabel* description);
+	void SubscribeDescription(QPlainTextEdit* description);
 	void SubscribeTooltip(QObject* object, const QString& tooltip);
 	bool eventFilter(QObject* object, QEvent* event) override;
 	void closeEvent(QCloseEvent* event) override;

--- a/rpcs3/rpcs3qt/settings_dialog.h
+++ b/rpcs3/rpcs3qt/settings_dialog.h
@@ -4,7 +4,6 @@
 
 #include <QDialog>
 #include <QLabel>
-#include <QPlainTextEdit>
 #include <QSlider>
 
 #include <memory>
@@ -65,9 +64,8 @@ private:
 	QString m_discord_state;
 
 	// Descriptions
-	std::vector<std::pair<QPlainTextEdit*, QString>> m_description_views;
+	QString m_default_description;
 	QHash<QObject*, QString> m_descriptions;
-	void SubscribeDescription(QPlainTextEdit* description);
 	void SubscribeTooltip(QObject* object, const QString& tooltip);
 	bool eventFilter(QObject* object, QEvent* event) override;
 	void closeEvent(QCloseEvent* event) override;

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -26,15 +26,8 @@
    <iconset resource="../resources.qrc">
     <normaloff>:/rpcs3.ico</normaloff>:/rpcs3.ico</iconset>
   </property>
-  <layout class="QVBoxLayout" name="settings_dialog_layout">
+  <layout class="QVBoxLayout" name="settings_dialog_layout" stretch="1,0">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="frameShape">
-      <enum>QFrame::Shape::NoFrame</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
      <widget class="QTabWidget" name="tab_widget_settings">
       <property name="enabled">
        <bool>true</bool>
@@ -48,7 +41,7 @@
        </rect>
       </property>
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
@@ -60,7 +53,17 @@
        <attribute name="title">
         <string>CPU</string>
        </attribute>
-       <layout class="QVBoxLayout" name="coreTabLayout" stretch="0,1,0">
+       <layout class="QVBoxLayout" name="coreTabLayout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="coreTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="coreTabScrollContents">
+           <layout class="QVBoxLayout" name="coreTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="coreTabItemLayout">
           <item>
@@ -322,28 +325,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_cpu">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QVBoxLayout" name="gb_description_cpu_layout">
            <item>
-            <widget class="QLabel" name="description_cpu">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_cpu">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -356,7 +363,17 @@
        <attribute name="title">
         <string>GPU</string>
        </attribute>
-       <layout class="QVBoxLayout" name="gpuTab_layout" stretch="0,1,0">
+       <layout class="QVBoxLayout" name="gpuTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="gpuTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="gpuTabScrollContents">
+           <layout class="QVBoxLayout" name="gpuTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="gpuTabLayout" stretch="1,1,1">
           <item>
@@ -1026,28 +1043,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_gpu">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QHBoxLayout" name="gb_description_gpu_layout">
            <item>
-            <widget class="QLabel" name="description_gpu">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_gpu">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -1060,7 +1081,17 @@
        <attribute name="title">
         <string>Audio</string>
        </attribute>
-       <layout class="QVBoxLayout" name="audioTab_layout" stretch="0,0,1,0">
+       <layout class="QVBoxLayout" name="audioTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="audioTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="audioTabScrollContents">
+           <layout class="QVBoxLayout" name="audioTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="audioTabLayoutTop" stretch="1,1,1">
           <item>
@@ -1574,28 +1605,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_audio">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QVBoxLayout" name="gb_description_audio_layout">
            <item>
-            <widget class="QLabel" name="description_audio">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_audio">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -1608,7 +1643,17 @@
        <attribute name="title">
         <string>I/O</string>
        </attribute>
-       <layout class="QVBoxLayout" name="inputTab_layout">
+       <layout class="QVBoxLayout" name="inputTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="inputTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="inputTabScrollContents">
+           <layout class="QVBoxLayout" name="inputTabScrollContentsLayout">
         <item>
          <layout class="QGridLayout" name="ioGridLayout" columnstretch="1,1,1">
           <item row="2" column="2">
@@ -1885,28 +1930,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_io">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QVBoxLayout" name="gb_description_io_layout">
            <item>
-            <widget class="QLabel" name="description_io">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_io">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -1919,7 +1968,17 @@
        <attribute name="title">
         <string>System</string>
        </attribute>
-       <layout class="QVBoxLayout" name="systemTab_layout" stretch="0,1,0">
+       <layout class="QVBoxLayout" name="systemTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="systemTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="systemTabScrollContents">
+           <layout class="QVBoxLayout" name="systemTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="systemTabHorizontalLayout" stretch="1,1,1">
           <item>
@@ -2193,28 +2252,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_system">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QHBoxLayout" name="gb_description_system_layout">
            <item>
-            <widget class="QLabel" name="description_system">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_system">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -2227,7 +2290,17 @@
        <attribute name="title">
         <string>Network</string>
        </attribute>
-       <layout class="QVBoxLayout" name="networkTab_layout" stretch="0,1,0">
+       <layout class="QVBoxLayout" name="networkTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="networkTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="networkTabScrollContents">
+           <layout class="QVBoxLayout" name="networkTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="networkTabLayout" stretch="0,0">
           <item>
@@ -2412,28 +2485,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_network">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QVBoxLayout" name="gb_description_network_layout">
            <item>
-            <widget class="QLabel" name="description_network">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_network">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -2446,7 +2523,17 @@
        <attribute name="title">
         <string>Advanced</string>
        </attribute>
-       <layout class="QVBoxLayout" name="advancedTab_layout" stretch="1,0,0">
+       <layout class="QVBoxLayout" name="advancedTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="advancedTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="advancedTabScrollContents">
+           <layout class="QVBoxLayout" name="advancedTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="advancedTabLayout" stretch="1,1,1">
           <item>
@@ -2962,28 +3049,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_advanced">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QVBoxLayout" name="gb_description_advanced_layout">
            <item>
-            <widget class="QLabel" name="description_advanced">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_advanced">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -2996,7 +3087,17 @@
        <attribute name="title">
         <string>Emulator</string>
        </attribute>
-       <layout class="QVBoxLayout" name="emulatorTab_layout" stretch="0,1,0">
+       <layout class="QVBoxLayout" name="emulatorTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="emulatorTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="emulatorTabScrollContents">
+           <layout class="QVBoxLayout" name="emulatorTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="emulatorTabLayout" stretch="1,1,1">
           <item>
@@ -3853,28 +3954,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_emulator">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QVBoxLayout" name="gb_description_emulator_layout">
            <item>
-            <widget class="QLabel" name="description_emulator">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_emulator">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -3887,7 +3992,17 @@
        <attribute name="title">
         <string>GUI</string>
        </attribute>
-       <layout class="QVBoxLayout" name="guiTab_layout" stretch="0,1,0">
+       <layout class="QVBoxLayout" name="guiTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="guiTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="guiTabScrollContents">
+           <layout class="QVBoxLayout" name="guiTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="guiTabLayout" stretch="1,1,1">
           <item>
@@ -4316,28 +4431,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_gui">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QVBoxLayout" name="gb_description_gui_layout">
            <item>
-            <widget class="QLabel" name="description_gui">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_gui">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -4350,7 +4469,17 @@
        <attribute name="title">
         <string>Debug</string>
        </attribute>
-       <layout class="QVBoxLayout" name="debugTab_layout" stretch="0,1,0">
+       <layout class="QVBoxLayout" name="debugTab_layout" stretch="1,0">
+        <item>
+         <widget class="QScrollArea" name="debugTabScrollArea">
+          <property name="frameShape">
+           <enum>QFrame::Shape::NoFrame</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="debugTabScrollContents">
+           <layout class="QVBoxLayout" name="debugTabScrollContentsLayout">
         <item>
          <layout class="QHBoxLayout" name="debugTabLayout" stretch="1,1,1">
           <item>
@@ -4824,28 +4953,32 @@
           </property>
          </spacer>
         </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
         <item>
          <widget class="QGroupBox" name="gb_description_debug">
+          <property name="flat">
+           <bool>true</bool>
+          </property>
           <property name="title">
            <string>Description</string>
           </property>
           <layout class="QVBoxLayout" name="gb_description_debug_layout">
            <item>
-            <widget class="QLabel" name="description_debug">
-             <property name="text">
-              <string>Point your mouse at an option to display a description in here.
-
-
-</string>
+            <widget class="QPlainTextEdit" name="description_debug">
+             <property name="focusPolicy">
+              <enum>Qt::FocusPolicy::ClickFocus</enum>
              </property>
-             <property name="textFormat">
-              <enum>Qt::TextFormat::PlainText</enum>
+             <property name="frameShape">
+              <enum>QFrame::Shape::NoFrame</enum>
              </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-             </property>
-             <property name="wordWrap">
+             <property name="readOnly">
               <bool>true</bool>
+             </property>
+             <property name="plainText">
+              <string>Point your mouse at an option to display a description in here.</string>
              </property>
             </widget>
            </item>
@@ -4854,7 +4987,6 @@
         </item>
        </layout>
       </widget>
-     </widget>
     </widget>
    </item>
    <item>

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>856</width>
-    <height>688</height>
+    <width>1073</width>
+    <height>902</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,564 +26,59 @@
    <iconset resource="../resources.qrc">
     <normaloff>:/rpcs3.ico</normaloff>:/rpcs3.ico</iconset>
   </property>
-  <layout class="QVBoxLayout" name="settings_dialog_layout" stretch="1,0">
+  <layout class="QVBoxLayout" name="settings_dialog_layout" stretch="1,0,0">
    <item>
-     <widget class="QTabWidget" name="tab_widget_settings">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>821</width>
-        <height>716</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <widget class="QWidget" name="coreTab">
-       <attribute name="title">
-        <string>CPU</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="coreTabLayout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="coreTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
+    <widget class="QTabWidget" name="tab_widget_settings">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="currentIndex">
+      <number>4</number>
+     </property>
+     <widget class="QWidget" name="coreTab">
+      <attribute name="title">
+       <string>CPU</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="coreTabLayout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="coreTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="coreTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1031</width>
+            <height>716</height>
+           </rect>
           </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="coreTabScrollContents">
-           <layout class="QVBoxLayout" name="coreTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="coreTabItemLayout">
-          <item>
-           <layout class="QVBoxLayout" name="coreTabLeftLayout">
-            <item>
-             <widget class="QGroupBox" name="gb_ppu">
-              <property name="title">
-               <string>PPU Decoder</string>
-              </property>
-              <layout class="QVBoxLayout" name="ppu_layout">
-               <item>
-                <widget class="QRadioButton" name="ppu__static">
-                 <property name="text">
-                  <string notr="true">Interpreter (static)</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="ppu_llvm">
-                 <property name="text">
-                  <string notr="true">LLVM Recompiler (fastest)</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_spu">
-              <property name="title">
-               <string>SPU Decoder</string>
-              </property>
-              <layout class="QVBoxLayout" name="spu_layout">
-               <item>
-                <widget class="QRadioButton" name="spu__static">
-                 <property name="text">
-                  <string notr="true">Interpreter (static)</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="spu_dynamic">
-                 <property name="text">
-                  <string notr="true">Interpreter (dynamic)</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="spu_asmjit">
-                 <property name="text">
-                  <string notr="true">ASMJIT Recompiler (faster)</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="spu_llvm">
-                 <property name="text">
-                  <string notr="true">LLVM Recompiler (fastest)</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="coreTabLeftLayoutSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="coreTabMiddleLayout">
-            <item>
-             <widget class="QGroupBox" name="gb_xfloat_accuracy">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>SPU XFloat Accuracy</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_xfloat_accuracy_layout">
-               <item>
-                <widget class="QComboBox" name="xfloatAccuracy"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_spuBlockSize">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>SPU Block Size</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_spuBlockSize_layout">
-               <item>
-                <widget class="QComboBox" name="spuBlockSize"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_max_preempt_count">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Max Power Saving CPU-preemptions</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_max_preempt_layout">
-               <item>
-                <widget class="QSlider" name="maxPreemptCount">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="maxPreemptLayout" stretch="0,0">
-                 <item>
-                  <widget class="QLabel" name="preemptText">
-                   <property name="text">
-                    <string>0</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="preemptReset">
-                   <property name="text">
-                    <string>Reset</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="coreTabMiddleLayoutSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="coreTabRightLayout" stretch="0,0,0">
-            <item>
-             <widget class="QGroupBox" name="gb_spu_threads">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Preferred SPU Threads</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_spu_threads_layout">
-               <item>
-                <widget class="QComboBox" name="preferredSPUThreads"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_threadsched">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Thread Scheduler</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_threadsched_layout">
-               <item>
-                <widget class="QComboBox" name="threadsched"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="coreTabRightLayoutSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="coreTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_cpu">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_description_cpu_layout">
+          <layout class="QVBoxLayout" name="coreTabScrollContentsLayout">
            <item>
-            <widget class="QPlainTextEdit" name="description_cpu">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="gpuTab">
-       <attribute name="title">
-        <string>GPU</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="gpuTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="gpuTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
-          </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="gpuTabScrollContents">
-           <layout class="QVBoxLayout" name="gpuTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="gpuTabLayout" stretch="1,1,1">
-          <item>
-           <layout class="QVBoxLayout" name="gpuTabLayoutLeft">
-            <item>
-             <widget class="QGroupBox" name="gb_renderer">
-              <property name="title">
-               <string>Renderer</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_renderer_layout">
+            <layout class="QHBoxLayout" name="coreTabItemLayout">
+             <item>
+              <layout class="QVBoxLayout" name="coreTabLeftLayout">
                <item>
-                <widget class="QComboBox" name="renderBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_graphicsAdapter">
-              <property name="title">
-               <string>Graphics Device</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_graphicsAdapter_layout">
-               <item>
-                <widget class="QComboBox" name="graphicsAdapterBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QWidget" name="widget_gpu_top" native="true">
-              <layout class="QHBoxLayout" name="widget_gpu_top_layout" stretch="1,1">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QGroupBox" name="gb_aspectRatio">
+                <widget class="QGroupBox" name="gb_ppu">
                  <property name="title">
-                  <string>Aspect Ratio</string>
+                  <string>PPU Decoder</string>
                  </property>
-                 <layout class="QVBoxLayout" name="gb_aspectRatio_layout">
+                 <layout class="QVBoxLayout" name="ppu_layout">
                   <item>
-                   <widget class="QComboBox" name="aspectBox"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_frameLimit">
-                 <property name="title">
-                  <string>Framelimit</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_frameLimit_layout">
-                  <item>
-                   <widget class="QComboBox" name="frameLimitBox"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QWidget" name="widget_gpu_bottom" native="true">
-              <layout class="QHBoxLayout" name="widget_gpu_bottom_layout" stretch="1,1">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QGroupBox" name="gb_anisotropicFilter">
-                 <property name="title">
-                  <string>Anisotropic Filter</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_anisotropicFilter_layout">
-                  <item>
-                   <widget class="QComboBox" name="anisotropicFilterOverride"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_antiAliasing">
-                 <property name="title">
-                  <string>Anti-Aliasing (MSAA)</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="gb_antiAliasing_layout">
-                  <item>
-                   <widget class="QComboBox" name="antiAliasing"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QWidget" name="widget_gpu_3" native="true">
-              <layout class="QHBoxLayout" name="widget_gpu_3_layout" stretch="1,1">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QGroupBox" name="gbZCULL">
-                 <property name="title">
-                  <string>ZCULL Accuracy</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="gbZCULL_layout">
-                  <item>
-                   <widget class="QComboBox" name="zcullPrecisionMode"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gbShaderPrecision">
-                 <property name="title">
-                  <string>Shader Quality</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="gbShaderPrecision_layout">
-                  <item>
-                   <widget class="QComboBox" name="shaderPrecision"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QWidget" name="widget_gpu_4" native="true">
-              <layout class="QHBoxLayout" name="widget_gpu_4_layout" stretch="1">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QGroupBox" name="gbVsync">
-                 <property name="title">
-                  <string>Vsync</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="gbVsync_layout">
-                  <item>
-                   <widget class="QComboBox" name="vsyncMode"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_stereo">
-              <property name="title">
-               <string>3D</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_stereo_layout">
-               <item>
-                <widget class="QCheckBox" name="stereoRenderEnabled">
-                 <property name="text">
-                  <string>Enable 3D Support</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="stereoRenderMode"/>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="gb_anaglyph_settings">
-                 <property name="title">
-                  <string>Anaglyph Settings</string>
-                 </property>
-                 <layout class="QHBoxLayout" name="layout_gb_anaglyph_settings">
-                  <item>
-                   <widget class="QPushButton" name="pb_anaglyph_settings">
+                   <widget class="QRadioButton" name="ppu__static">
                     <property name="text">
-                     <string>Configure</string>
+                     <string notr="true">Interpreter (static)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="ppu_llvm">
+                    <property name="text">
+                     <string notr="true">LLVM Recompiler (fastest)</string>
                     </property>
                    </widget>
                   </item>
@@ -591,217 +86,299 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="gb_screen_size">
+                <widget class="QGroupBox" name="gb_spu">
                  <property name="title">
-                  <string>Screen Size (Inch)</string>
+                  <string>SPU Decoder</string>
                  </property>
-                 <layout class="QVBoxLayout" name="layout_gb_screen_size">
+                 <layout class="QVBoxLayout" name="spu_layout">
                   <item>
-                   <widget class="QSpinBox" name="sb_screen_size"/>
+                   <widget class="QRadioButton" name="spu__static">
+                    <property name="text">
+                     <string notr="true">Interpreter (static)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="spu_dynamic">
+                    <property name="text">
+                     <string notr="true">Interpreter (dynamic)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="spu_asmjit">
+                    <property name="text">
+                     <string notr="true">ASMJIT Recompiler (faster)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="spu_llvm">
+                    <property name="text">
+                     <string notr="true">LLVM Recompiler (fastest)</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>
                </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="gpu_tab_layout_right_spacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="gpuTabLayoutMiddle">
-            <item>
-             <widget class="QGroupBox" name="gb_default_resolution">
-              <property name="title">
-               <string>Default Resolution</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_default_resolution_layout">
                <item>
-                <widget class="QComboBox" name="resBox"/>
+                <spacer name="coreTabLeftLayoutSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="layout_resolution_scale">
-              <property name="spacing">
-               <number>6</number>
-              </property>
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QGroupBox" name="gb_resolutionScale">
-                <property name="title">
-                 <string>Resolution Scale (Disable Strict Mode)</string>
-                </property>
-                <layout class="QVBoxLayout" name="gb_resolutionScale_layout">
-                 <item>
-                  <widget class="QWidget" name="resolutionScaleLayoutTop" native="true">
-                   <layout class="QHBoxLayout" name="horizontalLayout_23" stretch="0,1,0">
-                    <property name="spacing">
-                     <number>12</number>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="coreTabMiddleLayout">
+               <item>
+                <widget class="QGroupBox" name="gb_xfloat_accuracy">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>SPU XFloat Accuracy</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_xfloat_accuracy_layout">
+                  <item>
+                   <widget class="QComboBox" name="xfloatAccuracy"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_spuBlockSize">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>SPU Block Size</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_spuBlockSize_layout">
+                  <item>
+                   <widget class="QComboBox" name="spuBlockSize"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_max_preempt_count">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Max Power Saving CPU-preemptions</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_max_preempt_layout">
+                  <item>
+                   <widget class="QSlider" name="maxPreemptCount">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
                     </property>
-                    <property name="leftMargin">
-                     <number>0</number>
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
                     </property>
-                    <property name="topMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>0</number>
-                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="maxPreemptLayout" stretch="0,0">
                     <item>
-                     <widget class="QLabel" name="resolutionScaleMin">
+                     <widget class="QLabel" name="preemptText">
                       <property name="text">
-                       <string>25</string>
+                       <string>0</string>
                       </property>
                       <property name="alignment">
-                       <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
                       </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QSlider" name="resolutionScale">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="resolutionScaleMax">
+                     <widget class="QPushButton" name="preemptReset">
                       <property name="text">
-                       <string>800</string>
+                       <string>Reset</string>
                       </property>
                      </widget>
                     </item>
                    </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="resolutionScaleLayoutBottom" stretch="1,0">
-                   <item>
-                    <widget class="QLabel" name="resolutionScaleVal">
-                     <property name="text">
-                      <string>0</string>
-                     </property>
-                     <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="resolutionScaleReset">
-                     <property name="text">
-                      <string>Reset</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QGroupBox" name="gb_minimumScalableDimension">
-                <property name="title">
-                 <string>Resolution Scale Threshold</string>
-                </property>
-                <layout class="QVBoxLayout" name="gb_minimumScalableDimension_layout">
-                 <item>
-                  <layout class="QHBoxLayout" name="minimumScalableDimensionLayoutTop" stretch="0,1,0">
-                   <property name="spacing">
-                    <number>12</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="minimumScalableDimensionMin">
-                     <property name="text">
-                      <string>1</string>
-                     </property>
-                     <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSlider" name="minimumScalableDimension">
-                     <property name="orientation">
-                      <enum>Qt::Orientation::Horizontal</enum>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="minimumScalableDimensionMax">
-                     <property name="text">
-                      <string>1024</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <layout class="QHBoxLayout" name="minimumScalableDimensionLayoutBottom" stretch="1,0">
-                   <item>
-                    <widget class="QLabel" name="minimumScalableDimensionVal">
-                     <property name="text">
-                      <string>1x1</string>
-                     </property>
-                     <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignCenter</set>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="minimumScalableDimensionReset">
-                     <property name="text">
-                      <string>Reset</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_outputScaling">
-              <property name="title">
-               <string>Output Scaling</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_Upscaling_layout">
-               <item>
-                <widget class="QComboBox" name="outputScalingMode"/>
-               </item>
-               <item>
-                <widget class="Line" name="line">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
+                  </item>
+                 </layout>
                 </widget>
                </item>
                <item>
-                <widget class="QWidget" name="fsrSharpeningStrengthWidget" native="true">
-                 <layout class="QVBoxLayout" name="fsrSharpeningWidgetLayout">
+                <spacer name="coreTabMiddleLayoutSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="coreTabRightLayout" stretch="0,0,0">
+               <item>
+                <widget class="QGroupBox" name="gb_spu_threads">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Preferred SPU Threads</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_spu_threads_layout">
+                  <item>
+                   <widget class="QComboBox" name="preferredSPUThreads"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_threadsched">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Thread Scheduler</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_threadsched_layout">
+                  <item>
+                   <widget class="QComboBox" name="threadsched"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="coreTabRightLayoutSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="coreTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="gpuTab">
+      <attribute name="title">
+       <string>GPU</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="gpuTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="gpuTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="gpuTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1031</width>
+            <height>716</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="gpuTabScrollContentsLayout">
+           <item>
+            <layout class="QHBoxLayout" name="gpuTabLayout" stretch="1,1,1">
+             <item>
+              <layout class="QVBoxLayout" name="gpuTabLayoutLeft">
+               <item>
+                <widget class="QGroupBox" name="gb_renderer">
+                 <property name="title">
+                  <string>Renderer</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_renderer_layout">
+                  <item>
+                   <widget class="QComboBox" name="renderBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_graphicsAdapter">
+                 <property name="title">
+                  <string>Graphics Device</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_graphicsAdapter_layout">
+                  <item>
+                   <widget class="QComboBox" name="graphicsAdapterBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QWidget" name="widget_gpu_top" native="true">
+                 <layout class="QHBoxLayout" name="widget_gpu_top_layout" stretch="1,1">
                   <property name="leftMargin">
                    <number>0</number>
                   </property>
@@ -815,61 +392,2193 @@
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QLabel" name="fsrSharpeningStrengthLabel">
+                   <widget class="QGroupBox" name="gb_aspectRatio">
+                    <property name="title">
+                     <string>Aspect Ratio</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_aspectRatio_layout">
+                     <item>
+                      <widget class="QComboBox" name="aspectBox"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="gb_frameLimit">
+                    <property name="title">
+                     <string>Framelimit</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_frameLimit_layout">
+                     <item>
+                      <widget class="QComboBox" name="frameLimitBox"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QWidget" name="widget_gpu_bottom" native="true">
+                 <layout class="QHBoxLayout" name="widget_gpu_bottom_layout" stretch="1,1">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QGroupBox" name="gb_anisotropicFilter">
+                    <property name="title">
+                     <string>Anisotropic Filter</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_anisotropicFilter_layout">
+                     <item>
+                      <widget class="QComboBox" name="anisotropicFilterOverride"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="gb_antiAliasing">
+                    <property name="title">
+                     <string>Anti-Aliasing (MSAA)</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gb_antiAliasing_layout">
+                     <item>
+                      <widget class="QComboBox" name="antiAliasing"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QWidget" name="widget_gpu_3" native="true">
+                 <layout class="QHBoxLayout" name="widget_gpu_3_layout" stretch="1,1">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QGroupBox" name="gbZCULL">
+                    <property name="title">
+                     <string>ZCULL Accuracy</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gbZCULL_layout">
+                     <item>
+                      <widget class="QComboBox" name="zcullPrecisionMode"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="gbShaderPrecision">
+                    <property name="title">
+                     <string>Shader Quality</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gbShaderPrecision_layout">
+                     <item>
+                      <widget class="QComboBox" name="shaderPrecision"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QWidget" name="widget_gpu_4" native="true">
+                 <layout class="QHBoxLayout" name="widget_gpu_4_layout" stretch="1">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QGroupBox" name="gbVsync">
+                    <property name="title">
+                     <string>Vsync</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="gbVsync_layout">
+                     <item>
+                      <widget class="QComboBox" name="vsyncMode"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_stereo">
+                 <property name="title">
+                  <string>3D</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_stereo_layout">
+                  <item>
+                   <widget class="QCheckBox" name="stereoRenderEnabled">
+                    <property name="text">
+                     <string>Enable 3D Support</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="stereoRenderMode"/>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="gb_anaglyph_settings">
+                    <property name="title">
+                     <string>Anaglyph Settings</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="layout_gb_anaglyph_settings">
+                     <item>
+                      <widget class="QPushButton" name="pb_anaglyph_settings">
+                       <property name="text">
+                        <string>Configure</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="gb_screen_size">
+                    <property name="title">
+                     <string>Screen Size (Inch)</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="layout_gb_screen_size">
+                     <item>
+                      <widget class="QSpinBox" name="sb_screen_size"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="gpu_tab_layout_right_spacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="gpuTabLayoutMiddle">
+               <item>
+                <widget class="QGroupBox" name="gb_default_resolution">
+                 <property name="title">
+                  <string>Default Resolution</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_default_resolution_layout">
+                  <item>
+                   <widget class="QComboBox" name="resBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="layout_resolution_scale">
+                 <property name="spacing">
+                  <number>6</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QGroupBox" name="gb_resolutionScale">
+                   <property name="title">
+                    <string>Resolution Scale (Disable Strict Mode)</string>
+                   </property>
+                   <layout class="QVBoxLayout" name="gb_resolutionScale_layout">
+                    <item>
+                     <widget class="QWidget" name="resolutionScaleLayoutTop" native="true">
+                      <layout class="QHBoxLayout" name="horizontalLayout_23" stretch="0,1,0">
+                       <property name="spacing">
+                        <number>12</number>
+                       </property>
+                       <property name="leftMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="topMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="rightMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="bottomMargin">
+                        <number>0</number>
+                       </property>
+                       <item>
+                        <widget class="QLabel" name="resolutionScaleMin">
+                         <property name="text">
+                          <string>25</string>
+                         </property>
+                         <property name="alignment">
+                          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSlider" name="resolutionScale">
+                         <property name="orientation">
+                          <enum>Qt::Orientation::Horizontal</enum>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QLabel" name="resolutionScaleMax">
+                         <property name="text">
+                          <string>800</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                    <item>
+                     <layout class="QHBoxLayout" name="resolutionScaleLayoutBottom" stretch="1,0">
+                      <item>
+                       <widget class="QLabel" name="resolutionScaleVal">
+                        <property name="text">
+                         <string>0</string>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignmentFlag::AlignCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QPushButton" name="resolutionScaleReset">
+                        <property name="text">
+                         <string>Reset</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="gb_minimumScalableDimension">
+                   <property name="title">
+                    <string>Resolution Scale Threshold</string>
+                   </property>
+                   <layout class="QVBoxLayout" name="gb_minimumScalableDimension_layout">
+                    <item>
+                     <layout class="QHBoxLayout" name="minimumScalableDimensionLayoutTop" stretch="0,1,0">
+                      <property name="spacing">
+                       <number>12</number>
+                      </property>
+                      <item>
+                       <widget class="QLabel" name="minimumScalableDimensionMin">
+                        <property name="text">
+                         <string>1</string>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QSlider" name="minimumScalableDimension">
+                        <property name="orientation">
+                         <enum>Qt::Orientation::Horizontal</enum>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLabel" name="minimumScalableDimensionMax">
+                        <property name="text">
+                         <string>1024</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </item>
+                    <item>
+                     <layout class="QHBoxLayout" name="minimumScalableDimensionLayoutBottom" stretch="1,0">
+                      <item>
+                       <widget class="QLabel" name="minimumScalableDimensionVal">
+                        <property name="text">
+                         <string>1x1</string>
+                        </property>
+                        <property name="alignment">
+                         <set>Qt::AlignmentFlag::AlignCenter</set>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QPushButton" name="minimumScalableDimensionReset">
+                        <property name="text">
+                         <string>Reset</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_outputScaling">
+                 <property name="title">
+                  <string>Output Scaling</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_Upscaling_layout">
+                  <item>
+                   <widget class="QComboBox" name="outputScalingMode"/>
+                  </item>
+                  <item>
+                   <widget class="Line" name="line">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="fsrSharpeningStrengthWidget" native="true">
+                    <layout class="QVBoxLayout" name="fsrSharpeningWidgetLayout">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="fsrSharpeningStrengthLabel">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="text">
+                        <string>RCAS Sharpening Strength</string>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
+                       </property>
+                       <property name="margin">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <layout class="QHBoxLayout" name="fsrSharpeningLayoutTop">
+                       <item>
+                        <widget class="QLabel" name="minSharpeningVal">
+                         <property name="text">
+                          <string>0</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QSlider" name="fsrSharpeningStrength">
+                         <property name="orientation">
+                          <enum>Qt::Orientation::Horizontal</enum>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QLabel" name="maxSharpeningVal">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="text">
+                          <string>100</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <layout class="QHBoxLayout" name="fsrSharpeningLayoutBottom" stretch="1,0">
+                       <item>
+                        <widget class="QLabel" name="fsrSharpeningStrengthVal">
+                         <property name="text">
+                          <string>0</string>
+                         </property>
+                         <property name="alignment">
+                          <set>Qt::AlignmentFlag::AlignCenter</set>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QPushButton" name="fsrSharpeningStrengthReset">
+                         <property name="text">
+                          <string>Reset</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="gpu_tab_layout_middle_spacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="gpuTabLayoutRight">
+               <property name="rightMargin">
+                <number>12</number>
+               </property>
+               <property name="bottomMargin">
+                <number>12</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="gb_shader_mode">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>123</height>
+                  </size>
+                 </property>
+                 <property name="title">
+                  <string>Shader Mode</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout">
+                  <item>
+                   <widget class="QRadioButton" name="rb_legacy_recompiler">
+                    <property name="text">
+                     <string notr="true">Legacy (single threaded)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="rb_async_recompiler">
+                    <property name="text">
+                     <string notr="true">Async (multi threaded)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="rb_async_with_shader_interpreter">
+                    <property name="text">
+                     <string notr="true">Async with Shader Interpreter</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="rb_shader_interpreter_only">
+                    <property name="text">
+                     <string notr="true">Shader Interpreter only</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_additional_settings">
+                 <property name="title">
+                  <string>Additional Settings</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_additional_settings_layout">
+                  <item>
+                   <widget class="QCheckBox" name="dumpColor">
+                    <property name="text">
+                     <string>Write Color Buffers</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="strictModeRendering">
+                    <property name="text">
+                     <string>Strict Rendering Mode</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="stretchToDisplayArea">
+                    <property name="text">
+                     <string>Stretch To Display Area</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="multithreadedRSX">
+                    <property name="text">
+                     <string>Multithreaded RSX</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="asyncTextureStreaming">
+                    <property name="text">
+                     <string>Asynchronous Texture Streaming</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="additional_settings_spacer">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="gpuTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="audioTab">
+      <attribute name="title">
+       <string>Audio</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="audioTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="audioTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="audioTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1031</width>
+            <height>716</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="audioTabScrollContentsLayout">
+           <item>
+            <layout class="QHBoxLayout" name="audioTabLayoutTop" stretch="1,1,1">
+             <item>
+              <layout class="QVBoxLayout" name="audioTabLayoutTopLeft">
+               <item>
+                <widget class="QGroupBox" name="gb_audio_out">
+                 <property name="title">
+                  <string>Audio Out</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_out_layout">
+                  <item>
+                   <widget class="QComboBox" name="audioOutBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_audio_format">
+                 <property name="title">
+                  <string>Audio Format</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_format_layout">
+                  <item>
+                   <widget class="QComboBox" name="combo_audio_format"/>
+                  </item>
+                  <item>
+                   <widget class="QListWidget" name="list_audio_formats">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
                     </property>
+                    <property name="selectionMode">
+                     <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_audio_settings">
+                 <property name="title">
+                  <string>Audio Settings</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_settings_layout">
+                  <item>
+                   <widget class="QCheckBox" name="convert">
                     <property name="text">
-                     <string>RCAS Sharpening Strength</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
-                    </property>
-                    <property name="margin">
-                     <number>1</number>
+                     <string>Convert to 16-bit</string>
                     </property>
                    </widget>
                   </item>
                   <item>
-                   <layout class="QHBoxLayout" name="fsrSharpeningLayoutTop">
+                   <widget class="QCheckBox" name="audioDump">
+                    <property name="text">
+                     <string>Dump to File</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="spacer_audio_settings">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacerAudioLeft">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="audioTabLayoutTopMiddle">
+               <item>
+                <widget class="QGroupBox" name="gb_audio_device">
+                 <property name="title">
+                  <string>Audio Device</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_device_layout">
+                  <item>
+                   <widget class="QComboBox" name="audioDeviceBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_audio_channel_layout">
+                 <property name="title">
+                  <string>Audio Output Format</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_channel_layout_layout">
+                  <item>
+                   <widget class="QComboBox" name="combo_audio_channel_layout"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_audio_provider">
+                 <property name="title">
+                  <string>Audio Provider</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_provider_layout">
+                  <item>
+                   <widget class="QComboBox" name="audioProviderBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_audio_avport">
+                 <property name="title">
+                  <string>RSXAudio Avport</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_avport_layout">
+                  <item>
+                   <widget class="QComboBox" name="audioAvportBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_music_handler">
+                 <property name="title">
+                  <string>Music Handler</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_music_handler_layout">
+                  <item>
+                   <widget class="QComboBox" name="musicHandlerBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_audio_volume">
+                 <property name="title">
+                  <string>Volume</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_volume_layout">
+                  <item>
+                   <widget class="QWidget" name="master_volume" native="true">
+                    <layout class="QVBoxLayout" name="layout_master_volume">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="masterVolumeLabel">
+                       <property name="text">
+                        <string>Master: 0%</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="masterVolume">
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                       <property name="tickPosition">
+                        <enum>QSlider::TickPosition::TicksBelow</enum>
+                       </property>
+                       <property name="tickInterval">
+                        <number>50</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="spacer_audio_volume">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="audioTabLayoutTopRight">
+               <item>
+                <widget class="QGroupBox" name="gb_audio_buffering">
+                 <property name="title">
+                  <string>Buffering</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_audio_buffering_layout">
+                  <item>
+                   <widget class="QCheckBox" name="enableBuffering">
+                    <property name="text">
+                     <string>Enable Buffering</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="audio_buffer_duration" native="true">
+                    <layout class="QVBoxLayout" name="layout_audio_buffer_duration">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="audioBufferDurationLabel">
+                       <property name="text">
+                        <string>Audio Buffer Duration: 0ms</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="audioBufferDuration">
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                       <property name="tickPosition">
+                        <enum>QSlider::TickPosition::TicksBelow</enum>
+                       </property>
+                       <property name="tickInterval">
+                        <number>10</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="enableTimeStretching">
+                    <property name="text">
+                     <string>Enable Time Stretching</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="time_stretching_threshold" native="true">
+                    <layout class="QVBoxLayout" name="layout_time_stretching_threshold">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="timeStretchingThresholdLabel">
+                       <property name="text">
+                        <string>Time Stretching Threshold: 0%</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="timeStretchingThreshold">
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                       <property name="tickPosition">
+                        <enum>QSlider::TickPosition::TicksBelow</enum>
+                       </property>
+                       <property name="tickInterval">
+                        <number>10</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacerAudioRight">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="gb_microphone_settings">
+             <property name="title">
+              <string>Microphone Settings</string>
+             </property>
+             <layout class="QVBoxLayout" name="gb_microphone_settings_layout">
+              <item>
+               <layout class="QHBoxLayout" name="microphoneLayoutTop">
+                <item>
+                 <widget class="QLabel" name="microphoneLabel">
+                  <property name="text">
+                   <string>Microphone Type:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="microphoneBox"/>
+                </item>
+                <item>
+                 <spacer name="microphoneSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="microphoneLayoutBottom">
+                <item>
+                 <layout class="QVBoxLayout" name="microphoneLayoutLabel1and3">
+                  <item>
+                   <widget class="QLabel" name="microphone1Label">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Mic1:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="microphone3Label">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Mic3:</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="microphoneLayoutBox1and3">
+                  <item>
+                   <widget class="QComboBox" name="microphone1Box">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="microphone3Box">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="microphoneLayoutLabel2and4">
+                  <item>
+                   <widget class="QLabel" name="microphone2Label">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Mic2:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="microphone4Label">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Mic4:</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="microphoneLayoutBox2and4">
+                  <item>
+                   <widget class="QComboBox" name="microphone2Box">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="microphone4Box">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="audioTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="inputTab">
+      <attribute name="title">
+       <string>I/O</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="inputTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="inputTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="inputTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1031</width>
+            <height>716</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="inputTabScrollContentsLayout">
+           <item>
+            <layout class="QGridLayout" name="ioGridLayout" columnstretch="1,1,1">
+             <item row="2" column="2">
+              <widget class="QGroupBox" name="gb_ghltar_emulated">
+               <property name="title">
+                <string>Guitar Hero Live Emulated Guitar</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_ghltar_emulated_layout">
+                <item>
+                 <widget class="QComboBox" name="ghltarBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QGroupBox" name="gb_move_handler">
+               <property name="title">
+                <string>Move Handler</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_move_handler_layout">
+                <item>
+                 <widget class="QComboBox" name="moveBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QGroupBox" name="gb_turntable_emulated">
+               <property name="title">
+                <string>DJ Hero Emulated Turntable</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_turntable_emulated_layout">
+                <item>
+                 <widget class="QComboBox" name="turntableBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QGroupBox" name="gb_mouse_handler">
+               <property name="title">
+                <string>Mouse Handler</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_mouse_handler_layout">
+                <item>
+                 <widget class="QComboBox" name="mouseHandlerBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QGroupBox" name="gb_buzz_emulated">
+               <property name="title">
+                <string>Buzz! Emulated Controller</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_buzz_emulated_layout">
+                <item>
+                 <widget class="QComboBox" name="buzzBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QGroupBox" name="gb_keyboard_handler">
+               <property name="title">
+                <string>Keyboard Handler</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_keyboard_handler_layout">
+                <item>
+                 <widget class="QComboBox" name="keyboardHandlerBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QGroupBox" name="gb_pad_mode">
+               <property name="title">
+                <string>Pad Handler Mode</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_pad_mode_layout">
+                <item>
+                 <widget class="QComboBox" name="padModeBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QGroupBox" name="gb_camera_type">
+               <property name="title">
+                <string>Camera Input</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_camera_type_layout">
+                <item>
+                 <widget class="QComboBox" name="cameraTypeBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QGroupBox" name="gb_camera_flip">
+               <property name="title">
+                <string>Camera Flip</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_camera_flip_layout">
+                <item>
+                 <widget class="QComboBox" name="cameraFlipBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QGroupBox" name="gb_camera_id">
+               <property name="title">
+                <string>Camera</string>
+               </property>
+               <layout class="QVBoxLayout" name="camera_id_layout">
+                <item>
+                 <widget class="QComboBox" name="cameraIdBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QGroupBox" name="gb_camera_setting">
+               <property name="title">
+                <string>Camera Handler</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_camera_setting_layout">
+                <item>
+                 <widget class="QComboBox" name="cameraBox"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="3" column="2">
+              <widget class="QGroupBox" name="gb_midi_1">
+               <property name="title">
+                <string>Emulated MIDI Device 1</string>
+               </property>
+               <layout class="QVBoxLayout" name="midLayout1">
+                <item>
+                 <layout class="QHBoxLayout" name="midiHLayout1" stretch="1,2">
+                  <item>
+                   <widget class="QComboBox" name="midiTypeBox1"/>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="midiDeviceBox1"/>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <widget class="QGroupBox" name="gb_midi_3">
+               <property name="title">
+                <string>Emulated MIDI Device 3</string>
+               </property>
+               <layout class="QVBoxLayout" name="midLayout3">
+                <item>
+                 <layout class="QHBoxLayout" name="midiHLayout3" stretch="1,2">
+                  <item>
+                   <widget class="QComboBox" name="midiTypeBox3"/>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="midiDeviceBox3"/>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="4" column="2">
+              <widget class="QGroupBox" name="gb_midi_2">
+               <property name="title">
+                <string>Emulated MIDI Device 2</string>
+               </property>
+               <layout class="QVBoxLayout" name="midLayout2">
+                <item>
+                 <layout class="QHBoxLayout" name="midiHLayout2" stretch="1,2">
+                  <item>
+                   <widget class="QComboBox" name="midiTypeBox2"/>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="midiDeviceBox2"/>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item row="4" column="0" rowspan="2">
+              <widget class="QGroupBox" name="gb_additional_io_settings">
+               <property name="title">
+                <string>Additional Settings</string>
+               </property>
+               <layout class="QVBoxLayout" name="layout_gb_additional_io_settings">
+                <item>
+                 <widget class="QCheckBox" name="backgroundInputBox">
+                  <property name="text">
+                   <string>Enable Background Input</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="padConnectionBox">
+                  <property name="text">
+                   <string>Keep Pads Connected</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="showMoveCursorBox">
+                  <property name="text">
+                   <string>Show PS Move Cursor</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="lockOverlayInputToPlayerOne">
+                  <property name="text">
+                   <string>Lock Overlay Input To Player One</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="loadSdlMappings">
+                  <property name="text">
+                   <string>Use SDL GameController Database</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="mouseBasedGyroBox">
+                  <property name="text">
+                   <string>Enable Mouse-based Gyro</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacerIoAdditionalSettings">
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="inputTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="systemTab">
+      <attribute name="title">
+       <string>System</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="systemTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="systemTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="systemTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1031</width>
+            <height>716</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="systemTabScrollContentsLayout">
+           <item>
+            <layout class="QHBoxLayout" name="systemTabHorizontalLayout" stretch="1,1,1">
+             <item>
+              <layout class="QVBoxLayout" name="systemTabLeftLayout">
+               <item>
+                <widget class="QGroupBox" name="gb_sysLang">
+                 <property name="title">
+                  <string>Console Language</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_sysLang_layout">
+                  <item>
+                   <widget class="QComboBox" name="sysLangBox"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_console_region">
+                 <property name="title">
+                  <string>Console Region</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_console_region_layout">
+                  <item>
+                   <widget class="QComboBox" name="console_region"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_enterButtonAssignment">
+                 <property name="title">
+                  <string>Enter Button Assignment</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_enterButtonAssignment_layout">
+                  <item>
+                   <widget class="QRadioButton" name="enterButtonAssignCircle">
+                    <property name="text">
+                     <string notr="true">Enter with the Circle button</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QRadioButton" name="enterButtonAssignCross">
+                    <property name="text">
+                     <string notr="true">Enter with the Cross button</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_DiskCacheClearing">
+                 <property name="title">
+                  <string>Disk Cache</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_DiskCacheClearing_layout">
+                  <item>
+                   <widget class="QCheckBox" name="enableCacheClearing">
+                    <property name="text">
+                     <string>Clear cache automatically</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="maximumCacheSizeLabel">
+                    <property name="text">
+                     <string>Cache size: 3072 MB</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSlider" name="maximumCacheSize">
+                    <property name="pageStep">
+                     <number>512</number>
+                    </property>
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="tickPosition">
+                     <enum>QSlider::TickPosition::TicksBelow</enum>
+                    </property>
+                    <property name="tickInterval">
+                     <number>1024</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="systemTabLeftVerticalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="systemTabMiddleLayout">
+               <item>
+                <widget class="QGroupBox" name="gb_keyboardType">
+                 <property name="title">
+                  <string>Keyboard Type</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_keyboardType">
+                  <item>
+                   <widget class="QComboBox" name="keyboardType"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_dateFormat">
+                 <property name="title">
+                  <string>Date Format</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_dateFormat">
+                  <item>
+                   <widget class="QComboBox" name="dateFormat"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_timeFormat">
+                 <property name="title">
+                  <string>Time Format</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_timeFormat">
+                  <item>
+                   <widget class="QComboBox" name="timeFormat"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_console_time">
+                 <property name="title">
+                  <string>Console Time</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_2">
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout">
                     <item>
-                     <widget class="QLabel" name="minSharpeningVal">
-                      <property name="text">
-                       <string>0</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QSlider" name="fsrSharpeningStrength">
-                      <property name="orientation">
-                       <enum>Qt::Orientation::Horizontal</enum>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLabel" name="maxSharpeningVal">
+                     <widget class="QDateTimeEdit" name="console_time_edit">
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                        <horstretch>0</horstretch>
+                       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                        <horstretch>10</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
                       </property>
+                      <property name="layoutDirection">
+                       <enum>Qt::LayoutDirection::LeftToRight</enum>
+                      </property>
+                      <property name="wrapping">
+                       <bool>false</bool>
+                      </property>
+                      <property name="frame">
+                       <bool>true</bool>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
+                      </property>
+                      <property name="readOnly">
+                       <bool>false</bool>
+                      </property>
+                      <property name="buttonSymbols">
+                       <enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
+                      </property>
+                      <property name="accelerated">
+                       <bool>true</bool>
+                      </property>
+                      <property name="showGroupSeparator" stdset="0">
+                       <bool>false</bool>
+                      </property>
+                      <property name="calendarPopup">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="console_time_reset">
                       <property name="text">
-                       <string>100</string>
+                       <string>Set to Now</string>
                       </property>
                      </widget>
                     </item>
                    </layout>
                   </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="systemTabMiddleVerticalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="systemTabRightLayout">
+               <item>
+                <widget class="QGroupBox" name="gb_homebrew">
+                 <property name="title">
+                  <string>Homebrew</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_homebrew_layout">
                   <item>
-                   <layout class="QHBoxLayout" name="fsrSharpeningLayoutBottom" stretch="1,0">
+                   <widget class="QCheckBox" name="enableHostRoot">
+                    <property name="text">
+                     <string>Enable /host_root/</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="emptyHdd0Tmp">
+                    <property name="text">
+                     <string>Empty /dev_hdd0/tmp/</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="systemTabRightVerticalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="systemTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="networkTab">
+      <attribute name="title">
+       <string>Network</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="networkTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="networkTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="networkTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1031</width>
+            <height>716</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="networkTabScrollContentsLayout">
+           <item>
+            <layout class="QHBoxLayout" name="networkTabLayout" stretch="0,0">
+             <item>
+              <widget class="QGroupBox" name="gb_network_status">
+               <property name="title">
+                <string>Network Configuration</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_network_status_layout" stretch="0,0,0,0,0,0,0">
+                <item>
+                 <widget class="QGroupBox" name="gb_netStatusBox">
+                  <property name="title">
+                   <string>Network Status</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_netStatusBox_layout">
+                   <item>
+                    <widget class="QComboBox" name="netStatusBox"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_edit_dns">
+                  <property name="title">
+                   <string>DNS</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_edit_dns_layout">
+                   <item>
+                    <widget class="QLineEdit" name="edit_dns">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_edit_swaps">
+                  <property name="title">
+                   <string>IP/Hosts switches</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_edit_swaps_layout">
+                   <item>
+                    <widget class="QLineEdit" name="edit_swaps">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_edit_bind">
+                  <property name="title">
+                   <string>Bind address</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_edit_bind_layout">
+                   <item>
+                    <widget class="QLineEdit" name="edit_bind">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="enable_upnp">
+                  <property name="text">
+                   <string>Enable UPNP</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="derive_mac_from_psid">
+                  <property name="text">
+                   <string>Derive ethernet address from PSID</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="networkTabSpacerLeft">
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QGroupBox" name="gb_psn_config">
+               <property name="title">
+                <string>PSN Configuration</string>
+               </property>
+               <layout class="QVBoxLayout" name="gb_psn_config_layout">
+                <item>
+                 <widget class="QGroupBox" name="gb_psnStatusBox">
+                  <property name="title">
+                   <string>PSN Status</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_psnStatusBox_layout">
+                   <item>
+                    <widget class="QComboBox" name="psnStatusBox"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_psnCountryBox">
+                  <property name="title">
+                   <string>Country</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_psnCountryBox_layout">
+                   <item>
+                    <widget class="QComboBox" name="psnCountryBox"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="enable_clans">
+                  <property name="text">
+                   <string>Enable Clans</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="networkTabSpacerRight">
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="networkTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="advancedTab">
+      <attribute name="title">
+       <string>Advanced</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="advancedTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="advancedTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="advancedTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1019</width>
+            <height>737</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="advancedTabScrollContentsLayout">
+           <item>
+            <layout class="QHBoxLayout" name="advancedTabLayout" stretch="1,1,1">
+             <item>
+              <layout class="QVBoxLayout" name="advancedTabLayoutLeft">
+               <item>
+                <widget class="QGroupBox" name="gb_advanced_core">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Core</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_advanced_core_layout">
+                  <item>
+                   <widget class="QCheckBox" name="accurateRSXAccess">
+                    <property name="text">
+                     <string>Accurate RSX Reservation Access</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="accurateSpuDMA">
+                    <property name="text">
+                     <string>Accurate SPU DMA</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="antiCheatSavestates">
+                    <property name="text">
+                     <string>Anti-Cheat Savestates Mode</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="debugConsoleMode">
+                    <property name="text">
+                     <string>Debug Console Mode</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="setDAZandFTZ">
+                    <property name="text">
+                     <string>PPU Set DAZ and FTZ</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="mfcDelayCommand">
+                    <property name="text">
+                     <string>Delay each odd MFC Command</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="disableSpinOptimization">
+                    <property name="text">
+                     <string>Disable SPU GETLLAR Spin Optimization</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="enableSpuEventsBusyLoop">
+                    <property name="text">
+                     <string>Enable SPU Events Busy Loop</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="spuLoopDetection">
+                    <property name="text">
+                     <string>Enable SPU loop detection</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="ppuReservationPrority">
+                    <property name="text">
+                     <string>PPU Reservation Priority</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="llvmPrecompilation">
+                    <property name="text">
+                     <string>PPU/SPU LLVM Precompilation</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="silenceAllLogs">
+                    <property name="text">
+                     <string>Silence All Logs</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="compatibleSavestates">
+                    <property name="text">
+                     <string>SPU Compatible Savestates Mode</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_sleep_timers_accuracy">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Sleep Timers Accuracy</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_sleep_timers_accuracy_layout">
+                  <item>
+                   <widget class="QComboBox" name="sleepTimersAccuracy"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_max_spurs_threads">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Maximum Number of SPURS Threads</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_max_spurs_threads_layout">
+                  <item>
+                   <widget class="QComboBox" name="maxSPURSThreads"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_clockScale">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Clocks Scale</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_clockScale_layout">
+                  <item>
+                   <widget class="QSlider" name="clockScale">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="clockScaleLayout" stretch="1,0">
                     <item>
-                     <widget class="QLabel" name="fsrSharpeningStrengthVal">
+                     <widget class="QLabel" name="clockScaleText">
                       <property name="text">
-                       <string>0</string>
+                       <string>100%</string>
                       </property>
                       <property name="alignment">
                        <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -877,7 +2586,82 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="fsrSharpeningStrengthReset">
+                     <widget class="QPushButton" name="clockScaleReset">
+                      <property name="text">
+                       <string>Reset</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="advancedTabSpacerLeft">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="advancedTabLayoutMiddle">
+               <item>
+                <widget class="QGroupBox" name="gb_libs">
+                 <property name="title">
+                  <string>Firmware Libraries</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_libs_layout">
+                  <item>
+                   <widget class="QListWidget" name="hleList">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="selectionMode">
+                     <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QListWidget" name="lleList">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="selectionMode">
+                     <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="gb_lleLibs_layout" stretch="1,0">
+                    <property name="spacing">
+                     <number>6</number>
+                    </property>
+                    <property name="sizeConstraint">
+                     <enum>QLayout::SizeConstraint::SetNoConstraint</enum>
+                    </property>
+                    <item>
+                     <widget class="QLineEdit" name="searchBox"/>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="resetLleList">
                       <property name="text">
                        <string>Reset</string>
                       </property>
@@ -889,2609 +2673,785 @@
                 </widget>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="gpu_tab_layout_middle_spacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="gpuTabLayoutRight">
-            <property name="rightMargin">
-             <number>12</number>
-            </property>
-            <property name="bottomMargin">
-             <number>12</number>
-            </property>
-            <item>
-             <widget class="QGroupBox" name="gb_shader_mode">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>123</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Shader Mode</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout">
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="advancedTabLayoutRight">
                <item>
-                <widget class="QRadioButton" name="rb_legacy_recompiler">
-                 <property name="text">
-                  <string notr="true">Legacy (single threaded)</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="rb_async_recompiler">
-                 <property name="text">
-                  <string notr="true">Async (multi threaded)</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="rb_async_with_shader_interpreter">
-                 <property name="text">
-                  <string notr="true">Async with Shader Interpreter</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="rb_shader_interpreter_only">
-                 <property name="text">
-                  <string notr="true">Shader Interpreter only</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_additional_settings">
-              <property name="title">
-               <string>Additional Settings</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-              </property>
-              <layout class="QVBoxLayout" name="gb_additional_settings_layout">
-               <item>
-                <widget class="QCheckBox" name="dumpColor">
-                 <property name="text">
-                  <string>Write Color Buffers</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="strictModeRendering">
-                 <property name="text">
-                  <string>Strict Rendering Mode</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="stretchToDisplayArea">
-                 <property name="text">
-                  <string>Stretch To Display Area</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="multithreadedRSX">
-                 <property name="text">
-                  <string>Multithreaded RSX</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="asyncTextureStreaming">
-                 <property name="text">
-                  <string>Asynchronous Texture Streaming</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="additional_settings_spacer">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="gpuTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_gpu">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QHBoxLayout" name="gb_description_gpu_layout">
-           <item>
-            <widget class="QPlainTextEdit" name="description_gpu">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="audioTab">
-       <attribute name="title">
-        <string>Audio</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="audioTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="audioTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
-          </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="audioTabScrollContents">
-           <layout class="QVBoxLayout" name="audioTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="audioTabLayoutTop" stretch="1,1,1">
-          <item>
-           <layout class="QVBoxLayout" name="audioTabLayoutTopLeft">
-            <item>
-             <widget class="QGroupBox" name="gb_audio_out">
-              <property name="title">
-               <string>Audio Out</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_out_layout">
-               <item>
-                <widget class="QComboBox" name="audioOutBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_audio_format">
-              <property name="title">
-               <string>Audio Format</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_format_layout">
-               <item>
-                <widget class="QComboBox" name="combo_audio_format"/>
-               </item>
-               <item>
-                <widget class="QListWidget" name="list_audio_formats">
+                <widget class="QGroupBox" name="gb_advanced_gpu">
                  <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
                  </property>
-                 <property name="selectionMode">
-                  <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+                 <property name="title">
+                  <string>GPU</string>
                  </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_audio_settings">
-              <property name="title">
-               <string>Audio Settings</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_settings_layout">
-               <item>
-                <widget class="QCheckBox" name="convert">
-                 <property name="text">
-                  <string>Convert to 16-bit</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="audioDump">
-                 <property name="text">
-                  <string>Dump to File</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="spacer_audio_settings">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacerAudioLeft">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="audioTabLayoutTopMiddle">
-            <item>
-             <widget class="QGroupBox" name="gb_audio_device">
-              <property name="title">
-               <string>Audio Device</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_device_layout">
-               <item>
-                <widget class="QComboBox" name="audioDeviceBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_audio_channel_layout">
-              <property name="title">
-               <string>Audio Output Format</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_channel_layout_layout">
-               <item>
-                <widget class="QComboBox" name="combo_audio_channel_layout"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_audio_provider">
-              <property name="title">
-               <string>Audio Provider</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_provider_layout">
-               <item>
-                <widget class="QComboBox" name="audioProviderBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_audio_avport">
-              <property name="title">
-               <string>RSXAudio Avport</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_avport_layout">
-               <item>
-                <widget class="QComboBox" name="audioAvportBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_music_handler">
-              <property name="title">
-               <string>Music Handler</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_music_handler_layout">
-               <item>
-                <widget class="QComboBox" name="musicHandlerBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_audio_volume">
-              <property name="title">
-               <string>Volume</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_volume_layout">
-               <item>
-                <widget class="QWidget" name="master_volume" native="true">
-                 <layout class="QVBoxLayout" name="layout_master_volume">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
+                 <layout class="QVBoxLayout" name="gb_advanced_gpu_layout">
                   <item>
-                   <widget class="QLabel" name="masterVolumeLabel">
+                   <widget class="QCheckBox" name="allowHostGPULabels">
                     <property name="text">
-                     <string>Master: 0%</string>
+                     <string>Allow Host GPU Labels (Experimental)</string>
                     </property>
                    </widget>
                   </item>
                   <item>
-                   <widget class="QSlider" name="masterVolume">
+                   <widget class="QCheckBox" name="disableMslFastMath">
+                    <property name="text">
+                     <string>Disable MSL Fast Math</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="disableVertexCache">
+                    <property name="text">
+                     <string>Disable Vertex Cache</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="emulateDepthCompare">
+                    <property name="text">
+                     <string>Emulate Special Depth Comparison</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="forceHwMSAAResolve">
+                    <property name="text">
+                     <string>Force Hardware MSAA Resolve</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="handleTiledMemory">
+                    <property name="text">
+                     <string>Handle RSX Memory Tiling</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="readDepth">
+                    <property name="text">
+                     <string>Read Depth Buffer</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="readColor">
+                    <property name="text">
+                     <string>Read Color Buffers</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="useReBAR">
+                    <property name="text">
+                     <string>Use Re-BAR memory for GPU uploads</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="dumpDepth">
+                    <property name="text">
+                     <string>Write Depth Buffer</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_rsx_fifo_accuracy">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>RSX FIFO Accuracy</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_rsx_fifo_accuracy_layout">
+                  <item>
+                   <widget class="QComboBox" name="FIFOAccuracy"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_exclusiveFullscreen">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Exclusive Fullscreen Mode</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_exclusiveFullscreen_layout">
+                  <item>
+                   <widget class="QComboBox" name="exclusiveFullscreenMode"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_wakeupDelay">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>Driver Wake-Up Delay</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_wakeupDelay_layout">
+                  <item>
+                   <widget class="QSlider" name="wakeupDelay">
                     <property name="orientation">
                      <enum>Qt::Orientation::Horizontal</enum>
                     </property>
-                    <property name="tickPosition">
-                     <enum>QSlider::TickPosition::TicksBelow</enum>
-                    </property>
-                    <property name="tickInterval">
-                     <number>50</number>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <spacer name="spacer_audio_volume">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="audioTabLayoutTopRight">
-            <item>
-             <widget class="QGroupBox" name="gb_audio_buffering">
-              <property name="title">
-               <string>Buffering</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_audio_buffering_layout">
-               <item>
-                <widget class="QCheckBox" name="enableBuffering">
-                 <property name="text">
-                  <string>Enable Buffering</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="audio_buffer_duration" native="true">
-                 <layout class="QVBoxLayout" name="layout_audio_buffer_duration">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="audioBufferDurationLabel">
-                    <property name="text">
-                     <string>Audio Buffer Duration: 0ms</string>
-                    </property>
                    </widget>
                   </item>
                   <item>
-                   <widget class="QSlider" name="audioBufferDuration">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                    <property name="tickPosition">
-                     <enum>QSlider::TickPosition::TicksBelow</enum>
-                    </property>
-                    <property name="tickInterval">
-                     <number>10</number>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="enableTimeStretching">
-                 <property name="text">
-                  <string>Enable Time Stretching</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="time_stretching_threshold" native="true">
-                 <layout class="QVBoxLayout" name="layout_time_stretching_threshold">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="timeStretchingThresholdLabel">
-                    <property name="text">
-                     <string>Time Stretching Threshold: 0%</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSlider" name="timeStretchingThreshold">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                    <property name="tickPosition">
-                     <enum>QSlider::TickPosition::TicksBelow</enum>
-                    </property>
-                    <property name="tickInterval">
-                     <number>10</number>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <spacer name="verticalSpacerAudioRight">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_microphone_settings">
-          <property name="title">
-           <string>Microphone Settings</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_microphone_settings_layout">
-           <item>
-            <layout class="QHBoxLayout" name="microphoneLayoutTop">
-             <item>
-              <widget class="QLabel" name="microphoneLabel">
-               <property name="text">
-                <string>Microphone Type:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="microphoneBox"/>
-             </item>
-             <item>
-              <spacer name="microphoneSpacer">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="microphoneLayoutBottom">
-             <item>
-              <layout class="QVBoxLayout" name="microphoneLayoutLabel1and3">
-               <item>
-                <widget class="QLabel" name="microphone1Label">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Mic1:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="microphone3Label">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Mic3:</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="microphoneLayoutBox1and3">
-               <item>
-                <widget class="QComboBox" name="microphone1Box">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="microphone3Box">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="microphoneLayoutLabel2and4">
-               <item>
-                <widget class="QLabel" name="microphone2Label">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Mic2:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="microphone4Label">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Mic4:</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="microphoneLayoutBox2and4">
-               <item>
-                <widget class="QComboBox" name="microphone2Box">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="microphone4Box">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <spacer name="audioTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_audio">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_description_audio_layout">
-           <item>
-            <widget class="QPlainTextEdit" name="description_audio">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="inputTab">
-       <attribute name="title">
-        <string>I/O</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="inputTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="inputTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
-          </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="inputTabScrollContents">
-           <layout class="QVBoxLayout" name="inputTabScrollContentsLayout">
-        <item>
-         <layout class="QGridLayout" name="ioGridLayout" columnstretch="1,1,1">
-          <item row="2" column="2">
-           <widget class="QGroupBox" name="gb_ghltar_emulated">
-            <property name="title">
-             <string>Guitar Hero Live Emulated Guitar</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_ghltar_emulated_layout">
-             <item>
-              <widget class="QComboBox" name="ghltarBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QGroupBox" name="gb_move_handler">
-            <property name="title">
-             <string>Move Handler</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_move_handler_layout">
-             <item>
-              <widget class="QComboBox" name="moveBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QGroupBox" name="gb_turntable_emulated">
-            <property name="title">
-             <string>DJ Hero Emulated Turntable</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_turntable_emulated_layout">
-             <item>
-              <widget class="QComboBox" name="turntableBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QGroupBox" name="gb_mouse_handler">
-            <property name="title">
-             <string>Mouse Handler</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_mouse_handler_layout">
-             <item>
-              <widget class="QComboBox" name="mouseHandlerBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QGroupBox" name="gb_buzz_emulated">
-            <property name="title">
-             <string>Buzz! Emulated Controller</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_buzz_emulated_layout">
-             <item>
-              <widget class="QComboBox" name="buzzBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QGroupBox" name="gb_keyboard_handler">
-            <property name="title">
-             <string>Keyboard Handler</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_keyboard_handler_layout">
-             <item>
-              <widget class="QComboBox" name="keyboardHandlerBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QGroupBox" name="gb_pad_mode">
-            <property name="title">
-             <string>Pad Handler Mode</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_pad_mode_layout">
-             <item>
-              <widget class="QComboBox" name="padModeBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QGroupBox" name="gb_camera_type">
-            <property name="title">
-             <string>Camera Input</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_camera_type_layout">
-             <item>
-              <widget class="QComboBox" name="cameraTypeBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QGroupBox" name="gb_camera_flip">
-            <property name="title">
-             <string>Camera Flip</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_camera_flip_layout">
-             <item>
-              <widget class="QComboBox" name="cameraFlipBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QGroupBox" name="gb_camera_id">
-            <property name="title">
-             <string>Camera</string>
-            </property>
-            <layout class="QVBoxLayout" name="camera_id_layout">
-             <item>
-              <widget class="QComboBox" name="cameraIdBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QGroupBox" name="gb_camera_setting">
-            <property name="title">
-             <string>Camera Handler</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_camera_setting_layout">
-             <item>
-              <widget class="QComboBox" name="cameraBox"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QGroupBox" name="gb_midi_1">
-            <property name="title">
-             <string>Emulated MIDI Device 1</string>
-            </property>
-            <layout class="QVBoxLayout" name="midLayout1">
-             <item>
-              <layout class="QHBoxLayout" name="midiHLayout1" stretch="1,2">
-               <item>
-                <widget class="QComboBox" name="midiTypeBox1"/>
-               </item>
-               <item>
-                <widget class="QComboBox" name="midiDeviceBox1"/>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="5" column="2">
-           <widget class="QGroupBox" name="gb_midi_3">
-            <property name="title">
-             <string>Emulated MIDI Device 3</string>
-            </property>
-            <layout class="QVBoxLayout" name="midLayout3">
-             <item>
-              <layout class="QHBoxLayout" name="midiHLayout3" stretch="1,2">
-               <item>
-                <widget class="QComboBox" name="midiTypeBox3"/>
-               </item>
-               <item>
-                <widget class="QComboBox" name="midiDeviceBox3"/>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QGroupBox" name="gb_midi_2">
-            <property name="title">
-             <string>Emulated MIDI Device 2</string>
-            </property>
-            <layout class="QVBoxLayout" name="midLayout2">
-             <item>
-              <layout class="QHBoxLayout" name="midiHLayout2" stretch="1,2">
-               <item>
-                <widget class="QComboBox" name="midiTypeBox2"/>
-               </item>
-               <item>
-                <widget class="QComboBox" name="midiDeviceBox2"/>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="0" rowspan="2">
-           <widget class="QGroupBox" name="gb_additional_io_settings">
-            <property name="title">
-             <string>Additional Settings</string>
-            </property>
-            <layout class="QVBoxLayout" name="layout_gb_additional_io_settings">
-             <item>
-              <widget class="QCheckBox" name="backgroundInputBox">
-               <property name="text">
-                <string>Enable Background Input</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="padConnectionBox">
-               <property name="text">
-                <string>Keep Pads Connected</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="showMoveCursorBox">
-               <property name="text">
-                <string>Show PS Move Cursor</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="lockOverlayInputToPlayerOne">
-               <property name="text">
-                <string>Lock Overlay Input To Player One</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="loadSdlMappings">
-               <property name="text">
-                <string>Use SDL GameController Database</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="mouseBasedGyroBox">
-               <property name="text">
-                <string>Enable Mouse-based Gyro</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="verticalSpacerIoAdditionalSettings">
-               <property name="orientation">
-                <enum>Qt::Orientation::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="inputTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_io">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_description_io_layout">
-           <item>
-            <widget class="QPlainTextEdit" name="description_io">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="systemTab">
-       <attribute name="title">
-        <string>System</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="systemTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="systemTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
-          </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="systemTabScrollContents">
-           <layout class="QVBoxLayout" name="systemTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="systemTabHorizontalLayout" stretch="1,1,1">
-          <item>
-           <layout class="QVBoxLayout" name="systemTabLeftLayout">
-            <item>
-             <widget class="QGroupBox" name="gb_sysLang">
-              <property name="title">
-               <string>Console Language</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_sysLang_layout">
-               <item>
-                <widget class="QComboBox" name="sysLangBox"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_console_region">
-              <property name="title">
-               <string>Console Region</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_console_region_layout">
-               <item>
-                <widget class="QComboBox" name="console_region"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_enterButtonAssignment">
-              <property name="title">
-               <string>Enter Button Assignment</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_enterButtonAssignment_layout">
-               <item>
-                <widget class="QRadioButton" name="enterButtonAssignCircle">
-                 <property name="text">
-                  <string notr="true">Enter with the Circle button</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QRadioButton" name="enterButtonAssignCross">
-                 <property name="text">
-                  <string notr="true">Enter with the Cross button</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_DiskCacheClearing">
-              <property name="title">
-               <string>Disk Cache</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_DiskCacheClearing_layout">
-               <item>
-                <widget class="QCheckBox" name="enableCacheClearing">
-                 <property name="text">
-                  <string>Clear cache automatically</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="maximumCacheSizeLabel">
-                 <property name="text">
-                  <string>Cache size: 3072 MB</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSlider" name="maximumCacheSize">
-                 <property name="pageStep">
-                  <number>512</number>
-                 </property>
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                 <property name="tickPosition">
-                  <enum>QSlider::TickPosition::TicksBelow</enum>
-                 </property>
-                 <property name="tickInterval">
-                  <number>1024</number>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="systemTabLeftVerticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="systemTabMiddleLayout">
-            <item>
-             <widget class="QGroupBox" name="gb_keyboardType">
-              <property name="title">
-               <string>Keyboard Type</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_keyboardType">
-               <item>
-                <widget class="QComboBox" name="keyboardType"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_dateFormat">
-              <property name="title">
-               <string>Date Format</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_dateFormat">
-               <item>
-                <widget class="QComboBox" name="dateFormat"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_timeFormat">
-              <property name="title">
-               <string>Time Format</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_timeFormat">
-               <item>
-                <widget class="QComboBox" name="timeFormat"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_console_time">
-              <property name="title">
-               <string>Console Time</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_2">
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout">
-                 <item>
-                  <widget class="QDateTimeEdit" name="console_time_edit">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                     <horstretch>10</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="layoutDirection">
-                    <enum>Qt::LayoutDirection::LeftToRight</enum>
-                   </property>
-                   <property name="wrapping">
-                    <bool>false</bool>
-                   </property>
-                   <property name="frame">
-                    <bool>true</bool>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                   <property name="readOnly">
-                    <bool>false</bool>
-                   </property>
-                   <property name="buttonSymbols">
-                    <enum>QAbstractSpinBox::ButtonSymbols::UpDownArrows</enum>
-                   </property>
-                   <property name="accelerated">
-                    <bool>true</bool>
-                   </property>
-                   <property name="showGroupSeparator" stdset="0">
-                    <bool>false</bool>
-                   </property>
-                   <property name="calendarPopup">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="console_time_reset">
-                   <property name="text">
-                    <string>Set to Now</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="systemTabMiddleVerticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="systemTabRightLayout">
-            <item>
-             <widget class="QGroupBox" name="gb_homebrew">
-              <property name="title">
-               <string>Homebrew</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_homebrew_layout">
-               <item>
-                <widget class="QCheckBox" name="enableHostRoot">
-                 <property name="text">
-                  <string>Enable /host_root/</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="emptyHdd0Tmp">
-                 <property name="text">
-                  <string>Empty /dev_hdd0/tmp/</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="systemTabRightVerticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="systemTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_system">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QHBoxLayout" name="gb_description_system_layout">
-           <item>
-            <widget class="QPlainTextEdit" name="description_system">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="networkTab">
-       <attribute name="title">
-        <string>Network</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="networkTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="networkTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
-          </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="networkTabScrollContents">
-           <layout class="QVBoxLayout" name="networkTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="networkTabLayout" stretch="0,0">
-          <item>
-           <widget class="QGroupBox" name="gb_network_status">
-            <property name="title">
-             <string>Network Configuration</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_network_status_layout" stretch="0,0,0,0,0,0">
-             <item>
-              <widget class="QGroupBox" name="gb_netStatusBox">
-               <property name="title">
-                <string>Network Status</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_netStatusBox_layout">
-                <item>
-                 <widget class="QComboBox" name="netStatusBox"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_edit_dns">
-               <property name="title">
-                <string>DNS</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_edit_dns_layout">
-                <item>
-                 <widget class="QLineEdit" name="edit_dns">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_edit_swaps">
-               <property name="title">
-                <string>IP/Hosts switches</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_edit_swaps_layout">
-                <item>
-                 <widget class="QLineEdit" name="edit_swaps">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_edit_bind">
-               <property name="title">
-                <string>Bind address</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_edit_bind_layout">
-                <item>
-                 <widget class="QLineEdit" name="edit_bind">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="enable_upnp">
-               <property name="text">
-                <string>Enable UPNP</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="derive_mac_from_psid">
-               <property name="text">
-                <string>Derive ethernet address from PSID</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="networkTabSpacerLeft">
-               <property name="orientation">
-                <enum>Qt::Orientation::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="gb_psn_config">
-            <property name="title">
-             <string>PSN Configuration</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_psn_config_layout">
-             <item>
-              <widget class="QGroupBox" name="gb_psnStatusBox">
-               <property name="title">
-                <string>PSN Status</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_psnStatusBox_layout">
-                <item>
-                 <widget class="QComboBox" name="psnStatusBox"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_psnCountryBox">
-               <property name="title">
-                <string>Country</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_psnCountryBox_layout">
-                <item>
-                 <widget class="QComboBox" name="psnCountryBox"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="enable_clans">
-               <property name="text">
-                <string>Enable Clans</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="networkTabSpacerRight">
-               <property name="orientation">
-                <enum>Qt::Orientation::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="networkTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_network">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_description_network_layout">
-           <item>
-            <widget class="QPlainTextEdit" name="description_network">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="advancedTab">
-       <attribute name="title">
-        <string>Advanced</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="advancedTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="advancedTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
-          </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="advancedTabScrollContents">
-           <layout class="QVBoxLayout" name="advancedTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="advancedTabLayout" stretch="1,1,1">
-          <item>
-           <layout class="QVBoxLayout" name="advancedTabLayoutLeft">
-            <item>
-             <widget class="QGroupBox" name="gb_advanced_core">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Core</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_advanced_core_layout">
-               <item>
-                <widget class="QCheckBox" name="accurateRSXAccess">
-                 <property name="text">
-                  <string>Accurate RSX Reservation Access</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="accurateSpuDMA">
-                 <property name="text">
-                  <string>Accurate SPU DMA</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="antiCheatSavestates">
-                 <property name="text">
-                  <string>Anti-Cheat Savestates Mode</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="debugConsoleMode">
-                 <property name="text">
-                  <string>Debug Console Mode</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="setDAZandFTZ">
-                 <property name="text">
-                  <string>PPU Set DAZ and FTZ</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="mfcDelayCommand">
-                 <property name="text">
-                  <string>Delay each odd MFC Command</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="disableSpinOptimization">
-                 <property name="text">
-                  <string>Disable SPU GETLLAR Spin Optimization</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="enableSpuEventsBusyLoop">
-                 <property name="text">
-                  <string>Enable SPU Events Busy Loop</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="spuLoopDetection">
-                 <property name="text">
-                  <string>Enable SPU loop detection</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="ppuReservationPrority">
-                 <property name="text">
-                  <string>PPU Reservation Priority</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="llvmPrecompilation">
-                 <property name="text">
-                  <string>PPU/SPU LLVM Precompilation</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="silenceAllLogs">
-                 <property name="text">
-                  <string>Silence All Logs</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="compatibleSavestates">
-                 <property name="text">
-                  <string>SPU Compatible Savestates Mode</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_sleep_timers_accuracy">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Sleep Timers Accuracy</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_sleep_timers_accuracy_layout">
-               <item>
-                <widget class="QComboBox" name="sleepTimersAccuracy"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_max_spurs_threads">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Maximum Number of SPURS Threads</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_max_spurs_threads_layout">
-               <item>
-                <widget class="QComboBox" name="maxSPURSThreads"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_clockScale">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Clocks Scale</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_clockScale_layout">
-               <item>
-                <widget class="QSlider" name="clockScale">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="clockScaleLayout" stretch="1,0">
-                 <item>
-                  <widget class="QLabel" name="clockScaleText">
-                   <property name="text">
-                    <string>100%</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="clockScaleReset">
-                   <property name="text">
-                    <string>Reset</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="advancedTabSpacerLeft">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="advancedTabLayoutMiddle">
-            <item>
-             <widget class="QGroupBox" name="gb_libs">
-              <property name="title">
-               <string>Firmware Libraries</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_libs_layout">
-               <item>
-                <widget class="QListWidget" name="hleList">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="selectionMode">
-                  <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QListWidget" name="lleList">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="selectionMode">
-                  <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="gb_lleLibs_layout" stretch="1,0">
-                 <property name="spacing">
-                  <number>6</number>
-                 </property>
-                 <property name="sizeConstraint">
-                  <enum>QLayout::SizeConstraint::SetNoConstraint</enum>
-                 </property>
-                 <item>
-                  <widget class="QLineEdit" name="searchBox"/>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="resetLleList">
-                   <property name="text">
-                    <string>Reset</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="advancedTabLayoutRight">
-            <item>
-             <widget class="QGroupBox" name="gb_advanced_gpu">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>GPU</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_advanced_gpu_layout">
-               <item>
-                <widget class="QCheckBox" name="allowHostGPULabels">
-                 <property name="text">
-                  <string>Allow Host GPU Labels (Experimental)</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="disableMslFastMath">
-                 <property name="text">
-                  <string>Disable MSL Fast Math</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="disableVertexCache">
-                 <property name="text">
-                  <string>Disable Vertex Cache</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="emulateDepthCompare">
-                 <property name="text">
-                  <string>Emulate Special Depth Comparison</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="forceHwMSAAResolve">
-                 <property name="text">
-                  <string>Force Hardware MSAA Resolve</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="handleTiledMemory">
-                 <property name="text">
-                  <string>Handle RSX Memory Tiling</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="readDepth">
-                 <property name="text">
-                  <string>Read Depth Buffer</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="readColor">
-                 <property name="text">
-                  <string>Read Color Buffers</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="useReBAR">
-                 <property name="text">
-                  <string>Use Re-BAR memory for GPU uploads</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="dumpDepth">
-                 <property name="text">
-                  <string>Write Depth Buffer</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_rsx_fifo_accuracy">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>RSX FIFO Accuracy</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_rsx_fifo_accuracy_layout">
-               <item>
-                <widget class="QComboBox" name="FIFOAccuracy"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_exclusiveFullscreen">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Exclusive Fullscreen Mode</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_exclusiveFullscreen_layout">
-               <item>
-                <widget class="QComboBox" name="exclusiveFullscreenMode"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_wakeupDelay">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Driver Wake-Up Delay</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_wakeupDelay_layout">
-               <item>
-                <widget class="QSlider" name="wakeupDelay">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="wakeupDelayLayout" stretch="1,0">
-                 <item>
-                  <widget class="QLabel" name="wakeupText">
-                   <property name="text">
-                    <string>1 µs</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="wakeupReset">
-                   <property name="text">
-                    <string>Reset</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_vblank">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>VBlank Frequency</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_vblank_layout">
-               <item>
-                <widget class="QSlider" name="vblank">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="vBlankLayout" stretch="1,0">
-                 <item>
-                  <widget class="QLabel" name="vblankText">
-                   <property name="text">
-                    <string>60 Hz</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignmentFlag::AlignCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="vblankReset">
-                   <property name="text">
-                    <string>Reset</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="vblankNTSCFixup">
-                 <property name="text">
-                  <string>VBlank NTSC Fixup</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="advancedTabSpacerRight">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>13</width>
-                <height>13</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="advancedTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_advanced">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_description_advanced_layout">
-           <item>
-            <widget class="QPlainTextEdit" name="description_advanced">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="emulatorTab">
-       <attribute name="title">
-        <string>Emulator</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="emulatorTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="emulatorTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
-          </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="emulatorTabScrollContents">
-           <layout class="QVBoxLayout" name="emulatorTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="emulatorTabLayout" stretch="1,1,1">
-          <item>
-           <layout class="QVBoxLayout" name="emulatorTabLayoutLeft">
-            <item>
-             <widget class="QGroupBox" name="gb_emu_settings">
-              <property name="title">
-               <string>Emulator Settings</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_emu_settings_layout">
-               <item>
-                <widget class="QCheckBox" name="enableGamemode">
-                 <property name="text">
-                  <string>Enable GameMode</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="exitOnStop">
-                 <property name="text">
-                  <string>Exit RPCS3 when process finishes</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="pausedSavestates">
-                 <property name="text">
-                  <string>Pause emulation after loading savestates</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="pauseDuringHomeMenu">
-                 <property name="text">
-                  <string>Pause emulation during home menu</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="pauseOnFocusLoss">
-                 <property name="text">
-                  <string>Pause emulation on RPCS3 focus loss</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="preventDisplaySleep">
-                 <property name="text">
-                  <string>Prevent display sleep while running games</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="startGameFullscreen">
-                 <property name="text">
-                  <string>Start games in fullscreen mode</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="useNativeInterface">
-                 <property name="text">
-                  <string>Use native user interface</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="useRecursiveScan">
-                 <property name="text">
-                  <string>Use recursive scan</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_overlay_settings">
-              <property name="title">
-               <string>Overlay Settings</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_overlay_settings_layout">
-               <item>
-                <widget class="QCheckBox" name="playMusicDuringBoot">
-                 <property name="text">
-                  <string>Play music during boot sequence</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="recordWithOverlays">
-                 <property name="text">
-                  <string>Record and screenshot with overlays</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showAnalogLimiterToggleHint">
-                 <property name="text">
-                  <string>Show analog limiter toggle hint</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showAutosaveAutoloadHint">
-                 <property name="text">
-                  <string>Show autosave/autoload hint</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showCaptureHints">
-                 <property name="text">
-                  <string>Show capture hints</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showFatalErrorHints">
-                 <property name="text">
-                  <string>Show fatal error hints</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showMouseAndKeyboardToggleHint">
-                 <property name="text">
-                  <string>Show mouse and keyboard toggle hint</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showRpcnPopups">
-                 <property name="text">
-                  <string>Show netplay popups</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showPressureIntensityToggleHint">
-                 <property name="text">
-                  <string>Show pressure intensity toggle hint</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showPPUCompilationHint">
-                 <property name="text">
-                  <string>Show PPU compilation hint</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showShaderCompilationHint">
-                 <property name="text">
-                  <string>Show shader compilation hint</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="showTrophyPopups">
-                 <property name="text">
-                  <string>Show trophy popups</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="emulatorTabSpacerLeft">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_max_llvm">
-              <property name="title">
-               <string>Max LLVM Compile Threads</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_max_llvm_layout">
-               <item>
-                <widget class="QComboBox" name="maxLLVMThreads"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_shader_compiler_threads">
-              <property name="title">
-               <string>Max Shader Compile Threads</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_shader_compiler_threads_layout">
-               <item>
-                <widget class="QComboBox" name="shaderCompilerThreads"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="emulatorTabLayoutMiddle">
-            <item>
-             <widget class="QGroupBox" name="gb_viewport">
-              <property name="title">
-               <string>Viewport</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_viewport_layout">
-               <item>
-                <widget class="QCheckBox" name="gs_disableMouse">
-                 <property name="text">
-                  <string>Ignore doubleclicks for Fullscreen</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="gs_disableKbHotkeys">
-                 <property name="text">
-                  <string>Ignore keyboard hotkeys</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="gs_showMouseInFullscreen">
-                 <property name="text">
-                  <string>Show mouse cursor in Fullscreen</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="gs_lockMouseInFullscreen">
-                 <property name="text">
-                  <string>Lock mouse cursor in Fullscreen</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="gs_hideMouseOnIdle_widget" native="true">
-                 <layout class="QHBoxLayout" name="gs_hideMouseOnIdle_layout" stretch="0,0">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QCheckBox" name="gs_hideMouseOnIdle">
-                    <property name="text">
-                     <string>Hide mouse cursor if idle</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSpinBox" name="gs_hideMouseOnIdleTime">
-                    <property name="accelerated">
-                     <bool>true</bool>
-                    </property>
-                    <property name="correctionMode">
-                     <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                    </property>
-                    <property name="keyboardTracking">
-                     <bool>false</bool>
-                    </property>
-                    <property name="suffix">
-                     <string>ms</string>
-                    </property>
-                    <property name="minimum">
-                     <number>200</number>
-                    </property>
-                    <property name="maximum">
-                     <number>99999</number>
-                    </property>
-                    <property name="stepType">
-                     <enum>QAbstractSpinBox::StepType::DefaultStepType</enum>
-                    </property>
-                    <property name="value">
-                     <number>2000</number>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="gs_resizeOnBoot_widget" native="true">
-                 <layout class="QVBoxLayout" name="gs_resizeOnBoot_layout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QCheckBox" name="gs_resizeOnBoot">
-                    <property name="text">
-                     <string>Resize game window on boot</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="gs_resizeOnBootManual">
-                    <property name="text">
-                     <string>Resize manually</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="gs_resolution_layout">
+                   <layout class="QHBoxLayout" name="wakeupDelayLayout" stretch="1,0">
                     <item>
-                     <widget class="QGroupBox" name="gb_gs_width">
-                      <property name="title">
-                       <string>Width</string>
+                     <widget class="QLabel" name="wakeupText">
+                      <property name="text">
+                       <string>1 µs</string>
                       </property>
-                      <layout class="QVBoxLayout" name="gb_gs_width_layout">
-                       <item>
-                        <widget class="QSpinBox" name="gs_width">
-                         <property name="accelerated">
-                          <bool>true</bool>
-                         </property>
-                         <property name="correctionMode">
-                          <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                         </property>
-                         <property name="keyboardTracking">
-                          <bool>false</bool>
-                         </property>
-                         <property name="minimum">
-                          <number>0</number>
-                         </property>
-                         <property name="maximum">
-                          <number>9999</number>
-                         </property>
-                         <property name="value">
-                          <number>0</number>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
+                      <property name="alignment">
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
+                      </property>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QGroupBox" name="gb_gs_height">
-                      <property name="title">
-                       <string>Height</string>
+                     <widget class="QPushButton" name="wakeupReset">
+                      <property name="text">
+                       <string>Reset</string>
                       </property>
-                      <layout class="QVBoxLayout" name="gb_gs_height_layout">
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_vblank">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="title">
+                  <string>VBlank Frequency</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_vblank_layout">
+                  <item>
+                   <widget class="QSlider" name="vblank">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="vBlankLayout" stretch="1,0">
+                    <item>
+                     <widget class="QLabel" name="vblankText">
+                      <property name="text">
+                       <string>60 Hz</string>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignmentFlag::AlignCenter</set>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="vblankReset">
+                      <property name="text">
+                       <string>Reset</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="vblankNTSCFixup">
+                    <property name="text">
+                     <string>VBlank NTSC Fixup</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="advancedTabSpacerRight">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>13</width>
+                   <height>13</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="advancedTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="emulatorTab">
+      <attribute name="title">
+       <string>Emulator</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="emulatorTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="emulatorTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="emulatorTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1019</width>
+            <height>874</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="emulatorTabScrollContentsLayout">
+           <item>
+            <layout class="QHBoxLayout" name="emulatorTabLayout" stretch="1,1,1">
+             <item>
+              <layout class="QVBoxLayout" name="emulatorTabLayoutLeft">
+               <item>
+                <widget class="QGroupBox" name="gb_emu_settings">
+                 <property name="title">
+                  <string>Emulator Settings</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_emu_settings_layout">
+                  <item>
+                   <widget class="QCheckBox" name="enableGamemode">
+                    <property name="text">
+                     <string>Enable GameMode</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="exitOnStop">
+                    <property name="text">
+                     <string>Exit RPCS3 when process finishes</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="pausedSavestates">
+                    <property name="text">
+                     <string>Pause emulation after loading savestates</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="pauseDuringHomeMenu">
+                    <property name="text">
+                     <string>Pause emulation during home menu</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="pauseOnFocusLoss">
+                    <property name="text">
+                     <string>Pause emulation on RPCS3 focus loss</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="preventDisplaySleep">
+                    <property name="text">
+                     <string>Prevent display sleep while running games</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="startGameFullscreen">
+                    <property name="text">
+                     <string>Start games in fullscreen mode</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="useNativeInterface">
+                    <property name="text">
+                     <string>Use native user interface</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="useRecursiveScan">
+                    <property name="text">
+                     <string>Use recursive scan</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_overlay_settings">
+                 <property name="title">
+                  <string>Overlay Settings</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_overlay_settings_layout">
+                  <item>
+                   <widget class="QCheckBox" name="playMusicDuringBoot">
+                    <property name="text">
+                     <string>Play music during boot sequence</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="recordWithOverlays">
+                    <property name="text">
+                     <string>Record and screenshot with overlays</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showAnalogLimiterToggleHint">
+                    <property name="text">
+                     <string>Show analog limiter toggle hint</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showAutosaveAutoloadHint">
+                    <property name="text">
+                     <string>Show autosave/autoload hint</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showCaptureHints">
+                    <property name="text">
+                     <string>Show capture hints</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showFatalErrorHints">
+                    <property name="text">
+                     <string>Show fatal error hints</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showMouseAndKeyboardToggleHint">
+                    <property name="text">
+                     <string>Show mouse and keyboard toggle hint</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showRpcnPopups">
+                    <property name="text">
+                     <string>Show netplay popups</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showPressureIntensityToggleHint">
+                    <property name="text">
+                     <string>Show pressure intensity toggle hint</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showPPUCompilationHint">
+                    <property name="text">
+                     <string>Show PPU compilation hint</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showShaderCompilationHint">
+                    <property name="text">
+                     <string>Show shader compilation hint</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="showTrophyPopups">
+                    <property name="text">
+                     <string>Show trophy popups</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="emulatorTabSpacerLeft">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_max_llvm">
+                 <property name="title">
+                  <string>Max LLVM Compile Threads</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_max_llvm_layout">
+                  <item>
+                   <widget class="QComboBox" name="maxLLVMThreads"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_shader_compiler_threads">
+                 <property name="title">
+                  <string>Max Shader Compile Threads</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_shader_compiler_threads_layout">
+                  <item>
+                   <widget class="QComboBox" name="shaderCompilerThreads"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="emulatorTabLayoutMiddle">
+               <item>
+                <widget class="QGroupBox" name="gb_viewport">
+                 <property name="title">
+                  <string>Viewport</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_viewport_layout">
+                  <item>
+                   <widget class="QCheckBox" name="gs_disableMouse">
+                    <property name="text">
+                     <string>Ignore doubleclicks for Fullscreen</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="gs_disableKbHotkeys">
+                    <property name="text">
+                     <string>Ignore keyboard hotkeys</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="gs_showMouseInFullscreen">
+                    <property name="text">
+                     <string>Show mouse cursor in Fullscreen</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="gs_lockMouseInFullscreen">
+                    <property name="text">
+                     <string>Lock mouse cursor in Fullscreen</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="gs_hideMouseOnIdle_widget" native="true">
+                    <layout class="QHBoxLayout" name="gs_hideMouseOnIdle_layout" stretch="0,0">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QCheckBox" name="gs_hideMouseOnIdle">
+                       <property name="text">
+                        <string>Hide mouse cursor if idle</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="gs_hideMouseOnIdleTime">
+                       <property name="accelerated">
+                        <bool>true</bool>
+                       </property>
+                       <property name="correctionMode">
+                        <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                       </property>
+                       <property name="keyboardTracking">
+                        <bool>false</bool>
+                       </property>
+                       <property name="suffix">
+                        <string>ms</string>
+                       </property>
+                       <property name="minimum">
+                        <number>200</number>
+                       </property>
+                       <property name="maximum">
+                        <number>99999</number>
+                       </property>
+                       <property name="stepType">
+                        <enum>QAbstractSpinBox::StepType::DefaultStepType</enum>
+                       </property>
+                       <property name="value">
+                        <number>2000</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="gs_resizeOnBoot_widget" native="true">
+                    <layout class="QVBoxLayout" name="gs_resizeOnBoot_layout">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QCheckBox" name="gs_resizeOnBoot">
+                       <property name="text">
+                        <string>Resize game window on boot</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="gs_resizeOnBootManual">
+                       <property name="text">
+                        <string>Resize manually</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <layout class="QHBoxLayout" name="gs_resolution_layout">
                        <item>
-                        <widget class="QSpinBox" name="gs_height">
-                         <property name="frame">
-                          <bool>true</bool>
+                        <widget class="QGroupBox" name="gb_gs_width">
+                         <property name="title">
+                          <string>Width</string>
                          </property>
-                         <property name="accelerated">
-                          <bool>true</bool>
+                         <layout class="QVBoxLayout" name="gb_gs_width_layout">
+                          <item>
+                           <widget class="QSpinBox" name="gs_width">
+                            <property name="accelerated">
+                             <bool>true</bool>
+                            </property>
+                            <property name="correctionMode">
+                             <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                            </property>
+                            <property name="keyboardTracking">
+                             <bool>false</bool>
+                            </property>
+                            <property name="minimum">
+                             <number>0</number>
+                            </property>
+                            <property name="maximum">
+                             <number>9999</number>
+                            </property>
+                            <property name="value">
+                             <number>0</number>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QGroupBox" name="gb_gs_height">
+                         <property name="title">
+                          <string>Height</string>
                          </property>
-                         <property name="correctionMode">
-                          <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
-                         </property>
-                         <property name="keyboardTracking">
-                          <bool>false</bool>
-                         </property>
-                         <property name="minimum">
-                          <number>0</number>
-                         </property>
-                         <property name="maximum">
-                          <number>9999</number>
-                         </property>
-                         <property name="value">
-                          <number>0</number>
-                         </property>
+                         <layout class="QVBoxLayout" name="gb_gs_height_layout">
+                          <item>
+                           <widget class="QSpinBox" name="gs_height">
+                            <property name="frame">
+                             <bool>true</bool>
+                            </property>
+                            <property name="accelerated">
+                             <bool>true</bool>
+                            </property>
+                            <property name="correctionMode">
+                             <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+                            </property>
+                            <property name="keyboardTracking">
+                             <bool>false</bool>
+                            </property>
+                            <property name="minimum">
+                             <number>0</number>
+                            </property>
+                            <property name="maximum">
+                             <number>9999</number>
+                            </property>
+                            <property name="value">
+                             <number>0</number>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
                         </widget>
                        </item>
                       </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_shader_load">
+                 <property name="title">
+                  <string>Shader Loading Screen</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_shader_load_layout">
+                  <item>
+                   <widget class="QCheckBox" name="shaderLoadBgEnabled">
+                    <property name="text">
+                     <string>Allow custom background</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label_shaderLoadBgDarkening">
+                    <property name="text">
+                     <string>Background darkening:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSlider" name="shaderLoadBgDarkening">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label_shaderLoadBgBlur">
+                    <property name="text">
+                     <string>Background blur:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QSlider" name="shaderLoadBgBlur">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="spacer_shader_load">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_game_window_title">
+                 <property name="title">
+                  <string>Game Window Title</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="layout_gb_game_window_title">
+                  <item>
+                   <widget class="QLabel" name="label_game_window_title_format">
+                    <property name="text">
+                     <string notr="true">FPS: 60 | Renderer | Version | Game [ID]</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignmentFlag::AlignCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="layout_buttons_game_window_title">
+                    <item>
+                     <widget class="QPushButton" name="reset_button_game_window_title_format">
+                      <property name="toolTip">
+                       <string>Reset the game window title to default</string>
+                      </property>
+                      <property name="text">
+                       <string>Reset</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="edit_button_game_window_title_format">
+                      <property name="toolTip">
+                       <string>Edit the game window title</string>
+                      </property>
+                      <property name="text">
+                       <string>Edit</string>
+                      </property>
                      </widget>
                     </item>
                    </layout>
@@ -3500,642 +3460,400 @@
                 </widget>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_shader_load">
-              <property name="title">
-               <string>Shader Loading Screen</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_shader_load_layout">
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="emulatorTabLayoutRight">
                <item>
-                <widget class="QCheckBox" name="shaderLoadBgEnabled">
-                 <property name="text">
-                  <string>Allow custom background</string>
+                <widget class="QGroupBox" name="gb_performance_overlay">
+                 <property name="title">
+                  <string>Performance Overlay</string>
                  </property>
+                 <layout class="QVBoxLayout" name="gb_performance_overlay_layout">
+                  <item>
+                   <widget class="QCheckBox" name="perfOverlayEnabled">
+                    <property name="text">
+                     <string>Enable performance overlay</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="perfOverlayFramerateGraphEnabled">
+                    <property name="text">
+                     <string>Show framerate graph</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="perfOverlayFrametimeGraphEnabled">
+                    <property name="text">
+                     <string>Show frametime graph</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="perf_overlay_detail_level" native="true">
+                    <layout class="QVBoxLayout" name="layout_perf_overlay_detail_level">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_detail_level">
+                       <property name="text">
+                        <string>Detail Level:</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QComboBox" name="perfOverlayDetailLevel"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="perf_overlay_position" native="true">
+                    <layout class="QVBoxLayout" name="layout_perf_overlay_position">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_position">
+                       <property name="text">
+                        <string>Position:</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QComboBox" name="perfOverlayPosition"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label_margin_x">
+                    <property name="text">
+                     <string>Horizontal Margin:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="layout_margin_x" stretch="0,0">
+                    <item>
+                     <widget class="QCheckBox" name="perfOverlayCenterX">
+                      <property name="text">
+                       <string>Centered</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QDoubleSpinBox" name="perfOverlayMarginX">
+                      <property name="decimals">
+                       <number>1</number>
+                      </property>
+                      <property name="singleStep">
+                       <double>0.500000000000000</double>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label_margin_y">
+                    <property name="text">
+                     <string>Vertical Margin:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="layout_margin_y" stretch="0,0">
+                    <item>
+                     <widget class="QCheckBox" name="perfOverlayCenterY">
+                      <property name="text">
+                       <string>Centered</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QDoubleSpinBox" name="perfOverlayMarginY">
+                      <property name="decimals">
+                       <number>1</number>
+                      </property>
+                      <property name="singleStep">
+                       <double>0.500000000000000</double>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="perfOverlayUseWindowSpace">
+                    <property name="text">
+                     <string>Use Window Space</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="perf_overlay_update_interval" native="true">
+                    <layout class="QVBoxLayout" name="layout_perf_overlay_update_interval">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_update_interval">
+                       <property name="text">
+                        <string>Update Interval:</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="perfOverlayUpdateInterval">
+                       <property name="singleStep">
+                        <number>10</number>
+                       </property>
+                       <property name="pageStep">
+                        <number>100</number>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="perf_overlay_font_size" native="true">
+                    <layout class="QVBoxLayout" name="layout_perf_overlay_font_size">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_font_size">
+                       <property name="text">
+                        <string>Font Size: </string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="perfOverlayFontSize">
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="perf_overlay_opacity" native="true">
+                    <layout class="QVBoxLayout" name="layout_perf_overlay_opacity">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_opacity">
+                       <property name="text">
+                        <string>Opacity:</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="perfOverlayOpacity">
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="perf_overlay_framerate_datapoints" native="true">
+                    <layout class="QVBoxLayout" name="layout_perf_overlay_framerate_datapoints">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_framerate_datapoints">
+                       <property name="text">
+                        <string>Framerate datapoints:</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="slider_framerate_datapoints">
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="perf_overlay_frametime_datapoints" native="true">
+                    <layout class="QVBoxLayout" name="layout_perf_overlay_frametime_datapoints">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_frametime_datapoints">
+                       <property name="text">
+                        <string>Frametime datapoints:</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="slider_frametime_datapoints">
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="emulatorTabSpacerRight">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
                 </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_shaderLoadBgDarkening">
-                 <property name="text">
-                  <string>Background darkening:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSlider" name="shaderLoadBgDarkening">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_shaderLoadBgBlur">
-                 <property name="text">
-                  <string>Background blur:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSlider" name="shaderLoadBgBlur">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="spacer_shader_load">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_game_window_title">
-              <property name="title">
-               <string>Game Window Title</string>
-              </property>
-              <layout class="QVBoxLayout" name="layout_gb_game_window_title">
-               <item>
-                <widget class="QLabel" name="label_game_window_title_format">
-                 <property name="text">
-                  <string notr="true">FPS: 60 | Renderer | Version | Game [ID]</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="layout_buttons_game_window_title">
-                 <item>
-                  <widget class="QPushButton" name="reset_button_game_window_title_format">
-                   <property name="toolTip">
-                    <string>Reset the game window title to default</string>
-                   </property>
-                   <property name="text">
-                    <string>Reset</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="edit_button_game_window_title_format">
-                   <property name="toolTip">
-                    <string>Edit the game window title</string>
-                   </property>
-                   <property name="text">
-                    <string>Edit</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="emulatorTabLayoutRight">
-            <item>
-             <widget class="QGroupBox" name="gb_performance_overlay">
-              <property name="title">
-               <string>Performance Overlay</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_performance_overlay_layout">
-               <item>
-                <widget class="QCheckBox" name="perfOverlayEnabled">
-                 <property name="text">
-                  <string>Enable performance overlay</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="perfOverlayFramerateGraphEnabled">
-                 <property name="text">
-                  <string>Show framerate graph</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="perfOverlayFrametimeGraphEnabled">
-                 <property name="text">
-                  <string>Show frametime graph</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="perf_overlay_detail_level" native="true">
-                 <layout class="QVBoxLayout" name="layout_perf_overlay_detail_level">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_detail_level">
-                    <property name="text">
-                     <string>Detail Level:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="perfOverlayDetailLevel"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="perf_overlay_position" native="true">
-                 <layout class="QVBoxLayout" name="layout_perf_overlay_position">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_position">
-                    <property name="text">
-                     <string>Position:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="perfOverlayPosition"/>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_margin_x">
-                 <property name="text">
-                  <string>Horizontal Margin:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="layout_margin_x" stretch="0,0">
-                 <item>
-                  <widget class="QCheckBox" name="perfOverlayCenterX">
-                   <property name="text">
-                    <string>Centered</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="perfOverlayMarginX">
-                   <property name="decimals">
-                    <number>1</number>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.500000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_margin_y">
-                 <property name="text">
-                  <string>Vertical Margin:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="layout_margin_y" stretch="0,0">
-                 <item>
-                  <widget class="QCheckBox" name="perfOverlayCenterY">
-                   <property name="text">
-                    <string>Centered</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="perfOverlayMarginY">
-                   <property name="decimals">
-                    <number>1</number>
-                   </property>
-                   <property name="singleStep">
-                    <double>0.500000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="perfOverlayUseWindowSpace">
-                 <property name="text">
-                  <string>Use Window Space</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="perf_overlay_update_interval" native="true">
-                 <layout class="QVBoxLayout" name="layout_perf_overlay_update_interval">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_update_interval">
-                    <property name="text">
-                     <string>Update Interval:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSlider" name="perfOverlayUpdateInterval">
-                    <property name="singleStep">
-                     <number>10</number>
-                    </property>
-                    <property name="pageStep">
-                     <number>100</number>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="perf_overlay_font_size" native="true">
-                 <layout class="QVBoxLayout" name="layout_perf_overlay_font_size">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_font_size">
-                    <property name="text">
-                     <string>Font Size: </string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSlider" name="perfOverlayFontSize">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="perf_overlay_opacity" native="true">
-                 <layout class="QVBoxLayout" name="layout_perf_overlay_opacity">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_opacity">
-                    <property name="text">
-                     <string>Opacity:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSlider" name="perfOverlayOpacity">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="perf_overlay_framerate_datapoints" native="true">
-                 <layout class="QVBoxLayout" name="layout_perf_overlay_framerate_datapoints">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_framerate_datapoints">
-                    <property name="text">
-                     <string>Framerate datapoints:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSlider" name="slider_framerate_datapoints">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QWidget" name="perf_overlay_frametime_datapoints" native="true">
-                 <layout class="QVBoxLayout" name="layout_perf_overlay_frametime_datapoints">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_frametime_datapoints">
-                    <property name="text">
-                     <string>Frametime datapoints:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSlider" name="slider_frametime_datapoints">
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <spacer name="emulatorTabSpacerRight">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="emulatorTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_emulator">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_description_emulator_layout">
+             </item>
+            </layout>
+           </item>
            <item>
-            <widget class="QPlainTextEdit" name="description_emulator">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
+            <spacer name="emulatorTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
              </property>
-             <property name="readOnly">
-              <bool>true</bool>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
              </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
+            </spacer>
            </item>
           </layout>
          </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="guiTab">
-       <attribute name="title">
-        <string>GUI</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="guiTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="guiTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="guiTab">
+      <attribute name="title">
+       <string>GUI</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="guiTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="guiTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="guiTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1031</width>
+            <height>716</height>
+           </rect>
           </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="guiTabScrollContents">
-           <layout class="QVBoxLayout" name="guiTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="guiTabLayout" stretch="1,1,1">
-          <item>
-           <layout class="QVBoxLayout" name="guiTabLayoutLeft">
-            <item>
-             <widget class="QGroupBox" name="gb_stylesheets">
-              <property name="title">
-               <string>UI Stylesheets</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_stylesheets_layout">
+          <layout class="QVBoxLayout" name="guiTabScrollContentsLayout">
+           <item>
+            <layout class="QHBoxLayout" name="guiTabLayout" stretch="1,1,1">
+             <item>
+              <layout class="QVBoxLayout" name="guiTabLayoutLeft">
                <item>
-                <widget class="QComboBox" name="combo_stylesheets"/>
-               </item>
-               <item>
-                <widget class="QPushButton" name="pb_apply_stylesheet">
-                 <property name="text">
-                  <string>Apply</string>
+                <widget class="QGroupBox" name="gb_stylesheets">
+                 <property name="title">
+                  <string>UI Stylesheets</string>
                  </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_colors">
-              <property name="title">
-               <string>UI Colors</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_colors_layout">
-               <property name="leftMargin">
-                <number>9</number>
-               </property>
-               <property name="topMargin">
-                <number>9</number>
-               </property>
-               <property name="rightMargin">
-                <number>9</number>
-               </property>
-               <property name="bottomMargin">
-                <number>9</number>
-               </property>
-               <item>
-                <widget class="QCheckBox" name="cb_custom_colors">
-                 <property name="text">
-                  <string>Use custom UI Colors</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="pb_gl_icon_color">
-                 <property name="text">
-                  <string>Gamelist icons</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="pb_sd_icon_color">
-                 <property name="text">
-                  <string>Save manager icons</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="pb_tr_icon_color">
-                 <property name="text">
-                  <string>Trophy manager icons</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="guiTabSpacerLeft">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="guiTabLayoutMiddle">
-            <item>
-             <widget class="QGroupBox" name="gb_log">
-              <property name="title">
-               <string>Log</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_log_layout">
-               <item>
-                <widget class="QWidget" name="log_limit" native="true">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <layout class="QVBoxLayout" name="layout_log_limit">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
+                 <layout class="QVBoxLayout" name="gb_stylesheets_layout">
                   <item>
-                   <widget class="QLabel" name="label_log_limit">
-                    <property name="text">
-                     <string>Maximum log blocks (0 = no limit)</string>
-                    </property>
-                   </widget>
+                   <widget class="QComboBox" name="combo_stylesheets"/>
                   </item>
                   <item>
-                   <widget class="QSpinBox" name="spinbox_log_limit">
-                    <property name="minimum">
-                     <number>0</number>
-                    </property>
-                    <property name="maximum">
-                     <number>999999999</number>
+                   <widget class="QPushButton" name="pb_apply_stylesheet">
+                    <property name="text">
+                     <string>Apply</string>
                     </property>
                    </widget>
                   </item>
@@ -4143,183 +3861,56 @@
                 </widget>
                </item>
                <item>
-                <widget class="QWidget" name="tty_limit" native="true">
-                 <layout class="QVBoxLayout" name="layout_tty_limit">
+                <widget class="QGroupBox" name="gb_colors">
+                 <property name="title">
+                  <string>UI Colors</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_colors_layout">
                   <property name="leftMargin">
-                   <number>0</number>
+                   <number>9</number>
                   </property>
                   <property name="topMargin">
-                   <number>0</number>
+                   <number>9</number>
                   </property>
                   <property name="rightMargin">
-                   <number>0</number>
+                   <number>9</number>
                   </property>
                   <property name="bottomMargin">
-                   <number>0</number>
+                   <number>9</number>
                   </property>
                   <item>
-                   <widget class="QLabel" name="label_tty_limit">
+                   <widget class="QCheckBox" name="cb_custom_colors">
                     <property name="text">
-                     <string>Maximum TTY blocks (0 = no limit)</string>
+                     <string>Use custom UI Colors</string>
                     </property>
                    </widget>
                   </item>
                   <item>
-                   <widget class="QSpinBox" name="spinbox_tty_limit">
-                    <property name="maximum">
-                     <number>999999999</number>
+                   <widget class="QPushButton" name="pb_gl_icon_color">
+                    <property name="text">
+                     <string>Gamelist icons</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="pb_sd_icon_color">
+                    <property name="text">
+                     <string>Save manager icons</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="pb_tr_icon_color">
+                    <property name="text">
+                     <string>Trophy manager icons</string>
                     </property>
                    </widget>
                   </item>
                  </layout>
                 </widget>
                </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_gui_pad_input">
-              <property name="title">
-               <string>Pad Input</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_gui_pad_input_layout">
                <item>
-                <widget class="QCheckBox" name="cb_pad_navigation">
-                 <property name="text">
-                  <string>Enable Pad Navigation</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="cb_global_pad_navigation">
-                 <property name="text">
-                  <string>Allow Global Pad Navigation</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_gui_volume">
-              <property name="title">
-               <string>Volume</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_gui_volume_layout">
-               <item>
-                <widget class="QWidget" name="gui_volume" native="true">
-                 <layout class="QVBoxLayout" name="layout_gui_volume">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="guiVolumeLabel">
-                    <property name="text">
-                     <string>GUI: 0%</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QSlider" name="guiVolume">
-                    <property name="maximum">
-                     <number>100</number>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Orientation::Horizontal</enum>
-                    </property>
-                    <property name="tickPosition">
-                     <enum>QSlider::TickPosition::TicksBelow</enum>
-                    </property>
-                    <property name="tickInterval">
-                     <number>50</number>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="guiTabSpacerMiddle">
-              <property name="orientation">
-               <enum>Qt::Orientation::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="guiTabLayoutRight">
-            <item>
-             <widget class="QGroupBox" name="gb_gui_options">
-              <property name="title">
-               <string>UI Options</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_gui_options_layout">
-               <item>
-                <widget class="QCheckBox" name="cb_show_welcome">
-                 <property name="text">
-                  <string>Show Welcome Screen</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="cb_show_exit_game">
-                 <property name="text">
-                  <string>Show Exit Game Confirmation</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="cb_show_pkg_install">
-                 <property name="text">
-                  <string>Show PKG/PUP Installation Result</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="cb_show_obsolete_cfg_dialog">
-                 <property name="text">
-                  <string>Show Obsolete Settings Dialog</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="cb_show_same_buttons_dialog">
-                 <property name="text">
-                  <string>Show Duplicate Buttons Dialog</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="cb_show_restart_hint">
-                 <property name="text">
-                  <string>Show Restart Dialog</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="guiTabSpacerRight">
+                <spacer name="guiTabSpacerLeft">
                  <property name="orientation">
                   <enum>Qt::Orientation::Vertical</enum>
                  </property>
@@ -4335,570 +3926,498 @@
                 </spacer>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_updates">
-              <property name="title">
-               <string>Check for updates on startup</string>
-              </property>
-              <layout class="QVBoxLayout" name="layout_gb_updates">
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="guiTabLayoutMiddle">
                <item>
-                <widget class="QComboBox" name="combo_updates"/>
+                <widget class="QGroupBox" name="gb_log">
+                 <property name="title">
+                  <string>Log</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_log_layout">
+                  <item>
+                   <widget class="QWidget" name="log_limit" native="true">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <layout class="QVBoxLayout" name="layout_log_limit">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_log_limit">
+                       <property name="text">
+                        <string>Maximum log blocks (0 = no limit)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="spinbox_log_limit">
+                       <property name="minimum">
+                        <number>0</number>
+                       </property>
+                       <property name="maximum">
+                        <number>999999999</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="tty_limit" native="true">
+                    <layout class="QVBoxLayout" name="layout_tty_limit">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="label_tty_limit">
+                       <property name="text">
+                        <string>Maximum TTY blocks (0 = no limit)</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSpinBox" name="spinbox_tty_limit">
+                       <property name="maximum">
+                        <number>999999999</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_gui_pad_input">
+                 <property name="title">
+                  <string>Pad Input</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_gui_pad_input_layout">
+                  <item>
+                   <widget class="QCheckBox" name="cb_pad_navigation">
+                    <property name="text">
+                     <string>Enable Pad Navigation</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="cb_global_pad_navigation">
+                    <property name="text">
+                     <string>Allow Global Pad Navigation</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_gui_volume">
+                 <property name="title">
+                  <string>Volume</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="gb_gui_volume_layout">
+                  <item>
+                   <widget class="QWidget" name="gui_volume" native="true">
+                    <layout class="QVBoxLayout" name="layout_gui_volume">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="guiVolumeLabel">
+                       <property name="text">
+                        <string>GUI: 0%</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QSlider" name="guiVolume">
+                       <property name="maximum">
+                        <number>100</number>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Orientation::Horizontal</enum>
+                       </property>
+                       <property name="tickPosition">
+                        <enum>QSlider::TickPosition::TicksBelow</enum>
+                       </property>
+                       <property name="tickInterval">
+                        <number>50</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <spacer name="guiTabSpacerMiddle">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Vertical</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>0</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_discord">
-              <property name="title">
-               <string>Discord</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_discord_layout">
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="guiTabLayoutRight">
                <item>
-                <widget class="QCheckBox" name="useRichPresence">
-                 <property name="text">
-                  <string>Use Discord Rich Presence</string>
+                <widget class="QGroupBox" name="gb_gui_options">
+                 <property name="title">
+                  <string>UI Options</string>
                  </property>
+                 <layout class="QVBoxLayout" name="gb_gui_options_layout">
+                  <item>
+                   <widget class="QCheckBox" name="cb_show_welcome">
+                    <property name="text">
+                     <string>Show Welcome Screen</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="cb_show_exit_game">
+                    <property name="text">
+                     <string>Show Exit Game Confirmation</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="cb_show_pkg_install">
+                    <property name="text">
+                     <string>Show PKG/PUP Installation Result</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="cb_show_obsolete_cfg_dialog">
+                    <property name="text">
+                     <string>Show Obsolete Settings Dialog</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="cb_show_same_buttons_dialog">
+                    <property name="text">
+                     <string>Show Duplicate Buttons Dialog</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="cb_show_restart_hint">
+                    <property name="text">
+                     <string>Show Restart Dialog</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="guiTabSpacerRight">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
                 </widget>
                </item>
                <item>
-                <widget class="QLabel" name="label_discordState">
-                 <property name="text">
-                  <string>Discord Status:</string>
+                <widget class="QGroupBox" name="gb_updates">
+                 <property name="title">
+                  <string>Check for updates on startup</string>
                  </property>
+                 <layout class="QVBoxLayout" name="layout_gb_updates">
+                  <item>
+                   <widget class="QComboBox" name="combo_updates"/>
+                  </item>
+                 </layout>
                 </widget>
                </item>
                <item>
-                <widget class="QLineEdit" name="discordState">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
+                <widget class="QGroupBox" name="gb_discord">
+                 <property name="title">
+                  <string>Discord</string>
                  </property>
-                 <property name="maxLength">
-                  <number>128</number>
+                 <layout class="QVBoxLayout" name="gb_discord_layout">
+                  <item>
+                   <widget class="QCheckBox" name="useRichPresence">
+                    <property name="text">
+                     <string>Use Discord Rich Presence</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label_discordState">
+                    <property name="text">
+                     <string>Discord Status:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLineEdit" name="discordState">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="maxLength">
+                     <number>128</number>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="gb_uuid">
+                 <property name="title">
+                  <string>Installation ID</string>
                  </property>
+                 <layout class="QVBoxLayout" name="gb_uuid_layout">
+                  <item>
+                   <widget class="QLabel" name="label_uuid">
+                    <property name="text">
+                     <string>UUID-placeholder</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignmentFlag::AlignCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="pb_uuid">
+                    <property name="text">
+                     <string>Create new ID</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
                </item>
               </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="gb_uuid">
-              <property name="title">
-               <string>Installation ID</string>
-              </property>
-              <layout class="QVBoxLayout" name="gb_uuid_layout">
-               <item>
-                <widget class="QLabel" name="label_uuid">
-                 <property name="text">
-                  <string>UUID-placeholder</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignmentFlag::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="pb_uuid">
-                 <property name="text">
-                  <string>Create new ID</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="guiTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_gui">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_description_gui_layout">
+             </item>
+            </layout>
+           </item>
            <item>
-            <widget class="QPlainTextEdit" name="description_gui">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
+            <spacer name="guiTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
              </property>
-             <property name="readOnly">
-              <bool>true</bool>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
              </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
+            </spacer>
            </item>
           </layout>
          </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="debugTab">
-       <attribute name="title">
-        <string>Debug</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="debugTab_layout" stretch="1,0">
-        <item>
-         <widget class="QScrollArea" name="debugTabScrollArea">
-          <property name="frameShape">
-           <enum>QFrame::Shape::NoFrame</enum>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="debugTab">
+      <attribute name="title">
+       <string>Debug</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="debugTab_layout" stretch="1">
+       <item>
+        <widget class="QScrollArea" name="debugTabScrollArea">
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="debugTabScrollContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>1031</width>
+            <height>716</height>
+           </rect>
           </property>
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="debugTabScrollContents">
-           <layout class="QVBoxLayout" name="debugTabScrollContentsLayout">
-        <item>
-         <layout class="QHBoxLayout" name="debugTabLayout" stretch="1,1,1">
-          <item>
-           <widget class="QGroupBox" name="gb_debug_gpu">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="title">
-             <string>GPU</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
-            </property>
-            <layout class="QVBoxLayout" name="gb_debug_gpu_layout">
-             <item alignment="Qt::AlignmentFlag::AlignTop">
-              <widget class="QCheckBox" name="debugOutput">
-               <property name="text">
-                <string>Debug Output</string>
-               </property>
-              </widget>
-             </item>
+          <layout class="QVBoxLayout" name="debugTabScrollContentsLayout">
+           <item>
+            <layout class="QHBoxLayout" name="debugTabLayout" stretch="1,1,1">
              <item>
-              <widget class="QCheckBox" name="debugOverlay">
-               <property name="text">
-                <string>Debug Overlay</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="disableAsyncHostMM">
-               <property name="text">
-                <string>Disable Asynchronous Memory Manager</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="disableFIFOReordering">
-               <property name="text">
-                <string>Disable FIFO Reordering</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="disableHardwareTexelRemapping">
-               <property name="text">
-                <string>Disable Hardware ColorSpace Remapping</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="disableOnDiskShaderCache">
-               <property name="text">
-                <string>Disable On-Disk Shader Cache</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="disableVideoOutput">
-               <property name="text">
-                <string>Disable Video Output</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="disableVulkanMemAllocator">
-               <property name="text">
-                <string>Disable Vulkan Memory Allocator</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="disableHwOcclusionQueries">
-               <property name="text">
-                <string>Disable ZCull Occlusion Queries</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="forceCpuBlitEmulation">
-               <property name="text">
-                <string>Force CPU Blit Emulation</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="gpuTextureScaling">
-               <property name="text">
-                <string>Force GPU Texture Scaling</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="logProg">
-               <property name="text">
-                <string>Log Shader Programs</string>
-               </property>
-              </widget>
-             </item>
-             <item alignment="Qt::AlignmentFlag::AlignTop">
-              <widget class="QCheckBox" name="renderdocCompatibility">
+              <widget class="QGroupBox" name="gb_debug_gpu">
                <property name="enabled">
                 <bool>true</bool>
                </property>
-               <property name="text">
-                <string>Renderdoc Compatibility Mode</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="strictTextureFlushing">
-               <property name="text">
-                <string>Strict Texture Flushing</string>
-               </property>
-              </widget>
-             </item>
-             <item alignment="Qt::AlignmentFlag::AlignTop">
-              <widget class="QCheckBox" name="forceHighpZ">
-               <property name="text">
-                <string>Use High Precision Z-Buffer</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="verticalSpacerDebugGPU">
-               <property name="orientation">
-                <enum>Qt::Orientation::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="gb_debug_core">
-            <property name="title">
-             <string>Core</string>
-            </property>
-            <layout class="QVBoxLayout" name="gb_debug_core_layout">
-             <item>
-              <widget class="QCheckBox" name="alwaysStart">
-               <property name="text">
-                <string>Automatically start games after boot</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="perfReport">
-               <property name="text">
-                <string>Enable performance report</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="hookStFunc">
-               <property name="text">
-                <string>Hook static functions</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="mfcDebug">
-               <property name="text">
-                <string>MFC Debug</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="ppuDebug">
-               <property name="text">
-                <string>PPU Debug</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="spuDebug">
-               <property name="text">
-                <string>SPU Debug</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="spuProfiler">
-               <property name="text">
-                <string>SPU Profiler</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="verticalSpacerDebugCore">
-               <property name="orientation">
-                <enum>Qt::Orientation::Vertical</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_debug_cpu">
                <property name="title">
-                <string>CPU Accuracy</string>
+                <string>GPU</string>
                </property>
-               <layout class="QVBoxLayout" name="gb_debug_cpu_layout">
-                <item>
-                 <widget class="QCheckBox" name="accurateDFMA">
-                  <property name="text">
-                   <string>Accurate PPU/SPU Double-Precision FMA</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="accurateClineStores">
-                  <property name="text">
-                   <string>Accurate PPU/SPU Cache Line Stores</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="accuratePPUFPCC">
-                  <property name="text">
-                   <string>Accurate PPU Float Condition Control</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="accuratePPUSAT">
-                  <property name="text">
-                   <string>Accurate PPU Saturation Bit</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="accuratePPUNJ">
-                  <property name="text">
-                   <string>Accurate PPU Non-Java Mode</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="accuratePPUVNAN">
-                  <property name="text">
-                   <string>Accurate PPU Vector NaN Handling</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="PPUVNANfixup">
-                  <property name="text">
-                   <string>Approximate PPU Vector NaN Handling</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="verticalSpacerDebugCpu">
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Vertical</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>0</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="debug_more_stuff" native="true">
-            <layout class="QVBoxLayout" name="debug_more_stuff_layout" stretch="0,0,0,0,0,0,1">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QGroupBox" name="gb_accurate_ppu_128">
-               <property name="title">
-                <string>Accurate PPU 128 Reservations</string>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
                </property>
-               <layout class="QVBoxLayout" name="gb_accurate_ppu_128_layout">
-                <item>
-                 <widget class="QComboBox" name="combo_accurate_ppu_128"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_num_ppu_threads">
-               <property name="title">
-                <string>PPU Thread Count</string>
-               </property>
-               <layout class="QVBoxLayout" name="vbl_num_ppu_threads">
-                <item>
-                 <widget class="QComboBox" name="combo_num_ppu_threads"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_Level_of_Detail">
-               <property name="title">
-                <string>LOD Bias Offset</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_Level_of_Detail_Layout">
-                <item>
-                 <layout class="QHBoxLayout" name="TextureLODBiasLayout">
-                  <item>
-                   <widget class="QDoubleSpinBox" name="TextureLODBias"/>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="TextureLODBiasReset">
-                    <property name="text">
-                     <string>Reset</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_vulkansched">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="title">
-                <string>Vulkan Queue Scheduler</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_vksched_layout">
-                <item>
-                 <widget class="QComboBox" name="vulkansched"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_fbAliasingBias">
-               <property name="title">
-                <string>Framebuffer Aliasing Heuristic Bias</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_fbAliasingBias_layout">
-                <item>
-                 <widget class="QComboBox" name="fbAliasingBias"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_log_levels">
-               <property name="title">
-                <string>Log Levels</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_log_levels_layout">
-                <item>
-                 <widget class="QPushButton" name="pb_log_levels">
+               <layout class="QVBoxLayout" name="gb_debug_gpu_layout">
+                <item alignment="Qt::AlignmentFlag::AlignTop">
+                 <widget class="QCheckBox" name="debugOutput">
                   <property name="text">
-                   <string>Configure</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="gb_debug_io">
-               <property name="title">
-                <string>I/O</string>
-               </property>
-               <layout class="QVBoxLayout" name="gb_debug_io_layout">
-                <item>
-                 <widget class="QCheckBox" name="debugOverlayIO">
-                  <property name="text">
-                   <string>Debug Overlay For Pad Input</string>
+                   <string>Debug Output</string>
                   </property>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QCheckBox" name="debugOverlayMouse">
+                 <widget class="QCheckBox" name="debugOverlay">
                   <property name="text">
-                   <string>Debug Overlay For Mouse Input</string>
+                   <string>Debug Overlay</string>
                   </property>
                  </widget>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer">
+                 <widget class="QCheckBox" name="disableAsyncHostMM">
+                  <property name="text">
+                   <string>Disable Asynchronous Memory Manager</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="disableFIFOReordering">
+                  <property name="text">
+                   <string>Disable FIFO Reordering</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="disableHardwareTexelRemapping">
+                  <property name="text">
+                   <string>Disable Hardware ColorSpace Remapping</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="disableOnDiskShaderCache">
+                  <property name="text">
+                   <string>Disable On-Disk Shader Cache</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="disableVideoOutput">
+                  <property name="text">
+                   <string>Disable Video Output</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="disableVulkanMemAllocator">
+                  <property name="text">
+                   <string>Disable Vulkan Memory Allocator</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="disableHwOcclusionQueries">
+                  <property name="text">
+                   <string>Disable ZCull Occlusion Queries</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="forceCpuBlitEmulation">
+                  <property name="text">
+                   <string>Force CPU Blit Emulation</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="gpuTextureScaling">
+                  <property name="text">
+                   <string>Force GPU Texture Scaling</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="logProg">
+                  <property name="text">
+                   <string>Log Shader Programs</string>
+                  </property>
+                 </widget>
+                </item>
+                <item alignment="Qt::AlignmentFlag::AlignTop">
+                 <widget class="QCheckBox" name="renderdocCompatibility">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="text">
+                   <string>Renderdoc Compatibility Mode</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="strictTextureFlushing">
+                  <property name="text">
+                   <string>Strict Texture Flushing</string>
+                  </property>
+                 </widget>
+                </item>
+                <item alignment="Qt::AlignmentFlag::AlignTop">
+                 <widget class="QCheckBox" name="forceHighpZ">
+                  <property name="text">
+                   <string>Use High Precision Z-Buffer</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacerDebugGPU">
                   <property name="orientation">
                    <enum>Qt::Orientation::Vertical</enum>
                   </property>
@@ -4917,76 +4436,374 @@
               </widget>
              </item>
              <item>
-              <spacer name="verticalSpacerDebugMore">
-               <property name="orientation">
-                <enum>Qt::Orientation::Vertical</enum>
+              <widget class="QGroupBox" name="gb_debug_core">
+               <property name="title">
+                <string>Core</string>
                </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>0</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </spacer>
+               <layout class="QVBoxLayout" name="gb_debug_core_layout">
+                <item>
+                 <widget class="QCheckBox" name="alwaysStart">
+                  <property name="text">
+                   <string>Automatically start games after boot</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="perfReport">
+                  <property name="text">
+                   <string>Enable performance report</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="hookStFunc">
+                  <property name="text">
+                   <string>Hook static functions</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="mfcDebug">
+                  <property name="text">
+                   <string>MFC Debug</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="ppuDebug">
+                  <property name="text">
+                   <string>PPU Debug</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="spuDebug">
+                  <property name="text">
+                   <string>SPU Debug</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="spuProfiler">
+                  <property name="text">
+                   <string>SPU Profiler</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacerDebugCore">
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_debug_cpu">
+                  <property name="title">
+                   <string>CPU Accuracy</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_debug_cpu_layout">
+                   <item>
+                    <widget class="QCheckBox" name="accurateDFMA">
+                     <property name="text">
+                      <string>Accurate PPU/SPU Double-Precision FMA</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="accurateClineStores">
+                     <property name="text">
+                      <string>Accurate PPU/SPU Cache Line Stores</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="accuratePPUFPCC">
+                     <property name="text">
+                      <string>Accurate PPU Float Condition Control</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="accuratePPUSAT">
+                     <property name="text">
+                      <string>Accurate PPU Saturation Bit</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="accuratePPUNJ">
+                     <property name="text">
+                      <string>Accurate PPU Non-Java Mode</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="accuratePPUVNAN">
+                     <property name="text">
+                      <string>Accurate PPU Vector NaN Handling</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="PPUVNANfixup">
+                     <property name="text">
+                      <string>Approximate PPU Vector NaN Handling</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacerDebugCpu">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Vertical</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="debug_more_stuff" native="true">
+               <layout class="QVBoxLayout" name="debug_more_stuff_layout" stretch="0,0,0,0,0,0,1,0">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QGroupBox" name="gb_accurate_ppu_128">
+                  <property name="title">
+                   <string>Accurate PPU 128 Reservations</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_accurate_ppu_128_layout">
+                   <item>
+                    <widget class="QComboBox" name="combo_accurate_ppu_128"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_num_ppu_threads">
+                  <property name="title">
+                   <string>PPU Thread Count</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="vbl_num_ppu_threads">
+                   <item>
+                    <widget class="QComboBox" name="combo_num_ppu_threads"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_Level_of_Detail">
+                  <property name="title">
+                   <string>LOD Bias Offset</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_Level_of_Detail_Layout">
+                   <item>
+                    <layout class="QHBoxLayout" name="TextureLODBiasLayout">
+                     <item>
+                      <widget class="QDoubleSpinBox" name="TextureLODBias"/>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="TextureLODBiasReset">
+                       <property name="text">
+                        <string>Reset</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_vulkansched">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="title">
+                   <string>Vulkan Queue Scheduler</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_vksched_layout">
+                   <item>
+                    <widget class="QComboBox" name="vulkansched"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_fbAliasingBias">
+                  <property name="title">
+                   <string>Framebuffer Aliasing Heuristic Bias</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_fbAliasingBias_layout">
+                   <item>
+                    <widget class="QComboBox" name="fbAliasingBias"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_log_levels">
+                  <property name="title">
+                   <string>Log Levels</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_log_levels_layout">
+                   <item>
+                    <widget class="QPushButton" name="pb_log_levels">
+                     <property name="text">
+                      <string>Configure</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="gb_debug_io">
+                  <property name="title">
+                   <string>I/O</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="gb_debug_io_layout">
+                   <item>
+                    <widget class="QCheckBox" name="debugOverlayIO">
+                     <property name="text">
+                      <string>Debug Overlay For Pad Input</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="debugOverlayMouse">
+                     <property name="text">
+                      <string>Debug Overlay For Mouse Input</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Vertical</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>0</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacerDebugMore">
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </widget>
              </item>
             </layout>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <spacer name="debugTabSpacer">
-          <property name="orientation">
-           <enum>Qt::Orientation::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gb_description_debug">
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <property name="title">
-           <string>Description</string>
-          </property>
-          <layout class="QVBoxLayout" name="gb_description_debug_layout">
+           </item>
            <item>
-            <widget class="QPlainTextEdit" name="description_debug">
-             <property name="focusPolicy">
-              <enum>Qt::FocusPolicy::ClickFocus</enum>
+            <spacer name="debugTabSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
-             <property name="frameShape">
-              <enum>QFrame::Shape::NoFrame</enum>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
              </property>
-             <property name="readOnly">
-              <bool>true</bool>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
              </property>
-             <property name="plainText">
-              <string>Point your mouse at an option to display a description in here.</string>
-             </property>
-            </widget>
+            </spacer>
            </item>
           </layout>
          </widget>
-        </item>
-       </layout>
-      </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gb_description">
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="gb_description_debug_layout">
+      <item>
+       <widget class="auto_scroll_label" name="description">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Point your mouse at an option to display a description in here.
+
+
+</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -4998,6 +4815,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>auto_scroll_label</class>
+   <extends>QLabel</extends>
+   <header>auto_scroll_label.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../resources.qrc"/>
  </resources>


### PR DESCRIPTION
- Implements a different approach to https://github.com/RPCS3/rpcs3/pull/19161
- Unify all settings_dialog description widgets into a single widget outside of the scroll area
- Move the overarching scroll area into multiple scroll areas in the tabs themselves
- Let the description label auto-scroll if the text is too long

Thanks @lalitshankarch for the general idea.

closes #19161