### PR TITLE
vk: Execute driver management operations such as GC on a separate worker thread

### DIFF
--- a/rpcs3/Emu/RSX/VK/VKCommandStream.cpp
+++ b/rpcs3/Emu/RSX/VK/VKCommandStream.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "VKCommandStream.h"
+#include "VKResourceManager.h"
 #include "vkutils/descriptors.h"
 #include "vkutils/sync.h"
 
@@ -71,5 +72,65 @@ namespace vk
 	{
 		// Flush-only version used by asynchronous submit processing (MTRSX)
 		queue_submit_impl(*packet);
+	}
+
+	void driver_manager_t::operator()()
+	{
+		while (thread_ctrl::state() != thread_state::aborting)
+		{
+			const auto wake_token = m_wake_event.observe();
+			const auto last_eid = m_last_completed_eid.load();
+
+			if (auto eid = m_eid_ctr.load(); eid != last_eid)
+			{
+				vk::get_resource_manager()->eid_completed(eid);
+
+				m_last_completed_eid.store(eid);
+				m_completed_signal++;
+				m_completed_signal.notify_all();
+			}
+
+			thread_ctrl::wait_on(m_wake_event, wake_token);
+		}
+	}
+
+	void driver_manager_t::notify_completed(u64 eid)
+	{
+		m_eid_ctr.atomic_op([eid](u64& value)
+		{
+			value = std::max(value, eid);
+		});
+
+		m_wake_event++;
+		m_wake_event.notify_one();
+	}
+
+	void driver_manager_t::drain()
+	{
+		const u64 target_eid = m_eid_ctr.load(); //<- Last request at time of calling
+
+		// Now, we spam queue wake until our EID is reached
+		while (true)
+		{
+			const u32 completion_token = m_completed_signal.observe();
+			if (m_last_completed_eid.load() >= target_eid)
+			{
+				// Abort, watermark reached.
+				break;
+			}
+
+			if (thread_ctrl::state() == thread_state::aborting)
+			{
+				// Abort, emulation state changed.
+				break;
+			}
+
+			// Wake the worker thread.
+			m_wake_event++;
+			m_wake_event.notify_one();
+
+			// Wait for worker thread.
+			thread_ctrl::wait_on(m_completed_signal, completion_token);
+		}
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKCommandStream.h
+++ b/rpcs3/Emu/RSX/VK/VKCommandStream.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "VulkanAPI.h"
+#include "Utilities/Thread.h"
 
 namespace vk
 {
@@ -9,7 +10,6 @@ namespace vk
 	enum rctrl_command : u32 // callback commands
 	{
 		rctrl_queue_submit = 0x80000000,
-		rctrl_run_gc       = 0x80000001,
 	};
 
 	struct submit_packet
@@ -47,4 +47,22 @@ namespace vk
 			}
 		}
 	};
+
+	struct driver_manager_t
+	{
+		static constexpr std::string_view thread_name = "Vulkan Driver Manager"sv;
+		void operator()();
+
+		void notify_completed(u64 eid);
+		void drain();
+
+	private:
+		atomic_t<u64> m_eid_ctr = 0ull;
+		atomic_t<u64> m_last_completed_eid = 0ull;
+
+		atomic_t<u32> m_wake_event = 0u;
+		atomic_t<u32> m_completed_signal = 0u;     //<- Works around atomic_engine's lack of 64-bit observables support
+	};
+
+	using driver_manager_thread = named_thread<driver_manager_t>;
 }

