### PR TITLE
Input: Fix SDL3 compilation by patching haptic and camera types

### DIFF
--- a/rpcs3/Emu/Io/LogitechG27.h
+++ b/rpcs3/Emu/Io/LogitechG27.h
@@ -38,7 +38,8 @@ struct logitech_g27_ffb_slot
 	logitech_g27_ffb_state state = logitech_g27_ffb_state::inactive;
 	u64 last_update = 0;
 	SDL_HapticEffect last_effect {};
-	SDL_HapticEffectID effect_id = -1;
+//	SDL_HapticEffectID effect_id = -1;
+	int effect_id = -1;
 };
 
 struct sdl_mapping

--- a/rpcs3/Input/sdl_camera_handler.cpp
+++ b/rpcs3/Input/sdl_camera_handler.cpp
@@ -358,15 +358,15 @@ void sdl_camera_handler::start_camera()
 	const auto camera_permission = SDL_GetCameraPermissionState(m_camera);
 	switch (camera_permission)
 	{
-	case SDL_CameraPermissionState::SDL_CAMERA_PERMISSION_STATE_DENIED:
+	case -1:
 		camera_log.error("Camera permission denied");
 		set_state(camera_handler_state::closed);
 		reset();
 		return;
-	case SDL_CameraPermissionState::SDL_CAMERA_PERMISSION_STATE_PENDING:
+	case 0:
 		// TODO: try to get permission
 		break;
-	case SDL_CameraPermissionState::SDL_CAMERA_PERMISSION_STATE_APPROVED:
+	case 1:
 		break;
 	default:
 		fmt::throw_exception("Unknown SDL_CameraPermissionState %d", static_cast<s32>(camera_permission));


### PR DESCRIPTION
Replaced SDL_HapticEffectID with int and mapped SDL_CameraPermissionState enums to integers to fix compilation with older SDL3 headers.