### PR TITLE
rsx: Reimplement large portions of texture reconstruction (3D and Cubemap)

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -1591,10 +1591,12 @@ namespace rsx
 			for (u32 layer = 0; layer < layers; ++layer)
 			{
 				u32 mip_height = internal_height;
+				u32 mip_depth = depth;
 				for (u32 mipmap = 0; mipmap < mipmaps && mip_height > 0; ++mipmap)
 				{
-					size += pitch * mip_height * depth;
+					size += pitch * mip_height * mip_depth;
 					mip_height = std::max(mip_height / 2u, 1u);
+					mip_depth  = std::max(mip_depth / 2u, 1u);
 				}
 			}
 		}
@@ -1610,11 +1612,13 @@ namespace rsx
 			{
 				u32 mip_height = internal_height;
 				u32 mip_width = internal_width;
+				u32 mip_depth = depth;
 				for (u32 mipmap = 0; mipmap < mipmaps && mip_height > 0; ++mipmap)
 				{
-					size += (mip_width * bytes_per_block * mip_height * depth);
+					size += (mip_width * bytes_per_block * mip_height * mip_depth);
 					mip_height = std::max(mip_height / 2u, 1u);
 					mip_width = std::max(mip_width / 2u, 1u);
+					mip_depth  = std::max(mip_depth / 2u, 1u);
 				}
 			}
 		}

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -1570,6 +1570,7 @@ namespace rsx
 		const auto gcm_format = format & ~(CELL_GCM_TEXTURE_LN | CELL_GCM_TEXTURE_UN);
 		const bool packed = !(format & CELL_GCM_TEXTURE_LN);
 		const auto texel_rows_per_line = get_format_texel_rows_per_line(gcm_format);
+		const bool has_border = !!border;
 
 		if (!pitch && !packed)
 		{
@@ -1580,7 +1581,7 @@ namespace rsx
 					width, height, format, gcm_format);
 			}
 
-			pitch = get_format_packed_pitch(gcm_format, width, !!border, packed);
+			pitch = get_format_packed_pitch(gcm_format, width, has_border, packed);
 		}
 
 		u32 size = 0;
