### PR TITLE
Implement support for VK_EXT_MEMORY_BUDGET

### DIFF
--- a/rpcs3/Emu/RSX/VK/vkutils/data_heap.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/data_heap.cpp
@@ -185,7 +185,27 @@ namespace vk
 		const auto current_usage = vmm_get_application_memory_usage(target_heap);
 		const auto after_usage = current_usage + size;
 		const auto limit = (target_heap.total_bytes() * max_usage_percent) / 100;
-		return after_usage < limit;
+
+		if (after_usage >= limit)
+			return false;
+
+		auto allocator = g_render_device->get_allocator();
+		bool budget_info_available = false;
+
+		for (const auto& type_index : target_heap)
+		{
+			u64 heap_used = 0, heap_budget = 0;
+
+			if (!allocator->get_memory_budget(type_index, heap_used, heap_budget))
+				continue;
+
+			budget_info_available = true;
+
+			if ((heap_used + size) < (heap_budget * max_usage_percent) / 100)
+				return true;
+		}
+
+		return !budget_info_available;
 	}
 
 	void* data_heap::map_impl(usz offset, usz size)

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -121,6 +121,7 @@ namespace vk
 		optional_features_support.shader_stencil_export    = device_extensions.is_supported(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
 		optional_features_support.conditional_rendering    = device_extensions.is_supported(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
 		optional_features_support.external_memory_host     = device_extensions.is_supported(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+		optional_features_support.memory_budget            = device_extensions.is_supported(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME);
 		optional_features_support.synchronization_2        = device_extensions.is_supported(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
 		optional_features_support.unrestricted_depth_range = device_extensions.is_supported(VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME);
 #ifdef __APPLE__
@@ -560,6 +561,11 @@ namespace vk
 		if (pgpu->optional_features_support.extended_device_fault)
 		{
 			requested_extensions.push_back(VK_EXT_DEVICE_FAULT_EXTENSION_NAME);
+		}
+
+		if (pgpu->optional_features_support.memory_budget)
+		{
+			requested_extensions.push_back(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME);
 		}
 		
 #ifdef __APPLE__

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -96,6 +96,7 @@ namespace vk
 			bool debug_utils = false;
 			bool external_memory_host = false;
 			bool framebuffer_loops = false;
+			bool memory_budget = false;
 			bool shader_stencil_export = false;
 			bool surface_capabilities_2 = false;
 			bool synchronization_2 = false;
@@ -189,6 +190,7 @@ namespace vk
 		bool get_framebuffer_loops_support() const { return pgpu->optional_features_support.framebuffer_loops; }
 		bool get_barycoords_support() const { return pgpu->optional_features_support.barycentric_coords; }
 		bool get_synchronization2_support() const { return pgpu->optional_features_support.synchronization_2; }
+		bool get_memory_budget_support() const { return pgpu->optional_features_support.memory_budget; }
 		bool get_extended_device_fault_support() const { return pgpu->optional_features_support.extended_device_fault; }
 		bool get_texture_compression_bc_support() const { return pgpu->optional_features_support.texture_compression_bc; }
 

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.cpp
@@ -179,6 +179,12 @@ namespace vk
 		allocatorInfo.instance = inst;
 		allocatorInfo.vulkanApiVersion = VK_API_VERSION_1_2;
 
+		if (dev.get_memory_budget_support())
+		{
+			allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT;
+			m_has_memory_budget_ext = true;
+		}
+
 		std::vector<VkDeviceSize> heap_limits;
 		const auto vram_allocation_limit = g_cfg.video.vk.vram_allocation_limit * 0x100000ull;
 		if (vram_allocation_limit < dev.get_memory_mapping().device_local_total_bytes)
@@ -327,6 +333,26 @@ namespace vk
 
 		vmaGetAllocationInfo(m_allocator, static_cast<VmaAllocation>(mem_handle), &alloc_info);
 		return alloc_info.offset;
+	}
+
+	bool mem_allocator_vma::get_memory_budget(u32 memory_type_index, u64& out_used, u64& out_budget)
+	{
+		if (!m_has_memory_budget_ext)
+			return false;
+
+		const VkPhysicalDeviceMemoryProperties* mem_props = nullptr;
+		vmaGetMemoryProperties(m_allocator, &mem_props);
+
+		if (memory_type_index >= mem_props->memoryTypeCount)
+			return false;
+
+		const u32 heap_index = mem_props->memoryTypes[memory_type_index].heapIndex;
+		std::array<VmaBudget, VK_MAX_MEMORY_HEAPS> budgets;
+		vmaGetHeapBudgets(m_allocator, budgets.data());
+
+		out_used = budgets[heap_index].usage;
+		out_budget = budgets[heap_index].budget;
+		return true;
 	}
 
 	f32 mem_allocator_vma::get_memory_usage()

--- a/rpcs3/Emu/RSX/VK/vkutils/memory.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/memory.h
@@ -93,6 +93,7 @@ namespace vk
 		virtual VkDeviceMemory get_vk_device_memory(mem_handle_t mem_handle) = 0;
 		virtual u64 get_vk_device_memory_offset(mem_handle_t mem_handle) = 0;
 		virtual f32 get_memory_usage() = 0;
+		virtual bool get_memory_budget(u32 /*memory_type_index*/, u64& /*out_used*/, u64& /*out_budget*/) { return false; }
 
 		virtual void set_safest_allocation_flags() {}
 		virtual void set_fastest_allocation_flags() {}
@@ -123,6 +124,7 @@ namespace vk
 		VkDeviceMemory get_vk_device_memory(mem_handle_t mem_handle) override;
 		u64 get_vk_device_memory_offset(mem_handle_t mem_handle) override;
 		f32 get_memory_usage() override;
+		bool get_memory_budget(u32 memory_type_index, u64& out_used, u64& out_budget) override;
 
 		void set_safest_allocation_flags() override;
 		void set_fastest_allocation_flags() override;
@@ -131,6 +133,7 @@ namespace vk
 		VmaAllocator m_allocator;
 		std::array<VmaBudget, VK_MAX_MEMORY_HEAPS> stats;
 		u32 m_rebar_heap_idx = UINT32_MAX;
+		bool m_has_memory_budget_ext = false;
 	};
 
 


### PR DESCRIPTION
Only used to harden availability checks in can_allocate_heap for re-bar.