### PR TITLE
Qt: run initial dialogs on the main event loop

### DIFF
--- a/rpcs3/headless_application.cpp
+++ b/rpcs3/headless_application.cpp
@@ -21,7 +21,7 @@ headless_application::headless_application(int& argc, char** argv) : QCoreApplic
 {
 }
 
-bool headless_application::Init()
+void headless_application::Init()
 {
 	// Create callbacks from the emulator, which reference the handlers.
 	InitializeCallbacks();
@@ -34,8 +34,6 @@ bool headless_application::Init()
 
 	// As per Qt recommendations to avoid conflicts for POSIX functions
 	std::setlocale(LC_NUMERIC, "C");
-
-	return true;
 }
 
 void headless_application::InitializeConnects() const

--- a/rpcs3/headless_application.h
+++ b/rpcs3/headless_application.h
@@ -18,7 +18,7 @@ public:
 	headless_application(int& argc, char** argv);
 
 	/** Call this method before calling app.exec */
-	bool Init() override;
+	void Init() override;
 
 private:
 	void InitializeCallbacks();

--- a/rpcs3/main_application.h
+++ b/rpcs3/main_application.h
@@ -13,7 +13,7 @@ class main_application
 public:
 	main_application();
 
-	virtual bool Init() = 0;
+	virtual void Init() = 0;
 
 	static void InitializeEmulator(const std::string& user, bool show_gui, bool headless);
 

--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -984,23 +984,14 @@ int run_rpcs3(int argc, char** argv)
 			gui_app->SetGameScreenIndex(game_screen_index);
 		}
 
-		if (!gui_app->Init())
-		{
-			Emu.Quit(true);
-			return 0;
-		}
+		gui_app->Init();
 	}
 	else if (headless_application* headless_app = qobject_cast<headless_application*>(app.data()))
 	{
 		g_headless = true;
 
 		headless_app->SetActiveUser(active_user);
-
-		if (!headless_app->Init())
-		{
-			Emu.Quit(true);
-			return 0;
-		}
+		headless_app->Init();
 	}
 	else
 	{
@@ -1389,5 +1380,11 @@ int run_rpcs3(int argc, char** argv)
 	}
 
 	// run event loop (maybe only needed for the gui application)
+	if (gui_application* gui_app = qobject_cast<gui_application*>(app.data()))
+	{
+		// call gui_application::exec
+		return gui_app->exec();
+	}
+
 	return app->exec();
 }

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -29,9 +29,8 @@ class emu_settings : public QObject
 	*
 	*/
 	Q_OBJECT
-public:
-	std::set<emu_settings_type> m_broken_types; // list of broken settings
 
+public:
 	/** Creates a settings object which reads in the config.yml file at rpcs3/bin/%path%/config.yml
 	* Settings are only written when SaveSettings is called.
 	*/
@@ -91,15 +90,6 @@ public:
 	/** Try to find the settings type for a given string.*/
 	emu_settings_type FindSettingsType(const cfg::_base* node) const;
 
-	/** Gets all the renderer info for gpu settings.*/
-	std::shared_ptr<render_creator> m_render_creator;
-
-	/** Gets a list of all the microphones available.*/
-	microphone_creator m_microphone_creator;
-
-	/** Gets a list of all the midi devices available.*/
-	midi_creator m_midi_creator;
-
 	/** Loads the settings from path.*/
 	void LoadSettings(const std::string& title_id = "", bool create_config_from_global = true, const std::string& db_config = "");
 
@@ -121,6 +111,15 @@ public:
 	/** Resets the current settings to the global default. This includes all connected widgets. */
 	void RestoreDefaults();
 
+	/** Gets all the renderer info for gpu settings.*/
+	std::shared_ptr<render_creator> m_render_creator;
+
+	/** Gets a list of all the microphones available.*/
+	microphone_creator m_microphone_creator;
+
+	/** Gets a list of all the midi devices available.*/
+	midi_creator m_midi_creator;
+
 Q_SIGNALS:
 	void RestoreDefaultsSignal();
 
@@ -129,6 +128,7 @@ public Q_SLOTS:
 	void SaveSettings() const;
 
 private:
+	std::set<emu_settings_type> m_broken_types; // list of broken settings
 	YAML::Node m_default_settings; // The default settings as a YAML node.
 	YAML::Node m_current_settings; // The current settings as a YAML node.
 	std::string m_title_id;

