### PR TITLE
Check if final install paths are actually inside the target directory before installation

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -4650,10 +4650,10 @@ game_boot_result Emulator::RemoveGameFromYml(const std::string& title_id)
 	return game_boot_result::generic_error;
 }
 
-bool Emulator::IsPathInsideDir(std::string_view path, std::string_view dir) const
+bool Emulator::IsPathInsideDir(std::string_view path, std::string_view dir, bool check_if_exists) const
 {
-	const std::string dir_path = GetCallbacks().resolve_path(dir);
-	const std::string resolved_path = GetCallbacks().resolve_path(path);
+	const std::string dir_path = check_if_exists ? GetCallbacks().resolve_path(dir) : GetCallbacks().resolve_path_may_not_exist(dir);
+	const std::string resolved_path = check_if_exists ? GetCallbacks().resolve_path(path) : GetCallbacks().resolve_path_may_not_exist(path);
 
 	return !dir_path.empty() && !resolved_path.empty() && (resolved_path + '/').starts_with((dir_path.back() == '/') ? dir_path : (dir_path + '/'));
 }

--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -106,7 +106,8 @@ struct EmuCallbacks
 	std::function<void(const std::string&, std::optional<f32>)> play_sound;
 	std::function<bool(const std::string&, std::string&, s32&, s32&, s32&)> get_image_info; // (filename, sub_type, width, height, CellSearchOrientation)
 	std::function<bool(const std::string&, s32, s32, s32&, s32&, u8*, bool)> get_scaled_image; // (filename, target_width, target_height, width, height, dst, force_fit)
-	std::string(*resolve_path)(std::string_view) = [](std::string_view arg){ return std::string{arg}; }; // Resolve path using Qt
+	std::function<std::string(std::string_view)> resolve_path = [](std::string_view arg){ return std::string{arg}; }; // Resolve path using Qt (returns empty string if the file doesn't exist)
+	std::function<std::string(std::string_view)> resolve_path_may_not_exist = [](std::string_view arg){ return std::string{arg}; }; // Resolve path using Qt
 	std::function<std::vector<std::string>()> get_font_dirs;
 	std::function<bool(const std::vector<std::string>&)> on_install_pkgs;
 	std::function<void(u32)> add_breakpoint;
@@ -497,7 +498,7 @@ public:
 	game_boot_result RemoveGameFromYml(const std::string& title_id);
 
 	// Check if path is inside the specified directory
-	bool IsPathInsideDir(std::string_view path, std::string_view dir) const;
+	bool IsPathInsideDir(std::string_view path, std::string_view dir, bool check_if_exists = true) const;
 	game_boot_result VerifyPathCasing(std::string_view path, std::string_view dir, bool from_dir) const;
 
 	void EjectDisc();

--- a/rpcs3/Loader/ISO.cpp
+++ b/rpcs3/Loader/ISO.cpp
@@ -640,13 +640,14 @@ u64 iso_file_encrypted::read_at(u64 offset, void* buffer, u64 size)
 	const u64 total_size = this->size();
 	const u64 archive_first_offset = file_offset(offset);
 	const u64 archive_last_offset = archive_first_offset + max_size - 1;
-	iso_sector first_sec, last_sec;
 	void* aligned_buf = get_aligned_buf(); // thread-safe buffer
 
+	iso_sector first_sec {};
 	first_sec.lba_address = (archive_first_offset / ISO_SECTOR_SIZE) * ISO_SECTOR_SIZE;
 	first_sec.offset = archive_first_offset % ISO_SECTOR_SIZE;
 	first_sec.size = first_sec.offset + max_size <= ISO_SECTOR_SIZE ? max_size : ISO_SECTOR_SIZE - first_sec.offset;
 
+	iso_sector last_sec {};
 	last_sec.lba_address = last_sec.address_aligned = (archive_last_offset / ISO_SECTOR_SIZE) * ISO_SECTOR_SIZE;
 	// last_sec.offset = last_sec.offset_aligned = 0; // Always 0 so no need to set and use those attributes
 	last_sec.size = (archive_last_offset % ISO_SECTOR_SIZE) + 1;

--- a/rpcs3/Loader/TAR.cpp
+++ b/rpcs3/Loader/TAR.cpp
@@ -257,6 +257,11 @@ bool tar_object::extract(const std::string& prefix_path, bool is_vfs)
 				return false;
 			}
 		}
+		else if (!Emu.IsPathInsideDir(prefix_path, result, false))
+		{
+			tar_log.error("Error extracting %s: target path '%s' is outside of '%s'", name, result, prefix_path);
+			return false;
+		}
 
 		u64 mtime = octal_text_to_u64({header.mtime, std::size(header.mtime)});
 