--- a/rpcs3/Emu/RSX/VK/VKFramebuffer.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFramebuffer.cpp
@@ -135,6 +135,11 @@ namespace vk
 
 	void remove_framebuffers_with_image(const vk::image* image)
 	{
+		if (!image)
+		{
+			return;
+		}
+
 		remove_framebuffers_with_filter([image](const auto& fbo)
 		{
 			return fbo->references(image);
@@ -143,6 +148,11 @@ namespace vk
 
 	void remove_framebuffers_with_image(VkImage handle)
 	{
+		if (!handle)
+		{
+			return;
+		}
+
 		remove_framebuffers_with_filter([handle](const auto& fbo)
 		{
 			return fbo->references(handle);

--- a/rpcs3/Emu/RSX/VK/VKFramebuffer.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFramebuffer.cpp
@@ -5,10 +5,12 @@
 #include "vkutils/image_helpers.h"
 
 #include <unordered_map>
+#include "Utilities/mutex.h"
 
 namespace vk
 {
 	std::unordered_map<u64, std::vector<std::unique_ptr<vk::framebuffer_holder>>> g_framebuffers_cache;
+	shared_mutex g_framebuffers_mutex;
 
 	union framebuffer_storage_key
 	{
@@ -29,15 +31,25 @@ namespace vk
 	vk::framebuffer_holder* get_framebuffer(VkDevice dev, u16 width, u16 height, VkBool32 has_input_attachments, VkRenderPass renderpass, const std::vector<vk::image*>& image_list)
 	{
 		framebuffer_storage_key key(width, height, has_input_attachments);
-		auto& queue = g_framebuffers_cache[key.encoded];
 
-		for (const auto& fbo : queue)
+		reader_lock lock(g_framebuffers_mutex);
+
+		if (auto found = g_framebuffers_cache.find(key.encoded);
+			found != g_framebuffers_cache.end())
 		{
-			if (fbo->matches(image_list, width, height))
+			auto& queue = found->second;
+			for (const auto& fbo : queue)
 			{
-				return fbo.get();
+				if (fbo->matches(image_list, width, height))
+				{
+					return fbo.get();
+				}
 			}
 		}
+
+		lock.upgrade();
+
+		// NOTE: We don't need to recheck the cache here. If a dupe exists, it will be dropped in 2 frames.
 
 		std::vector<std::unique_ptr<vk::image_view>> image_views;
 		image_views.reserve(image_list.size());
@@ -51,22 +63,32 @@ namespace vk
 		auto value = std::make_unique<vk::framebuffer_holder>(dev, renderpass, width, height, std::move(image_views));
 		auto ret = value.get();
 
-		queue.push_back(std::move(value));
+		g_framebuffers_cache[key.encoded].push_back(std::move(value));
 		return ret;
 	}
 
 	vk::framebuffer_holder* get_framebuffer(VkDevice dev, u16 width, u16 height, VkBool32 has_input_attachments, VkRenderPass renderpass, VkFormat format, VkImage attachment)
 	{
 		framebuffer_storage_key key(width, height, has_input_attachments);
-		auto& queue = g_framebuffers_cache[key.encoded];
 
-		for (const auto& e : queue)
+		reader_lock lock(g_framebuffers_mutex);
+
+		if (auto found = g_framebuffers_cache.find(key.encoded);
+			found != g_framebuffers_cache.end())
 		{
-			if (e->attachments[0]->info.image == attachment)
+			auto& queue = found->second;
+			for (const auto& e : queue)
 			{
-				return e.get();
+				if (e->attachments[0]->info.image == attachment)
+				{
+					return e.get();
+				}
 			}
 		}
+
+		lock.upgrade();
+
+		// NOTE: Cache recheck avoided intentionally here.
 
 		VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
 		std::vector<std::unique_ptr<vk::image_view>> views;
@@ -75,20 +97,19 @@ namespace vk
 		auto value = std::make_unique<vk::framebuffer_holder>(dev, renderpass, width, height, std::move(views));
 		auto ret = value.get();
 
-		queue.push_back(std::move(value));
+		g_framebuffers_cache[key.encoded].push_back(std::move(value));
 		return ret;
 	}
 
-	void remove_unused_framebuffers()
+	void remove_framebuffers_with_filter(
+		const std::predicate<const std::unique_ptr<vk::framebuffer_holder>&> auto criteria)
 	{
-		// Remove stale framebuffers. Ref counted to prevent use-after-free
+		std::lock_guard lock(g_framebuffers_mutex);
+
 		for (auto It = g_framebuffers_cache.begin(); It != g_framebuffers_cache.end();)
 		{
 			It->second.erase(
-				std::remove_if(It->second.begin(), It->second.end(), [](const auto& fbo)
-				{
-					return (fbo->unused_check_count() >= 2);
-				}),
+				std::remove_if(It->second.begin(), It->second.end(), criteria),
 				It->second.end()
 			);
 
@@ -103,8 +124,34 @@ namespace vk
 		}
 	}
 
+	void remove_unused_framebuffers()
+	{
+		// Remove stale framebuffers. Ref counted to prevent use-after-free
+		remove_framebuffers_with_filter([](const auto& fbo)
+		{
+			return (fbo->unused_check_count() >= 2);
+		});
+	}
+
+	void remove_framebuffers_with_image(const vk::image* image)
+	{
+		remove_framebuffers_with_filter([image](const auto& fbo)
+		{
+			return fbo->references(image);
+		});
+	}
+
+	void remove_framebuffers_with_image(VkImage handle)
+	{
+		remove_framebuffers_with_filter([handle](const auto& fbo)
+		{
+			return fbo->references(handle);
+		});
+	}
+
 	void clear_framebuffer_cache()
 	{
+		std::lock_guard lock(g_framebuffers_mutex);
 		g_framebuffers_cache.clear();
 	}
 }

--- a/rpcs3/Emu/RSX/VK/VKFramebuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKFramebuffer.h
@@ -14,4 +14,7 @@ namespace vk
 
 	void remove_unused_framebuffers();
 	void clear_framebuffer_cache();
+
+	void remove_framebuffers_with_image(const vk::image* image);
+	void remove_framebuffers_with_image(VkImage handle);
 }

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -412,6 +412,7 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 {
 	// Initialize dependencies
 	g_fxo->need<rsx::dma_manager>();
+	g_fxo->need<vk::driver_manager_thread>();
 
 	if (!m_instance.create("RPCS3"))
 	{
@@ -1028,6 +1029,7 @@ bool VKGSRender::on_vram_exhausted(rsx::problem_severity severity)
 		// Hard sync before trying to evict anything. This guarantees no UAF crashes in the driver.
 		// As a bonus, we also get a free gc pass
 		flush_command_queue(true, true);
+		g_fxo->get<vk::driver_manager_thread>().drain();
 
 		if (m_texture_cache.is_overallocated())
 		{
@@ -2687,12 +2689,6 @@ void VKGSRender::renderctl(u32 request_code, void* args)
 		const auto packet = reinterpret_cast<vk::queue_submit_t*>(args);
 		vk::queue_submit(packet);
 		free(packet);
-		break;
-	}
-	case vk::rctrl_run_gc:
-	{
-		auto eid = reinterpret_cast<u64>(args);
-		vk::on_event_completed(eid, true);
 		break;
 	}
 	default:

--- a/rpcs3/Emu/RSX/VK/VKPresent.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPresent.cpp
@@ -83,6 +83,12 @@ bool VKGSRender::reinitialize_swapchain()
 	// Drain all the queues
 	vkDeviceWaitIdle(*m_device);
 
+	// Clean the FBO caches
+	for (u32 i = 0; i < m_swapchain->get_swap_image_count(); ++i)
+	{
+		vk::remove_framebuffers_with_image(m_swapchain->get_image(i));
+	}
+
 	// Reset frame context storage
 	for (auto& ctx : m_frame_context_storage)
 	{
@@ -704,17 +710,25 @@ void VKGSRender::flip(const rsx::display_flip_info_t& info)
 			single_target_pass = vk::get_renderpass(*m_device, key);
 			ensure(single_target_pass != VK_NULL_HANDLE);
 
-			if (!m_overlay_recording_img ||
-				m_overlay_recording_img->type() != image_to_flip->type() ||
-				m_overlay_recording_img->format() != image_to_flip->format() ||
-				m_overlay_recording_img->width() != image_to_flip->width() ||
-				m_overlay_recording_img->height() != image_to_flip->height() ||
-				m_overlay_recording_img->layers() != image_to_flip->layers())
+			if (m_overlay_recording_img)
+			{
+				// Validate
+				if (m_overlay_recording_img->format() != image_to_flip->format() ||
+					m_overlay_recording_img->width() != image_to_flip->width() ||
+					m_overlay_recording_img->height() != image_to_flip->height())
+				{
+					// Dispose correctly
+					vk::remove_framebuffers_with_image(m_overlay_recording_img.get());
+					vk::get_resource_manager()->dispose(m_overlay_recording_img);
+				}
+			}
+
+			if (!m_overlay_recording_img)
 			{
 				m_overlay_recording_img = std::make_unique<vk::image>(*m_device, m_device->get_memory_mapping().device_local, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-					image_to_flip->type(), image_to_flip->format(), image_to_flip->width(), image_to_flip->height(), 1, 1, image_to_flip->layers(), VK_SAMPLE_COUNT_1_BIT,
+					VK_IMAGE_TYPE_2D, image_to_flip->format(), image_to_flip->width(), image_to_flip->height(), 1, 1, 1, VK_SAMPLE_COUNT_1_BIT,
 					VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
-					0, VMM_ALLOCATION_POOL_UNDEFINED);
+					0, VMM_ALLOCATION_POOL_SYSTEM);
 			}
 
 			m_overlay_recording_img->change_layout(*m_current_command_buffer, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);

--- a/rpcs3/Emu/RSX/VK/VKQueryPool.cpp
+++ b/rpcs3/Emu/RSX/VK/VKQueryPool.cpp
@@ -76,16 +76,19 @@ namespace vk
 	void query_pool_manager::allocate_new_pool(vk::command_buffer& cmd)
 	{
 		ensure(!m_current_query_pool);
+		{
+			std::lock_guard lock(m_query_pool_cache_lock); // If we're creating a new pool, we probably have items in the cache.
 
-		if (m_query_pool_cache.size() > 0)
-		{
-			m_current_query_pool = std::move(m_query_pool_cache.front());
-			m_query_pool_cache.pop_front();
-		}
-		else
-		{
-			const u32 count = ::size32(query_slot_status);
-			m_current_query_pool = std::make_unique<query_pool>(*owner, query_type, count);
+			if (m_query_pool_cache.size() > 0)
+			{
+				m_current_query_pool = std::move(m_query_pool_cache.front());
+				m_query_pool_cache.pop_front();
+			}
+			else
+			{
+				const u32 count = ::size32(query_slot_status);
+				m_current_query_pool = std::make_unique<query_pool>(*owner, query_type, count);
+			}
 		}
 
 		// From spec: "After query pool creation, each query must be reset before it is used."
@@ -241,6 +244,7 @@ namespace vk
 			return;
 		}
 
+		std::lock_guard lock(m_query_pool_cache_lock);
 		m_query_pool_cache.emplace_back(std::move(pool));
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKQueryPool.h
+++ b/rpcs3/Emu/RSX/VK/VKQueryPool.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "VulkanAPI.h"
+#include "Utilities/mutex.h"
+
 #include <deque>
 
 namespace vk
@@ -34,10 +36,12 @@ namespace vk
 		};
 
 		std::vector<std::unique_ptr<query_pool>> m_consumed_pools;
-		std::deque<std::unique_ptr<query_pool>> m_query_pool_cache;
 		std::unique_ptr<query_pool> m_current_query_pool;
 		std::deque<u32> m_available_slots;
 		u32 m_pool_lifetime_counter = 0;
+
+		std::deque<std::unique_ptr<query_pool>> m_query_pool_cache;
+		shared_mutex m_query_pool_cache_lock;
 
 		VkQueryType query_type = VK_QUERY_TYPE_OCCLUSION;
 		VkQueryResultFlags result_flags = VK_QUERY_RESULT_PARTIAL_BIT;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -306,16 +306,11 @@ namespace vk
 		return (bytes_spilled > 0);
 	}
 
-	render_target::~render_target()
+	drawable_surface_t::~drawable_surface_t()
 	{
 		if (value)
 		{
 			vk::remove_framebuffers_with_image(this);
-		}
-
-		if (resolve_surface)
-		{
-			vk::remove_framebuffers_with_image(resolve_surface.get());
 		}
 	}
 
@@ -331,7 +326,7 @@ namespace vk
 			VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 			usage |= (this->info.usage & (VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT));
 
-			resolve_surface.reset(new vk::viewable_image(
+			resolve_surface.reset(new vk::drawable_surface_t(
 				*g_render_device,
 				g_render_device->get_memory_mapping().device_local,
 				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.cpp
@@ -1,4 +1,5 @@
 #include "vkutils/data_heap.h"
+#include "VKFramebuffer.h"
 #include "VKRenderTargets.h"
 #include "VKResourceManager.h"
 #include "Emu/RSX/rsx_methods.h"
@@ -303,6 +304,19 @@ namespace vk
 
 		rsx_log.warning("Surface cache will attempt to spill %llu bytes.", bytes_spilled);
 		return (bytes_spilled > 0);
+	}
+
+	render_target::~render_target()
+	{
+		if (value)
+		{
+			vk::remove_framebuffers_with_image(this);
+		}
+
+		if (resolve_surface)
+		{
+			vk::remove_framebuffers_with_image(resolve_surface.get());
+		}
 	}
 
 	// Get the linear resolve target bound to this surface. Initialize if none exists

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -104,6 +104,7 @@ namespace vk
 		bool is_bound = false;          // set when the surface is bound for rendering
 
 		using viewable_image::viewable_image;
+		virtual ~render_target();
 
 		vk::viewable_image* get_surface(rsx::surface_access access_type) override;
 		bool is_depth_surface() const override;

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -67,7 +67,14 @@ namespace vk
 		}
 	};
 
-	class render_target : public viewable_image, public rsx::render_target_descriptor<vk::viewable_image*>
+	struct drawable_surface_t : public viewable_image
+	{
+		using viewable_image::viewable_image;
+
+		virtual ~drawable_surface_t();
+	};
+
+	class render_target : public drawable_surface_t, public rsx::render_target_descriptor<vk::viewable_image*>
 	{
 		// Cyclic reference hazard tracking
 		image_reference_sync_barrier m_cyclic_ref_tracker;
@@ -103,8 +110,7 @@ namespace vk
 		u64 spill_request_tag = 0;      // timestamp when spilling was requested
 		bool is_bound = false;          // set when the surface is bound for rendering
 
-		using viewable_image::viewable_image;
-		virtual ~render_target();
+		using drawable_surface_t::drawable_surface_t;
 
 		vk::viewable_image* get_surface(rsx::surface_access access_type) override;
 		bool is_depth_surface() const override;

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.cpp
@@ -10,6 +10,7 @@ namespace vk
 		std::unordered_map<uptr, vmm_allocation_t> allocations;
 		std::unordered_map<uptr, atomic_t<u64>> memory_usage;
 		std::unordered_map<vmm_allocation_pool, atomic_t<u64>> pool_usage;
+		shared_mutex mutex;
 
 		void clear()
 		{
@@ -87,19 +88,13 @@ namespace vk
 		return g_last_completed_event.load();
 	}
 
-	void on_event_completed(u64 event_id, bool flush)
+	void on_event_completed(u64 event_id)
 	{
-		if (!flush && g_cfg.video.multithreaded_rsx)
+		g_fxo->get<vk::driver_manager_thread>().notify_completed(event_id);
+		g_last_completed_event.atomic_op([event_id](u64& value)
 		{
-			auto& offloader_thread = g_fxo->get<rsx::dma_manager>();
-			ensure(!offloader_thread.is_current_thread());
-
-			offloader_thread.backend_ctrl(rctrl_run_gc, reinterpret_cast<void*>(event_id));
-			return;
-		}
-
-		g_resource_manager.eid_completed(event_id);
-		g_last_completed_event = std::max(event_id, g_last_completed_event.load());
+			value = std::max(event_id, value);
+		});
 	}
 
 	void print_debug_markers()
@@ -119,6 +114,8 @@ namespace vk
 	{
 		auto key = reinterpret_cast<uptr>(handle);
 		const vmm_allocation_t info = { memory_size, memory_type, pool };
+
+		std::lock_guard lock(g_vmm_stats.mutex);
 
 		if (const auto ins = g_vmm_stats.allocations.insert_or_assign(key, info);
 			!ins.second)
@@ -140,6 +137,8 @@ namespace vk
 
 	void vmm_notify_memory_freed(void* handle)
 	{
+		std::lock_guard lock(g_vmm_stats.mutex);
+
 		auto key = reinterpret_cast<uptr>(handle);
 		if (auto found = g_vmm_stats.allocations.find(key);
 			found != g_vmm_stats.allocations.end())
@@ -153,12 +152,14 @@ namespace vk
 
 	void vmm_reset()
 	{
+		std::lock_guard lock(g_vmm_stats.mutex);
+
 		g_vmm_stats.clear();
 		g_event_ctr = 0;
 		g_last_completed_event = 0;
 	}
 
-	u64 vmm_get_application_memory_usage(const memory_type_info& memory_type)
+	u64 vmm_get_application_memory_usage_impl(const memory_type_info& memory_type)
 	{
 		u64 result = 0;
 		for (const auto& memory_type_index : memory_type)
@@ -175,13 +176,32 @@ namespace vk
 		return result;
 	}
 
+	u64 vmm_get_application_memory_usage(const memory_type_info& memory_type)
+	{
+		reader_lock lock(g_vmm_stats.mutex);
+		return vmm_get_application_memory_usage_impl(memory_type);
+	}
+
+	u64 vmm_get_application_pool_usage_impl(vmm_allocation_pool pool)
+	{
+		if (auto found = g_vmm_stats.pool_usage.find(pool);
+			found != g_vmm_stats.pool_usage.end())
+		{
+			return found->second;
+		}
+		return 0ull;
+	}
+
 	u64 vmm_get_application_pool_usage(vmm_allocation_pool pool)
 	{
-		return g_vmm_stats.pool_usage[pool];
+		reader_lock lock(g_vmm_stats.mutex);
+		return vmm_get_application_pool_usage_impl(pool);
 	}
 
 	rsx::problem_severity vmm_determine_memory_load_severity()
 	{
+		reader_lock lock(g_vmm_stats.mutex);
+
 		const auto vmm_load = get_current_mem_allocator()->get_memory_usage();
 		rsx::problem_severity load_severity = rsx::problem_severity::low;
 
@@ -211,7 +231,7 @@ namespace vk
 
 			// Query actual usage for comparison. Maybe we just have really fragmented memory...
 			const auto mem_info = get_current_renderer()->get_memory_mapping();
-			const auto local_memory_usage = vmm_get_application_memory_usage(mem_info.device_local);
+			const auto local_memory_usage = vmm_get_application_memory_usage_impl(mem_info.device_local);
 
 			constexpr u64 _1M = 0x100000;
 			const auto res_scale = rsx::get_current_renderer()->resolution_scaling_config.scale_factor();
@@ -264,12 +284,16 @@ namespace vk
 
 	void vmm_notify_object_allocated(vmm_allocation_pool pool)
 	{
+		std::lock_guard lock(g_vmm_stats.mutex);
+
 		ensure(pool >= VMM_ALLOCATION_POOL_SAMPLER);
 		g_vmm_stats.pool_usage[pool]++;
 	}
 
 	void vmm_notify_object_freed(vmm_allocation_pool pool)
 	{
+		std::lock_guard lock(g_vmm_stats.mutex);
+
 		ensure(pool >= VMM_ALLOCATION_POOL_SAMPLER);
 		g_vmm_stats.pool_usage[pool]--;
 	}

--- a/rpcs3/Emu/RSX/VK/VKResourceManager.h
+++ b/rpcs3/Emu/RSX/VK/VKResourceManager.h
@@ -6,7 +6,7 @@
 
 #include "Utilities/mutex.h"
 
-#include <deque>
+#include <list>
 #include <memory>
 
 namespace vk
@@ -14,7 +14,7 @@ namespace vk
 	u64 get_event_id();
 	u64 current_event_id();
 	u64 last_completed_event_id();
-	void on_event_completed(u64 event_id, bool flush = false);
+	void on_event_completed(u64 event_id);
 
 	struct eid_scope_t
 	{
@@ -52,8 +52,8 @@ namespace vk
 	private:
 		sampler_pool_t m_sampler_pool;
 
-		std::deque<eid_scope_t> m_eid_map;
-		shared_mutex m_eid_map_lock;
+		std::list<eid_scope_t> m_eid_map;
+		mutable shared_mutex m_eid_map_lock;
 
 		std::vector<std::function<void()>> m_exit_handlers;
 
@@ -61,7 +61,6 @@ namespace vk
 		{
 			const auto eid = current_event_id();
 			{
-				std::lock_guard lock(m_eid_map_lock);
 				if (m_eid_map.empty() || m_eid_map.back().eid != eid)
 				{
 					m_eid_map.emplace_back(eid);
@@ -88,7 +87,12 @@ namespace vk
 
 		void flush()
 		{
-			m_eid_map.clear();
+			std::list<eid_scope_t> dispose_queue;
+			{
+				std::lock_guard lock(m_eid_map_lock);
+				dispose_queue.splice(dispose_queue.begin(), m_eid_map);
+			}
+
 			m_sampler_pool.clear();
 		}
 
@@ -135,11 +139,13 @@ namespace vk
 
 		void dispose(vk::disposable_t& disposable) override
 		{
+			std::lock_guard lock(m_eid_map_lock);
 			get_current_eid_scope().m_disposables.emplace_back(std::move(disposable));
 		}
 
 		inline void dispose(std::unique_ptr<vk::gpu_debug_marker>& object)
 		{
+			std::lock_guard lock(m_eid_map_lock);
 			// Special case as we may need to read these out.
 			// FIXME: We can manage these markers better and remove this exception.
 			get_current_eid_scope().m_debug_markers.emplace_back(std::move(object));
@@ -154,32 +160,51 @@ namespace vk
 
 		void push_down_current_scope()
 		{
+			std::lock_guard lock(m_eid_map_lock);
 			get_current_eid_scope().eid++;
 		}
 
 		void eid_completed(u64 eid)
 		{
-			while (!m_eid_map.empty())
+			// We move scope objects into this so that they're destroyed outside the lock.
+			// These objects should outlive the lock, the idea is to release the main thread while the caller handles the callback spam.
+			std::list<eid_scope_t> discarded_scopes;
 			{
-				const auto& scope = m_eid_map.front();
-				if (scope.eid > eid)
+				reader_lock lock(m_eid_map_lock);
+
+				// First, scan to find the newest item that is going out of scope
+				auto newest_it = m_eid_map.begin();
+				while (newest_it != m_eid_map.end() && newest_it->eid <= eid)
 				{
-					break;
+					newest_it++;
 				}
 
-				eid_scope_t tmp(0);
+				// Any hits?
+				if (newest_it == m_eid_map.begin())
 				{
-					std::lock_guard lock(m_eid_map_lock);
-					m_eid_map.front().swap(tmp);
-					m_eid_map.pop_front();
+					return;
 				}
+
+				// Take all of the entries in one sweep
+				lock.upgrade();
+
+				// Post-upgrade iterators should be safe
+				discarded_scopes.splice(
+					discarded_scopes.end(),
+					m_eid_map,
+					m_eid_map.begin(),
+					newest_it);
 			}
+
+			// Cleanup runs here on the discard pile
 		}
 
 		void trim();
 
 		std::vector<const gpu_debug_marker*> gather_debug_markers() const
 		{
+			reader_lock lock(m_eid_map_lock);
+
 			std::vector<const gpu_debug_marker*> result;
 			for (const auto& scope : m_eid_map)
 			{

--- a/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/descriptors.cpp
@@ -256,12 +256,24 @@ namespace vk
 
 		do
 		{
-			for (u32 index = 0; index < m_device_subpools.size(); ++index)
+			// Happy path - maybe we have a free subpool
 			{
-				if (!m_device_subpools[index].busy)
+				reader_lock lock(m_subpool_lock);
+
+				for (u32 index = 0; index < m_device_subpools.size(); ++index)
 				{
-					m_current_subpool_index = index;
-					goto done; // Nested break
+					if (!m_device_subpools[index].busy)
+					{
+						m_current_subpool_index = index;
+						m_device_subpools[m_current_subpool_index].busy = VK_TRUE;
+						m_current_pool_handle = m_device_subpools[m_current_subpool_index].handle;
+						break;
+					}
+				}
+
+				if (m_current_subpool_index != umax)
+				{
+					return;
 				}
 			}
 
@@ -286,16 +298,13 @@ namespace vk
 			{
 				.handle = subpool,
 				.size = m_autoscaling_config.current_size,
-				.busy = VK_FALSE
+				.busy = VK_TRUE
 			});
 
 			m_current_subpool_index = m_device_subpools.size() - 1;
+			m_current_pool_handle = m_device_subpools[m_current_subpool_index].handle;
 
 		} while (m_current_subpool_index == umax);
-
-	done:
-		m_device_subpools[m_current_subpool_index].busy = VK_TRUE;
-		m_current_pool_handle = m_device_subpools[m_current_subpool_index].handle;
 	}
 
 	std::pair<VkResult, VkDescriptorPool> descriptor_pool::new_subpool()

--- a/rpcs3/Emu/RSX/VK/vkutils/framebuffer_object.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/framebuffer_object.hpp
@@ -93,15 +93,14 @@ namespace vk
 			return true;
 		}
 
-		bool references(const vk::image* image) const
-		{
-			ensure(image);
-			return std::ranges::find_if(attachments, FN(x->info.image == image->value)) != attachments.end();
-		}
-
 		bool references(VkImage handle) const
 		{
-			return std::ranges::find_if(attachments, FN(x->info.image == handle)) != attachments.end();
+			return !!handle && std::ranges::find_if(attachments, FN(x->info.image == handle)) != attachments.end();
+		}
+
+		bool references(const vk::image* image) const
+		{
+			return !!image && references(image->value);
 		}
 
 		framebuffer(const framebuffer&) = delete;

--- a/rpcs3/Emu/RSX/VK/vkutils/framebuffer_object.hpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/framebuffer_object.hpp
@@ -93,6 +93,17 @@ namespace vk
 			return true;
 		}
 
+		bool references(const vk::image* image) const
+		{
+			ensure(image);
+			return std::ranges::find_if(attachments, FN(x->info.image == image->value)) != attachments.end();
+		}
+
+		bool references(VkImage handle) const
+		{
+			return std::ranges::find_if(attachments, FN(x->info.image == handle)) != attachments.end();
+		}
+
 		framebuffer(const framebuffer&) = delete;
 		framebuffer(framebuffer&&) = delete;
 


### PR DESCRIPTION
The GC is very callback heavy and some drivers (NVIDIA) can stall for considerable amount of time when executing some resource removal operations. Previously this async logic was just stuffed in with the MTRSX setting but it needed to be pulled out into its own thread.

I also took the opportunity to just add locks for thread safety in most functions that use GC callbacks.

Closes https://github.com/RPCS3/rpcs3/issues/19206
Closes https://github.com/RPCS3/rpcs3/issues/17879