--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -123,8 +123,10 @@ game_list_frame::game_list_frame(std::shared_ptr<gui_settings> gui_settings, std
 	add_column(gui::game_list_columns::compat);
 	add_column(gui::game_list_columns::dir_size);
 
-	m_progress_dialog = new progress_dialog(tr("Loading games"), tr("Loading games, please wait..."), tr("Cancel"), 0, 0, false, this, Qt::Dialog | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
+	m_progress_dialog = new progress_dialog(tr("Loading games"), tr("Loading games, please wait..."), tr("Cancel"), 0, 100, false, this, Qt::Dialog | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
 	m_progress_dialog->setMinimumDuration(200); // Only show the progress dialog after some time has passed
+	m_progress_dialog->SetValue(m_progress_dialog->maximum());
+	m_progress_dialog->accept();
 
 	// Events
 	connect(m_progress_dialog, &QProgressDialog::canceled, this, [this]()

--- a/rpcs3/rpcs3qt/gui_application.cpp
+++ b/rpcs3/rpcs3qt/gui_application.cpp
@@ -91,64 +91,167 @@ gui_application::~gui_application()
 #endif
 }
 
-bool gui_application::Init()
+int gui_application::exec()
+{
+	// Show a series of dialogs using the main event loop before finally showing the main window.
+	// We used to do this synchronous with e.g. QDialog::exec() before we called gui_application::exec(),
+	// but when you call quit() (as seen in these dialogs) without a running event loop,
+	// then the destructors of QObjects won't be called, leading to all sorts of issues.
+	struct dialog_step
+	{
+		bool condition {};
+		std::function<void()> func {};
+	};
+
+	std::shared_ptr<u32> step_index = std::make_shared<u32>(0);
+	std::shared_ptr<std::vector<dialog_step>> steps = std::make_shared<std::vector<dialog_step>>();
+
+	m_show_next_dialog = [this, step_index, steps]()
+	{
+		ensure(steps && step_index);
+		const dialog_step step = ::at32(*steps, (*step_index)++);
+		ensure(step.func);
+
+		if (step.condition)
+		{
+			step.func();
+		}
+		else
+		{
+			m_show_next_dialog();
+		}
+	};
+
+	steps->push_back(dialog_step
+	{
+		.condition = !rpcs3::is_release_build() && !rpcs3::is_local_build(),
+		.func = [this]()
+		{
+			const std::string_view branch_name = rpcs3::get_full_branch();
+			gui_log.warning("Experimental Build Warning! Build origin: %s", branch_name);
+
+			QMessageBox* msg = new QMessageBox();
+			msg->setAttribute(Qt::WA_DeleteOnClose);
+			msg->setWindowModality(Qt::WindowModal);
+			msg->setWindowTitle(tr("Experimental Build Warning"));
+			msg->setIcon(QMessageBox::Critical);
+			msg->setTextFormat(Qt::RichText);
+			msg->setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+			msg->setDefaultButton(QMessageBox::No);
+			msg->setText(gui::utils::make_paragraph(tr(
+				"Please understand that this build is not an official RPCS3 release.\n"
+				"This build contains changes that may break games, or even <b>damage</b> your data.\n"
+				"We recommend to download and use the official build from the %0.\n"
+				"\n"
+				"Build origin: %1\n"
+				"Do you wish to use this build anyway?")
+				.arg(gui::utils::make_link(tr("RPCS3 website"), "https://rpcs3.net/download"))
+				.arg(Qt::convertFromPlainText(branch_name.data()))));
+			msg->layout()->setSizeConstraint(QLayout::SetFixedSize);
+			connect(msg, &QMessageBox::finished, this, [this](int)
+			{
+				const QMessageBox* box = qobject_cast<QMessageBox*>(sender());
+				if (!box || box->standardButton(box->clickedButton()) == QMessageBox::No)
+				{
+					Emu.Quit(true);
+					return;
+				}
+				m_show_next_dialog();
+			});
+			msg->open();
+		}
+	});
+	steps->push_back(dialog_step
+	{
+		.condition = m_render_creator->vulkan_timed_out,
+		.func = [this]()
+		{
+			gui_log.error("Vulkan device enumeration timed out");
+
+			QMessageBox* msg = new QMessageBox();
+			msg->setAttribute(Qt::WA_DeleteOnClose);
+			msg->setWindowModality(Qt::WindowModal);
+			msg->setIcon(QMessageBox::Critical);
+			msg->setStandardButtons(QMessageBox::Ignore | QMessageBox::Abort);
+			msg->setDefaultButton(QMessageBox::Abort);
+			msg->setWindowTitle(tr("Vulkan Check Timeout"));
+			msg->setText(tr("Querying for Vulkan-compatible devices is taking too long. This is usually caused by malfunctioning "
+			                "graphics drivers, reinstalling them could fix the issue.\n\n"
+			                "Selecting ignore starts the emulator without Vulkan support."));
+			msg->layout()->setSizeConstraint(QLayout::SetFixedSize);
+			connect(msg, &QMessageBox::finished, this, [this](int)
+			{
+				const QMessageBox* box = qobject_cast<QMessageBox*>(sender());
+				if (!box || box->standardButton(box->clickedButton()) == QMessageBox::Abort)
+				{
+					Emu.Quit(true);
+					return;
+				}
+				m_show_next_dialog();
+			});
+			msg->open();
+		}
+	});
+	steps->push_back(dialog_step
+	{
+		.condition = m_gui_settings->GetValue(gui::ib_show_welcome).toBool(),
+		.func = [this]()
+		{
+			welcome_dialog* welcome = new welcome_dialog(m_gui_settings, false);
+			connect(welcome, &QDialog::finished, this, [this](int result)
+			{
+				if (result == QDialog::Rejected)
+				{
+					Emu.Quit(true);
+					return;
+				}
+				m_show_next_dialog();
+			});
+			welcome->open();
+		}
+	});
+	steps->push_back(dialog_step
+	{
+		.condition = true,
+		.func = [this]()
+		{
+			if (m_main_window)
+			{
+				m_main_window->show();
+			}
+
+#ifdef __APPLE__
+			if (!m_render_creator->Vulkan.supported)
+			{
+				QMessageBox::warning(nullptr,
+									 tr("Warning"),
+									 tr("Vulkan is not supported on this Mac.\n"
+										"No graphics will be rendered."));
+			}
+#endif
+
+			// Check maxfiles
+			if (utils::get_maxfiles() < 4096)
+			{
+				QMessageBox::warning(nullptr,
+										tr("Warning"),
+										tr("The current limit of maximum file descriptors is too low.\n"
+										"Some games will crash.\n"
+										"\n"
+										"Please increase the limit before running RPCS3."));
+			}
+		}
+	});
+
+	m_show_next_dialog();
+
+	return QGuiApplication::exec();
+}
+
+void gui_application::Init()
 {
 #ifndef __APPLE__
 	setWindowIcon(QIcon(":/rpcs3.ico"));
-#endif
-
-	if (!rpcs3::is_release_build() && !rpcs3::is_local_build())
-	{
-		const std::string_view branch_name = rpcs3::get_full_branch();
-		gui_log.warning("Experimental Build Warning! Build origin: %s", branch_name);
-
-		QMessageBox msg;
-		msg.setWindowModality(Qt::WindowModal);
-		msg.setWindowTitle(tr("Experimental Build Warning"));
-		msg.setIcon(QMessageBox::Critical);
-		msg.setTextFormat(Qt::RichText);
-		msg.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-		msg.setDefaultButton(QMessageBox::No);
-		msg.setText(gui::utils::make_paragraph(tr(
-			"Please understand that this build is not an official RPCS3 release.\n"
-			"This build contains changes that may break games, or even <b>damage</b> your data.\n"
-			"We recommend to download and use the official build from the %0.\n"
-			"\n"
-			"Build origin: %1\n"
-			"Do you wish to use this build anyway?")
-			.arg(gui::utils::make_link(tr("RPCS3 website"), "https://rpcs3.net/download"))
-			.arg(Qt::convertFromPlainText(branch_name.data()))));
-		msg.layout()->setSizeConstraint(QLayout::SetFixedSize);
-
-		if (msg.exec() == QMessageBox::No)
-		{
-			return false;
-		}
-	}
-
-	if (m_render_creator->vulkan_timed_out)
-	{
-		gui_log.error("Vulkan device enumeration timed out");
-		const auto button = QMessageBox::critical(nullptr, tr("Vulkan Check Timeout"),
-			tr("Querying for Vulkan-compatible devices is taking too long. This is usually caused by malfunctioning "
-				"graphics drivers, reinstalling them could fix the issue.\n\n"
-				"Selecting ignore starts the emulator without Vulkan support."),
-			QMessageBox::Ignore | QMessageBox::Abort, QMessageBox::Abort);
-
-		if (button != QMessageBox::Ignore)
-		{
-			return false;
-		}
-	}
-
-#ifdef __APPLE__
-	if (!m_render_creator->Vulkan.supported)
-	{
-		QMessageBox::warning(nullptr,
-							 tr("Warning"),
-							 tr("Vulkan is not supported on this Mac.\n"
-								"No graphics will be rendered."));
-	}
 #endif
 
 	m_emu_settings = std::make_shared<emu_settings>(m_render_creator);
@@ -183,7 +286,7 @@ bool gui_application::Init()
 	// Create the main window
 	if (m_show_gui)
 	{
-		m_main_window = new main_window(m_gui_settings, m_emu_settings, m_persistent_settings, nullptr);
+		m_main_window = new main_window(m_gui_settings, m_emu_settings, m_persistent_settings, m_with_cli_boot, nullptr);
 
 		const auto codes    = GetAvailableLanguageCodes();
 		const auto language = m_gui_settings->GetValue(gui::loc_language).toString();
@@ -205,33 +308,8 @@ bool gui_application::Init()
 		connect(this, &gui_application::OnEnableDiscInsert, m_main_window, &main_window::OnEnableDiscInsert);
 
 		connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, [this](){ OnChangeStyleSheetRequest(); });
-	}
 
-	if (m_gui_settings->GetValue(gui::ib_show_welcome).toBool())
-	{
-		welcome_dialog* welcome = new welcome_dialog(m_gui_settings, false);
-
-		if (welcome->exec() == QDialog::Rejected)
-		{
-			// If the agreement on RPCS3's usage conditions was not accepted by the user, ask the main window to gracefully terminate
-			return false;
-		}
-	}
-
-	// Check maxfiles
-	if (utils::get_maxfiles() < 4096)
-	{
-		QMessageBox::warning(nullptr,
-							 tr("Warning"),
-							 tr("The current limit of maximum file descriptors is too low.\n"
-								"Some games will crash.\n"
-								"\n"
-								"Please increase the limit before running RPCS3."));
-	}
-
-	if (m_main_window && !m_main_window->Init(m_with_cli_boot))
-	{
-		return false;
+		m_main_window->Init();
 	}
 
 #ifdef WITH_DISCORD_RPC
@@ -251,8 +329,6 @@ bool gui_application::Init()
 		register_device_notification(m_main_window->winId());
 	}
 #endif
-
-	return true;
 }
 
 void gui_application::SwitchTranslator(const QString& language_code)

--- a/rpcs3/rpcs3qt/gui_application.h
+++ b/rpcs3/rpcs3qt/gui_application.h
@@ -67,7 +67,9 @@ public:
 	}
 
 	/** Call this method before calling app.exec */
