### PR TITLE
rsx_debugger: fix g8b8 conversion

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellGifDec.cpp
@@ -502,8 +502,8 @@ error_code cellGifDecDecodeData(vm::ptr<GifDecoder> mainHandle, vm::cptr<GifStre
 	}
 
 	//Decode GIF file. (TODO: Is there any faster alternative? Can we do it without external libraries?)
-	int width, height, actual_components;
-	auto image = std::unique_ptr<unsigned char,decltype(&::free)>
+	int width = 0, height = 0, actual_components = 0;
+	auto image = std::unique_ptr<u8, decltype(&::free)>
 		(
 			stbi_load_from_memory(gif.get(), ::narrow<int>(fileSize), &width, &height, &actual_components, 4),
 			&::free
@@ -515,6 +515,7 @@ error_code cellGifDecDecodeData(vm::ptr<GifDecoder> mainHandle, vm::cptr<GifStre
 	const int bytesPerLine = static_cast<int>(dataCtrlParam->outputBytesPerLine);
 	constexpr char nComponents = 4;
 	const u32 image_size = width * height * nComponents;
+	u8* src = image.get();
 
 	switch(current_outParam.outputColorSpace)
 	{
@@ -527,12 +528,12 @@ error_code cellGifDecDecodeData(vm::ptr<GifDecoder> mainHandle, vm::cptr<GifStre
 			{
 				const int dstOffset = i * bytesPerLine;
 				const int srcOffset = width * nComponents * i;
-				memcpy(&data[dstOffset], &image.get()[srcOffset], linesize);
+				std::memcpy(&data[dstOffset], &src[srcOffset], linesize);
 			}
 		}
 		else
 		{
-			memcpy(data.get_ptr(), image.get(), image_size);
+			std::memcpy(data.get_ptr(), src, image_size);
 		}
 		break;
 	}
@@ -549,10 +550,10 @@ error_code cellGifDecDecodeData(vm::ptr<GifDecoder> mainHandle, vm::cptr<GifStre
 				const int srcOffset = width * nComponents * i;
 				for (int j = 0; j < linesize; j += nComponents)
 				{
-					output[j + 0] = image.get()[srcOffset + j + 3];
-					output[j + 1] = image.get()[srcOffset + j + 0];
-					output[j + 2] = image.get()[srcOffset + j + 1];
-					output[j + 3] = image.get()[srcOffset + j + 2];
+					output[j + 0] = src[srcOffset + j + 3];
+					output[j + 1] = src[srcOffset + j + 0];
+					output[j + 2] = src[srcOffset + j + 1];
+					output[j + 3] = src[srcOffset + j + 2];
 				}
 				std::memcpy(&data[dstOffset], output.get(), linesize);
 			}
@@ -560,7 +561,7 @@ error_code cellGifDecDecodeData(vm::ptr<GifDecoder> mainHandle, vm::cptr<GifStre
 		else
 		{
 			const auto img = std::make_unique<uint[]>(image_size);
-			uint* source_current = reinterpret_cast<uint*>(image.get());
+			uint* source_current = reinterpret_cast<uint*>(src);
 			uint* dest_current = img.get();
 			for (uint i = 0; i < image_size / nComponents; i++)
 			{

--- a/rpcs3/rpcs3qt/rsx_debugger.cpp
+++ b/rpcs3/rpcs3qt/rsx_debugger.cpp
@@ -799,13 +799,22 @@ void rsx_debugger::GetBuffers() const
 		{
 			for (u32 y = 0; y < height; y++)
 			{
+				u8* line = buffer + y * pitch * 2;
+
 				for (u32 x = 0; x < std::max(pitch, 1u) - 1; x += 2)
 				{
-					const usz line_start = y * pitch;
+					const u32 rev_x = pitch - 2 - x;
 
-					std::memcpy(buffer + line_start * 2 + x * 2 + 1, buffer + line_start * 2 + x, 2);
-					buffer[line_start * 2 + x * 2 + 0] = 0;
-					buffer[line_start * 2 + x * 2 + 3] = 0xff;
+					const uint8_t* src = line + rev_x;
+					uint8_t* dst = line + rev_x * 2;
+
+					const uint8_t g = src[0];
+					const uint8_t b = src[1];
+
+					dst[0] = 0;
+					dst[1] = g;
+					dst[2] = b;
+					dst[3] = 0xff;
 				}
 			}
 


### PR DESCRIPTION
- Fix fix g8b8 conversion in rsx debugger:
```
src:    00 01        02 03        04 05        06 07        08 09        0a 0b        0c 0d        0e 0f        10 11        12 13        14 15        16 17     
old: 00 00 00 ff  00 01 ff ff  00 00 02 ff  00 03 ff ff  00 00 04 ff  00 05 ff ff  00 00 06 ff  00 07 ff ff  00 00 08 ff  00 09 ff ff  00 00 0a ff  00 0b ff ff  
new: 00 00 01 ff  00 02 03 ff  00 04 05 ff  00 06 07 ff  00 08 09 ff  00 0a 0b ff  00 0c 0d ff  00 0e 0f ff  00 10 11 ff  00 12 13 ff  00 14 15 ff  00 16 17 ff 
```