@@ -1592,9 +1593,11 @@ namespace rsx
 			{
 				u32 mip_height = internal_height;
 				u32 mip_depth = depth;
+
 				for (u32 mipmap = 0; mipmap < mipmaps && mip_height > 0; ++mipmap)
 				{
-					size += pitch * mip_height * mip_depth;
+					const auto padded_h = has_border ? (mip_height + 2u) : mip_height;
+					size += pitch * padded_h * mip_depth;
 					mip_height = std::max(mip_height / 2u, 1u);
 					mip_depth  = std::max(mip_depth / 2u, 1u);
 				}
@@ -1608,14 +1611,19 @@ namespace rsx
 
 			const u32 internal_height = (height + texel_rows_per_line - 1) / texel_rows_per_line;  // Convert texels to blocks
 			const u32 internal_width = (width + texels_per_block - 1) / texels_per_block;          // Convert texels to blocks
+
 			for (u32 layer = 0; layer < layers; ++layer)
 			{
 				u32 mip_height = internal_height;
 				u32 mip_width = internal_width;
 				u32 mip_depth = depth;
+
 				for (u32 mipmap = 0; mipmap < mipmaps && mip_height > 0; ++mipmap)
 				{
-					size += (mip_width * bytes_per_block * mip_height * mip_depth);
+					const auto padded_w = has_border ? rsx::next_pow2(mip_width + 8u) : mip_width;
+					const auto padded_h = has_border ? rsx::next_pow2(mip_height + 8u) : mip_height;
+					size += (padded_w * bytes_per_block * padded_h * mip_depth);
+
 					mip_height = std::max(mip_height / 2u, 1u);
 					mip_width = std::max(mip_width / 2u, 1u);
 					mip_depth  = std::max(mip_depth / 2u, 1u);

--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -1634,18 +1634,45 @@ namespace rsx
 		return size;
 	}
 
-	usz get_texture_size(const rsx::fragment_texture& texture)
+	usz get_texture_size_with_mipmaps(const RSXTexture auto& texture, u16 mipmaps)
 	{
 		return get_texture_size(texture.format(), texture.width(), texture.height(), texture.depth(),
-			texture.pitch(), texture.get_exact_mipmap_count(), texture.cubemap() ? 6 : 1,
+			texture.pitch(), mipmaps, texture.cubemap() ? 6 : 1,
 			texture.border_type() ^ 1);
 	}
 
-	usz get_texture_size(const rsx::vertex_texture& texture)
+	usz get_texture_size_impl(const RSXTexture auto& texture, u8 mip_level)
 	{
-		return get_texture_size(texture.format(), texture.width(), texture.height(), texture.depth(),
-			texture.pitch(), texture.get_exact_mipmap_count(), texture.cubemap() ? 6 : 1,
-			texture.border_type() ^ 1);
+		const auto max_levels = texture.get_exact_mipmap_count();
+		if (mip_level != RSX_GCM_MIP_LEVEL_IGNORED &&
+			mip_level >= max_levels)
+		{
+			// Mip level out of bounds
+			return 0;
+		}
+
+		const auto base_levels = (mip_level != RSX_GCM_MIP_LEVEL_IGNORED)
+			? static_cast<u16>(mip_level + 1)
+			: max_levels;
+
+		const auto base_size = get_texture_size_with_mipmaps(texture, base_levels);
+		if (mip_level == 0 || mip_level == RSX_GCM_MIP_LEVEL_IGNORED)
+		{
+			return base_size;
+		}
+
+		const auto leading_size = get_texture_size_with_mipmaps(texture, base_levels - 1);
+		return base_size - leading_size;
+	}
+
+	usz get_texture_size(const rsx::fragment_texture& texture, u8 mip_level)
+	{
+		return get_texture_size_impl(texture, mip_level);
+	}
+
+	usz get_texture_size(const rsx::vertex_texture& texture, u8 mip_level)
+	{
+		return get_texture_size_impl(texture, mip_level);
 	}
 
 	u32 get_remap_encoding(const texture_channel_remap_t& remap)

--- a/rpcs3/Emu/RSX/Common/TextureUtils.h
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.h
@@ -6,10 +6,16 @@
 #include "../RSXTexture.h"
 
 #include <vector>
+#include <concepts>
 
 namespace rsx
 {
 	using flags32_t = u32;
+
+	template <typename T>
+	concept RSXTexture =
+			std::same_as<T, rsx::fragment_texture> ||
+			std::same_as<T, rsx::vertex_texture>;
 
 	enum texture_upload_context : u32
 	{
@@ -345,10 +351,12 @@ namespace rsx
 	u8 get_format_texel_rows_per_line(u32 format);
 
 	/**
-	* Get number of bytes occupied by texture in RSX mem
+	* Get number of bytes occupied by texture in RSX mem.
+	* Specify mip_level to compute size for exactly one mipmap level.
 	*/
-	usz get_texture_size(const rsx::fragment_texture &texture);
-	usz get_texture_size(const rsx::vertex_texture &texture);
+	constexpr u8 RSX_GCM_MIP_LEVEL_IGNORED = UINT8_MAX;
+	usz get_texture_size(const rsx::fragment_texture &texture, u8 mip_level = RSX_GCM_MIP_LEVEL_IGNORED);
+	usz get_texture_size(const rsx::vertex_texture &texture, u8 mip_level = RSX_GCM_MIP_LEVEL_IGNORED);
 
 	/**
 	* Get packed pitch

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -319,6 +319,11 @@ namespace rsx
 				return external_handle;
 			}
 
+			u8 exact_mip_count() const
+			{
+				return 1 + sections_to_copy.reduce(0, FN(std::max<u8>(x, y.level)));
+			}
+
 		private:
 			static deferred_subresource make_unwrap(
 				deferred_request_command op,

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2090,7 +2090,7 @@ namespace rsx
 			// Check surface cache early if the option is enabled
 			if (options.prefer_surface_cache)
 			{
-				const u16 block_h = (attr.depth * attr.slice_h);
+				const u32 block_h = (attr.depth * attr.slice_h);
 				overlapping_fbos = m_rtts.get_merged_texture_memory_region(cmd, attr.address, attr.width, block_h, attr.pitch, attr.bpp, rsx::surface_access::shader_read);
 
 				if (!overlapping_fbos.empty())
@@ -2151,7 +2151,7 @@ namespace rsx
 			if (!options.prefer_surface_cache)
 			{
 				// Now check for surface cache hits
-				const u16 block_h = (attr.depth * attr.slice_h);
+				const u32 block_h = (attr.depth * attr.slice_h);
 				overlapping_fbos = m_rtts.get_merged_texture_memory_region(cmd, attr.address, attr.width, block_h, attr.pitch, attr.bpp, rsx::surface_access::shader_read);
 			}
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2495,7 +2495,7 @@ namespace rsx
 			bool force_bg_load = desc.force_bg_load;
 			u16 levels_found = 1;
 
-			options.skip_texture_merge = false;        //<- We should use this for a speedup but it is currently broken :(
+			options.skip_texture_merge = true;         //<- We expect all the data to live on either host or guest. Gaps here will be closed by the blit-engine surface cache integration work later (e.g mipchain gen using nv3089).
 			options.skip_texture_barriers = true;      //<- We'll be copying the data out, ignore texture barriers.
 			options.prefer_surface_cache = (base_level.upload_context == rsx::texture_upload_context::framebuffer_storage);
 

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -693,7 +693,7 @@ namespace rsx
 		virtual image_view_type generate_3d_from_2d_images(commandbuffer_type&, const deferred_subresource& desc) = 0;
 		virtual image_view_type generate_atlas_from_images(commandbuffer_type&, const deferred_subresource& desc) = 0;
 		virtual image_view_type generate_2d_mipmaps_from_images(commandbuffer_type&, const deferred_subresource& desc) = 0;
-		virtual void update_image_contents(commandbuffer_type&, image_view_type dst, image_resource_type src, u16 width, u16 height) = 0;
+		virtual void update_image_contents(commandbuffer_type&, image_view_type dst, const deferred_subresource& desc) = 0;
 		virtual bool render_target_format_is_compatible(image_storage_type* tex, u32 gcm_format) = 0;
 		virtual void prepare_for_dma_transfers(commandbuffer_type&) = 0;
 		virtual void cleanup_after_dma_transfers(commandbuffer_type&) = 0;
@@ -1970,7 +1970,7 @@ namespace rsx
 						continue;
 
 					if (desc.op == deferred_request_command::copy_image_dynamic)
-						update_image_contents(cmd, It->second.second, desc.src0(), desc.width, desc.height);
+						update_image_contents(cmd, It->second.second, desc);
 
 					return It->second.second;
 				}

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -401,8 +401,14 @@ namespace rsx
 
 			sampled_image_descriptor() = default;
 
-			sampled_image_descriptor(image_view_type handle, texture_upload_context ctx, rsx::format_class ftype,
-				size3f scale, rsx::texture_dimension_extended type, bool cyclic_reference = false,
+			sampled_image_descriptor(
+				image_view_type handle,
+				texture_upload_context ctx,
+				rsx::format_class ftype,
+				size3f scale,
+				rsx::texture_dimension_extended type,
+				u32 ref_address_,
+				bool cyclic_reference = false,
 				u8 msaa_samples = 1)
 			{
 				image_handle = handle;
@@ -411,6 +417,7 @@ namespace rsx
 				is_cyclic_reference = cyclic_reference;
 				image_type = type;
 				samples = msaa_samples;
+				ref_address = ref_address_;
 
 				texcoord_xform.scale[0] = scale.width;
 				texcoord_xform.scale[1] = scale.height;
@@ -421,9 +428,13 @@ namespace rsx
 				texcoord_xform.clamp = false;
 			}
 
-			sampled_image_descriptor(deferred_subresource&& desc,
-				texture_upload_context ctx, rsx::format_class ftype, size3f scale,
-				rsx::texture_dimension_extended type)
+			sampled_image_descriptor(
+				deferred_subresource&& desc,
+				texture_upload_context ctx,
+				rsx::format_class ftype,
+				size3f scale,
+				rsx::texture_dimension_extended type,
+				u32 ref_address_)
 			{
 				external_subresource_desc = std::move(desc);
 
@@ -431,6 +442,7 @@ namespace rsx
 				upload_context = ctx;
 				format_class = ftype;
 				image_type = type;
+				ref_address = ref_address_;
 
 				texcoord_xform.scale[0] = scale.width;
 				texcoord_xform.scale[1] = scale.height;
@@ -2097,7 +2109,15 @@ namespace rsx
 				// Most mesh textures are stored as compressed to make the most of the limited memory
 				if (auto cached_texture = find_texture_from_dimensions(attr.address, attr.gcm_format, attr.width, attr.height, attr.depth))
 				{
-					return{ cached_texture->get_view(remap), cached_texture->get_context(), cached_texture->get_format_class(), scale, cached_texture->get_image_type() };
+					return
+					{
+						cached_texture->get_view(remap),
+						cached_texture->get_context(),
+						cached_texture->get_format_class(),
+						scale,
+						cached_texture->get_image_type(),
+						cached_texture->get_section_base()
+					};
 				}
 
 				return {};
@@ -2202,7 +2222,15 @@ namespace rsx
 						break;
 					}
 
-					return{ cached_texture->get_view(remap), cached_texture->get_context(), cached_texture->get_format_class(), scale, cached_texture->get_image_type() };
+					return
+					{
+						cached_texture->get_view(remap),
+						cached_texture->get_context(),
+						cached_texture->get_format_class(),
+						scale,
+						cached_texture->get_image_type(),
+						cached_texture->get_section_base()
+					};
 				}
 			}
 
@@ -2274,8 +2302,17 @@ namespace rsx
 						{
 							// Clipped view
 							auto viewed_image = last->get_raw_texture();
-							sampled_image_descriptor result = { viewed_image->get_view(remap), last->get_context(),
-								viewed_image->format_class(), scale, extended_dimension, false, viewed_image->samples() };
+							sampled_image_descriptor result =
+							{
+								viewed_image->get_view(remap),
+								last->get_context(),
+								viewed_image->format_class(),
+								scale,
+								extended_dimension,
+								attr.address,
+								false,
+								viewed_image->samples()
+							};
 
 							helpers::calculate_sample_clip_parameters(result, position2i(0, 0), size2i(attr.width, attr.height), size2i(normalized_width, last->get_height()));
 							return result;
@@ -2294,7 +2331,8 @@ namespace rsx
 							last->get_context(),
 							classify_format(gcm_format),
 							scale,
-							extended_dimension
+							extended_dimension,
+							attr.address
 						};
 					}
 				}
@@ -2881,8 +2919,15 @@ namespace rsx
 			auto uploaded = upload_image_from_cpu(cmd, tex_range, attributes.width, attributes.height, attributes.depth, tex.get_exact_mipmap_count(), attributes.pitch, attributes.gcm_format,
 				texture_upload_context::shader_read, subresources_layout, extended_dimension, attributes.swizzled);
 
-			return{ uploaded->get_view(tex.decoded_remap()),
-					texture_upload_context::shader_read, format_class, scale, extended_dimension };
+			return
+			{
+				uploaded->get_view(tex.decoded_remap()),
+				texture_upload_context::shader_read,
+				format_class,
+				scale,
+				extended_dimension,
+				attributes.address
+			};
 		}
 
 		// FIXME: This function is way too large and needs an urgent refactor.

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2502,15 +2502,14 @@ namespace rsx
 				attributes.depth = 6;
 				subsurface_count = 1;
 				tex_size = static_cast<u32>(get_texture_size(tex));
-				required_surface_height = tex_size / attributes.pitch;
-				attributes.slice_h = required_surface_height / attributes.depth;
+				required_surface_height = tex_size / attributes.pitch;                                   //<- Cubemap mipmaps are laid inline with their respective faces.
+				attributes.slice_h = required_surface_height / attributes.depth;                         //<- Slice height should match attr.height * 2 assuming full mipchain per face.
 				break;
 			case rsx::texture_dimension_extended::texture_dimension_3d:
 				attributes.depth = tex.depth();
 				subsurface_count = 1;
-				tex_size = static_cast<u32>(get_texture_size(tex));
-				required_surface_height = tex_size / attributes.pitch;
-				attributes.slice_h = required_surface_height / attributes.depth;
+				required_surface_height = static_cast<u32>(get_texture_size(tex, 0)) / attributes.pitch; //<- Mipmaps for 3D are laid out one at a time, we compute only level 0 size.
+				attributes.slice_h = required_surface_height / attributes.depth;                         //<- Should match attr.height for most cases unless block textures or borders are involved.
 				break;
 			default:
 				fmt::throw_exception("Unsupported texture dimension %d", static_cast<int>(extended_dimension));

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -321,6 +321,16 @@ namespace rsx
 
 			u8 exact_mip_count() const
 			{
+				switch (op)
+				{
+				case rsx::deferred_request_command::cubemap_unwrap:
+					return static_cast<u8>(mipmaps);
+				case rsx::deferred_request_command::mipmap_gather:
+					return static_cast<u8>(sections_to_copy.size());
+				default:
+					break;
+				}
+
 				return 1 + sections_to_copy.reduce(0, FN(std::max<u8>(x, y.level)));
 			}
 
@@ -1865,6 +1875,31 @@ namespace rsx
 			return evicted_set.violation_handled;
 		}
 
+		// Expands a _3d_unwrap descriptor into the explicit slice list used by _3d_gather.
+		static void expand_3d_unwrap_sections(rsx::simple_array<copy_region_descriptor>& sections, const deferred_subresource& desc, u8 level)
+		{
+			sections.reserve(sections.size() + desc.depth);
+
+			for (u16 n = 0; n < desc.depth; ++n)
+			{
+				sections.push_back(
+				{
+					.src = desc.external_handle,
+					.xform = surface_transform::coordinate_transform,
+					.level = level,
+					.src_x = 0,
+					.src_y = static_cast<u16>(desc.slice_h * n),
+					.dst_x = 0,
+					.dst_y = 0,
+					.dst_z = n,
+					.src_w = desc.width,
+					.src_h = desc.height,
+					.dst_w = desc.width,
+					.dst_h = desc.height
+				});
+			}
+		}
+
 		image_view_type create_temporary_subresource(commandbuffer_type &cmd, deferred_subresource& desc)
 		{
 			if (!desc.do_not_cache) [[likely]]
@@ -1939,25 +1974,7 @@ namespace rsx
 			case deferred_request_command::_3d_unwrap:
 			{
 				rsx::simple_array<copy_region_descriptor> sections;
-				sections.resize(desc.depth);
-				for (u16 n = 0; n < desc.depth; ++n)
-				{
-					sections[n] =
-					{
-						.src = desc.external_handle,
-						.xform = surface_transform::coordinate_transform,
-						.level = 0,
-						.src_x = 0,
-						.src_y = static_cast<u16>(desc.slice_h * n),
-						.dst_x = 0,
-						.dst_y = 0,
-						.dst_z = n,
-						.src_w = desc.width,
-						.src_h = desc.height,
-						.dst_w = desc.width,
-						.dst_h = desc.height
-					};
-				}
+				expand_3d_unwrap_sections(sections, desc, 0);
 
 				auto unwrap_desc = desc;
 				unwrap_desc.sections_to_copy = std::move(sections);
@@ -2425,6 +2442,133 @@ namespace rsx
 			return result.first;
 		}
 
+		// Combine multiple mip level scan results into one gather op
+		template <typename RsxTextureType, typename surface_store_type, typename ...Args>
+		void gather_3d_mipmap_levels(
+			commandbuffer_type& cmd,
+			sampled_image_descriptor& base_level,
+			const RsxTextureType& tex,
+			const image_section_attributes_t& attributes,
+			const size3f& scale,
+			texture_cache_search_options options,
+			surface_store_type& m_rtts,
+			Args&&... extras)
+		{
+			auto& desc = base_level.external_subresource_desc;
+			rsx::simple_array<copy_region_descriptor> sections;
+			auto attr2 = attributes;
+			u32 mipchain_length = static_cast<u32>(get_texture_size(tex, 0));
+			bool force_bg_load = desc.force_bg_load;
+			u16 levels_found = 1;
+
+			options.skip_texture_merge = false;        //<- We should use this for a speedup but it is currently broken :(
+			options.skip_texture_barriers = true;      //<- We'll be copying the data out, ignore texture barriers.
+			options.prefer_surface_cache = (base_level.upload_context == rsx::texture_upload_context::framebuffer_storage);
+
+			for (u8 level = 1; level < attributes.mipmaps; ++level)
+			{
+				attr2.address = attributes.address + mipchain_length;
+				attr2.width = std::max<u16>(attr2.width / 2, 1);
+				attr2.height = std::max<u16>(attr2.height / 2, 1);
+				attr2.depth = std::max<u16>(attr2.depth / 2, 1);
+				attr2.mipmaps = 1;
+
+				// NOTE: Linear textures have the higher mip levels keep the same pitch as the base. This does not work for swizzled though.
+				if (attributes.swizzled)
+				{
+					attr2.pitch = get_format_packed_pitch(attr2.gcm_format, attr2.width, tex.border_type() == CELL_GCM_TEXTURE_BORDER_TEXTURE, true);
+				}
+
+				const u32 level_size = static_cast<u32>(get_texture_size(tex, level));
+				if (!level_size || !attr2.pitch)
+				{
+					break;
+				}
+
+				attr2.slice_h = static_cast<u16>((level_size / attr2.pitch) / attr2.depth);
+
+				const auto range = utils::address_range32::start_length(attr2.address, level_size);
+				auto ret = fast_texture_search(cmd, attr2, scale, tex.decoded_remap(),
+					options, range, rsx::texture_dimension_extended::texture_dimension_3d,
+					m_rtts, std::forward<Args>(extras)...);
+
+				if (!ret.validate() || ret.image_handle)
+				{
+					// Level is unavailable, or resolved to a whole image which we cannot splice in as a 2D source.
+					break;
+				}
+
+				if (sections.empty())
+				{
+					// Expand the base sections here. One-shot.
+					if (desc.op == deferred_request_command::_3d_unwrap)
+					{
+						expand_3d_unwrap_sections(sections, desc, 0);
+					}
+					else
+					{
+						sections = std::move(desc.sections_to_copy);
+					}
+
+					ensure(!sections.empty()); // Impossible situation
+				}
+
+				auto& sub_desc = ret.external_subresource_desc;
+				const auto insert_pos = sections.size();
+
+				switch (sub_desc.op)
+				{
+				case deferred_request_command::_3d_unwrap:
+					expand_3d_unwrap_sections(sections, sub_desc, level);
+					break;
+				case deferred_request_command::copy_image_static:
+				case deferred_request_command::copy_image_dynamic:
+				case deferred_request_command::blit_image_static:
+				case deferred_request_command::atlas_gather:
+					if (attr2.depth > 1) break;
+					[[ fallthrough ]];
+				case deferred_request_command::_3d_gather:
+					for (const auto& section : sub_desc.sections_to_copy)
+					{
+						sections.push_back(section);
+						sections.back().level = level;
+					}
+					break;
+				default:
+					break;
+				}
+
+				if (sections.size() == insert_pos)
+				{
+					// Nothing was added.
+					break;
+				}
+
+				force_bg_load |= sub_desc.force_bg_load;
+				mipchain_length += level_size;
+				levels_found++;
+			}
+
+			if (levels_found == 1)
+			{
+				// No new mip levels found. Restore the original desc if it was modified.
+				if (desc.sections_to_copy.empty() &&
+					desc.op != deferred_request_command::_3d_unwrap)
+				{
+					ensure(!sections.empty());
+					desc.sections_to_copy = std::move(sections);
+				}
+				return;
+			}
+
+			// Create the new descriptor for all our new data.
+			desc.op = deferred_request_command::_3d_gather;
+			desc.mipmaps = levels_found;
+			desc.force_bg_load = force_bg_load;
+			desc.sections_to_copy = std::move(sections);
+			desc.cache_range = utils::address_range32::start_length(attributes.address, mipchain_length);
+		}
+
 		template <typename RsxTextureType, typename surface_store_type, typename ...Args>
 		sampled_image_descriptor upload_texture(commandbuffer_type& cmd, const RsxTextureType& tex, surface_store_type& m_rtts, Args&&... extras)
 		{
@@ -2560,6 +2704,15 @@ namespace rsx
 				}
 
 				result.surface_cache_tag = m_rtts.write_tag;
+
+				// A 3D texture keeps each mipmap level in its own group of depth slices separate as complete sub-textures.
+				// Scan for each of the mip levels individually. Best-effort impl, we cannot promise to capture all of them.
+				if (attributes.mipmaps > 1 && !result.image_handle &&
+					(result.external_subresource_desc.op == deferred_request_command::_3d_gather ||
+					 result.external_subresource_desc.op == deferred_request_command::_3d_unwrap))
+				{
+					gather_3d_mipmap_levels(cmd, result, tex, attributes, scale, options, m_rtts, std::forward<Args>(extras)...);
+				}
 
 				if (subsurface_count == 1)
 				{

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -2136,8 +2136,19 @@ namespace rsx
 				{
 					const bool force_convert = !render_target_format_is_compatible(last.surface, attr.gcm_format);
 
-					return helpers::process_framebuffer_resource_fast<sampled_image_descriptor>(
-						cmd, last.surface, attr, position2u(last.src_area.x, last.src_area.y), scale, extended_dimension, remap, false, force_convert);
+					// Need to check for cyclic ref since we now allow offsets.
+					const bool surface_is_rop_target = m_rtts.address_is_bound(last.base_address);
+
+					auto result = helpers::process_framebuffer_resource_fast<sampled_image_descriptor>(
+						cmd, last.surface, attr, position2u(last.src_area.x, last.src_area.y), scale, extended_dimension, remap, surface_is_rop_target, force_convert);
+
+					if (!options.skip_texture_barriers && result.is_cyclic_reference)
+					{
+						ensure(surface_is_rop_target);
+						insert_texture_barrier(cmd, last.surface);
+					}
+
+					return result;
 				}
 
 				return {};

--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -200,19 +200,21 @@ namespace rsx
 			// One large surface to be partitioned into cubemap faces.
 			static deferred_subresource create_cubemap_unwrap(
 				image_resource_type src,
+				const position2u& src_offset,
 				const image_section_attributes_t& attr,
 				const texture_channel_remap_t& remap)
 			{
-				return make_unwrap(deferred_request_command::cubemap_unwrap, src, attr, remap);
+				return make_unwrap(deferred_request_command::cubemap_unwrap, src, src_offset, attr, remap);
 			}
 
 			// One large surface to be partitioned into a 3D array.
 			static deferred_subresource create_3d_unwrap(
 				image_resource_type src,
+				const position2u& src_offset,
 				const image_section_attributes_t& attr,
 				const texture_channel_remap_t& remap)
 			{
-				return make_unwrap(deferred_request_command::_3d_unwrap, src, attr, remap);
+				return make_unwrap(deferred_request_command::_3d_unwrap, src, src_offset, attr, remap);
 			}
 
 			// 2D section splat
@@ -319,6 +321,14 @@ namespace rsx
 				return external_handle;
 			}
 
+			position2u unwrap_offset() const
+			{
+				ensure(op == deferred_request_command::cubemap_unwrap || op == deferred_request_command::_3d_unwrap);
+				ensure(sections_to_copy.size() == 1);
+				const auto& section = sections_to_copy.front();
+				return { section.src_x, section.src_y };
+			}
+
 			u8 exact_mip_count() const
 			{
 				switch (op)
@@ -335,9 +345,19 @@ namespace rsx
 			}
 
 		private:
+			static void embed_src_offset(deferred_subresource& target, const position2u& offset)
+			{
+				ensure(target.sections_to_copy.empty());
+				// Embed a single copy block with the src offsets.
+				target.sections_to_copy.push_back({});
+				target.sections_to_copy.back().src_x = static_cast<u16>(offset.x);
+				target.sections_to_copy.back().src_y = static_cast<u16>(offset.y);
+			}
+
 			static deferred_subresource make_unwrap(
 				deferred_request_command op,
 				image_resource_type src,
+				const position2u& src_offset,
 				const image_section_attributes_t& attr,
 				const texture_channel_remap_t& remap)
 			{
@@ -349,6 +369,7 @@ namespace rsx
 				result.external_handle = src;
 				result.op = op;
 				result.remap = remap;
+				embed_src_offset(result, src_offset);
 				return result;
 			}
 
@@ -1879,6 +1900,7 @@ namespace rsx
 		static void expand_3d_unwrap_sections(rsx::simple_array<copy_region_descriptor>& sections, const deferred_subresource& desc, u8 level)
 		{
 			sections.reserve(sections.size() + desc.depth);
+			const auto src_offset = desc.unwrap_offset();
 
 			for (u16 n = 0; n < desc.depth; ++n)
 			{
@@ -1887,8 +1909,8 @@ namespace rsx
 					.src = desc.external_handle,
 					.xform = surface_transform::coordinate_transform,
 					.level = level,
-					.src_x = 0,
-					.src_y = static_cast<u16>(desc.slice_h * n),
+					.src_x = static_cast<u16>(src_offset.x),
+					.src_y = static_cast<u16>(src_offset.y + (desc.slice_h * n)),
 					.dst_x = 0,
 					.dst_y = 0,
 					.dst_z = n,
@@ -1897,6 +1919,42 @@ namespace rsx
 					.dst_w = desc.width,
 					.dst_h = desc.height
 				});
+			}
+		}
+
+		// Expands a cube_unwrap descriptor into explicit slice list for use with cube_gather
+		static void expand_cube_unwrap_sections(rsx::simple_array<copy_region_descriptor>& sections, const deferred_subresource& desc)
+		{
+			sections.resize(6u * desc.mipmaps);
+			const auto src_offset = desc.unwrap_offset();
+
+			for (u16 n = 0, section_id = 0; n < 6; ++n)
+			{
+				u16 mip_w = desc.width, mip_h = desc.height;
+				u16 y_offset = static_cast<u16>(src_offset.y + (desc.slice_h * n));
+
+				for (u8 mip = 0; mip < desc.mipmaps; ++mip)
+				{
+					sections[section_id++] =
+					{
+						.src = desc.external_handle,
+						.xform = surface_transform::coordinate_transform,
+						.level = mip,
+						.src_x = static_cast<u16>(src_offset.x),
+						.src_y = y_offset,
+						.dst_x = 0,
+						.dst_y = 0,
+						.dst_z = n,
+						.src_w = mip_w,
+						.src_h = mip_h,
+						.dst_w = mip_w,
+						.dst_h = mip_h
+					};
+
+					y_offset += mip_h;
+					mip_w = std::max<u16>(mip_w / 2, 1);
+					mip_h = std::max<u16>(mip_h / 2, 1);
+				}
 			}
 		}
 
@@ -1930,37 +1988,11 @@ namespace rsx
 			}
 			case deferred_request_command::cubemap_unwrap:
 			{
-				rsx::simple_array<copy_region_descriptor> sections(6 * desc.mipmaps);
-				for (u16 n = 0, section_id = 0; n < 6; ++n)
-				{
-					u16 mip_w = desc.width, mip_h = desc.height;
-					u16 y_offset = static_cast<u16>(desc.slice_h * n);
-
-					for (u8 mip = 0; mip < desc.mipmaps; ++mip)
-					{
-						sections[section_id++] =
-						{
-							.src = desc.external_handle,
-							.xform = surface_transform::coordinate_transform,
-							.level = mip,
-							.src_x = 0,
-							.src_y = y_offset,
-							.dst_x = 0,
-							.dst_y = 0,
-							.dst_z = n,
-							.src_w = mip_w,
-							.src_h = mip_h,
-							.dst_w = mip_w,
-							.dst_h = mip_h
-						};
-
-						y_offset += mip_h;
-						mip_w = std::max<u16>(mip_w / 2, 1);
-						mip_h = std::max<u16>(mip_h / 2, 1);
-					}
-				}
+				rsx::simple_array<copy_region_descriptor> sections;
+				expand_cube_unwrap_sections(sections, desc);
 
 				auto unwrap_desc = desc;
+				unwrap_desc.op = deferred_request_command::cubemap_gather;
 				unwrap_desc.sections_to_copy = std::move(sections);
 
 				result = generate_cubemap_from_images(cmd, unwrap_desc);
@@ -1977,6 +2009,7 @@ namespace rsx
 				expand_3d_unwrap_sections(sections, desc, 0);
 
 				auto unwrap_desc = desc;
+				unwrap_desc.op = deferred_request_command::_3d_gather;
 				unwrap_desc.sections_to_copy = std::move(sections);
 
 				result = generate_3d_from_2d_images(cmd, unwrap_desc);
@@ -2079,7 +2112,7 @@ namespace rsx
 					const bool force_convert = !render_target_format_is_compatible(texptr, attr.gcm_format);
 
 					auto result = helpers::process_framebuffer_resource_fast<sampled_image_descriptor>(
-						cmd, texptr, attr, scale, extended_dimension, remap, true, force_convert);
+						cmd, texptr, attr, {}, scale, extended_dimension, remap, true, force_convert);
 
 					if (!options.skip_texture_barriers && result.is_cyclic_reference)
 					{
@@ -2098,12 +2131,13 @@ namespace rsx
 			auto fast_fbo_check = [&]() -> sampled_image_descriptor
 			{
 				const auto& last = overlapping_fbos.back();
-				if (last.src_area.x == 0 && last.src_area.y == 0 && !last.is_clipped)
+
+				if (!last.is_clipped) //<- A non-clipped hit fully contains the requested box. We're good to go with the framebuffer processing.
 				{
 					const bool force_convert = !render_target_format_is_compatible(last.surface, attr.gcm_format);
 
 					return helpers::process_framebuffer_resource_fast<sampled_image_descriptor>(
-						cmd, last.surface, attr, scale, extended_dimension, remap, false, force_convert);
+						cmd, last.surface, attr, position2u(last.src_area.x, last.src_area.y), scale, extended_dimension, remap, false, force_convert);
 				}
 
 				return {};

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -634,6 +634,7 @@ namespace rsx
 		sampled_image_descriptor process_framebuffer_resource_fast(commandbuffer_type& cmd,
 			render_target_type texptr,
 			const image_section_attributes_t& attr,
+			const position2u& offset,
 			const size3f& scale,
 			texture_dimension_extended extended_dimension,
 			const texture_channel_remap_t& decoded_remap,
@@ -648,13 +649,18 @@ namespace rsx
 			bool is_depth = texptr->is_depth_surface();
 			auto attr2 = attr;
 
+			// Track the clipping offset. Typically it is {0, 0} which means exact match, but subregions can also use this function and we need to scale this up from guest to host.
+			auto scaled_offset = offset;
+
 			if (texptr->resolution_scaling_config.scale_percent != 100)
 			{
 				const auto [scaled_w, scaled_h] = rsx::apply_resolution_scale<true>(texptr->resolution_scaling_config, attr.width, attr.height, surface_width, surface_height);
 				const auto [unused, scaled_slice_h] = rsx::apply_resolution_scale<false>(texptr->resolution_scaling_config, RSX_SURFACE_DIMENSION_IGNORED, attr.slice_h, surface_width, surface_height);
+				const auto [scaled_off_x, scaled_off_y] = rsx::apply_resolution_scale<false>(texptr->resolution_scaling_config, static_cast<u16>(offset.x), static_cast<u16>(offset.y), surface_width, surface_height);
 				attr2.width = scaled_w;
 				attr2.height = scaled_h;
 				attr2.slice_h = scaled_slice_h;
+				scaled_offset = { scaled_off_x, scaled_off_y };
 			}
 
 			if (const bool gcm_format_is_depth = is_gcm_depth_format(attr2.gcm_format);
@@ -695,7 +701,7 @@ namespace rsx
 
 				rsx::surface_access access_type = rsx::surface_access::shader_read;
 
-				if (attr.width != surface_width || attr.height != surface_height)
+				if (offset.x || offset.y || attr.width != surface_width || attr.height != surface_height)
 				{
 					// If we can get away with clip only, do it
 					if (attr.edge_clamped)
@@ -727,14 +733,15 @@ namespace rsx
 					const auto format_class = (force_convert) ? classify_format(attr2.gcm_format) : texptr->format_class();
 
 					// This path is only reachable when the source region fully covers the request.
-					const coord3u xfer_rect = { 0, 0, 0, attr2.width, attr2.height, 1 };
+					const coord3u dst_rect = { 0, 0, 0, attr2.width, attr2.height, 1 };
+					const coord3u src_rect = { scaled_offset.x, scaled_offset.y, 0, attr2.width, attr2.height, 1 };
 
 					texptr->memory_barrier(cmd, rsx::surface_access::transfer_read);
 					return
 					{
 						deferred_subresource_type::create_copy(
 							texptr->get_surface(rsx::surface_access::transfer_read),
-							attr2, xfer_rect, rsx::surface_transform::coordinate_transform, decoded_remap, surface_is_rop_target),
+							attr2, src_rect, dst_rect, rsx::surface_transform::coordinate_transform, decoded_remap, surface_is_rop_target),
 						texture_upload_context::framebuffer_storage, format_class, scale, extended_dimension
 					};
 				}
@@ -746,7 +753,7 @@ namespace rsx
 
 				if (requires_clip)
 				{
-					calculate_sample_clip_parameters(result, position2i(0, 0), size2i(attr.width, attr.height), size2i(surface_width, surface_height));
+					calculate_sample_clip_parameters(result, position2i(offset.x, offset.y), size2i(attr.width, attr.height), size2i(surface_width, surface_height));
 				}
 
 				return result;
@@ -759,7 +766,7 @@ namespace rsx
 			{
 				return
 				{
-					deferred_subresource_type::create_3d_unwrap(texptr->get_surface(rsx::surface_access::transfer_read), attr2, decoded_remap),
+					deferred_subresource_type::create_3d_unwrap(texptr->get_surface(rsx::surface_access::transfer_read), scaled_offset, attr2, decoded_remap),
 					texture_upload_context::framebuffer_storage, format_class, scale,
 					rsx::texture_dimension_extended::texture_dimension_3d
 				};
@@ -769,7 +776,7 @@ namespace rsx
 
 			return
 			{
-				deferred_subresource_type::create_cubemap_unwrap(texptr->get_surface(rsx::surface_access::transfer_read), attr2, decoded_remap),
+				deferred_subresource_type::create_cubemap_unwrap(texptr->get_surface(rsx::surface_access::transfer_read), scaled_offset, attr2, decoded_remap),
 				texture_upload_context::framebuffer_storage, format_class, scale,
 				rsx::texture_dimension_extended::texture_dimension_cubemap
 			};

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -652,11 +652,23 @@ namespace rsx
 			// Track the clipping offset. Typically it is {0, 0} which means exact match, but subregions can also use this function and we need to scale this up from guest to host.
 			auto scaled_offset = offset;
 
+			// If src and dst are mismatched in bpp, scale the offset to match dest bpp.
+			// That way we can use coordinate transform to reverse the conversion, which we already need to do anyway.
+			// We do that before res scaling to avoid rounding errors.
+			if (scaled_offset.x)
+			{
+				if (const auto surface_bpp = texptr->get_bpp();
+					surface_bpp != attr.bpp)
+				{
+					scaled_offset.x = (scaled_offset.x * surface_bpp) / attr.bpp;
+				}
+			}
+
 			if (texptr->resolution_scaling_config.scale_percent != 100)
 			{
 				const auto [scaled_w, scaled_h] = rsx::apply_resolution_scale<true>(texptr->resolution_scaling_config, attr.width, attr.height, surface_width, surface_height);
 				const auto [unused, scaled_slice_h] = rsx::apply_resolution_scale<false>(texptr->resolution_scaling_config, RSX_SURFACE_DIMENSION_IGNORED, attr.slice_h, surface_width, surface_height);
-				const auto [scaled_off_x, scaled_off_y] = rsx::apply_resolution_scale<false>(texptr->resolution_scaling_config, static_cast<u16>(offset.x), static_cast<u16>(offset.y), surface_width, surface_height);
+				const auto [scaled_off_x, scaled_off_y] = rsx::apply_resolution_scale<false>(texptr->resolution_scaling_config, static_cast<u16>(scaled_offset.x), static_cast<u16>(scaled_offset.y), surface_width, surface_height);
 				attr2.width = scaled_w;
 				attr2.height = scaled_h;
 				attr2.slice_h = scaled_slice_h;

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -742,14 +742,25 @@ namespace rsx
 						deferred_subresource_type::create_copy(
 							texptr->get_surface(rsx::surface_access::transfer_read),
 							attr2, src_rect, dst_rect, rsx::surface_transform::coordinate_transform, decoded_remap, surface_is_rop_target),
-						texture_upload_context::framebuffer_storage, format_class, scale, extended_dimension
+						texture_upload_context::framebuffer_storage,
+						format_class, scale, extended_dimension,
+						texptr->base_addr
 					};
 				}
 
 				texptr->memory_barrier(cmd, access_type);
 				auto viewed_surface = texptr->get_surface(access_type);
-				sampled_image_descriptor result = { viewed_surface->get_view(decoded_remap), texture_upload_context::framebuffer_storage,
-						texptr->format_class(), scale, rsx::texture_dimension_extended::texture_dimension_2d, surface_is_rop_target, viewed_surface->samples() };
+				sampled_image_descriptor result =
+				{
+					viewed_surface->get_view(decoded_remap),
+					texture_upload_context::framebuffer_storage,
+					texptr->format_class(),
+					scale,
+					rsx::texture_dimension_extended::texture_dimension_2d,
+					texptr->base_addr,
+					surface_is_rop_target,
+					viewed_surface->samples()
+				};
 
 				if (requires_clip)
 				{
@@ -768,7 +779,8 @@ namespace rsx
 				{
 					deferred_subresource_type::create_3d_unwrap(texptr->get_surface(rsx::surface_access::transfer_read), scaled_offset, attr2, decoded_remap),
 					texture_upload_context::framebuffer_storage, format_class, scale,
-					rsx::texture_dimension_extended::texture_dimension_3d
+					rsx::texture_dimension_extended::texture_dimension_3d,
+					texptr->base_addr
 				};
 			}
 
@@ -778,7 +790,8 @@ namespace rsx
 			{
 				deferred_subresource_type::create_cubemap_unwrap(texptr->get_surface(rsx::surface_access::transfer_read), scaled_offset, attr2, decoded_remap),
 				texture_upload_context::framebuffer_storage, format_class, scale,
-				rsx::texture_dimension_extended::texture_dimension_cubemap
+				rsx::texture_dimension_extended::texture_dimension_cubemap,
+				texptr->base_addr
 			};
 		}
 
@@ -867,7 +880,8 @@ namespace rsx
 				{
 					deferred_subresource_type::create_cubemap_gather(attr2, std::move(sections), decoded_remap, !complete),
 					upload_context, format_class, scale,
-					rsx::texture_dimension_extended::texture_dimension_cubemap
+					rsx::texture_dimension_extended::texture_dimension_cubemap,
+					attr.address
 				};
 			}
 			else if (extended_dimension == rsx::texture_dimension_extended::texture_dimension_3d && attr.depth > 1)
@@ -882,7 +896,8 @@ namespace rsx
 				{
 					deferred_subresource_type::create_3d_gather(attr2, std::move(sections), decoded_remap, !complete),
 					upload_context, format_class, scale,
-					rsx::texture_dimension_extended::texture_dimension_3d
+					rsx::texture_dimension_extended::texture_dimension_3d,
+					attr.address
 				};
 			}
 
@@ -904,7 +919,8 @@ namespace rsx
 			{
 				deferred_subresource_type::create_atlas_gather(attr2, std::move(sections), decoded_remap, !complete),
 				upload_context, format_class, scale,
-				rsx::texture_dimension_extended::texture_dimension_2d
+				rsx::texture_dimension_extended::texture_dimension_2d,
+				attr.address
 			};
 
 			result.simplify();

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -395,35 +395,39 @@ namespace rsx
 				const size2u dst_size = { dimensions.width / attr.bpp, dimensions.height };
 				const size2u src_size = { dimensions.width / section_bpp, dimensions.height };
 
-				const u32 dst_slice_begin = slice * attr.slice_h;      // Output slice low watermark
-				const u32 dst_slice_end = dst_slice_begin + attr.height;   // Output slice high watermark
-
+				// NOTE: Computed dst_y is slice-local, not 2d-local. Our slice_h becomes our height.
+				// FIXME: This approach does not support mipmap levels.
+				const u32 dst_slice_h = attr.height;
 				const auto dst_y = dst_offset.y;
 				const auto dst_h = dst_size.height;
 
 				const auto write_section_end = dst_y + dst_h;
-				if (dst_y >= dst_slice_end || write_section_end <= dst_slice_begin)
+				const bool input_consumed = (write_section_end < attr.slice_h);
+
+				if (dst_y >= dst_slice_h)
 				{
 					// Belongs to a different slice
-					return { write_section_end <= dst_slice_begin, false };
+					return { input_consumed, false };
 				}
 
 				const u16 dst_w = static_cast<u16>(dst_size.width);
 				const u16 src_w = static_cast<u16>(src_size.width);
-				const u16 height = std::min(dst_slice_end, write_section_end) - dst_y;
+				const u16 height = std::min(dst_slice_h, write_section_end) - dst_y;
+				const bool output_covered = (write_section_end >= dst_slice_h);
 
 				if (scaling)
 				{
 					// Since output is upscaled, also upscale on dst
 
 					const auto& scaling_config = rsx::get_current_renderer()->resolution_scaling_config;
-					const auto [_dst_x, _dst_y] = rsx::apply_resolution_scale<false>(scaling_config, static_cast<u16>(dst_offset.x), static_cast<u16>(dst_y - dst_slice_begin), attr.width, attr.height);
+					const auto [_dst_x, _dst_y] = rsx::apply_resolution_scale<false>(scaling_config, static_cast<u16>(dst_offset.x), static_cast<u16>(dst_y), attr.width, attr.height);
 					const auto [_dst_w, _dst_h] = rsx::apply_resolution_scale<true>(scaling_config, dst_w, height, attr.width, attr.height);
 
 					out.push_back
 					({
 						.src = section->get_raw_texture(),
 						.xform = surface_transform::identity,
+						.base_addr = section->get_section_base(),
 						.level = 0,
 						.src_x = static_cast<u16>(src_offset.x),   // src.x
 						.src_y = static_cast<u16>(src_offset.y),   // src.y
@@ -436,26 +440,27 @@ namespace rsx
 						.dst_h = _dst_h
 					});
 
-					return { write_section_end <= dst_slice_end, write_section_end >= dst_slice_end };
+					return { input_consumed, output_covered };
 				}
 
 				out.push_back
 				({
 					.src = section->get_raw_texture(),
 					.xform = surface_transform::identity,
+					.base_addr = section->get_section_base(),
 					.level = 0,
 					.src_x = static_cast<u16>(src_offset.x),         // src.x
 					.src_y = static_cast<u16>(src_offset.y),         // src.y
 					.dst_x = static_cast<u16>(dst_offset.x),         // dst.x
-					.dst_y = static_cast<u16>(dst_y - dst_slice_begin),  // dst.y
-					.dst_z = 0,
+					.dst_y = static_cast<u16>(dst_y),                // dst.y
+					.dst_z = slice,
 					.src_w = src_w,
 					.src_h = height,
 					.dst_w = dst_w,
 					.dst_h = height
 				});
 
-				return { write_section_end <= dst_slice_end, write_section_end >= dst_slice_end };
+				return { input_consumed, output_covered };
 			};
 
 			u32 current_address = attr.address;

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -340,6 +340,7 @@ namespace rsx
 				std::tie(dst_x, dst_y) = rsx::apply_resolution_scale<false>(section.surface->resolution_scaling_config, dst_x, dst_y, attr.width, attr.height);
 
 				section.surface->memory_barrier(cmd, rsx::surface_access::transfer_read);
+				const bool output_covered = (section.dst_area.width >= attr.width) && (section_end >= slice_end);
 
 				out.push_back
 				({
@@ -358,7 +359,7 @@ namespace rsx
 					.dst_h = dst_height
 				});
 
-				return { section_end <= slice_end, section_end >= slice_end };
+				return { section_end <= slice_end, output_covered };
 			};
 
 			auto add_local_resource = [&](auto& section, u32 address, u16 slice, bool scaling) -> std::pair<bool, bool> // [ input fully consumed, output fully covered ]
@@ -404,7 +405,7 @@ namespace rsx
 				const u16 dst_w = static_cast<u16>(dst_size.width);
 				const u16 src_w = static_cast<u16>(src_size.width);
 				const u16 height = std::min(dst_slice_h, write_section_end) - dst_y;
-				const bool output_covered = (write_section_end >= dst_slice_h);
+				const bool output_covered = (dst_w >= attr.width) && (write_section_end >= dst_slice_h);
 
 				if (scaling)
 				{

--- a/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_helpers.h
@@ -255,15 +255,12 @@ namespace rsx
 			bool unordered_list = false;
 
 			rsx::simple_array<sort_helper> sort_list;
-			rsx::simple_array<utils::address_range32> sort_ranges;
 			sort_list.reserve(available_slices);
-			sort_ranges.reserve(available_slices);
 
 			// Generate sorting tree if both resources are available and overlapping
 			for (u32 index = 0; index < fbos.size(); ++index)
 			{
 				const auto range = fbos[index].surface->get_memory_range();
-				sort_ranges.push_back(range);
 				sort_list.push_back({
 					.tag = fbos[index].surface->last_use_tag,
 					.list = 0,
@@ -278,7 +275,6 @@ namespace rsx
 					continue;
 
 				const auto range = local[index]->get_section_range();
-				sort_ranges.push_back(range);
 				sort_list.push_back({
 					.tag = local[index]->last_write_tag,
 					.list = 1,
@@ -293,14 +289,9 @@ namespace rsx
 			}
 
 			// Check if ordered
-			for (u32 i = 0; i < sort_list.size(); ++i)
+			for (u32 i = 1; i < sort_list.size(); ++i)
 			{
-				if (i == 0)
-				{
-					continue;
-				}
-
-				if (sort_ranges[i].start < sort_ranges[i - 1].end)
+				if (sort_list[i].bounds.start <= sort_list[i - 1].bounds.end)
 				{
 					unordered_list = true;
 					break;

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -512,11 +512,12 @@ void GLGSRender::bind_texture_env()
 
 		using deferred_subresource_t = gl::texture_cache::deferred_subresource;
 		auto image = static_cast<gl::viewable_image*>(base->image());
+		auto rtt = gl::try_as_rtt(base->image());
 
 		if (is_msaa)
 		{
 			// MSAA resolve
-			auto rtt = gl::as_rtt(base->image());
+			ensure(rtt);
 			rtt->memory_barrier(cmd, rsx::surface_access::transfer_read);
 			image = rtt->get_surface(rsx::surface_access::transfer_read);
 		}
@@ -534,7 +535,11 @@ void GLGSRender::bind_texture_env()
 			const coord3u flatten_rect = { 0, 0, 0, flatten_attrs.width, flatten_attrs.height, 1 };
 			auto flatten_op = deferred_subresource_t::create_copy(
 				image, flatten_attrs, flatten_rect, rsx::surface_transform::identity, decoded_remap, desc->is_cyclic_reference);
-			flatten_op.cache_range = utils::address_range32::start_length(desc->ref_address, attr.pitch * attr.height);
+
+			ensure(desc->ref_address);
+			flatten_op.cache_range = rtt
+				? rtt->get_memory_range()
+				: utils::address_range32::start_length(desc->ref_address, attr.pitch * attr.height);
 
 			return m_gl_texture_cache.create_temporary_subresource(cmd, flatten_op);
 		}

--- a/rpcs3/Emu/RSX/GL/GLDraw.cpp
+++ b/rpcs3/Emu/RSX/GL/GLDraw.cpp
@@ -391,13 +391,9 @@ void GLGSRender::load_texture_env()
 		{
 			actual_mipcount = tex.get_exact_mipmap_count();
 		}
-		else if (sampler_state->external_subresource_desc.op == rsx::deferred_request_command::mipmap_gather)
+		else if (sampler_state->external_subresource_desc.op != rsx::deferred_request_command::nop)
 		{
-			actual_mipcount = sampler_state->external_subresource_desc.sections_to_copy.size();
-		}
-		else if (sampler_state->external_subresource_desc.op == rsx::deferred_request_command::cubemap_unwrap)
-		{
-			actual_mipcount = sampler_state->external_subresource_desc.mipmaps;
+			actual_mipcount = sampler_state->external_subresource_desc.exact_mip_count();
 		}
 
 		m_fs_sampler_states[i].apply(tex, fs_sampler_state[i].get(), actual_mipcount > 1);

--- a/rpcs3/Emu/RSX/GL/GLRenderTargets.h
+++ b/rpcs3/Emu/RSX/GL/GLRenderTargets.h
@@ -121,6 +121,21 @@ namespace gl
 	{
 		return ensure(dynamic_cast<const gl::render_target*>(t));
 	}
+
+	static inline gl::render_target* try_as_rtt(gl::texture* t)
+	{
+		return dynamic_cast<gl::render_target*>(t);
+	}
+
+	static inline const gl::render_target* try_as_rtt(const gl::texture* t)
+	{
+		return dynamic_cast<const gl::render_target*>(t);
+	}
+
+	static inline bool is_rtt(const gl::texture* t)
+	{
+		return dynamic_cast<const gl::render_target*>(t) != nullptr;
+	}
 }
 
 struct gl_render_target_traits

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -585,8 +585,7 @@ namespace gl
 		gl::texture_view* generate_cubemap_from_images(gl::command_context& cmd, const deferred_subresource& desc) override
 		{
 			auto _template = get_template_from_collection_impl(desc.sections_to_copy);
-			const u8 mip_count = 1 + desc.sections_to_copy.reduce(0, FN(std::max<u8>(x, y.level)));
-			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_CUBE_MAP, desc.gcm_format, desc.width, desc.height, 1, mip_count, desc.remap);
+			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_CUBE_MAP, desc.gcm_format, desc.width, desc.height, 1, desc.exact_mip_count(), desc.remap);
 
 			if (desc.force_bg_load)
 			{
@@ -600,7 +599,7 @@ namespace gl
 		gl::texture_view* generate_3d_from_2d_images(gl::command_context& cmd, const deferred_subresource& desc) override
 		{
 			auto _template = get_template_from_collection_impl(desc.sections_to_copy);
-			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_3D, desc.gcm_format, desc.width, desc.height, desc.depth, 1, desc.remap);
+			auto result = create_temporary_subresource_impl(cmd, _template, GL_NONE, GL_TEXTURE_3D, desc.gcm_format, desc.width, desc.height, desc.depth, desc.exact_mip_count(), desc.remap);
 
 			if (desc.force_bg_load)
 			{

--- a/rpcs3/Emu/RSX/GL/GLTextureCache.h
+++ b/rpcs3/Emu/RSX/GL/GLTextureCache.h
@@ -651,19 +651,9 @@ namespace gl
 			}
 		}
 
-		void update_image_contents(gl::command_context& cmd, gl::texture_view* dst, gl::texture* src, u16 width, u16 height) override
+		void update_image_contents(gl::command_context& cmd, gl::texture_view* dst, const deferred_subresource& desc) override
 		{
-			rsx::simple_array<copy_region_descriptor> region =
-			{{
-				.src = src,
-				.xform = rsx::surface_transform::identity,
-				.src_w = width,
-				.src_h = height,
-				.dst_w = width,
-				.dst_h = height
-			}};
-
-			copy_transfer_regions_impl(cmd, dst->image(), region);
+			copy_transfer_regions_impl(cmd, dst->image(), desc.sections_to_copy);
 		}
 
 		cached_texture_section* create_new_texture(gl::command_context& cmd, const utils::address_range32 &rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch,

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -846,11 +846,12 @@ bool VKGSRender::bind_interpreter_texture_env()
 
 		using deferred_subresource_t = vk::texture_cache::deferred_subresource;
 		auto image = static_cast<vk::viewable_image*>(base->image());
+		auto rtt = vk::try_as_rtt(base->image());
 
 		if (is_msaa)
 		{
 			// MSAA resolve
-			auto rtt = vk::as_rtt(base->image());
+			ensure(rtt);
 			rtt->memory_barrier(*m_current_command_buffer, rsx::surface_access::transfer_read);
 			image = rtt->get_surface(rsx::surface_access::transfer_read);
 		}
@@ -868,7 +869,11 @@ bool VKGSRender::bind_interpreter_texture_env()
 			const coord3u flatten_rect = { 0, 0, 0, flatten_attrs.width, flatten_attrs.height, 1 };
 			auto flatten_op = deferred_subresource_t::create_copy(
 				image, flatten_attrs, flatten_rect, rsx::surface_transform::identity, decoded_remap, desc->is_cyclic_reference);
-			flatten_op.cache_range = utils::address_range32::start_length(desc->ref_address, attr.pitch * attr.height);
+
+			ensure(desc->ref_address);
+			flatten_op.cache_range = rtt
+				? rtt->get_memory_range()
+				: utils::address_range32::start_length(desc->ref_address, attr.pitch * attr.height);
 
 			return m_texture_cache.create_temporary_subresource(*m_current_command_buffer, flatten_op);
 		}

--- a/rpcs3/Emu/RSX/VK/VKDraw.cpp
+++ b/rpcs3/Emu/RSX/VK/VKDraw.cpp
@@ -467,14 +467,9 @@ void VKGSRender::load_texture_env()
 			{
 				actual_mipmaps = static_cast<f32>(mipmap_count);
 			}
-			else if (sampler_state->external_subresource_desc.op == rsx::deferred_request_command::mipmap_gather)
+			else if (sampler_state->external_subresource_desc.op != rsx::deferred_request_command::nop)
 			{
-				// Clamp min and max lod
-				actual_mipmaps = static_cast<f32>(sampler_state->external_subresource_desc.sections_to_copy.size());
-			}
-			else if (sampler_state->external_subresource_desc.op == rsx::deferred_request_command::cubemap_unwrap)
-			{
-				actual_mipmaps = static_cast<f32>(sampler_state->external_subresource_desc.mipmaps);
+				actual_mipmaps = sampler_state->external_subresource_desc.exact_mip_count();
 			}
 			else
 			{

--- a/rpcs3/Emu/RSX/VK/VKRenderTargets.h
+++ b/rpcs3/Emu/RSX/VK/VKRenderTargets.h
@@ -141,6 +141,21 @@ namespace vk
 		return ensure(dynamic_cast<const vk::render_target*>(t));
 	}
 
+	static inline vk::render_target* try_as_rtt(vk::image* t)
+	{
+		return dynamic_cast<vk::render_target*>(t);
+	}
+
+	static inline const vk::render_target* try_as_rtt(const vk::image* t)
+	{
+		return dynamic_cast<const vk::render_target*>(t);
+	}
+
+	static inline bool is_rtt(const vk::image* t)
+	{
+		return dynamic_cast<const vk::render_target*>(t) != nullptr;
+	}
+
 	struct surface_cache_traits
 	{
 		using surface_storage_type = std::unique_ptr<vk::render_target>;

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -972,21 +972,11 @@ namespace vk
 			dst->aspect(), *vk::get_upload_heap(), desc.pitch, vk::upload_contents_inline);
 	}
 
-	void texture_cache::update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, vk::image* src, u16 width, u16 height)
+	void texture_cache::update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, const deferred_subresource& desc)
 	{
-		rsx::simple_array<copy_region_descriptor> region =
-		{ {
-			.src = src,
-			.xform = rsx::surface_transform::identity,
-			.src_w = width,
-			.src_h = height,
-			.dst_w = width,
-			.dst_h = height
-		} };
-
 		auto dst = dst_view->image();
 		dst->push_layout(cmd, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-		copy_transfer_regions_impl(cmd, dst, region);
+		copy_transfer_regions_impl(cmd, dst, desc.sections_to_copy);
 		dst->pop_layout(cmd);
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -760,7 +760,7 @@ namespace vk
 	{
 		const auto& sections_to_copy = desc.sections_to_copy;
 		auto _template = get_template_from_collection_impl(sections_to_copy);
-		const u8 mip_count = 1 + sections_to_copy.reduce(0, FN(std::max<u8>(x, y.level)));
+		const u8 mip_count = desc.exact_mip_count();
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_2D,
 			VK_IMAGE_VIEW_TYPE_CUBE, desc.gcm_format, desc.width, desc.height, 1, mip_count, desc.remap);
 
@@ -809,8 +809,9 @@ namespace vk
 	{
 		const auto& sections_to_copy = desc.sections_to_copy;
 		auto _template = get_template_from_collection_impl(sections_to_copy);
+		const u8 mip_count = desc.exact_mip_count();
 		auto result = create_temporary_subresource_view_impl(cmd, _template, VK_IMAGE_TYPE_3D,
-			VK_IMAGE_VIEW_TYPE_3D, desc.gcm_format, desc.width, desc.height, desc.depth, 1, desc.remap);
+			VK_IMAGE_VIEW_TYPE_3D, desc.gcm_format, desc.width, desc.height, desc.depth, mip_count, desc.remap);
 
 		if (!result)
 		{
@@ -820,7 +821,7 @@ namespace vk
 
 		const auto image = result->image();
 		VkImageAspectFlags dst_aspect = vk::get_aspect_flags(result->info.format);
-		VkImageSubresourceRange dst_range = { dst_aspect, 0, 1, 0, 1 };
+		VkImageSubresourceRange dst_range = { dst_aspect, 0, mip_count, 0, 1 };
 		vk::change_image_layout(cmd, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst_range);
 
 		if (desc.force_bg_load)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.h
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.h
@@ -472,7 +472,7 @@ namespace vk
 
 		void initialize_subresource_from_memory(vk::command_buffer& cmd, vk::image* dst, const deferred_subresource& desc, rsx::texture_dimension_extended type) const;
 
-		void update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, vk::image* src, u16 width, u16 height) override;
+		void update_image_contents(vk::command_buffer& cmd, vk::image_view* dst_view, const deferred_subresource& desc) override;
 
 		cached_texture_section* create_new_texture(vk::command_buffer& cmd, const utils::address_range32& rsx_range, u16 width, u16 height, u16 depth, u16 mipmaps, u32 pitch,
 			u32 gcm_format, rsx::texture_upload_context context, rsx::texture_dimension_extended type, bool swizzled, rsx::component_order swizzle_flags, rsx::flags32_t flags) override;


### PR DESCRIPTION
Another huge set of bugs uncovered when debugging a hackfix for LBP2 (@Yahfz). Turns out so much of the texture processing logic was broken. The problems were confirmed using hardware tests and have been fixed accordingly.
Fully supports reconstructing 3D textures with mipchains from host memory (VRAM). This should fix problems that may be observed when WCB is disabled in some games, but tbh the blast radius is enormous, so test any games you may have access to.

Tests:

1. Generic 3D mipchain
[texture3d_mips.zip](https://github.com/user-attachments/files/31089145/texture3d_mips.zip)

2. Host-only 3D mipchain
[texture3d_unwrap.zip](https://github.com/user-attachments/files/31089148/texture3d_unwrap.zip)

<details>
<summary>Test results</summary>

Result (PS3):

<img width="1279" height="721" alt="image" src="https://github.com/user-attachments/assets/ad8c661b-6a18-4965-add3-cf2e497249d8" />

Result (Master, no WCB, host-only - beware strobing)

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/0ead86df-48c7-4dec-a328-a8dedf14316d" />

Result (PR, no WCB)

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/23d5e99c-c83e-44cd-b96b-0278083717b9" />

NOTE: The strobing is expected, because only 1 frame was rendered. It is not a bug. I can fix it by drawing to all the frame outputs but the whole point of the hw tests is to trace a single operation one time and that is a lot more convenient this way.

</details>

Closes https://github.com/RPCS3/rpcs3/issues/18607
Closes https://github.com/RPCS3/rpcs3/issues/18757
Closes https://github.com/RPCS3/rpcs3/issues/17453