### PR TITLE
rsx: Fix nv0039 image (de)interleaving functionality

### DIFF
--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -73,10 +73,8 @@ namespace rsx
 			const auto read_address = get_address(src_offset, src_dma);
 			const auto write_address = get_address(dst_offset, dst_dma);
 			// LINE_LENGTH_IN is an element count; FORMAT_IN/OUT select the byte stride between elements.
-			const auto read_length =
-				in_pitch * (line_count - 1) + line_length * in_format;
-			const auto write_length =
-				out_pitch * (line_count - 1) + line_length * out_format;
+			const auto read_length = in_pitch * (line_count - 1) + line_length * in_format;
+			const auto write_length = out_pitch * (line_count - 1) + line_length * out_format;
 
 			RSX(ctx)->invalidate_fragment_program(dst_dma, dst_offset, write_length);
 

--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -72,8 +72,11 @@ namespace rsx
 			const bool is_block_transfer = (in_pitch == out_pitch && out_pitch + 0u == line_length);
 			const auto read_address = get_address(src_offset, src_dma);
 			const auto write_address = get_address(dst_offset, dst_dma);
-			const auto read_length = in_pitch * (line_count - 1) + line_length;
-			const auto write_length = out_pitch * (line_count - 1) + line_length;
+			// LINE_LENGTH_IN is an element count; FORMAT_IN/OUT select the byte stride between elements.
+			const auto read_length =
+				in_pitch * (line_count - 1) + line_length * in_format;
+			const auto write_length =
+				out_pitch * (line_count - 1) + line_length * out_format;
 
 			RSX(ctx)->invalidate_fragment_program(dst_dma, dst_offset, write_length);
 
@@ -110,7 +113,7 @@ namespace rsx
 			const bool is_overlapping = dst_dma == src_dma && [&]() -> bool
 			{
 				const u32 src_max = src_offset + read_length;
-				const u32 dst_max = dst_offset + (out_pitch * (line_count - 1) + line_length);
+				const u32 dst_max = dst_offset + write_length;
 				return (src_offset >= dst_offset && src_offset < dst_max) ||
 				 (dst_offset >= src_offset && dst_offset < src_max);
 			}();

--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -14,13 +14,13 @@ namespace rsx
 	namespace nv0039
 	{
 		// Transfer with stride
-		inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 element_count, u32 height, s32 src_pitch, s32 dst_pitch, u8 src_stride, u8 dst_stride)
+		inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 column_count, u32 height, s32 src_pitch, s32 dst_pitch, u8 src_stride, u8 dst_stride)
 		{
 			for (u32 row = 0; row < height; ++row)
 			{
 				auto dst_ptr = dst;
 				auto src_ptr = src;
-				for (u32 element = 0; element < element_count; ++element)
+				for (u32 column = 0; column < column_count; ++column)
 				{
 					*dst_ptr = *src_ptr;
 

--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -69,12 +69,16 @@ namespace rsx
 			u32 dst_offset = REGS(ctx)->nv0039_output_offset();
 			u32 dst_dma = REGS(ctx)->nv0039_output_location();
 
-			const bool is_block_transfer = (in_pitch == out_pitch && out_pitch + 0u == line_length);
+			const auto in_width_in_bytes = line_length * in_format;
+			const auto out_width_in_bytes = line_length * out_format;
+			const bool is_block_transfer =
+				in_format == 1 && out_format == 1 &&
+				in_pitch + 0u == in_width_in_bytes &&
+				out_pitch + 0u == out_width_in_bytes;
 			const auto read_address = get_address(src_offset, src_dma);
 			const auto write_address = get_address(dst_offset, dst_dma);
-			// LINE_LENGTH_IN is an element count; FORMAT_IN/OUT select the byte stride between elements.
-			const auto read_length = in_pitch * (line_count - 1) + line_length * in_format;
-			const auto write_length = out_pitch * (line_count - 1) + line_length * out_format;
+			const auto read_length = in_pitch * (line_count - 1) + in_width_in_bytes;
+			const auto write_length = out_pitch * (line_count - 1) + out_width_in_bytes;
 
 			RSX(ctx)->invalidate_fragment_program(dst_dma, dst_offset, write_length);
 

--- a/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv0039.cpp
@@ -14,13 +14,13 @@ namespace rsx
 	namespace nv0039
 	{
 		// Transfer with stride
-		inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 width, u32 height, s32 src_pitch, s32 dst_pitch, u8 src_stride, u8 dst_stride)
+		inline void block2d_copy_with_stride(u8* dst, const u8* src, u32 element_count, u32 height, s32 src_pitch, s32 dst_pitch, u8 src_stride, u8 dst_stride)
 		{
 			for (u32 row = 0; row < height; ++row)
 			{
 				auto dst_ptr = dst;
 				auto src_ptr = src;
-				while (src_ptr < src + width)
+				for (u32 element = 0; element < element_count; ++element)
 				{
 					*dst_ptr = *src_ptr;
 


### PR DESCRIPTION
`block2d_copy_with_stride` took a `width` which should really have been an `element_count`. When `stride > 1`, this means the copy was only partial leading to apparent corruption. This PR fixes the copy logic, and also updates the corresponding barrier/sync range logic.

Before:
<img width="1280" height="720" alt="rpcs3-pr-before" src="https://github.com/user-attachments/assets/1ade2602-b965-476c-a09e-cb586a577816" />

After:
<img width="1280" height="720" alt="rpcs3-pr-after" src="https://github.com/user-attachments/assets/7527374c-ff0d-4dd2-b082-9c61ce4a31e8" />

Disclosure: this bug was originally identified + fixed with AI tools, however it was manually reviewed and verified (see above images).

Relates to https://github.com/RPCS3/rpcs3/issues/19198