### PR TITLE
rsx: Implement flat shading semantics

### DIFF
--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -50,6 +50,8 @@ GLGSRender::GLGSRender(utils::serial* ar) noexcept : GSRender(ar)
 	backend_config.supports_multidraw = true;
 	backend_config.supports_normalized_barycentrics = true;
 	backend_config.supports_hw_instanced_rendering = true;
+	// OpenGL 3.2+ defaults to GL_LAST_VERTEX_CONVENTION.
+	backend_config.supports_last_provoking_vertex = true;
 
 	if (g_cfg.video.antialiasing_level != msaa_level::none)
 	{
@@ -139,8 +141,6 @@ void GLGSRender::on_init_thread()
 
 	gl::init();
 	gl::set_command_context(gl_state);
-	// OpenGL 3.2+ defaults to GL_LAST_VERTEX_CONVENTION.
-	backend_config.supports_last_provoking_vertex = true;
 
 	update_swap_interval();
 

--- a/rpcs3/Emu/RSX/GL/GLGSRender.cpp
+++ b/rpcs3/Emu/RSX/GL/GLGSRender.cpp
@@ -139,6 +139,8 @@ void GLGSRender::on_init_thread()
 
 	gl::init();
 	gl::set_command_context(gl_state);
+	// OpenGL 3.2+ defaults to GL_LAST_VERTEX_CONVENTION.
+	backend_config.supports_last_provoking_vertex = true;
 
 	update_swap_interval();
 

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -156,8 +156,12 @@ void GLVertexDecompilerThread::insertOutputs(std::stringstream& OS, const std::v
 	{
 		if (i.need_declare)
 		{
-			// All outputs must be declared always to allow setting default values
-			OS << "layout(location=" << gl::get_varying_register_location(i.name) << ") out vec4 " << i.name << ";\n";
+			// All outputs must be declared always to allow setting default values.
+			// NV4097_SET_SHADE_MODE applies to the front/back diffuse and specular colors.
+			const bool flat_color = (m_prog.ctrl & RSX_SHADER_CONTROL_FLAT_SHADING) &&
+				(std::string_view(i.name).starts_with("diff_color") || std::string_view(i.name).starts_with("spec_color"));
+			OS << "layout(location=" << gl::get_varying_register_location(i.name) << ") out "
+				<< (flat_color ? "flat " : "") << "vec4 " << i.name << ";\n";
 		}
 	}
 }

--- a/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/GL/GLVertexProgram.cpp
@@ -159,7 +159,7 @@ void GLVertexDecompilerThread::insertOutputs(std::stringstream& OS, const std::v
 			// All outputs must be declared always to allow setting default values.
 			// NV4097_SET_SHADE_MODE applies to the front/back diffuse and specular colors.
 			const bool flat_color = (m_prog.ctrl & RSX_SHADER_CONTROL_FLAT_SHADING) &&
-				(std::string_view(i.name).starts_with("diff_color") || std::string_view(i.name).starts_with("spec_color"));
+				(i.name.starts_with("diff_color"sv) || i.name.starts_with("spec_color"sv));
 			OS << "layout(location=" << gl::get_varying_register_location(i.name) << ") out "
 				<< (flat_color ? "flat " : "") << "vec4 " << i.name << ";\n";
 		}

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -688,7 +688,7 @@ namespace glsl
 		const auto is_flat_color = [&prog](const _varying_register_config& reg)
 		{
 			return (prog.ctrl & RSX_SHADER_CONTROL_FLAT_SHADING) &&
-				(reg.name.starts_with("diff_color") || reg.name.starts_with("spec_color"));
+				(reg.name.starts_with("diff_color"sv) || reg.name.starts_with("spec_color"sv));
 		};
 
 		if (!(prog.ctrl & RSX_SHADER_CONTROL_ATTRIBUTE_INTERPOLATION))

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -685,12 +685,18 @@ namespace glsl
 
 		// Make the output a little nicer
 		std::sort(varying_list.begin(), varying_list.end(), FN(x.location < y.location));
+		const auto is_flat_color = [&prog](const _varying_register_config& reg)
+		{
+			return (prog.ctrl & RSX_SHADER_CONTROL_FLAT_SHADING) &&
+				(reg.name.starts_with("diff_color") || reg.name.starts_with("spec_color"));
+		};
 
 		if (!(prog.ctrl & RSX_SHADER_CONTROL_ATTRIBUTE_INTERPOLATION))
 		{
 			for (const auto& reg : varying_list)
 			{
-				OS << "layout(location=" << reg.location << ") in " << reg.type << " " << reg.name << ";\n";
+				OS << "layout(location=" << reg.location << ") in " << (is_flat_color(reg) ? "flat " : "")
+					<< reg.type << " " << reg.name << ";\n";
 			}
 
 			OS << "\n";
@@ -718,7 +724,14 @@ namespace glsl
 
 		for (const auto& reg : varying_list)
 		{
-			OS << "vec4 " << reg.name << " = _interpolate_varying3(" << reg.name << "_raw);\n";
+			if (is_flat_color(reg))
+			{
+				OS << "vec4 " << reg.name << " = " << reg.name << "_raw[2];\n";
+			}
+			else
+			{
+				OS << "vec4 " << reg.name << " = _interpolate_varying3(" << reg.name << "_raw);\n";
+			}
 		}
 
 		OS << "\n";

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2110,7 +2110,7 @@ namespace rsx
 	{
 		if (m_graphics_state.test(rsx::pipeline_state::xform_instancing_state_dirty))
 		{
-			current_vertex_program.ctrl &= RSX_SHADER_CONTROL_FLAT_SHADING;
+			current_vertex_program.ctrl &= ~RSX_SHADER_CONTROL_INSTANCED_CONSTANTS;
 			if (rsx::method_registers.current_draw_clause.is_trivial_instanced_draw)
 			{
 				current_vertex_program.ctrl |= RSX_SHADER_CONTROL_INSTANCED_CONSTANTS;
@@ -2129,9 +2129,10 @@ namespace rsx
 
 		ensure(!m_graphics_state.test(rsx::pipeline_state::vertex_program_ucode_dirty));
 		current_vertex_program.output_mask = rsx::method_registers.vertex_attrib_output_mask();
+
 		current_vertex_program.ctrl &= ~RSX_SHADER_CONTROL_FLAT_SHADING;
-		if (backend_config.supports_last_provoking_vertex &&
-			rsx::method_registers.shade_mode() == rsx::shading_mode::flat)
+		if (rsx::method_registers.shade_mode() == rsx::shading_mode::flat &&
+			backend_config.supports_last_provoking_vertex)
 		{
 			current_vertex_program.ctrl |= RSX_SHADER_CONTROL_FLAT_SHADING;
 		}
@@ -2175,8 +2176,8 @@ namespace rsx
 		current_fragment_program.two_sided_lighting = m_ctx->register_state->two_side_light_en();
 		current_fragment_program.mrt_buffers_count = rsx::utility::get_mrt_buffers_count(m_ctx->register_state->surface_color_target());
 
-		if (backend_config.supports_last_provoking_vertex &&
-			m_ctx->register_state->shade_mode() == rsx::shading_mode::flat)
+		if (m_ctx->register_state->shade_mode() == rsx::shading_mode::flat &&
+			backend_config.supports_last_provoking_vertex)
 		{
 			current_fragment_program.ctrl |= RSX_SHADER_CONTROL_FLAT_SHADING;
 		}

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -2110,7 +2110,7 @@ namespace rsx
 	{
 		if (m_graphics_state.test(rsx::pipeline_state::xform_instancing_state_dirty))
 		{
-			current_vertex_program.ctrl = 0;
+			current_vertex_program.ctrl &= RSX_SHADER_CONTROL_FLAT_SHADING;
 			if (rsx::method_registers.current_draw_clause.is_trivial_instanced_draw)
 			{
 				current_vertex_program.ctrl |= RSX_SHADER_CONTROL_INSTANCED_CONSTANTS;
@@ -2129,6 +2129,12 @@ namespace rsx
 
 		ensure(!m_graphics_state.test(rsx::pipeline_state::vertex_program_ucode_dirty));
 		current_vertex_program.output_mask = rsx::method_registers.vertex_attrib_output_mask();
+		current_vertex_program.ctrl &= ~RSX_SHADER_CONTROL_FLAT_SHADING;
+		if (backend_config.supports_last_provoking_vertex &&
+			rsx::method_registers.shade_mode() == rsx::shading_mode::flat)
+		{
+			current_vertex_program.ctrl |= RSX_SHADER_CONTROL_FLAT_SHADING;
+		}
 
 		for (u32 textures_ref = current_vp_metadata.referenced_textures_mask, i = 0; textures_ref; textures_ref >>= 1, ++i)
 		{
@@ -2168,6 +2174,12 @@ namespace rsx
 		current_fragment_program.texcoord_control_mask = m_ctx->register_state->texcoord_control_mask();
 		current_fragment_program.two_sided_lighting = m_ctx->register_state->two_side_light_en();
 		current_fragment_program.mrt_buffers_count = rsx::utility::get_mrt_buffers_count(m_ctx->register_state->surface_color_target());
+
+		if (backend_config.supports_last_provoking_vertex &&
+			m_ctx->register_state->shade_mode() == rsx::shading_mode::flat)
+		{
+			current_fragment_program.ctrl |= RSX_SHADER_CONTROL_FLAT_SHADING;
+		}
 
 		if (m_ctx->register_state->current_draw_clause.classify_mode() == primitive_class::polygon)
 		{

--- a/rpcs3/Emu/RSX/RSXThread.h
+++ b/rpcs3/Emu/RSX/RSXThread.h
@@ -91,6 +91,7 @@ namespace rsx
 		bool supports_asynchronous_compute;    // Async compute
 		bool supports_host_gpu_labels;         // Advanced host synchronization
 		bool supports_normalized_barycentrics; // Basically all GPUs except NVIDIA have properly normalized barycentrics
+		bool supports_last_provoking_vertex;   // Flat shading using RSX's last-vertex convention
 	};
 
 	struct desync_fifo_cmd_info

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -642,6 +642,11 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 
 	backend_config.supports_multidraw = true;
 	backend_config.supports_hw_instanced_rendering = true;
+	backend_config.supports_last_provoking_vertex = m_device->get_provoking_vertex_last_support();
+	if (!backend_config.supports_last_provoking_vertex)
+	{
+		rsx_log.warning("VK_EXT_provoking_vertex with provokingVertexLast is unavailable; RSX flat shading will fall back to smooth interpolation.");
+	}
 
 	// NVIDIA has broken attribute interpolation
 	backend_config.supports_normalized_barycentrics = (

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -642,6 +642,7 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 
 	backend_config.supports_multidraw = true;
 	backend_config.supports_hw_instanced_rendering = true;
+
 	backend_config.supports_last_provoking_vertex = m_device->get_provoking_vertex_last_support();
 	if (!backend_config.supports_last_provoking_vertex)
 	{

--- a/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
@@ -161,8 +161,9 @@ namespace vk
 
 		VkPipelineRasterizationStateCreateInfo rs = create_info.state.rs;
 		VkPipelineRasterizationProvokingVertexStateCreateInfoEXT provoking_vertex_state{};
-		if (m_device->get_provoking_vertex_last_support())
+		if (flags & USE_LAST_PROVOKING_VERTEX)
 		{
+			ensure(m_device->get_provoking_vertex_last_support());
 			provoking_vertex_state.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT;
 			provoking_vertex_state.pNext = rs.pNext;
 			provoking_vertex_state.provokingVertexMode = VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT;

--- a/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
+++ b/rpcs3/Emu/RSX/VK/VKPipelineCompiler.cpp
@@ -159,11 +159,21 @@ namespace vk
 		VkPipelineColorBlendStateCreateInfo cs = create_info.state.cs;
 		cs.pAttachments = create_info.state.att_state;
 
+		VkPipelineRasterizationStateCreateInfo rs = create_info.state.rs;
+		VkPipelineRasterizationProvokingVertexStateCreateInfoEXT provoking_vertex_state{};
+		if (m_device->get_provoking_vertex_last_support())
+		{
+			provoking_vertex_state.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT;
+			provoking_vertex_state.pNext = rs.pNext;
+			provoking_vertex_state.provokingVertexMode = VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT;
+			rs.pNext = &provoking_vertex_state;
+		}
+
 		VkGraphicsPipelineCreateInfo info = {};
 		info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
 		info.pVertexInputState = &vi;
 		info.pInputAssemblyState = &create_info.state.ia;
-		info.pRasterizationState = &create_info.state.rs;
+		info.pRasterizationState = &rs;
 		info.pColorBlendState = &cs;
 		info.pMultisampleState = pmss;
 		info.pViewportState = &vp;

--- a/rpcs3/Emu/RSX/VK/VKPipelineCompiler.h
+++ b/rpcs3/Emu/RSX/VK/VKPipelineCompiler.h
@@ -58,7 +58,8 @@ namespace vk
 			COMPILE_DEFAULT = 0,
 			COMPILE_INLINE = 1,
 			COMPILE_DEFERRED = 2,
-			SEPARATE_SHADER_OBJECTS = 4
+			SEPARATE_SHADER_OBJECTS = 4,
+			USE_LAST_PROVOKING_VERTEX = 8
 		};
 
 		using op_flags = rsx::flags32_t;

--- a/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
+++ b/rpcs3/Emu/RSX/VK/VKProgramBuffer.h
@@ -50,6 +50,10 @@ namespace vk
 		{
 			vk::pipe_compiler::op_flags compiler_flags = compile_async ? vk::pipe_compiler::COMPILE_DEFERRED : vk::pipe_compiler::COMPILE_INLINE;
 			compiler_flags |= vk::pipe_compiler::SEPARATE_SHADER_OBJECTS;
+			if (vertexProgramData.use_last_provoking_vertex)
+			{
+				compiler_flags |= vk::pipe_compiler::USE_LAST_PROVOKING_VERTEX;
+			}
 
 			auto compiler = vk::get_pipe_compiler();
 			auto result = compiler->compile(

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -307,8 +307,12 @@ void VKVertexDecompilerThread::insertOutputs(std::stringstream& OS, const std::v
 	{
 		if (i.need_declare)
 		{
-			// All outputs must be declared always to allow setting default values
-			OS << "layout(location=" << vk::get_varying_register_location(i.name) << ") out vec4 " << i.name << ";\n";
+			// All outputs must be declared always to allow setting default values.
+			// NV4097_SET_SHADE_MODE applies to the front/back diffuse and specular colors.
+			const bool flat_color = (m_prog.ctrl & RSX_SHADER_CONTROL_FLAT_SHADING) &&
+				(std::string_view(i.name).starts_with("diff_color") || std::string_view(i.name).starts_with("spec_color"));
+			OS << "layout(location=" << vk::get_varying_register_location(i.name) << ") out "
+				<< (flat_color ? "flat " : "") << "vec4 " << i.name << ";\n";
 		}
 	}
 

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -497,6 +497,8 @@ VKVertexProgram::~VKVertexProgram()
 
 void VKVertexProgram::Decompile(const RSXVertexProgram& prog)
 {
+	use_last_provoking_vertex = !!(prog.ctrl & RSX_SHADER_CONTROL_FLAT_SHADING);
+
 	std::string source;
 	VKVertexDecompilerThread decompiler(prog, source, parr, *this);
 	decompiler.Task();

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.cpp
@@ -310,7 +310,7 @@ void VKVertexDecompilerThread::insertOutputs(std::stringstream& OS, const std::v
 			// All outputs must be declared always to allow setting default values.
 			// NV4097_SET_SHADE_MODE applies to the front/back diffuse and specular colors.
 			const bool flat_color = (m_prog.ctrl & RSX_SHADER_CONTROL_FLAT_SHADING) &&
-				(std::string_view(i.name).starts_with("diff_color") || std::string_view(i.name).starts_with("spec_color"));
+				(i.name.starts_with("diff_color"sv) || i.name.starts_with("spec_color"sv));
 			OS << "layout(location=" << vk::get_varying_register_location(i.name) << ") out "
 				<< (flat_color ? "flat " : "") << "vec4 " << i.name << ";\n";
 		}

--- a/rpcs3/Emu/RSX/VK/VKVertexProgram.h
+++ b/rpcs3/Emu/RSX/VK/VKVertexProgram.h
@@ -63,6 +63,7 @@ public:
 	VkShaderModule handle = nullptr;
 	vk::glsl::shader shader;
 	std::vector<vk::glsl::program_input> uniforms;
+	bool use_last_provoking_vertex = false;
 
 	// Quick attribute indices
 	struct

--- a/rpcs3/Emu/RSX/VK/vkutils/device.cpp
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.cpp
@@ -35,6 +35,7 @@ namespace vk
 		VkPhysicalDeviceBorderColorSwizzleFeaturesEXT border_color_swizzle_info{};
 		VkPhysicalDeviceFaultFeaturesEXT device_fault_info{};
 		VkPhysicalDeviceMultiDrawFeaturesEXT multidraw_info{};
+		VkPhysicalDeviceProvokingVertexFeaturesEXT provoking_vertex_info{};
 
 		// Core features
 		shader_support_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES;
@@ -88,6 +89,13 @@ namespace vk
 			features2.pNext      = &multidraw_info;
 		}
 
+		if (device_extensions.is_supported(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME))
+		{
+			provoking_vertex_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT;
+			provoking_vertex_info.pNext = features2.pNext;
+			features2.pNext             = &provoking_vertex_info;
+		}
+
 		vkGetPhysicalDeviceFeatures2(dev, &features2);
 
 		shader_types_support.allow_float64 = !!features2.features.shaderFloat64;
@@ -104,6 +112,7 @@ namespace vk
 		optional_features_support.barycentric_coords  = !!shader_barycentric_info.fragmentShaderBarycentric;
 		optional_features_support.framebuffer_loops   = !!fbo_loops_info.attachmentFeedbackLoopLayout;
 		optional_features_support.extended_device_fault = !!device_fault_info.deviceFault;
+		optional_features_support.provoking_vertex_last = !!provoking_vertex_info.provokingVertexLast;
 
 		features = features2.features;
 
@@ -561,6 +570,11 @@ namespace vk
 		{
 			requested_extensions.push_back(VK_EXT_DEVICE_FAULT_EXTENSION_NAME);
 		}
+
+		if (pgpu->optional_features_support.provoking_vertex_last)
+		{
+			requested_extensions.push_back(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME);
+		}
 		
 #ifdef __APPLE__
 		if (pgpu->optional_features_support.portability)
@@ -803,6 +817,15 @@ namespace vk
 			shader_barycentric_info.pNext = const_cast<void*>(device.pNext);
 			shader_barycentric_info.fragmentShaderBarycentric = VK_TRUE;
 			device.pNext = &shader_barycentric_info;
+		}
+
+		VkPhysicalDeviceProvokingVertexFeaturesEXT provoking_vertex_info{};
+		if (pgpu->optional_features_support.provoking_vertex_last)
+		{
+			provoking_vertex_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT;
+			provoking_vertex_info.pNext = const_cast<void*>(device.pNext);
+			provoking_vertex_info.provokingVertexLast = VK_TRUE;
+			device.pNext = &provoking_vertex_info;
 		}
 
 		if (auto error = vkCreateDevice(*pgpu, &device, nullptr, &dev))

--- a/rpcs3/Emu/RSX/VK/vkutils/device.h
+++ b/rpcs3/Emu/RSX/VK/vkutils/device.h
@@ -103,6 +103,7 @@ namespace vk
 			bool extended_device_fault = false;
 			bool texture_compression_bc = false;
 			bool portability = false;
+			bool provoking_vertex_last = false;
 		} optional_features_support;
 
 		friend class render_device;
@@ -191,6 +192,7 @@ namespace vk
 		bool get_synchronization2_support() const { return pgpu->optional_features_support.synchronization_2; }
 		bool get_extended_device_fault_support() const { return pgpu->optional_features_support.extended_device_fault; }
 		bool get_texture_compression_bc_support() const { return pgpu->optional_features_support.texture_compression_bc; }
+		bool get_provoking_vertex_last_support() const { return pgpu->optional_features_support.provoking_vertex_last; }
 
 		u64 get_descriptor_update_after_bind_support() const { return pgpu->descriptor_indexing_support.update_after_bind_mask; }
 		u32 get_descriptor_max_draw_calls() const { return pgpu->descriptor_max_draw_calls; }

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -458,6 +458,7 @@ namespace gcm
 		RSX_SHADER_CONTROL_ATTRIBUTE_INTERPOLATION  = 0x00010000, // Rasterizing triangles and not lines or points
 		RSX_SHADER_CONTROL_INSTANCED_CONSTANTS      = 0x00020000, // Support instance ID offsets when loading constants
 		RSX_SHADER_CONTROL_INTERPRETER_MODEL        = 0x00040000, // Compile internals expecting interpreter
+		RSX_SHADER_CONTROL_FLAT_SHADING             = 0x00000800, // Interpolate front/back colors using the provoking vertex
 
 		RSX_SHADER_CONTROL_8BIT_FRAMEBUFFER         = 0x00080000, // Quantize outputs to 8-bit FBO
 		RSX_SHADER_CONTROL_SRGB_FRAMEBUFFER         = 0x00100000, // Outputs are SRGB. We could reuse UNKNOWN1 but we just keep the namespaces separate.

--- a/rpcs3/Emu/RSX/gcm_enums.h
+++ b/rpcs3/Emu/RSX/gcm_enums.h
@@ -455,10 +455,10 @@ namespace gcm
 		RSX_SHADER_CONTROL_UNKNOWN1                 = 0x00008000, // seemingly set when srgb packer is used??
 
 		// Custom
+		RSX_SHADER_CONTROL_FLAT_SHADING             = 0x00000800, // Interpolate front/back colors using the provoking vertex
 		RSX_SHADER_CONTROL_ATTRIBUTE_INTERPOLATION  = 0x00010000, // Rasterizing triangles and not lines or points
 		RSX_SHADER_CONTROL_INSTANCED_CONSTANTS      = 0x00020000, // Support instance ID offsets when loading constants
 		RSX_SHADER_CONTROL_INTERPRETER_MODEL        = 0x00040000, // Compile internals expecting interpreter
-		RSX_SHADER_CONTROL_FLAT_SHADING             = 0x00000800, // Interpolate front/back colors using the provoking vertex
 
 		RSX_SHADER_CONTROL_8BIT_FRAMEBUFFER         = 0x00080000, // Quantize outputs to 8-bit FBO
 		RSX_SHADER_CONTROL_SRGB_FRAMEBUFFER         = 0x00100000, // Outputs are SRGB. We could reuse UNKNOWN1 but we just keep the namespaces separate.

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -709,6 +709,7 @@ namespace rsx
 			state_signals[NV4097_SET_TEX_COORD_CONTROL + 9] = rsx::fragment_program_state_dirty;
 			state_signals[NV4097_SET_TWO_SIDE_LIGHT_EN] = rsx::fragment_program_state_dirty;
 			state_signals[NV4097_SET_POINT_SPRITE_CONTROL] = rsx::fragment_program_state_dirty;
+			state_signals[NV4097_SET_SHADE_MODE] = rsx::vertex_program_state_dirty | rsx::fragment_program_state_dirty;
 			state_signals[NV4097_SET_USER_CLIP_PLANE_CONTROL] = rsx::vertex_state_dirty;
 			state_signals[NV4097_SET_TRANSFORM_BRANCH_BITS] = rsx::vertex_state_dirty;
 			state_signals[NV4097_SET_CLIP_MIN] = rsx::invalidate_zclip_bits;

--- a/rpcs3/Emu/RSX/rsx_methods.h
+++ b/rpcs3/Emu/RSX/rsx_methods.h
@@ -495,6 +495,11 @@ namespace rsx
 			return decode<NV4097_SET_LINE_SMOOTH_ENABLE>().line_smooth_enabled();
 		}
 
+		shading_mode shade_mode() const
+		{
+			return decode<NV4097_SET_SHADE_MODE>().shading();
+		}
+
 		bool poly_offset_point_enabled() const
 		{
 			return decode<NV4097_SET_POLY_OFFSET_POINT_ENABLE>().poly_offset_point_enabled();


### PR DESCRIPTION
## Summary

- Honor NV4097_SET_SHADE_MODE.
- Use flat interpolation for diffuse and specular color varyings.
- Preserve RSX last-vertex provoking semantics.
- Enable VK_EXT_provoking_vertex where supported.
- Keep smooth shading unchanged.

## Problem

I encountered rendering issues of the font in the game
Rozen Maiden: Wechseln Sie Welt ab, it uses zero-alpha separator
vertices while constructing glyph masks. RPCS3 ignored CELL_GCM_FLAT
and smoothly interpolated the alpha values, producing visible bridge
triangles and missing portions of glyphs.

## User impact

This fixes corrupted alpha masks and partially missing glyph contours in titles that rely on `CELL_GCM_FLAT` color interpolation. *Rozen Maiden: Wechseln Sie Welt ab* provides a reproducible example, but the implementation handles the RSX shading state generally and does not introduce a title-specific workaround.

## Visual comparison

### Before

<img width="1495" height="313" alt="2026-08-16 08_40_50-FPS_ 60 03 _ Vulkan _ 0 0 42-19753 _ Rozen Maiden -Wechseln sie welt ab-  BLJM61" src="https://github.com/user-attachments/assets/fb35a897-ce10-4c78-9ca6-2dd8c54a71f6" />

Parts of the glyph contours are missing.

### After

<img width="1756" height="358" alt="2026-08-17 05_07_29-FPS_ 59 96 _ Vulkan _ 0 0 42 _ Rozen Maiden -Wechseln sie welt ab-  BLJM61120" src="https://github.com/user-attachments/assets/a045ba26-7258-43ca-b345-192cab77adc7" />

The same glyph-mask geometry renders with complete, continuous contours after honoring flat color interpolation and the RSX last-vertex provoking convention.