--- a/rpcs3/Loader/mself.cpp
+++ b/rpcs3/Loader/mself.cpp
@@ -3,6 +3,7 @@
 #include "Utilities/File.h"
 #include "util/logs.hpp"
 #include "Emu/VFS.h"
+#include "Emu/System.h"
 
 #include "mself.hpp"
 
@@ -50,6 +51,13 @@ bool extract_mself(const std::string& file, const std::string& extract_to)
 	for (const mself_record& rec : recs)
 	{
 		const std::string name = vfs::escape(rec.name);
+		const std::string file_path = extract_to + name;
+
+		if (!Emu.IsPathInsideDir(extract_to, file_path, false))
+		{
+			mself_log.error("Error extracting %s from MSELF: target path '%s' would be extracted outside of '%s'", name, file_path, extract_to);
+			return false;
+		}
 
 		const u64 pos = rec.get_pos(mself_size);
 
@@ -63,19 +71,19 @@ bool extract_mself(const std::string& file, const std::string& extract_to)
 		mself.seek(pos);
 		mself.read(buffer.data(), rec.size);
 
-		if (!fs::create_path(fs::get_parent_dir(extract_to + name)))
+		if (!fs::create_path(fs::get_parent_dir(file_path)))
 		{
-			mself_log.error("Error creating directory %s (%s)", fs::get_parent_dir(extract_to + name), fs::g_tls_error);
+			mself_log.error("Error creating directory %s (%s)", fs::get_parent_dir(file_path), fs::g_tls_error);
 			return false;
 		}
 
-		if (!fs::write_file(extract_to + name, fs::rewrite, buffer))
+		if (!fs::write_file(file_path, fs::rewrite, buffer))
 		{
-			mself_log.error("Error creating %s (%s)", extract_to + name, fs::g_tls_error);
+			mself_log.error("Error creating %s (%s)", file_path, fs::g_tls_error);
 			return false;
 		}
 
-		mself_log.success("Extracted '%s' to '%s'", name, extract_to + name);
+		mself_log.success("Extracted '%s' to '%s'", name, file_path);
 	}
 
 	mself_log.success("Extraction complete!");

--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -23,11 +23,11 @@ headless_application::headless_application(int& argc, char** argv) : QCoreApplic
 
 bool headless_application::Init()
 {
-	// Force init the emulator
-	InitializeEmulator(m_active_user.empty() ? "00000001" : m_active_user, false, true);
-
 	// Create callbacks from the emulator, which reference the handlers.
 	InitializeCallbacks();
+
+	// Force init the emulator
+	InitializeEmulator(m_active_user.empty() ? "00000001" : m_active_user, false, true);
 
 	// Create connects to propagate events throughout Gui.
 	InitializeConnects();

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -39,6 +39,7 @@
 #endif
 
 #include <QDateTime>
+#include <QDir>
 #include <QFileInfo> // This shouldn't be outside rpcs3qt...
 #include <QImageReader> // This shouldn't be outside rpcs3qt...
 #include <QStandardPaths> // This shouldn't be outside rpcs3qt...
@@ -381,6 +382,24 @@ EmuCallbacks main_application::CreateCallbacks()
 	{
 		// May result in an empty string if path does not exist
 		return QFileInfo(QString::fromUtf8(sv.data(), static_cast<int>(sv.size()))).canonicalFilePath().toStdString();
+	};
+
+	callbacks.resolve_path_may_not_exist = [](std::string_view sv)
+	{
+		const QString path = QString::fromUtf8(sv.data(), static_cast<int>(sv.size()));
+		QFileInfo fi(path);
+
+		QString tail;
+
+		while (!fi.exists())
+		{
+			tail = fi.fileName() + "/" + tail;
+			fi.setFile(fi.path());
+		}
+
+		const QString result = QDir(fi.canonicalFilePath()).filePath(tail);
+
+		return QDir::cleanPath(result).toStdString();
 	};
 
 	callbacks.get_font_dirs = []()

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -171,11 +171,11 @@ bool gui_application::Init()
 		m_active_user = m_persistent_settings->GetCurrentUser("00000001").toStdString();
 	}
 
-	// Force init the emulator
-	InitializeEmulator(m_active_user, m_show_gui, false);
-
 	// Create callbacks from the emulator, which reference the handlers.
 	InitializeCallbacks();
+
+	// Force init the emulator
+	InitializeEmulator(m_active_user, m_show_gui, false);
 
 	// Create connects to propagate events throughout Gui.
 	InitializeConnects();


### PR DESCRIPTION
- Do not install files from pkg or tar unless they resolve to be actually in the target directory
- Initialize callbacks before initializing the emulator, otherwise resolve_path always returns the original path