### PR TITLE
Implement AVX2 path for `gv_rol32`

### DIFF
--- a/rpcs3/util/simd.hpp
+++ b/rpcs3/util/simd.hpp
@@ -3013,6 +3013,10 @@ inline v128 gv_rol32(const v128& a, const v128& b)
 {
 #if defined(__AVX512VL__)
 	return _mm_rolv_epi32(a, b);
+#elif defined(__AVX2__)
+	const auto amt1 = _mm_and_si128(b, _mm_set1_epi32(31));
+	const auto amt2 = _mm_sub_epi32(_mm_set1_epi32(32), amt1);
+	return _mm_or_si128(_mm_sllv_epi32(a, amt1), _mm_srlv_epi32(a, amt2));
 #elif defined(ARCH_ARM64)
 	const auto amt1 = vandq_s32(b, gv_bcst32(31));
 	const auto amt2 = vsubq_s32(amt1, gv_bcst32(32));


### PR DESCRIPTION
Sources:

SIMD Everywhere: [simde/x86/avx512/rolv.h](https://github.com/simd-everywhere/simde/blob/6be46b92aad2bf5928fae742144cbbd8eb875679/simde/x86/avx512/rolv.h#L64)

Compiler explorer: [Link](https://godbolt.org/z/erMbehf3K)