-	bool Init() override;
+	void Init() override;
+
+	int exec();
 
 	static s32 get_language_id();
 
@@ -127,6 +129,8 @@ private:
 	u64 m_pause_delayed_tag = 0;
 	typename Emulator::stop_counter_t m_emu_focus_out_emulation_id{};
 	bool m_is_pause_on_focus_loss_active = false;
+
+	std::function<void()> m_show_next_dialog;
 
 #ifdef _WIN32
 	void register_device_notification(WId window_id);

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -171,13 +171,14 @@ extern void qt_events_aware_op(int repeat_duration_ms, std::function<bool()> wra
 	}
 }
 
-main_window::main_window(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget* parent)
+main_window::main_window(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, bool with_cli_boot, QWidget* parent)
 	: QMainWindow(parent)
 	, ui(new Ui::main_window)
 	, m_gui_settings(gui_settings)
 	, m_emu_settings(std::move(emu_settings))
 	, m_persistent_settings(std::move(persistent_settings))
 	, m_updater(nullptr, gui_settings)
+	, m_with_cli_boot(with_cli_boot)
 {
 	Q_INIT_RESOURCE(resources);
 
@@ -194,7 +195,7 @@ main_window::~main_window()
 /* An init method is used so that RPCS3App can create the necessary connects before calling init (specifically the stylesheet connect).
  * Simplifies logic a bit.
  */
-bool main_window::Init([[maybe_unused]] bool with_cli_boot)
+void main_window::Init()
 {
 	setAcceptDrops(true);
 
@@ -280,13 +281,6 @@ bool main_window::Init([[maybe_unused]] bool with_cli_boot)
 		m_game_list_frame->GetGameCompatibility()->RequestCompatibility(true);
 	});
 #endif
