### PR TITLE
windows: Fix clang x64/arm64 builds

### DIFF
--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -32,6 +32,7 @@
 #include "module_verifier.hpp"
 #include "util/dyn_lib.hpp"
 #include <shellapi.h>
+#include <process.h>
 
 // TODO(cjj19970505@live.cn)
 // When compiling with WIN32_LEAN_AND_MEAN definition


### PR DESCRIPTION
Explicitly includes the `<process.h>` header, required for `_P_WAIT` usage