### PR TITLE
SPU LLVM: Remove unsafe ARM checksum specialization

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -1838,25 +1838,17 @@ public:
 			llvm::Value* starta_pc = m_ir->CreateAnd(get_pc(starta), 0x3fffc);
 			llvm::Value* data_addr = _ptr(m_lsptr, starta_pc);
 
-#ifndef ARCH_ARM64
 			llvm::Value* acc0 = nullptr;
 			llvm::Value* acc1 = nullptr;
 			bool toggle = true;
-#endif
 
 			// Use a 512bit simple checksum to verify integrity if size is atleast 512b * 3
 			// This code uses a 512bit vector for all hardware to ensure behavior matches.
 			// The checksum path is still faster even on narrow hardware.
 			if ((end - starta) >= 192 && !g_cfg.core.precise_spu_verification)
 			{
-#ifdef ARCH_ARM64
-				// Loop if there is at least 288 bytes of data to checksum on ARM.
-				// Each ARM checksum block consumes 6 NEON vectors: 2 direct adds and 2 UABD accumulates.
-				constexpr u32 checksum_block_size = 96;
-#else
 				// Loop if there is atleast (16 * stride) bytes of data to checksum to save some instruction cache
 				constexpr u32 checksum_block_size = 64;
-#endif
 				constexpr u32 checksum_loop_vectors = 16;
 				const u32 checksum_vectors_per_block = checksum_block_size / stride;
 				const u32 checksum_loop_blocks = (checksum_loop_vectors + checksum_vectors_per_block - 1) / checksum_vectors_per_block;
@@ -1874,7 +1866,6 @@ public:
 					}
 				}
 
-#ifndef ARCH_ARM64
 				if (use_checksum_loop)
 				{
 					const auto acc_init = ConstantAggregateZero::get(get_type<u32[16]>());
@@ -2009,178 +2000,6 @@ public:
 				// Compare result with zero
 				const auto cond = m_ir->CreateICmpNE(elem, m_ir->getInt64(0));
 				m_ir->CreateCondBr(cond, label_diff, label_body, m_md_unlikely);
-#else
-				// Very cursed "checksumming" code
-				// 96 bytes per ARM checksum step
-				//vls[0] -> add
-				//vls[1], vls[2] -> uaba
-				//vls[3] -> add
-				//vls[4], vls[5] -> uaba
-				//This allows us to save on some ALU ops relative to load instructions
-				const auto acc_init = ConstantAggregateZero::get(get_type<u32[4]>());
-				llvm::Value* checksum_parts[4] = {acc_init, acc_init, acc_init, acc_init};
-				u32 checksum[16] = {0};
-
-				const auto update_checksum = [&](const u32* words)
-				{
-					for (u32 i = 0; i < 4; i++)
-					{
-						checksum[i] += words[i];
-						checksum[4 + i] += words[4 + i] > words[8 + i] ? words[4 + i] - words[8 + i] : words[8 + i] - words[4 + i];
-						checksum[8 + i] += words[12 + i];
-						checksum[12 + i] += words[16 + i] > words[20 + i] ? words[16 + i] - words[20 + i] : words[20 + i] - words[16 + i];
-					}
-				};
-
-				if (use_checksum_loop)
-				{
-					for (u32 j = starta; j < checksum_loop_end; j += checksum_block_size)
-					{
-						u32 words[24];
-
-						for (u32 i = 0; i < 24; i++)
-						{
-							words[i] = func.data[(j + i * 4 - start) / 4];
-						}
-
-						update_checksum(words);
-					}
-
-					const auto loop_block = BasicBlock::Create(m_context, "spu_checksum_loop", m_function);
-					const auto loop_next = BasicBlock::Create(m_context, "spu_checksum_next", m_function);
-					const auto loop_preheader = m_ir->GetInsertBlock();
-					m_ir->CreateBr(loop_block);
-
-					m_ir->SetInsertPoint(loop_block);
-					const auto offset = m_ir->CreatePHI(get_type<u32>(), 2);
-					llvm::PHINode* acc_phi[4];
-					llvm::Value* next_acc[4];
-
-					for (u32 part = 0; part < 4; part++)
-					{
-						acc_phi[part] = m_ir->CreatePHI(get_type<u32[4]>(), 2);
-						acc_phi[part]->addIncoming(checksum_parts[part], loop_preheader);
-						next_acc[part] = acc_phi[part];
-					}
-
-					offset->addIncoming(m_ir->getInt32(0), loop_preheader);
-
-					const auto offset64 = m_ir->CreateZExt(offset, get_type<u64>());
-
-					for (u32 block = 0; block < checksum_loop_blocks; block++)
-					{
-						llvm::Value* vls[6];
-
-						for (u32 part = 0; part < 6; part++)
-						{
-							vls[part] = m_ir->CreateAlignedLoad(get_type<u32[4]>(), _ptr(data_addr, m_ir->CreateAdd(offset64, m_ir->getInt64(block * checksum_block_size + part * 16))), llvm::MaybeAlign{4});
-						}
-
-						next_acc[0] = m_ir->CreateAdd(next_acc[0], vls[0]);
-						next_acc[1] = m_ir->CreateAdd(next_acc[1], m_ir->CreateCall(get_intrinsic<u32[4]>(llvm::Intrinsic::aarch64_neon_uabd), {vls[1], vls[2]}));
-						next_acc[2] = m_ir->CreateAdd(next_acc[2], vls[3]);
-						next_acc[3] = m_ir->CreateAdd(next_acc[3], m_ir->CreateCall(get_intrinsic<u32[4]>(llvm::Intrinsic::aarch64_neon_uabd), {vls[4], vls[5]}));
-					}
-
-					const auto next_offset = m_ir->CreateAdd(offset, m_ir->getInt32(checksum_loop_size));
-					const auto loop_again = m_ir->CreateICmpULT(next_offset, m_ir->getInt32(checksum_loop_end - starta));
-					m_ir->CreateCondBr(loop_again, loop_block, loop_next);
-
-					offset->addIncoming(next_offset, loop_block);
-
-					for (u32 part = 0; part < 4; part++)
-					{
-						acc_phi[part]->addIncoming(next_acc[part], loop_block);
-						checksum_parts[part] = next_acc[part];
-					}
-
-					check_iterations += (checksum_loop_end - starta) / checksum_block_size;
-
-					m_ir->SetInsertPoint(loop_next);
-				}
-
-				for (u32 j = use_checksum_loop ? checksum_loop_end : starta; j < end; j += checksum_block_size)
-				{
-					llvm::Value* vls[6] = {};
-					u32 words[24] = {};
-					bool any_data = false;
-
-					for (u32 part = 0; part < 6; part++)
-					{
-						int indices[4];
-						bool holes = false;
-						bool data = false;
-
-						for (u32 i = 0; i < 4; i++)
-						{
-							const u32 k = j + (part * 4 + i) * 4;
-
-							if (k < start || k >= end || !func.data[(k - start) / 4])
-							{
-								indices[i] = 4;
-								holes      = true;
-							}
-							else
-							{
-								indices[i] = i;
-								data       = true;
-								words[part * 4 + i] = func.data[(k - start) / 4];
-							}
-						}
-
-						if (!data)
-						{
-							vls[part] = acc_init;
-							continue;
-						}
-
-						any_data = true;
-
-						// Load unaligned code block from LS
-						vls[part] = m_ir->CreateAlignedLoad(get_type<u32[4]>(), _ptr(data_addr, j + part * 16 - starta), llvm::MaybeAlign{4});
-
-						// Mask if necessary
-						if (holes)
-						{
-							vls[part] = m_ir->CreateShuffleVector(vls[part], acc_init, llvm::ArrayRef(indices, 4));
-						}
-					}
-
-					if (!any_data)
-					{
-						// Skip full-sized holes
-						continue;
-					}
-
-					checksum_parts[0] = m_ir->CreateAdd(checksum_parts[0], vls[0]);
-					checksum_parts[1] = m_ir->CreateAdd(checksum_parts[1], m_ir->CreateCall(get_intrinsic<u32[4]>(llvm::Intrinsic::aarch64_neon_uabd), {vls[1], vls[2]}));
-					checksum_parts[2] = m_ir->CreateAdd(checksum_parts[2], vls[3]);
-					checksum_parts[3] = m_ir->CreateAdd(checksum_parts[3], m_ir->CreateCall(get_intrinsic<u32[4]>(llvm::Intrinsic::aarch64_neon_uabd), {vls[4], vls[5]}));
-
-					update_checksum(words);
-
-					check_iterations++;
-				}
-
-				llvm::Value* elem = nullptr;
-
-				for (u32 part = 0; part < 4; part++)
-				{
-					auto* const_vector = ConstantDataVector::get(m_context, llvm::ArrayRef(checksum + part * 4, 4));
-					llvm::Value* acc = m_ir->CreateXor(checksum_parts[part], const_vector);
-					acc = m_ir->CreateBitCast(acc, get_type<u64[2]>());
-
-					for (u32 i = 0; i < 2; i++)
-					{
-						const auto lane = m_ir->CreateExtractElement(acc, i);
-						elem = elem ? m_ir->CreateOr(elem, lane) : lane;
-					}
-				}
-
-				// Compare result with zero
-				const auto cond = m_ir->CreateICmpNE(elem, m_ir->getInt64(0));
-				m_ir->CreateCondBr(cond, label_diff, label_body, m_md_unlikely);
-#endif
 			}
 #ifdef ARCH_ARM64
 			else


