### PR TITLE
Swap PR number with PR text in update manager

### DIFF
--- a/rpcs3/rpcs3qt/update_manager.cpp
+++ b/rpcs3/rpcs3qt/update_manager.cpp
@@ -388,7 +388,7 @@ void update_manager::update(bool auto_accept, bool is_first_call)
 
 			if (entry.pr > 0)
 			{
-				entry_html = tr("&nbsp;&nbsp;&bull; %0: %1 (<a href=\"https://github.com/RPCS3/rpcs3/pull/%2\">#%2</a>)").arg(version_str, title_str, QString::number(entry.pr));
+				entry_html = tr("&nbsp;&nbsp;&bull; %0 (<a href=\"https://github.com/RPCS3/rpcs3/pull/%1\">#%1</a>): %2").arg(version_str, QString::number(entry.pr), title_str);
 			}
 			else
 			{


### PR DESCRIPTION
Minor follow up of #18465.
Provide the PR number just after the build number in the update manager dialog, allowing also to align any PR number and text in the list.. It avoids also the PR link is no more visible in case the related text is to long

### Master:
0.0.40-19111: SaveStates: Fix restart after saving (#18459)
0.0.40-19112: Swap PR number with PR text in update manager (#18460)

### PR:
0.0.40-19111 (#18459): SaveStates: Fix restart after saving
0.0.40-19112 (#18460): Swap PR number with PR text in update manager
