### PR TITLE
Fix legacy discord-rpc macOS deployment target

### DIFF
--- a/3rdparty/discord-rpc/CMakeLists.txt
+++ b/3rdparty/discord-rpc/CMakeLists.txt
@@ -9,6 +9,23 @@ if (USE_DISCORD_RPC AND (WIN32 OR CMAKE_SYSTEM MATCHES "Linux" OR APPLE))
 	set(WARNINGS_AS_ERRORS FALSE CACHE BOOL "When enabled, compiles with `-Werror` (on *nix platforms).")
 
 	add_subdirectory(discord-rpc EXCLUDE_FROM_ALL)
+
+	if (APPLE)
+		foreach(property IN ITEMS LINK_LIBRARIES INTERFACE_LINK_LIBRARIES)
+			get_target_property(discord_rpc_links discord-rpc ${property})
+
+			if (discord_rpc_links)
+				string(REPLACE
+					", -mmacosx-version-min=10.10"
+					""
+					discord_rpc_links
+					"${discord_rpc_links}"
+				)
+
+				set_property(TARGET discord-rpc PROPERTY ${property} "${discord_rpc_links}")
+			endif()
+		endforeach()
+	endif()
 	target_include_directories(3rdparty_discordRPC SYSTEM INTERFACE discord-rpc/include)
 	target_compile_definitions(3rdparty_discordRPC INTERFACE -DWITH_DISCORD_RPC)
 	target_link_libraries(3rdparty_discordRPC INTERFACE discord-rpc)


### PR DESCRIPTION
Upstream alternative fix: https://github.com/Vestrel/discord-rpc/pull/2

The current `discord-rpc` submodule hardcodes `-mmacosx-version-min=10.10` as part of an AppKit link item.

This propagates through the static `discord-rpc` target into RPCS3's final link command and overrides the deployment target selected by RPCS3.

With RPCS3 configured using:

```text
CMAKE_OSX_DEPLOYMENT_TARGET=15.0
```

the unmodified dependency caused the resulting ARM64 executable to be linked for macOS 11.0.

This change removes the legacy `-mmacosx-version-min=10.10` fragment from `discord-rpc`'s `LINK_LIBRARIES` and `INTERFACE_LINK_LIBRARIES` properties after the submodule target is created, allowing RPCS3's configured deployment target to take effect.

The workaround is conditional on Apple platforms and becomes a no-op if the dependency no longer contains the legacy flag.

Tested on Apple Silicon with:

* CMake 4.4.2
* Clang/LLVM 22.1.8
* `CMAKE_OSX_DEPLOYMENT_TARGET=15.0`

After the change:

* The generated RPCS3 link command contains only `-mmacosx-version-min=15.0`.
* RPCS3 builds successfully.
* The resulting executable reports `LC_BUILD_VERSION minos 15.0`.
* `git diff --check` passes.

That mismatch caused a large number of linker warnings such as:

```text
object file ... was built for newer 'macOS' version (15.0) than being linked (11.0)

building for macOS-11.0, but linking with ... Qt... built for newer version 13.0
```