### PR TITLE
Use max() to bring negative floats up to 0.0 before uint conversion.

### DIFF
--- a/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentPrologue.glsl
+++ b/rpcs3/Emu/RSX/Program/GLSLSnippets/RSXProg/RSXFragmentPrologue.glsl
@@ -15,13 +15,13 @@ R"(
 // Default. Used when we're not utilizing native fp16
 vec4 round_to_8bit(const in vec4 v4)
 {
-	uvec4 raw = uvec4(floor(fma(_fx12_truncate(v4), vec4(255.), vec4(0.5))));
+	uvec4 raw = uvec4(max(floor(fma(_fx12_truncate(v4), vec4(255.), vec4(0.5))), vec4(0.)));
 	return vec4(raw) / vec4(255.);
 }
 #ifndef _32_BIT_OUTPUT
 f16vec4 round_to_8bit(const in f16vec4 v4)
 {
-	uvec4 raw = uvec4(floor(fma(_fx12_truncate(vec4(v4)), f16vec4(255.), f16vec4(0.5))));
+	uvec4 raw = uvec4(max(floor(fma(_fx12_truncate(vec4(v4)), f16vec4(255.), f16vec4(0.5))), vec4(0.)));
 	return f16vec4(raw) / f16vec4(255.);
 }
 #endif


### PR DESCRIPTION
Some games show unexpected colors due to conversions with scalar constructors from a float to a uint. The GLSL spec says that these conversions are undefined if the float is negative. These same conversion rules apply for vector constructors (like uvec4).

The solution here is to use max(x, 0.0) to bring the negative float value up to 0.0 before converting to uint.