### PR TITLE
cellOskDialog: Only abort if the dialog is actually open

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellOskDialog.cpp
@@ -799,29 +799,28 @@ error_code cellOskDialogAbort()
 		return CELL_MSGDIALOG_ERROR_DIALOG_NOT_OPENED;
 	}
 
-	const error_code result = osk->state.atomic_op([](OskDialogState& state) -> error_code
+	const bool abort = osk->state.atomic_op([](OskDialogState& state)
 	{
-		// Check for open dialog. In this case the dialog is "Open" if it was not unloaded before.
-		if (state == OskDialogState::Unloaded)
+		// Check for open dialog.
+		if (state == OskDialogState::Open)
 		{
-			return CELL_MSGDIALOG_ERROR_DIALOG_NOT_OPENED;
+			state = OskDialogState::Abort;
+			return true;
 		}
 
-		state = OskDialogState::Abort;
-
-		return CELL_OK;
+		return false;
 	});
 
-	if (result == CELL_OK)
+	if (abort)
 	{
 		osk->osk_input_result = CELL_OSKDIALOG_INPUT_FIELD_RESULT_ABORT;
 		osk->Close(FAKE_CELL_OSKDIALOG_CLOSE_ABORT);
+
+		g_fxo->get<osk_info>().last_dialog_state = CELL_SYSUTIL_OSKDIALOG_FINISHED;
+
+		cellOskDialog.notice("cellOskDialogAbort: sending CELL_SYSUTIL_OSKDIALOG_FINISHED");
+		sysutil_send_system_cmd(CELL_SYSUTIL_OSKDIALOG_FINISHED, 0);
 	}
-
-	g_fxo->get<osk_info>().last_dialog_state = CELL_SYSUTIL_OSKDIALOG_FINISHED;
-
-	cellOskDialog.notice("cellOskDialogAbort: sending CELL_SYSUTIL_OSKDIALOG_FINISHED");
-	sysutil_send_system_cmd(CELL_SYSUTIL_OSKDIALOG_FINISHED, 0);
 
 	return CELL_OK;
 }

--- a/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_osk.cpp
@@ -1057,7 +1057,7 @@ namespace rsx
 		{
 			const std::u16string ws = u32string_to_utf16(m_preview.value);
 			const usz length = std::min(osk_text.size(), ws.length() + 1) * sizeof(char16_t);
-			memcpy(osk_text.data(), ws.c_str(), length);
+			std::memcpy(osk_text.data(), ws.c_str(), length);
 
 			osk.notice("on_text_changed: osk_text='%s'", utf16_to_ascii8(ws));
 


### PR DESCRIPTION
- Only abort the OSK dialog if the dialog is actually open
- Only send the FINISHED callback if the dialog was actually open

The underlying issue is that the game calls cellOskDialogAbort directly after the dialog sends FINISHED after
the user accepts the input and still before calling cellOskDialogUnloadAsync.

cellOskDialogUnloadAsync will then treat the dialog as aborted and does not deliver the result string.
Even if we always copy the string on unload, we still get abort as result in CellOskDialogCallbackReturnParam and the game discards it.

This leads to a possible conclusion that cellOskDialogAbort is not working properly.
This is not really well tested and researched, so I'll keep it as draft for now.
I'll try to confirm this properly when I get the chance.

fixes #19253