### PR TITLE
VSH: improve XMB integration and game lifecycle

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -1569,6 +1569,13 @@ error_code sys_fs_opendir(ppu_thread& ppu, vm::cptr<char> path, vm::ptr<u32> fd)
 			// Preprocess entries
 			data.back().name = vfs::unescape(data.back().name);
 
+			// TEST12345 is an RPCS3 scaffold required by some test ELFs, not an installed title.
+			if (Emu.IsVsh() && vpath == "/dev_hdd0/game"sv && data.back().name == "TEST12345"sv)
+			{
+				data.pop_back();
+				continue;
+			}
+
 			if (!data.back().is_directory && data.back().name == "."sv)
 			{
 				// Files hidden from emulation

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -350,6 +350,16 @@ void _sys_process_exit(ppu_thread& ppu, s32 status, u32 arg2, u32 arg3)
 
 	sys_process.warning("_sys_process_exit(status=%d, arg2=0x%x, arg3=0x%x)", status, arg2, arg3);
 
+	if (Emu.IsChildProcess() && !Emu.IsVsh() && Emu.GetLastBoot().ends_with("/vsh/module/vsh.self"sv))
+	{
+		sys_process.success("Returning to VSH");
+
+		std::vector<std::string> argv{"/dev_flash/vsh/module/vsh.self"};
+		std::vector<std::string> envp;
+		std::vector<u8> data;
+		return lv2_exitspawn(ppu, argv, envp, data);
+	}
+
 	Emu.CallFromMainThread([]()
 	{
 		sys_process.success("Process finished");
@@ -420,6 +430,8 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 	Emu.CallFromMainThread([is_real_reboot, argv = std::move(argv), envp = std::move(envp), data = std::move(data)]() mutable
 	{
 		sys_process.success("Process finished -> %s", argv[0]);
+		const bool is_vsh_return = Emu.IsChildProcess() && !Emu.IsVsh() &&
+		                           Emu.GetLastBoot().ends_with("/vsh/module/vsh.self"sv) && argv[0] == "/dev_flash/vsh/module/vsh.self"sv;
 
 		std::string disc;
 
@@ -430,6 +442,7 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 
 		std::string path = vfs::get(argv[0]);
 		std::string hdd1 = vfs::get("/dev_hdd1/");
+		std::string vsh_turnoff = is_vsh_return ? vfs::get("/dev_hdd0/tmp/turnoff") : std::string{};
 
 		const u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 
@@ -475,7 +488,8 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 		};
 
 		Emu.after_kill_callback = [func = std::move(func), argv = std::move(argv), envp = std::move(envp), data = std::move(data),
-			disc = std::move(disc), path = std::move(path), hdd1 = std::move(hdd1), old_config = Emu.GetUsedConfig(), old_db_config = Emu.GetUsedDatabaseConfig(), klic]() mutable
+									  disc = std::move(disc), path = std::move(path), hdd1 = std::move(hdd1), vsh_turnoff = std::move(vsh_turnoff),
+									  old_config = Emu.GetUsedConfig(), old_db_config = Emu.GetUsedDatabaseConfig(), klic]() mutable
 		{
 			Emu.argv = std::move(argv);
 			Emu.envp = std::move(envp);
@@ -490,6 +504,12 @@ void lv2_exitspawn(ppu_thread& ppu, std::vector<std::string>& argv, std::vector<
 			}
 
 			Emu.SetForceBoot(true);
+
+			// VSH normally remains resident while a game runs. Clear its active-session marker before emulating the return with a fresh boot.
+			if (!vsh_turnoff.empty() && fs::is_file(vsh_turnoff) && !fs::remove_file(vsh_turnoff))
+			{
+				sys_process.error("Failed to remove VSH turnoff marker: %s", fs::g_tls_error);
+			}
 
 			auto res = Emu.BootGame(path, "", true, cfg_mode::continuous, old_config, old_db_config);
 

--- a/rpcs3/Emu/Cell/lv2/sys_process.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_process.cpp
@@ -527,10 +527,67 @@ void sys_process_exit3(ppu_thread& ppu, s32 status)
 	return _sys_process_exit(ppu, status, 0, 0);
 }
 
-error_code sys_process_spawns_a_self2(vm::ptr<u32> pid, u32 primary_prio, u64 flags, vm::ptr<void> stack, u32 stack_size, u32 mem_id, vm::ptr<void> param_sfo, vm::ptr<void> dbg_data)
+error_code sys_process_spawns_a_self2(ppu_thread& ppu, vm::ptr<u32> pid, u32 primary_prio, u64 flags, vm::ptr<void> stack, u32 stack_size, u32 mem_id, vm::ptr<void> param_sfo, vm::ptr<void> dbg_data)
 {
 	sys_process.todo("sys_process_spawns_a_self2(pid=*0x%x, primary_prio=0x%x, flags=0x%llx, stack=*0x%x, stack_size=0x%x, mem_id=0x%x, param_sfo=*0x%x, dbg_data=*0x%x"
 		, pid, primary_prio, flags, stack, stack_size, mem_id, param_sfo, dbg_data);
+
+	// VSH uses this syscall both for concurrent system processes and for games.
+	// RPCS3 cannot emulate the former yet, so preserve their existing stub behavior.
+	if (!stack || stack_size < sizeof(u64) * 3 || stack_size % sizeof(u64) ||
+		!vm::check_addr(stack.addr(), vm::page_readable, stack_size))
+	{
+		return CELL_OK;
+	}
+
+	auto pstr = vm::bpptr<char, u64, u64>::make(stack.addr());
+	const auto executable = *pstr;
+
+	if (!executable)
+	{
+		return CELL_OK;
+	}
+
+	const std::string path = executable.get_ptr();
+	const bool is_hdd_game = path.starts_with("/dev_hdd0/game/"sv) && path.ends_with("/USRDIR/EBOOT.BIN"sv);
+	const bool is_disc_game = path == "/dev_bdvd/PS3_GAME/USRDIR/EBOOT.BIN"sv;
+
+	if (!is_hdd_game && !is_disc_game)
+	{
+		return CELL_OK;
+	}
+
+	std::vector<std::string> argv;
+	std::vector<std::string> envp;
+	bool reading_env = false;
+	bool complete = false;
+
+	for (u32 i = 0; i < stack_size / sizeof(u64); i++)
+	{
+		auto ptr = *pstr++;
+
+		if (!ptr)
+		{
+			if (reading_env)
+			{
+				complete = true;
+				break;
+			}
+
+			reading_env = true;
+			continue;
+		}
+
+		(reading_env ? envp : argv).emplace_back(ptr.get_ptr());
+	}
+
+	if (!complete)
+	{
+		return CELL_OK;
+	}
+
+	std::vector<u8> data;
+	lv2_exitspawn(ppu, argv, envp, data);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/Cell/lv2/sys_process.h
+++ b/rpcs3/Emu/Cell/lv2/sys_process.h
@@ -125,4 +125,4 @@ error_code sys_process_detach_child(u64 unk);
 void _sys_process_exit(ppu_thread& ppu, s32 status, u32 arg2, u32 arg3);
 void _sys_process_exit2(ppu_thread& ppu, s32 status, vm::ptr<sys_exit2_param> arg, u32 arg_size, u32 arg4);
 void sys_process_exit3(ppu_thread& ppu, s32 status);
-error_code sys_process_spawns_a_self2(vm::ptr<u32> pid, u32 primary_prio, u64 flags, vm::ptr<void> stack, u32 stack_size, u32 mem_id, vm::ptr<void> param_sfo, vm::ptr<void> dbg_data);
+error_code sys_process_spawns_a_self2(ppu_thread& ppu, vm::ptr<u32> pid, u32 primary_prio, u64 flags, vm::ptr<void> stack, u32 stack_size, u32 mem_id, vm::ptr<void> param_sfo, vm::ptr<void> dbg_data);

--- a/rpcs3/Emu/Cell/lv2/sys_time.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_time.cpp
@@ -3,6 +3,7 @@
 
 #include "sys_process.h"
 #include "Emu/System.h"
+#include "Emu/IdManager.h"
 #include "Emu/system_config.h"
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/timers.hpp"
@@ -12,6 +13,11 @@
 
 u64 g_timebase_offs{};
 static u64 systemtime_offset;
+
+struct vsh_time_state
+{
+	atomic_t<bool> startup_restore_seen = false;
+};
 
 #ifndef __linux__
 #include "util/asm.hpp"
@@ -440,7 +446,37 @@ error_code sys_time_set_current_time(s64 sec, s64 nsec)
 		return CELL_EINVAL;
 	}
 
-	g_cfg.sys.console_time_offset.set(sec - std::time(nullptr));
+	const b8 is_vsh = Emu.IsVsh();
+
+	if (is_vsh)
+	{
+		g_fxo->need<vsh_time_state>();
+
+		// VSH first calls this during startup to restore its persisted RTC delta.
+		// Keep RPCS3's persisted time for that call, then accept later XMB changes.
+		if (!g_fxo->get<vsh_time_state>().startup_restore_seen.exchange(true))
+		{
+			return CELL_OK;
+		}
+	}
+
+	const s64 host_time = std::time(nullptr);
+	s64 console_time_offset = std::bit_cast<s64>(static_cast<u64>(sec) - static_cast<u64>(host_time));
+
+	if (is_vsh && static_cast<u64>(sec) == (1ull << 32) + static_cast<u32>(sec) &&
+		(console_time_offset < g_cfg.sys.console_time_offset.min || console_time_offset > g_cfg.sys.console_time_offset.max))
+	{
+		// VSH zero-extends its signed 32-bit RTC delta before adding it to the clock.
+		// Recover the intended seconds from the single observed 32-bit wrap.
+		console_time_offset = std::bit_cast<s64>(static_cast<u64>(static_cast<u32>(sec)) - static_cast<u64>(host_time));
+	}
+
+	if (console_time_offset < g_cfg.sys.console_time_offset.min || console_time_offset > g_cfg.sys.console_time_offset.max)
+	{
+		return CELL_EINVAL;
+	}
+
+	g_cfg.sys.console_time_offset.set(console_time_offset);
 
 	if (Emu.GetCallbacks().save_emu_settings)
 	{

--- a/rpcs3/Emu/Cell/lv2/sys_time.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_time.cpp
@@ -2,6 +2,7 @@
 #include "sys_time.h"
 
 #include "sys_process.h"
+#include "Emu/System.h"
 #include "Emu/system_config.h"
 #include "Emu/Cell/ErrorCodes.h"
 #include "Emu/Cell/timers.hpp"
@@ -434,6 +435,18 @@ error_code sys_time_set_current_time(s64 sec, s64 nsec)
 		return CELL_ENOSYS;
 	}
 
+	if (nsec < 0 || nsec >= 1'000'000'000)
+	{
+		return CELL_EINVAL;
+	}
+
+	g_cfg.sys.console_time_offset.set(sec - std::time(nullptr));
+
+	if (Emu.GetCallbacks().save_emu_settings)
+	{
+		Emu.GetCallbacks().save_emu_settings();
+	}
+
 	return CELL_OK;
 }
 
@@ -446,7 +459,14 @@ u64 sys_time_get_timebase_frequency()
 
 error_code sys_time_get_rtc(vm::ptr<u64> rtc)
 {
-	sys_time.todo("sys_time_get_rtc(rtc=*0x%x)", rtc);
+	sys_time.trace("sys_time_get_rtc(rtc=*0x%x)", rtc);
+
+	if (!rtc)
+	{
+		return CELL_EFAULT;
+	}
+
+	*rtc = std::time(nullptr);
 
 	return CELL_OK;
 }


### PR DESCRIPTION
This PR improves VSH integration and user experience.

## Changes

1. Adds support for launching games installed on `dev_hdd0` directly from VSH.
2. Returns to VSH when exiting a game that was launched from VSH.
3. Date/Time settings changed in VSH now update and persist the corresponding RPCS3 settings.
4. Hides the `Corrupted Data` entry caused by the test game from VSH's game selection.

## Result

The VSH workflow now more closely matches real hardware behavior:

1. Boot into VSH.
2. Launch an installed game from the Game column.
3. Press the PS button and select “Exit Game”.
4. Return to VSH without restarting RPCS3 or showing a false system-recovery warning.

Here's a video showing the complete workflow: booting into VSH, changing the date/time settings (which persist in RPCS3), launching a game, and returning to VSH after exiting it:

https://github.com/user-attachments/assets/53b308ca-5b3f-4b34-ab66-5313350055ca

## Testing

The changes in this PR were thoroughly tested on macOS and Linux with various games installed from PKG files.

It was also tested on binaries that were outside of the games tab (e.g. PlayStation Home)