### PR TITLE
[SPU LLVM] Avoid GFNI combine bug in `SHUFB`

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -7581,7 +7581,7 @@ public:
 
 		// Calculate shuffle
 
-		bool shuf_zero_when_msb = false;
+		bool or_combine_safe = false;
 
 		value_t<u8[16]> ab_shuf;
 		if (single_src)
@@ -7593,7 +7593,7 @@ public:
 			else
 			{
 				ab_shuf = eval(pshufb(single_src.value(), cv));
-				shuf_zero_when_msb = true;
+				or_combine_safe = true;
 			}
 		}
 		else if (a_is_splat && b_is_splat)
@@ -7623,7 +7623,7 @@ public:
 			ab_shuf = eval(select_by_bit4(c, a_shuf, b_shuf));
 
 			// pshufb zeros when the MSB is set
-			shuf_zero_when_msb = !(a_is_splat || b_is_splat);
+			or_combine_safe = !(a_is_splat || b_is_splat);
 		}
 
 		if (perm_only)
@@ -7639,10 +7639,14 @@ public:
 		{
 			idx_consts = eval(splat<u8[16]>(0));
 		}
-		else if (m_use_avx512_icl)
+		else if (m_use_gfni)
 		{
+			// TODO: Due to vpblendvb, the pshufb OR combine path is one fewer micro-ops post Rocket Lake. Check if it is faster.
 			const auto gfni = gf2p8affineqb(c, build<u8[16]>(0x40, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x40, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20), 0x7f);
 			idx_consts = eval(select(noncast<s8[16]>(gfni) >= 0, splat<u8[16]>(0), gfni));
+			
+			// Logic assumes that the MSB is always set
+			or_combine_safe = false;
 		}
 		else
 		{
@@ -7652,7 +7656,7 @@ public:
 
 		// Combine shuffle and special index constants
 
-		if (shuf_zero_when_msb)
+		if (or_combine_safe)
 			set_vr(op.rt4, ab_shuf | idx_consts);
 		else
 			set_vr(op.rt4, select(noncast<s8[16]>(c) >= 0, ab_shuf, idx_consts));


### PR DESCRIPTION
Due to a bug where `SHUFB`'s GFNI constant generation path expects to be combine using a select instead of a OR, issues occurred on non-AVX512 CPUs so support was reverted (see #19217). That issue still occurs with AVX512 when the shuffle is single source. This patch fixes it and re-lower the target requirements back to GFNI by avoiding the OR well on that path. I also renamed a variable and added a comment to better clarify its behavior.

Interestingly I noticed a performance quirk on post-AVX512 Intel CPUs where the AVX variable blend instructions was increase to 3 micro-operations potentially making the GFNI path one micro-op longer then the normal one. I added a TODO and didn't investigate further.