### PR DESCRIPTION
## AI usage disclosure

OpenAI Codex was used to inspect the RPCS3 source and logs, diagnose the checksum collision, write the code change, run local build checks, and draft this pull-request description. I directed the investigation and performed the human validation: I reproduced the missed triggers on an Apple M4 Pro, repeatedly tested ARM64 and x64 builds at the affected location, and confirmed that both previously missed gameplay/cutscene triggers consistently execute with this change. I reviewed the observed behavior and authorized this submission under my account.

## Summary

- remove the ARM64-only UABD checksum specialization used by SPU LLVM block verification
- use the existing architecture-independent 512-bit checksum on ARM64 as well

## Root cause

The ARM64 path folds two instruction vectors using an unsigned absolute difference. That operation is symmetric: `UABD(a, b) == UABD(b, a)`. Swapping the paired 128-bit chunks therefore leaves that part of the checksum unchanged.

This can make SPU local-store code changes pass verification and allow stale compiled code to be reused. In LEGO Dimensions (BLES02105), this manifested as missed gameplay and cutscene triggers on Apple Silicon.

The generic checksum keeps the source word positions in separate lanes and does not have this paired-vector symmetry.

## Impact

ARM64 uses the same verification behavior as the other architectures. This prioritizes correct invalidation while retaining the existing vector checksum path; a separately benchmarked ARM optimization can be added later as long as it preserves the generic checksum's collision behavior.

## Validation

- the modified `SPULLVMRecompiler.cpp` translation unit builds successfully on macOS ARM64 with LLVM 22
- tested on an Apple M4 Pro
- two previously missed scene/cutscene triggers consistently fire with this change
- the x64 path and ARM64 generic path produce correct behavior in the same save/location

The complete reused local build directory later stopped in unrelated NP sources because Homebrew Protobuf headers had been upgraded beyond the checked-in generated code version; the changed translation unit itself compiled successfully.
