### PR TITLE
rsx/fp: Fix decoding of LOOP and REP instructions

### DIFF
--- a/rpcs3/Emu/RSX/Program/CgBinaryFragmentProgram.cpp
+++ b/rpcs3/Emu/RSX/Program/CgBinaryFragmentProgram.cpp
@@ -402,12 +402,12 @@ void CgBinaryDisasm::TaskFP()
 			{
 				if (!src0.exec_if_eq && !src0.exec_if_gr && !src0.exec_if_lt)
 				{
-					AddCodeAsm(fmt::format("{ %u, %u, %u }", src1.end_counter, src1.init_counter, src1.increment));
+					AddCodeAsm(fmt::format("{ %u, %u, %u }", src1.rep_count, src1.init_counter, src1.increment));
 				}
 				else
 				{
 					m_loop_end_offsets.push_back(src2.end_offset << 2);
-					AddCodeAsm(fmt::format("{ %u, %u, %u }", src1.end_counter, src1.init_counter, src1.increment));
+					AddCodeAsm(fmt::format("{ %u, %u, %u }", src1.rep_count, src1.init_counter, src1.increment));
 				}
 				break;
 			}

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
@@ -1423,6 +1423,8 @@ std::string FragmentProgramDecompiler::Decompile()
 			!block.succ.empty() &&
 			(block.succ.front().type == EdgeType::IF || block.succ.front().type == EdgeType::LOOP);
 
+		auto sext8 = [](u32 value) { return static_cast<s32>(value << 24u) >> 24; };
+
 		for (const auto& inst : block.instructions)
 		{
 			if (early_epilogue && &inst == &block.instructions.back())
@@ -1461,12 +1463,16 @@ std::string FragmentProgramDecompiler::Decompile()
 					AddCode("if($cond)");
 					break;
 				case RSX_FP_OPCODE_LOOP:
-					AddCode(fmt::format("$ifcond for(int i%u = %u; i%u < %u; i%u += %u) //LOOP",
-							m_loop_count, src1.init_counter, m_loop_count, src1.end_counter, m_loop_count, src1.increment));
-					break;
 				case RSX_FP_OPCODE_REP:
-					AddCode(fmt::format("if($cond) for(int i%u = %u; i%u < %u; i%u += %u) //REP",
-							m_loop_count, src1.init_counter, m_loop_count, src1.end_counter, m_loop_count, src1.increment));
+					AddCode(
+						fmt::format("$ifcond for(int i%u = 0; i%u < %u; i%u++) // %s { %u, %d }",
+							m_loop_count,
+							m_loop_count, src1.rep_count,
+							m_loop_count,
+							FP::get_opcode_name(static_cast<FP_opcode>(m_instruction->opcode)),
+							src1.init_counter,
+							sext8(src1.increment))
+					);
 					break;
 				case RSX_FP_OPCODE_RET:
 					AddFlowOp("return");

--- a/rpcs3/Emu/RSX/Program/RSXFragmentProgram.h
+++ b/rpcs3/Emu/RSX/Program/RSXFragmentProgram.h
@@ -123,7 +123,7 @@ union SRC1
 	struct
 	{
 		u32                  : 2;
-		u32 end_counter      : 8; // End counter value for LOOP or rep count for REP
+		u32 rep_count        : 8; // Repeat count for LOOP and REP
 		u32 init_counter     : 8; // Initial counter value for LOOP
 		u32                  : 1;
 		u32 increment        : 8; // Increment value for LOOP


### PR DESCRIPTION
- Verified with hardware tests. RSX does not support proper loops.
- The LOOP/REP instruction simply codes a "REPEAT n" instruction for a block of code.
- There is no accumulator register. The compiler emits a preamble inside the loop block to simulate the running counter.
- Oddly enough, the original start and step values are stored in the instruction but are unused. Maybe useful for debugging real hardware?

Closes https://github.com/RPCS3/rpcs3/issues/19214