-
-	if (const auto update_value = m_gui_settings->GetValue(gui::m_check_upd_start).toString(); update_value != gui::update_off)
-	{
-		const bool in_background = with_cli_boot || update_value == gui::update_bkg;
-		const bool auto_accept   = !in_background && update_value == gui::update_auto;
-		m_updater.check_for_updates(true, in_background, auto_accept, this);
-	}
 #endif
 
 	// Disable vsh if not present.
@@ -295,14 +289,30 @@ bool main_window::Init([[maybe_unused]] bool with_cli_boot)
 	// Focus to search bar by default
 	ui->mw_searchbar->setFocus();
 
-	// Refresh gamelist last
-	m_game_list_frame->Refresh(true);
-
 	update_gui_pad_thread();
+}
 
-	show();
+void main_window::show()
+{
+	QMainWindow::show();
 
-	return true;
+	if (std::exchange(m_shown, true))
+	{
+		return;
+	}
+
+	// Check for updates when the main window is shown for the first time
+#ifdef RPCS3_UPDATE_SUPPORTED
+	if (const auto update_value = m_gui_settings->GetValue(gui::m_check_upd_start).toString(); update_value != gui::update_off)
+	{
+		const bool in_background = m_with_cli_boot || update_value == gui::update_bkg;
+		const bool auto_accept   = !in_background && update_value == gui::update_auto;
+		m_updater.check_for_updates(true, in_background, auto_accept, this);
+	}
+#endif
+
+	// Refresh gamelist when the main window is shown for the first time
+	m_game_list_frame->Refresh(true);
 }
 
 void main_window::update_gui_pad_thread()

