### PR TITLE
Sort enumerated GPUs according to priority (Discrete, Integrated, Software, etc)

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -134,7 +134,7 @@ namespace vk
 		operator VkPhysicalDevice() const;
 		operator VkInstance() const;
 
-		bool is_integrated_gpu() const { return props.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU; }
+		VkPhysicalDeviceType get_type() const { return props.deviceType; }
 	};
 
 	class render_device

--- a/rpcs3/Emu/RSX/VK/vkutils/instance.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/instance.cpp
@@ -260,6 +260,25 @@ namespace vk
 				gpus[i].create(m_instance, pdevs[i], extensions_loaded);
 		}
 
+		auto priority = [](const physical_device& dev)
+		{
+			switch (dev.get_type())
+			{
+			case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+				return 0;
+			case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+				return 1;
+			default:
+				return 2;
+			}
+		};
+
+		std::stable_sort(gpus.begin(), gpus.end(),
+			[&](const physical_device& a, const physical_device& b)
+			{
+				return priority(a) < priority(b);
+			});
+
 		return gpus;
 	}
 


### PR DESCRIPTION
This PR fixes the default GPU selection logic for laptops with hybrid graphics.

# Before

<img width="412" height="159" alt="Graphics Before" src="https://github.com/user-attachments/assets/8b947b7e-5f7f-48e2-83e4-01d9b9f16e33" />

# After

<img width="409" height="162" alt="Graphics After" src="https://github.com/user-attachments/assets/152f5468-1062-4070-a577-6e48534dabb9" />


