### PR TITLE
unedat: Fix some OOB

### DIFF
--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -868,7 +868,7 @@ bool EDATADecrypter::ReadHeader()
 	//}
 
 	file_size = edatHeader.file_size;
-	total_blocks = ::narrow<u32>(utils::aligned_div(edatHeader.file_size, edatHeader.block_size));
+	total_blocks = (edatHeader.block_size == 0) ? 0 : ::narrow<u32>(utils::aligned_div(edatHeader.file_size, edatHeader.block_size));
 
 	// Try decrypting the first block instead
 	u8 data_sample[1];

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -16,17 +16,19 @@ LOG_CHANNEL(edat_log, "EDAT");
 
 void generate_key(int crypto_mode, int version, u8* key_final, u8* iv_final, const u8* key, const u8* iv)
 {
-	int mode = crypto_mode & 0xF0000000;
-	uchar temp_iv[16]{};
+	const int mode = crypto_mode & 0xF0000000;
 	switch (mode)
 	{
 	case 0x10000000:
+	{
 		// Encrypted ERK.
 		// Decrypt the key with EDAT_KEY + EDAT_IV and copy the original IV.
+		u8 temp_iv[16]{};
 		memcpy(temp_iv, EDAT_IV, 0x10);
 		aescbc128_decrypt(const_cast<u8*>(version ? EDAT_KEY_1 : EDAT_KEY_0), temp_iv, key, key_final, 0x10);
 		memcpy(iv_final, iv, 0x10);
 		break;
+	}
 	case 0x20000000:
 		// Default ERK.
 		// Use EDAT_KEY and EDAT_IV.
@@ -44,16 +46,18 @@ void generate_key(int crypto_mode, int version, u8* key_final, u8* iv_final, con
 
 void generate_hash(int hash_mode, int version, u8* hash_final, const u8* hash)
 {
-	int mode = hash_mode & 0xF0000000;
-	uchar temp_iv[16]{};
+	const int mode = hash_mode & 0xF0000000;
 	switch (mode)
 	{
 	case 0x10000000:
+	{
 		// Encrypted HASH.
 		// Decrypt the hash with EDAT_KEY + EDAT_IV.
+		u8 temp_iv[16]{};
 		memcpy(temp_iv, EDAT_IV, 0x10);
 		aescbc128_decrypt(const_cast<u8*>(version ? EDAT_KEY_1 : EDAT_KEY_0), temp_iv, hash, hash_final, 0x10);
 		break;
+	}
 	case 0x20000000:
 		// Default HASH.
 		// Use EDAT_HASH.
@@ -70,10 +74,10 @@ void generate_hash(int hash_mode, int version, u8* hash_final, const u8* hash)
 bool decrypt(int hash_mode, int crypto_mode, int version, const u8* in, u8* out, usz length, const u8* key, const u8* iv, const u8* hash, const u8* test_hash)
 {
 	// Setup buffers for key, iv and hash.
-	unsigned char key_final[0x10] = {};
-	unsigned char iv_final[0x10] = {};
-	unsigned char hash_final_10[0x10] = {};
-	unsigned char hash_final_14[0x14] = {};
+	u8 key_final[0x10] = {};
+	u8 iv_final[0x10] = {};
+	u8 hash_final_10[0x10] = {};
+	u8 hash_final_14[0x14] = {};
 
 	// Generate crypto key and hash.
 	generate_key(crypto_mode, version, key_final, iv_final, key, iv);
@@ -119,22 +123,22 @@ bool decrypt(int hash_mode, int crypto_mode, int version, const u8* in, u8* out,
 std::tuple<u64, s32, s32> dec_section(const u8* metadata)
 {
 	std::array<u8, 0x10> dec;
-	dec[0x00] = (metadata[0xC] ^ metadata[0x8] ^ metadata[0x10]);
-	dec[0x01] = (metadata[0xD] ^ metadata[0x9] ^ metadata[0x11]);
-	dec[0x02] = (metadata[0xE] ^ metadata[0xA] ^ metadata[0x12]);
-	dec[0x03] = (metadata[0xF] ^ metadata[0xB] ^ metadata[0x13]);
-	dec[0x04] = (metadata[0x4] ^ metadata[0x8] ^ metadata[0x14]);
-	dec[0x05] = (metadata[0x5] ^ metadata[0x9] ^ metadata[0x15]);
-	dec[0x06] = (metadata[0x6] ^ metadata[0xA] ^ metadata[0x16]);
-	dec[0x07] = (metadata[0x7] ^ metadata[0xB] ^ metadata[0x17]);
-	dec[0x08] = (metadata[0xC] ^ metadata[0x0] ^ metadata[0x18]);
-	dec[0x09] = (metadata[0xD] ^ metadata[0x1] ^ metadata[0x19]);
-	dec[0x0A] = (metadata[0xE] ^ metadata[0x2] ^ metadata[0x1A]);
-	dec[0x0B] = (metadata[0xF] ^ metadata[0x3] ^ metadata[0x1B]);
-	dec[0x0C] = (metadata[0x4] ^ metadata[0x0] ^ metadata[0x1C]);
-	dec[0x0D] = (metadata[0x5] ^ metadata[0x1] ^ metadata[0x1D]);
-	dec[0x0E] = (metadata[0x6] ^ metadata[0x2] ^ metadata[0x1E]);
-	dec[0x0F] = (metadata[0x7] ^ metadata[0x3] ^ metadata[0x1F]);
+	dec[0x0] = (metadata[0xC] ^ metadata[0x8] ^ metadata[0x10]);
+	dec[0x1] = (metadata[0xD] ^ metadata[0x9] ^ metadata[0x11]);
+	dec[0x2] = (metadata[0xE] ^ metadata[0xA] ^ metadata[0x12]);
+	dec[0x3] = (metadata[0xF] ^ metadata[0xB] ^ metadata[0x13]);
+	dec[0x4] = (metadata[0x4] ^ metadata[0x8] ^ metadata[0x14]);
+	dec[0x5] = (metadata[0x5] ^ metadata[0x9] ^ metadata[0x15]);
+	dec[0x6] = (metadata[0x6] ^ metadata[0xA] ^ metadata[0x16]);
+	dec[0x7] = (metadata[0x7] ^ metadata[0xB] ^ metadata[0x17]);
+	dec[0x8] = (metadata[0xC] ^ metadata[0x0] ^ metadata[0x18]);
+	dec[0x9] = (metadata[0xD] ^ metadata[0x1] ^ metadata[0x19]);
+	dec[0xA] = (metadata[0xE] ^ metadata[0x2] ^ metadata[0x1A]);
+	dec[0xB] = (metadata[0xF] ^ metadata[0x3] ^ metadata[0x1B]);
+	dec[0xC] = (metadata[0x4] ^ metadata[0x0] ^ metadata[0x1C]);
+	dec[0xD] = (metadata[0x5] ^ metadata[0x1] ^ metadata[0x1D]);
+	dec[0xE] = (metadata[0x6] ^ metadata[0x2] ^ metadata[0x1E]);
+	dec[0xF] = (metadata[0x7] ^ metadata[0x3] ^ metadata[0x1F]);
 
 	u64 offset = read_from_ptr<be_t<u64>>(dec, 0);
 	s32 length = read_from_ptr<be_t<s32>>(dec, 8);
@@ -145,13 +149,13 @@ std::tuple<u64, s32, s32> dec_section(const u8* metadata)
 
 u128 get_block_key(int block, const NPD_HEADER& npd)
 {
-	unsigned char empty_key[0x10] = {};
-	const unsigned char* src_key = (npd.version <= 1) ? empty_key : npd.dev_hash;
+	const u8 empty_key[0x10] = {};
+	const u8* src_key = (npd.version <= 1) ? empty_key : npd.dev_hash;
 	u128 dest_key{};
 	std::memcpy(&dest_key, src_key, 0xC);
 
-	s32 swappedBlock = std::bit_cast<be_t<s32>>(block);
-	std::memcpy(reinterpret_cast<uchar*>(&dest_key) + 0xC, &swappedBlock, sizeof(swappedBlock));
+	const s32 swappedBlock = std::bit_cast<be_t<s32>>(block);
+	std::memcpy(reinterpret_cast<u8*>(&dest_key) + 0xC, &swappedBlock, sizeof(swappedBlock));
 	return dest_key;
 }
 
@@ -161,8 +165,8 @@ u128 get_block_key(int block, const NPD_HEADER& npd)
 s64 decrypt_block(const fs::file& in, std::vector<u8>& out, const EDAT_HEADER& edat, const NPD_HEADER& npd, const u8* crypt_key, u32 block_num, u32 total_blocks, u64 size_left, bool is_out_buffer_aligned = false)
 {
 	// Get metadata info and setup buffers.
-	const int metadata_section_size = ((edat.flags & EDAT_COMPRESSED_FLAG) != 0 || (edat.flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
-	const int metadata_offset = 0x100;
+	const u64 metadata_section_size = ((edat.flags & EDAT_COMPRESSED_FLAG) != 0 || (edat.flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
+	constexpr u64 metadata_offset = 0x100;
 
 	u8 hash[0x10] = { 0 };
 	u8 key_result[0x10] = { 0 };
@@ -172,7 +176,7 @@ s64 decrypt_block(const fs::file& in, std::vector<u8>& out, const EDAT_HEADER& e
 	u64 metadata_sec_offset = 0;
 	u64 length = 0;
 	s32 compression_end = 0;
-	unsigned char empty_iv[0x10] = {};
+	u8 empty_iv[0x10] = {};
 
 	// Decrypt the metadata.
 	if ((edat.flags & EDAT_COMPRESSED_FLAG) != 0)
@@ -255,7 +259,7 @@ s64 decrypt_block(const fs::file& in, std::vector<u8>& out, const EDAT_HEADER& e
 	auto b_key = get_block_key(block_num, npd);
 
 	// Encrypt the block key with the crypto key.
-	aesecb128_encrypt(crypt_key, reinterpret_cast<uchar*>(&b_key), key_result);
+	aesecb128_encrypt(crypt_key, reinterpret_cast<u8*>(&b_key), key_result);
 
 	if ((edat.flags & EDAT_FLAG_0x10) != 0)
 	{
@@ -394,7 +398,7 @@ bool check_data(const u8* key, const EDAT_HEADER& edat, const NPD_HEADER& npd, c
 	f.read(header_hash, 0x10);
 
 	// Setup the hashing mode and the crypto mode used in the file.
-	const int crypto_mode = 0x1;
+	constexpr int crypto_mode = 0x1;
 	int hash_mode = ((edat.flags & EDAT_ENCRYPTED_KEY_FLAG) == 0) ? 0x00000002 : 0x10000002;
 	if ((edat.flags & EDAT_DEBUG_DATA_FLAG) != 0)
 	{
@@ -405,8 +409,8 @@ bool check_data(const u8* key, const EDAT_HEADER& edat, const NPD_HEADER& npd, c
 	}
 
 	// Setup header key and iv buffers.
-	unsigned char header_key[0x10] = { 0 };
-	unsigned char header_iv[0x10] = { 0 };
+	u8 header_key[0x10] = { 0 };
+	u8 header_iv[0x10] = { 0 };
 
 	// Test the header hash (located at offset 0xA0).
 	if (!decrypt(hash_mode, crypto_mode, (npd.version == 4), header, empty_header, 0xA0, header_key, header_iv, key, header_hash))
@@ -423,7 +427,6 @@ bool check_data(const u8* key, const EDAT_HEADER& edat, const NPD_HEADER& npd, c
 	}
 
 	// Parse the metadata info.
-	const int metadata_section_size = ((edat.flags & EDAT_COMPRESSED_FLAG) != 0 || (edat.flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
 	if ((edat.flags & EDAT_COMPRESSED_FLAG) != 0)
 	{
 		if (verbose)
@@ -434,6 +437,8 @@ bool check_data(const u8* key, const EDAT_HEADER& edat, const NPD_HEADER& npd, c
 	{
 		return false;
 	}
+
+	const u64 metadata_section_size = ((edat.flags & EDAT_COMPRESSED_FLAG) != 0 || (edat.flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
 
 	const usz block_num = utils::aligned_div<u64>(edat.file_size, edat.block_size);
 	constexpr usz metadata_offset = 0x100;
@@ -477,12 +482,12 @@ bool check_data(const u8* key, const EDAT_HEADER& edat, const NPD_HEADER& npd, c
 	if ((edat.flags & EDAT_DEBUG_DATA_FLAG) == 0)
 	{
 		// Setup buffers.
-		unsigned char metadata_signature[0x28] = { 0 };
-		unsigned char header_signature[0x28] = { 0 };
-		unsigned char signature_hash[20] = { 0 };
-		unsigned char signature_r[0x15] = { 0 };
-		unsigned char signature_s[0x15] = { 0 };
-		unsigned char zero_buf[0x15] = { 0 };
+		u8 metadata_signature[0x28] = { 0 };
+		u8 header_signature[0x28] = { 0 };
+		u8 signature_hash[20] = { 0 };
+		u8 signature_r[0x15] = { 0 };
+		u8 signature_s[0x15] = { 0 };
+		u8 zero_buf[0x15] = { 0 };
 
 		// Setup ECDSA curve and public key.
 		ecdsa_set_curve(VSH_CURVE_P, VSH_CURVE_A, VSH_CURVE_B, VSH_CURVE_N, VSH_CURVE_GX, VSH_CURVE_GY);
@@ -563,7 +568,7 @@ bool validate_dev_klic(const u8* klicensee, const NPD_HEADER& npd)
 		return true;
 	}
 
-	unsigned char dev[0x60]{};
+	u8 dev[0x60]{};
 
 	// Build the dev buffer (first 0x60 bytes of NPD header in big-endian).
 	std::memcpy(dev, &npd, 0x60);
@@ -576,7 +581,7 @@ bool validate_dev_klic(const u8* klicensee, const NPD_HEADER& npd)
 	std::memcpy(dev + 0x8, &license, 4);
 	std::memcpy(dev + 0xC, &type, 4);
 
-	// Check for an empty dev_hash (can't validate if devklic is NULL);
+	// Check for an empty dev_hash (can't validate if devklic is nullptr);
 	u128 klic;
 	std::memcpy(&klic, klicensee, sizeof(klic));
 
@@ -584,7 +589,7 @@ bool validate_dev_klic(const u8* klicensee, const NPD_HEADER& npd)
 	u128 key = klic ^ std::bit_cast<u128>(NP_OMAC_KEY_2);
 
 	// Hash with generated key and compare with dev_hash.
-	return cmac_hash_compare(reinterpret_cast<uchar*>(&key), 0x10, dev, 0x60, npd.dev_hash, 0x10);
+	return cmac_hash_compare(reinterpret_cast<u8*>(&key), 0x10, dev, 0x60, npd.dev_hash, 0x10);
 }
 
 bool validate_npd_hashes(std::string_view file_name, const u8* klicensee, const NPD_HEADER& npd, const EDAT_HEADER& edat, bool verbose)
@@ -647,8 +652,8 @@ bool validate_npd_hashes(std::string_view file_name, const u8* klicensee, const 
 
 void read_npd_edat_header(const fs::file* input, NPD_HEADER& NPD, EDAT_HEADER& EDAT)
 {
-	char npd_header[0x80]{};
-	char edat_header[0x10]{};
+	u8 npd_header[0x80]{};
+	u8 edat_header[0x10]{};
 
 	usz pos = input->pos();
 	pos += input->read_at(pos, npd_header, sizeof(npd_header));
@@ -666,7 +671,7 @@ void read_npd_edat_header(const fs::file* input, NPD_HEADER& NPD, EDAT_HEADER& E
 	NPD.expire_time = read_from_ptr<be_t<s64>>(npd_header, 120);
 
 	EDAT.flags = read_from_ptr<be_t<s32>>(edat_header, 0);
-	EDAT.block_size = read_from_ptr<be_t<s32>>(edat_header, 4);
+	EDAT.block_size = read_from_ptr<be_t<u32>>(edat_header, 4);
 	EDAT.file_size = read_from_ptr<be_t<u64>>(edat_header, 8);
 }
 
@@ -677,7 +682,7 @@ u128 GetEdatRifKeyFromRapFile(const fs::file& rap_file)
 
 	rap_file.read<u128>(rapkey);
 
-	rap_to_rif(reinterpret_cast<const uchar*>(&rapkey), reinterpret_cast<uchar*>(&rifkey));
+	rap_to_rif(reinterpret_cast<const u8*>(&rapkey), reinterpret_cast<u8*>(&rifkey));
 
 	return rifkey;
 }
@@ -761,16 +766,16 @@ fs::file DecryptEDAT(const fs::file& input, const std::string& input_file_name, 
 		memcpy(&devklic, NP_PSP_KEY_2, 0x10);
 		break;
 	case 8:
+	{
+		if (custom_klic)
+			memcpy(&devklic, custom_klic, 0x10);
+		else
 		{
-			if (custom_klic != NULL)
-				memcpy(&devklic, custom_klic, 0x10);
-			else
-			{
-				edat_log.error("Invalid custom klic!");
-				return fs::file{};
-			}
-			break;
+			edat_log.error("Invalid custom klic!");
+			return fs::file{};
 		}
+		break;
+	}
 	default:
 		edat_log.error("Invalid mode!");
 		return fs::file{};
@@ -901,7 +906,7 @@ u64 EDATADecrypter::ReadData(u64 pos, u8* data, u64 size)
 
 	for (u32 i = starting_block; i < ending_block; i++)
 	{
-		u64 res = decrypt_block(edata_file, data_buf, edatHeader, npdHeader, reinterpret_cast<uchar*>(&dec_key), i, total_blocks, edatHeader.file_size, true);
+		u64 res = decrypt_block(edata_file, data_buf, edatHeader, npdHeader, reinterpret_cast<u8*>(&dec_key), i, total_blocks, edatHeader.file_size, true);
 
 		if (res == umax)
 		{

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -158,7 +158,7 @@ u128 get_block_key(int block, const NPD_HEADER& npd)
 // for out data, allocate a buffer the size of 'edat.block_size'
 // Also, set 'in file' to the beginning of the encrypted data, which may be offset if inside another file, but normally just reset to beginning of file
 // returns number of bytes written, -1 for error
-s64 decrypt_block(const fs::file& in, u8* out, const EDAT_HEADER& edat, const NPD_HEADER& npd, const u8* crypt_key, u32 block_num, u32 total_blocks, u64 size_left, bool is_out_buffer_aligned = false)
+s64 decrypt_block(const fs::file& in, std::vector<u8>& out, const EDAT_HEADER& edat, const NPD_HEADER& npd, const u8* crypt_key, u32 block_num, u32 total_blocks, u64 size_left, bool is_out_buffer_aligned = false)
 {
 	// Get metadata info and setup buffers.
 	const int metadata_section_size = ((edat.flags & EDAT_COMPRESSED_FLAG) != 0 || (edat.flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
@@ -240,15 +240,16 @@ s64 decrypt_block(const fs::file& in, u8* out, const EDAT_HEADER& edat, const NP
 	std::vector<u8> dec_data_buf(length);
 
 	// Try to use out buffer for file reads if no padding is needed instead of a new buffer
-	u8* enc_data = enc_data_buf.empty() ? out : enc_data_buf.data();
+	std::vector<u8>* enc_data = enc_data_buf.empty() ? &out : &enc_data_buf;
 
 	// Variable to avoid copies when possible
-	u8* dec_data = dec_data_buf.data();
+	std::vector<u8>* dec_data = &dec_data_buf;
 
 	std::memset(hash, 0, 0x10);
 	std::memset(key_result, 0, 0x10);
 
-	in.read_at(offset, enc_data, length);
+	ensure(enc_data->size() >= length);
+	in.read_at(offset, enc_data->data(), length);
 
 	// Generate a key for the current block.
 	auto b_key = get_block_key(block_num, npd);
@@ -293,7 +294,7 @@ s64 decrypt_block(const fs::file& in, u8* out, const EDAT_HEADER& edat, const NP
 		// Simply copy the data without the header or the footer.
 		if (should_decompress)
 		{
-			std::memcpy(dec_data, enc_data, length);
+			std::memcpy(dec_data->data(), enc_data->data(), length);
 		}
 		else
 		{
@@ -307,7 +308,7 @@ s64 decrypt_block(const fs::file& in, u8* out, const EDAT_HEADER& edat, const NP
 		const u8* iv = (npd.version <= 1) ? empty_iv : npd.digest;
 
 		// Call main crypto routine on this data block.
-		if (!decrypt(hash_mode, crypto_mode, (npd.version == 4), enc_data, dec_data, length, key_result, iv, hash, hash_result))
+		if (!decrypt(hash_mode, crypto_mode, (npd.version == 4), enc_data->data(), dec_data->data(), length, key_result, iv, hash, hash_result))
 		{
 			edat_log.error("Block at offset 0x%llx has invalid hash!", offset);
 			return -1;
@@ -317,7 +318,7 @@ s64 decrypt_block(const fs::file& in, u8* out, const EDAT_HEADER& edat, const NP
 	// Apply additional de-compression if needed and write the decrypted data.
 	if (should_decompress)
 	{
-		const int res = decompress(out, dec_data, edat.block_size);
+		const int res = decompress(out.data(), dec_data->data(), edat.block_size);
 
 		size_left -= res;
 
@@ -333,9 +334,11 @@ s64 decrypt_block(const fs::file& in, u8* out, const EDAT_HEADER& edat, const NP
 		return res;
 	}
 
-	if (dec_data != out)
+	if (dec_data != &out)
 	{
-		std::memcpy(out, dec_data, pad_length);
+		ensure(out.size() >= pad_length);
+		ensure(dec_data->size() >= pad_length);
+		std::memcpy(out.data(), dec_data->data(), pad_length);
 	}
 
 	return pad_length;
@@ -898,7 +901,7 @@ u64 EDATADecrypter::ReadData(u64 pos, u8* data, u64 size)
 
 	for (u32 i = starting_block; i < ending_block; i++)
 	{
-		u64 res = decrypt_block(edata_file, data_buf.data(), edatHeader, npdHeader, reinterpret_cast<uchar*>(&dec_key), i, total_blocks, edatHeader.file_size, true);
+		u64 res = decrypt_block(edata_file, data_buf, edatHeader, npdHeader, reinterpret_cast<uchar*>(&dec_key), i, total_blocks, edatHeader.file_size, true);
 
 		if (res == umax)
 		{

--- a/rpcs3/Crypto/unedat.cpp
+++ b/rpcs3/Crypto/unedat.cpp
@@ -14,7 +14,7 @@
 
 LOG_CHANNEL(edat_log, "EDAT");
 
-void generate_key(int crypto_mode, int version, unsigned char *key_final, unsigned char *iv_final, unsigned char *key, unsigned char *iv)
+void generate_key(int crypto_mode, int version, u8* key_final, u8* iv_final, const u8* key, const u8* iv)
 {
 	int mode = crypto_mode & 0xF0000000;
 	uchar temp_iv[16]{};
@@ -42,7 +42,7 @@ void generate_key(int crypto_mode, int version, unsigned char *key_final, unsign
 	}
 }
 
-void generate_hash(int hash_mode, int version, unsigned char *hash_final, unsigned char *hash)
+void generate_hash(int hash_mode, int version, u8* hash_final, const u8* hash)
 {
 	int mode = hash_mode & 0xF0000000;
 	uchar temp_iv[16]{};
@@ -67,7 +67,7 @@ void generate_hash(int hash_mode, int version, unsigned char *hash_final, unsign
 	};
 }
 
-bool decrypt(int hash_mode, int crypto_mode, int version, unsigned char *in, unsigned char *out, usz length, unsigned char *key, unsigned char *iv, unsigned char *hash, unsigned char *test_hash)
+bool decrypt(int hash_mode, int crypto_mode, int version, const u8* in, u8* out, usz length, const u8* key, const u8* iv, const u8* hash, const u8* test_hash)
 {
 	// Setup buffers for key, iv and hash.
 	unsigned char key_final[0x10] = {};
@@ -116,7 +116,7 @@ bool decrypt(int hash_mode, int crypto_mode, int version, unsigned char *in, uns
 }
 
 // EDAT/SDAT functions.
-std::tuple<u64, s32, s32> dec_section(unsigned char* metadata)
+std::tuple<u64, s32, s32> dec_section(const u8* metadata)
 {
 	std::array<u8, 0x10> dec;
 	dec[0x00] = (metadata[0xC] ^ metadata[0x8] ^ metadata[0x10]);
@@ -143,10 +143,10 @@ std::tuple<u64, s32, s32> dec_section(unsigned char* metadata)
 	return std::make_tuple(offset, length, compression_end);
 }
 
-u128 get_block_key(int block, NPD_HEADER *npd)
+u128 get_block_key(int block, const NPD_HEADER& npd)
 {
 	unsigned char empty_key[0x10] = {};
-	unsigned char *src_key = (npd->version <= 1) ? empty_key : npd->dev_hash;
+	const unsigned char* src_key = (npd.version <= 1) ? empty_key : npd.dev_hash;
 	u128 dest_key{};
 	std::memcpy(&dest_key, src_key, 0xC);
 
@@ -155,13 +155,13 @@ u128 get_block_key(int block, NPD_HEADER *npd)
 	return dest_key;
 }
 
-// for out data, allocate a buffer the size of 'edat->block_size'
+// for out data, allocate a buffer the size of 'edat.block_size'
 // Also, set 'in file' to the beginning of the encrypted data, which may be offset if inside another file, but normally just reset to beginning of file
 // returns number of bytes written, -1 for error
-s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *npd, u8* crypt_key, u32 block_num, u32 total_blocks, u64 size_left, bool is_out_buffer_aligned = false)
+s64 decrypt_block(const fs::file& in, u8* out, const EDAT_HEADER& edat, const NPD_HEADER& npd, const u8* crypt_key, u32 block_num, u32 total_blocks, u64 size_left, bool is_out_buffer_aligned = false)
 {
 	// Get metadata info and setup buffers.
-	const int metadata_section_size = ((edat->flags & EDAT_COMPRESSED_FLAG) != 0 || (edat->flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
+	const int metadata_section_size = ((edat.flags & EDAT_COMPRESSED_FLAG) != 0 || (edat.flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
 	const int metadata_offset = 0x100;
 
 	u8 hash[0x10] = { 0 };
@@ -175,17 +175,17 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 	unsigned char empty_iv[0x10] = {};
 
 	// Decrypt the metadata.
-	if ((edat->flags & EDAT_COMPRESSED_FLAG) != 0)
+	if ((edat.flags & EDAT_COMPRESSED_FLAG) != 0)
 	{
 		metadata_sec_offset = metadata_offset + u64{block_num} * metadata_section_size;
 
 		u8 metadata[0x20]{};
 
-		in->read_at(metadata_sec_offset, metadata, 0x20);
+		in.read_at(metadata_sec_offset, metadata, 0x20);
 
 		// If the data is compressed, decrypt the metadata.
 		// NOTE: For NPD version 1 the metadata is not encrypted.
-		if (npd->version <= 1)
+		if (npd.version <= 1)
 		{
 			offset = read_from_ptr<be_t<u64>>(metadata, 0x10);
 			length = read_from_ptr<be_t<s32>>(metadata, 0x18);
@@ -198,13 +198,13 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 
 		std::memcpy(hash_result, metadata, 0x10);
 	}
-	else if ((edat->flags & EDAT_FLAG_0x20) != 0)
+	else if ((edat.flags & EDAT_FLAG_0x20) != 0)
 	{
 		// If FLAG 0x20, the metadata precedes each data block.
-		metadata_sec_offset = metadata_offset + u64{block_num} * (metadata_section_size + edat->block_size);
+		metadata_sec_offset = metadata_offset + u64{block_num} * (metadata_section_size + edat.block_size);
 
 		u8 metadata[0x20]{};
-		in->read_at(metadata_sec_offset, metadata, 0x20);
+		in.read_at(metadata_sec_offset, metadata, 0x20);
 
 		std::memcpy(hash_result, metadata, 0x14);
 
@@ -213,22 +213,22 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 			hash_result[j] = metadata[j] ^ metadata[j + 0x10];
 
 		offset = metadata_sec_offset + 0x20;
-		length = edat->block_size;
+		length = edat.block_size;
 
-		if ((block_num == (total_blocks - 1)) && (edat->file_size % edat->block_size))
-			length = static_cast<s32>(edat->file_size % edat->block_size);
+		if ((block_num == (total_blocks - 1)) && (edat.file_size % edat.block_size))
+			length = static_cast<s32>(edat.file_size % edat.block_size);
 	}
 	else
 	{
 		metadata_sec_offset = metadata_offset + u64{block_num} * metadata_section_size;
 
-		in->read_at(metadata_sec_offset, hash_result, 0x10);
+		in.read_at(metadata_sec_offset, hash_result, 0x10);
 
-		offset = metadata_offset + u64{block_num} * edat->block_size + total_blocks * metadata_section_size;
-		length = edat->block_size;
+		offset = metadata_offset + u64{block_num} * edat.block_size + total_blocks * metadata_section_size;
+		length = edat.block_size;
 
-		if ((block_num == (total_blocks - 1)) && (edat->file_size % edat->block_size))
-			length = static_cast<s32>(edat->file_size % edat->block_size);
+		if ((block_num == (total_blocks - 1)) && (edat.file_size % edat.block_size))
+			length = static_cast<s32>(edat.file_size % edat.block_size);
 	}
 
 	// Locate the real data.
@@ -248,7 +248,7 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 	std::memset(hash, 0, 0x10);
 	std::memset(key_result, 0, 0x10);
 
-	in->read_at(offset, enc_data, length);
+	in.read_at(offset, enc_data, length);
 
 	// Generate a key for the current block.
 	auto b_key = get_block_key(block_num, npd);
@@ -256,7 +256,7 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 	// Encrypt the block key with the crypto key.
 	aesecb128_encrypt(crypt_key, reinterpret_cast<uchar*>(&b_key), key_result);
 
-	if ((edat->flags & EDAT_FLAG_0x10) != 0)
+	if ((edat.flags & EDAT_FLAG_0x10) != 0)
 	{
 		aesecb128_encrypt(crypt_key, key_result, hash);  // If FLAG 0x10 is set, encrypt again to get the final hash.
 	}
@@ -266,25 +266,25 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 	}
 
 	// Setup the crypto and hashing mode based on the extra flags.
-	int crypto_mode = ((edat->flags & EDAT_FLAG_0x02) == 0) ? 0x2 : 0x1;
+	int crypto_mode = ((edat.flags & EDAT_FLAG_0x02) == 0) ? 0x2 : 0x1;
 	int hash_mode;
 
-	if ((edat->flags & EDAT_FLAG_0x10) == 0)
+	if ((edat.flags & EDAT_FLAG_0x10) == 0)
 		hash_mode = 0x02;
-	else if ((edat->flags & EDAT_FLAG_0x20) == 0)
+	else if ((edat.flags & EDAT_FLAG_0x20) == 0)
 		hash_mode = 0x04;
 	else
 		hash_mode = 0x01;
 
-	if ((edat->flags & EDAT_ENCRYPTED_KEY_FLAG) != 0)
+	if ((edat.flags & EDAT_ENCRYPTED_KEY_FLAG) != 0)
 	{
 		crypto_mode |= 0x10000000;
 		hash_mode |= 0x10000000;
 	}
 
-	const bool should_decompress = ((edat->flags & EDAT_COMPRESSED_FLAG) != 0) && compression_end;
+	const bool should_decompress = ((edat.flags & EDAT_COMPRESSED_FLAG) != 0) && compression_end;
 
-	if ((edat->flags & EDAT_DEBUG_DATA_FLAG) != 0)
+	if ((edat.flags & EDAT_DEBUG_DATA_FLAG) != 0)
 	{
 		// Reset the flags.
 		crypto_mode |= 0x01000000;
@@ -304,10 +304,10 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 	else
 	{
 		// IV is null if NPD version is 1 or 0.
-		u8* iv = (npd->version <= 1) ? empty_iv : npd->digest;
+		const u8* iv = (npd.version <= 1) ? empty_iv : npd.digest;
 
 		// Call main crypto routine on this data block.
-		if (!decrypt(hash_mode, crypto_mode, (npd->version == 4), enc_data, dec_data, length, key_result, iv, hash, hash_result))
+		if (!decrypt(hash_mode, crypto_mode, (npd.version == 4), enc_data, dec_data, length, key_result, iv, hash, hash_result))
 		{
 			edat_log.error("Block at offset 0x%llx has invalid hash!", offset);
 			return -1;
@@ -317,7 +317,7 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 	// Apply additional de-compression if needed and write the decrypted data.
 	if (should_decompress)
 	{
-		const int res = decompress(out, dec_data, edat->block_size);
+		const int res = decompress(out, dec_data, edat.block_size);
 
 		size_left -= res;
 
@@ -342,35 +342,35 @@ s64 decrypt_block(const fs::file* in, u8* out, EDAT_HEADER *edat, NPD_HEADER *np
 }
 
 // set file offset to beginning before calling
-bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, bool verbose)
+bool check_data(const u8* key, const EDAT_HEADER& edat, const NPD_HEADER& npd, const fs::file& f, bool verbose)
 {
 	u8 header[0xA0] = { 0 };
 	u8 empty_header[0xA0] = { 0 };
 	u8 header_hash[0x10] = { 0 };
 	u8 metadata_hash[0x10] = { 0 };
 
-	const u64 file_offset = f->pos();
+	const u64 file_offset = f.pos();
 
 	// Check NPD version and flags.
-	if ((npd->version == 0) || (npd->version == 1))
+	if ((npd.version == 0) || (npd.version == 1))
 	{
-		if (edat->flags & 0x7EFFFFFE)
+		if (edat.flags & 0x7EFFFFFE)
 		{
 			edat_log.error("Bad header flags!");
 			return false;
 		}
 	}
-	else if (npd->version == 2)
+	else if (npd.version == 2)
 	{
-		if (edat->flags & 0x7EFFFFE0)
+		if (edat.flags & 0x7EFFFFE0)
 		{
 			edat_log.error("Bad header flags!");
 			return false;
 		}
 	}
-	else if ((npd->version == 3) || (npd->version == 4))
+	else if ((npd.version == 3) || (npd.version == 4))
 	{
-		if (edat->flags & 0x7EFFFFC0)
+		if (edat.flags & 0x7EFFFFC0)
 		{
 			edat_log.error("Bad header flags!");
 			return false;
@@ -383,17 +383,17 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 	}
 
 	// Read in the file header.
-	f->read(header, 0xA0);
+	f.read(header, 0xA0);
 
 	// Read in the header and metadata section hashes.
-	f->seek(file_offset + 0x90);
-	f->read(metadata_hash, 0x10);
-	f->read(header_hash, 0x10);
+	f.seek(file_offset + 0x90);
+	f.read(metadata_hash, 0x10);
+	f.read(header_hash, 0x10);
 
 	// Setup the hashing mode and the crypto mode used in the file.
 	const int crypto_mode = 0x1;
-	int hash_mode = ((edat->flags & EDAT_ENCRYPTED_KEY_FLAG) == 0) ? 0x00000002 : 0x10000002;
-	if ((edat->flags & EDAT_DEBUG_DATA_FLAG) != 0)
+	int hash_mode = ((edat.flags & EDAT_ENCRYPTED_KEY_FLAG) == 0) ? 0x00000002 : 0x10000002;
+	if ((edat.flags & EDAT_DEBUG_DATA_FLAG) != 0)
 	{
 		hash_mode |= 0x01000000;
 
@@ -406,13 +406,13 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 	unsigned char header_iv[0x10] = { 0 };
 
 	// Test the header hash (located at offset 0xA0).
-	if (!decrypt(hash_mode, crypto_mode, (npd->version == 4), header, empty_header, 0xA0, header_key, header_iv, key, header_hash))
+	if (!decrypt(hash_mode, crypto_mode, (npd.version == 4), header, empty_header, 0xA0, header_key, header_iv, key, header_hash))
 	{
 		if (verbose)
 			edat_log.warning("Header hash is invalid!");
 
 		// If the header hash test fails and the data is not DEBUG, then RAP/RIF/KLIC key is invalid.
-		if ((edat->flags & EDAT_DEBUG_DATA_FLAG) != EDAT_DEBUG_DATA_FLAG)
+		if ((edat.flags & EDAT_DEBUG_DATA_FLAG) != EDAT_DEBUG_DATA_FLAG)
 		{
 			edat_log.error("RAP/RIF/KLIC key is invalid!");
 			return false;
@@ -420,24 +420,24 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 	}
 
 	// Parse the metadata info.
-	const int metadata_section_size = ((edat->flags & EDAT_COMPRESSED_FLAG) != 0 || (edat->flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
-	if (((edat->flags & EDAT_COMPRESSED_FLAG) != 0))
+	const int metadata_section_size = ((edat.flags & EDAT_COMPRESSED_FLAG) != 0 || (edat.flags & EDAT_FLAG_0x20) != 0) ? 0x20 : 0x10;
+	if ((edat.flags & EDAT_COMPRESSED_FLAG) != 0)
 	{
 		if (verbose)
 			edat_log.warning("COMPRESSED data detected!");
 	}
 
-	if (!edat->block_size)
+	if (!edat.block_size)
 	{
 		return false;
 	}
 
-	const usz block_num = utils::aligned_div<u64>(edat->file_size, edat->block_size);
+	const usz block_num = utils::aligned_div<u64>(edat.file_size, edat.block_size);
 	constexpr usz metadata_offset = 0x100;
 	const usz metadata_size = utils::mul_saturate<u64>(metadata_section_size, block_num);
 	u64 metadata_section_offset = metadata_offset;
 
-	if (utils::add_saturate<u64>(utils::add_saturate<u64>(file_offset, metadata_section_offset), metadata_size) > f->size())
+	if (utils::add_saturate<u64>(utils::add_saturate<u64>(file_offset, metadata_section_offset), metadata_size) > f.size())
 	{
 		return false;
 	}
@@ -452,26 +452,26 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 		const usz offset = file_offset + metadata_section_offset;
 
 		// Read in the metadata.
-		f->read_at(offset, metadata.get() + bytes_read, metadata_section_size);
+		f.read_at(offset, metadata.get() + bytes_read, metadata_section_size);
 
 		// Adjust sizes.
 		bytes_read += metadata_section_size;
 
-		if (((edat->flags & EDAT_FLAG_0x20) != 0)) // Metadata block before each data block.
-			metadata_section_offset += (metadata_section_size + edat->block_size);
+		if (((edat.flags & EDAT_FLAG_0x20) != 0)) // Metadata block before each data block.
+			metadata_section_offset += (metadata_section_size + edat.block_size);
 		else
 			metadata_section_offset += metadata_section_size;
 	}
 
 	// Test the metadata section hash (located at offset 0x90).
-	if (!decrypt(hash_mode, crypto_mode, (npd->version == 4), metadata.get(), empty_metadata.get(), metadata_size, header_key, header_iv, key, metadata_hash))
+	if (!decrypt(hash_mode, crypto_mode, (npd.version == 4), metadata.get(), empty_metadata.get(), metadata_size, header_key, header_iv, key, metadata_hash))
 	{
 		if (verbose)
 			edat_log.warning("Metadata section hash is invalid!");
 	}
 
 	// Checking ECDSA signatures.
-	if ((edat->flags & EDAT_DEBUG_DATA_FLAG) == 0)
+	if ((edat.flags & EDAT_DEBUG_DATA_FLAG) == 0)
 	{
 		// Setup buffers.
 		unsigned char metadata_signature[0x28] = { 0 };
@@ -486,9 +486,9 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 		ecdsa_set_pub(VSH_PUB);
 
 		// Read in the metadata and header signatures.
-		f->seek(0xB0);
-		f->read(metadata_signature, 0x28);
-		f->read(header_signature, 0x28);
+		f.seek(0xB0);
+		f.read(metadata_signature, 0x28);
+		f.read(header_signature, 0x28);
 
 		// Checking metadata signature.
 		// Setup signature r and s.
@@ -503,13 +503,13 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 		else
 		{
 			// Setup signature hash.
-			if ((edat->flags & EDAT_FLAG_0x20) != 0) //Sony failed again, they used buffer from 0x100 with half size of real metadata.
+			if ((edat.flags & EDAT_FLAG_0x20) != 0) //Sony failed again, they used buffer from 0x100 with half size of real metadata.
 			{
 				const usz metadata_buf_size = block_num * 0x10;
 
 				std::vector<u8> metadata_buf(metadata_buf_size);
 
-				f->read_at(file_offset + metadata_offset, metadata_buf.data(), metadata_buf_size);
+				f.read_at(file_offset + metadata_offset, metadata_buf.data(), metadata_buf_size);
 
 				sha1(metadata_buf.data(), metadata_buf_size, signature_hash);
 			}
@@ -519,7 +519,7 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 			if (!ecdsa_verify(signature_hash, signature_r, signature_s))
 			{
 				edat_log.warning("Metadata signature is invalid!");
-				if (((edat->block_size + 0ull) * block_num) > 0x100000000)
+				if (((edat.block_size + 0ull) * block_num) > 0x100000000)
 					edat_log.warning("*Due to large file size, metadata signature status may be incorrect!");
 			}
 		}
@@ -542,7 +542,7 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 
 			u8 header_buf[0xD8]{};
 
-			f->read_at(file_offset, header_buf, 0xD8);
+			f.read_at(file_offset, header_buf, 0xD8);
 			sha1(header_buf, 0xD8, signature_hash);
 
 			if (!ecdsa_verify(signature_hash, signature_r, signature_s))
@@ -553,9 +553,9 @@ bool check_data(u8* key, EDAT_HEADER* edat, NPD_HEADER* npd, const fs::file* f, 
 	return true;
 }
 
-bool validate_dev_klic(const u8* klicensee, NPD_HEADER *npd)
+bool validate_dev_klic(const u8* klicensee, const NPD_HEADER& npd)
 {
-	if ((npd->license & 0x3) != 0x3)
+	if ((npd.license & 0x3) != 0x3)
 	{
 		return true;
 	}
@@ -563,12 +563,12 @@ bool validate_dev_klic(const u8* klicensee, NPD_HEADER *npd)
 	unsigned char dev[0x60]{};
 
 	// Build the dev buffer (first 0x60 bytes of NPD header in big-endian).
-	std::memcpy(dev, npd, 0x60);
+	std::memcpy(dev, &npd, 0x60);
 
 	// Fix endianness.
-	s32 version = std::bit_cast<be_t<s32>>(npd->version);
-	s32 license = std::bit_cast<be_t<s32>>(npd->license);
-	s32 type = std::bit_cast<be_t<s32>>(npd->type);
+	s32 version = std::bit_cast<be_t<s32>>(npd.version);
+	s32 license = std::bit_cast<be_t<s32>>(npd.license);
+	s32 type = std::bit_cast<be_t<s32>>(npd.type);
 	std::memcpy(dev + 0x4, &version, 4);
 	std::memcpy(dev + 0x8, &license, 4);
 	std::memcpy(dev + 0xC, &type, 4);
@@ -581,13 +581,13 @@ bool validate_dev_klic(const u8* klicensee, NPD_HEADER *npd)
 	u128 key = klic ^ std::bit_cast<u128>(NP_OMAC_KEY_2);
 
 	// Hash with generated key and compare with dev_hash.
-	return cmac_hash_compare(reinterpret_cast<uchar*>(&key), 0x10, dev, 0x60, npd->dev_hash, 0x10);
+	return cmac_hash_compare(reinterpret_cast<uchar*>(&key), 0x10, dev, 0x60, npd.dev_hash, 0x10);
 }
 
-bool validate_npd_hashes(std::string_view file_name, const u8* klicensee, NPD_HEADER* npd, EDAT_HEADER* edat, bool verbose)
+bool validate_npd_hashes(std::string_view file_name, const u8* klicensee, const NPD_HEADER& npd, const EDAT_HEADER& edat, bool verbose)
 {
 	// Ignore header validation in DEBUG data.
-	if (edat->flags & EDAT_DEBUG_DATA_FLAG)
+	if (edat.flags & EDAT_DEBUG_DATA_FLAG)
 	{
 		return true;
 	}
@@ -609,7 +609,7 @@ bool validate_npd_hashes(std::string_view file_name, const u8* klicensee, NPD_HE
 	std::unique_ptr<u8[]> buf_upper(new u8[buf_len]);
 
 	// Build the title buffer (content_id + file_name).
-	std::memcpy(buf.get(), npd->content_id, 0x30);
+	std::memcpy(buf.get(), npd.content_id, 0x30);
 	std::memcpy(buf.get() + 0x30, file_name.data(), file_name.size());
 
 	std::memcpy(buf_lower.get(), buf.get(), buf_len);
@@ -627,9 +627,9 @@ bool validate_npd_hashes(std::string_view file_name, const u8* klicensee, NPD_HE
 	// Hash with NPDRM_OMAC_KEY_3 and compare with title_hash.
 	// Try to ignore case sensivity with file extension
 	const bool title_hash_result =
-		cmac_hash_compare(const_cast<u8*>(NP_OMAC_KEY_3), 0x10, buf.get(), buf_len, npd->title_hash, 0x10) ||
-		cmac_hash_compare(const_cast<u8*>(NP_OMAC_KEY_3), 0x10, buf_lower.get(), buf_len, npd->title_hash, 0x10) ||
-		cmac_hash_compare(const_cast<u8*>(NP_OMAC_KEY_3), 0x10, buf_upper.get(), buf_len, npd->title_hash, 0x10);
+		cmac_hash_compare(const_cast<u8*>(NP_OMAC_KEY_3), 0x10, buf.get(), buf_len, npd.title_hash, 0x10) ||
+		cmac_hash_compare(const_cast<u8*>(NP_OMAC_KEY_3), 0x10, buf_lower.get(), buf_len, npd.title_hash, 0x10) ||
+		cmac_hash_compare(const_cast<u8*>(NP_OMAC_KEY_3), 0x10, buf_upper.get(), buf_len, npd.title_hash, 0x10);
 
 	if (verbose)
 	{
@@ -703,7 +703,7 @@ bool VerifyEDATHeaderWithKLicense(const fs::file& input, std::string_view input_
 	// Perform header validation (EDAT only).
 	char real_file_name[CRYPTO_MAX_PATH]{};
 	extract_file_name(input_file_name, real_file_name);
-	if (!validate_npd_hashes(real_file_name, custom_klic, &NPD, &EDAT, false))
+	if (!validate_npd_hashes(real_file_name, custom_klic, NPD, EDAT, false))
 	{
 		edat_log.error("NPD hash validation failed!");
 		return false;
@@ -812,7 +812,7 @@ bool EDATADecrypter::ReadHeader()
 		char real_file_name[CRYPTO_MAX_PATH]{};
 		extract_file_name(m_file_name, real_file_name);
 
-		if (!validate_npd_hashes(real_file_name, reinterpret_cast<const u8*>(&dec_key), &npdHeader, &edatHeader, false))
+		if (!validate_npd_hashes(real_file_name, reinterpret_cast<const u8*>(&dec_key), npdHeader, edatHeader, false))
 		{
 			edat_log.error("NPD hash validation failed!");
 			return true;
@@ -898,7 +898,7 @@ u64 EDATADecrypter::ReadData(u64 pos, u8* data, u64 size)
 
 	for (u32 i = starting_block; i < ending_block; i++)
 	{
-		u64 res = decrypt_block(&edata_file, data_buf.data(), &edatHeader, &npdHeader, reinterpret_cast<uchar*>(&dec_key), i, total_blocks, edatHeader.file_size, true);
+		u64 res = decrypt_block(edata_file, data_buf.data(), edatHeader, npdHeader, reinterpret_cast<uchar*>(&dec_key), i, total_blocks, edatHeader.file_size, true);
 
 		if (res == umax)
 		{

--- a/rpcs3/Crypto/unedat.h
+++ b/rpcs3/Crypto/unedat.h
@@ -54,7 +54,7 @@ struct NPD_HEADER
 struct EDAT_HEADER
 {
 	s32 flags;
-	s32 block_size;
+	u32 block_size;
 	u64 file_size;
 };
 


### PR DESCRIPTION
- Fix EDAT_HEADER block_size data type. It was s32 instead of u32, leading to potential overflow
- Use u64 instead of int for sizes and offsets to prevent overflows
- Use more const
- Use rpcs3 data types
- Use more std::vector and references instead of raw pointers
- Add some sanity checks when writing to std::vector
- Don't divide by block_size if it's 0