--- a/rpcs3/rpcs3qt/main_window.h
+++ b/rpcs3/rpcs3qt/main_window.h
@@ -70,9 +70,10 @@ class main_window : public QMainWindow
 	};
 
 public:
-	explicit main_window(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, QWidget* parent = nullptr);
+	explicit main_window(std::shared_ptr<gui_settings> gui_settings, std::shared_ptr<emu_settings> emu_settings, std::shared_ptr<persistent_settings> persistent_settings, bool with_cli_boot, QWidget* parent = nullptr);
 	~main_window();
-	bool Init(bool with_cli_boot);
+	void show();
+	void Init();
 	QIcon GetAppIcon() const;
 	void OnMissingFw();
 	static bool InstallPackages(main_window* mw, QStringList file_paths = {}, bool from_boot = false);
@@ -201,4 +202,6 @@ private:
 	std::unique_ptr<gui_pad_thread> m_gui_pad_thread;
 
 	system_state m_system_state = system_state::stopped;
+	bool m_with_cli_boot = false;
+	bool m_shown = false;
 };

--- a/rpcs3/rpcs3qt/progress_dialog.cpp
+++ b/rpcs3/rpcs3qt/progress_dialog.cpp
@@ -8,7 +8,6 @@ progress_dialog::progress_dialog(const QString& windowTitle, const QString& labe
 {
 	setWindowTitle(windowTitle);
 	setMinimumSize(QLabel("This is the very length of the progressdialog due to hidpi reasons.").sizeHint().width(), sizeHint().height());
-	setValue(0);
 	setWindowModality(Qt::WindowModal);
 
 	if (delete_on_close)

--- a/rpcs3/rpcs3qt/welcome_dialog.cpp
+++ b/rpcs3/rpcs3qt/welcome_dialog.cpp
@@ -20,6 +20,8 @@ welcome_dialog::welcome_dialog(std::shared_ptr<gui_settings> gui_settings, bool 
 
 	setAttribute(Qt::WA_DeleteOnClose);
 	setWindowFlag(Qt::WindowCloseButtonHint, false); // disable the close button shown on the dialog's top right corner
+	setModal(true);
+
 	layout()->setSizeConstraint(QLayout::SetFixedSize);
 
 	ui->icon_label->load(QStringLiteral(":/rpcs3.svg"));


### PR DESCRIPTION
- Qt: run initial dialogs on the main event loop

Shows initial dialogs like the welcome dialog that may lead to a quit() using the main event loop.
We used to do this synchronous with e.g. QDialog::exec() before we called gui_application::exec(),
but when you call quit() (as seen in these dialogs) without a running event loop,
then the destructors of QObjects may not be called, leading to all sorts of issues, like an exception when destroying an unjoined thread.

fixes #19186
closes #19187