### PR TITLE
[Qt] Hide titlebars by default

### DIFF
--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -184,7 +184,7 @@ namespace gui
 	const gui_save mw_logger           = gui_save(main_window, "loggerVisible",    false);
 	const gui_save mw_gamelist         = gui_save(main_window, "gamelistVisible",  true);
 	const gui_save mw_toolBarVisible   = gui_save(main_window, "toolBarVisible",   true);
-	const gui_save mw_titleBarsVisible = gui_save(main_window, "titleBarsVisible", true);
+	const gui_save mw_titleBarsVisible = gui_save(main_window, "titleBarsVisible", false);
 	const gui_save mw_geometry         = gui_save(main_window, "geometry",         QByteArray());
 	const gui_save mw_windowState      = gui_save(main_window, "windowState",      QByteArray());
 	const gui_save mw_mwState          = gui_save(main_window, "mwState",          QByteArray());


### PR DESCRIPTION
Probably horrific timing given digant's PR just got merged but it's long overdue in the default configuration for these titlebars to be hidden (I feel like the extra game list detail should be integrated elsewhere, if possible).
They're a relic of abandoned Windows-specific MDI conventions, which directly contravened the guidance for Mac OS X document windowing (and I assume other platforms too didn't adopt this MDI concept) and which are also abandoned on Windows, only to be seen in MMC with Aero Basic drawing still. 
<img width="1512" height="184" alt="image" src="https://github.com/user-attachments/assets/f37fdceb-ea0d-4644-a1a8-bf2910da27ac" />

Beyond the issue of UX principles they also just look ugly & waste space, compare these screenshots I took on Mac OS X's native Qt styling, and with the pseudo-Windows styling available on Mac, the title-bar free look is cleaner and saves precious UI real-estate. The option to enable them should remain for those who may find some portions of the MDI useful (e.g. tearing out game list/logs) but hiding them by default is the most sensible choice.
<img width="728" height="537" alt="Screenshot 2026-08-16 at 00 30 37" src="https://github.com/user-attachments/assets/070fce27-f64a-40dc-89d4-de056969825d" />
<img width="728" height="537" alt="Screenshot 2026-08-16 at 00 30 43" src="https://github.com/user-attachments/assets/b4a99f34-7482-48bf-b8bd-44809884570d" />
<img width="728" height="537" alt="Screenshot 2026-08-16 at 00 30 56" src="https://github.com/user-attachments/assets/6d7166c6-f7b7-4f2a-b106-96013e18e508" />
<img width="728" height="537" alt="Screenshot 2026-08-16 at 00 31 01" src="https://github.com/user-attachments/assets/b4d8e094-4010-4b96-9d2c-ff31c73c1c3f" />
