### PR TITLE
Make optional VSH on File ➔ All Titles ➔ Create LLVM Caches dialog

### DIFF
--- a/rpcs3/rpcs3qt/game_list_actions.cpp
+++ b/rpcs3/rpcs3qt/game_list_actions.cpp
@@ -1235,20 +1235,48 @@ void game_list_actions::BatchActionBySerials(progress_dialog* pdlg, const std::s
 
 void game_list_actions::BatchCreateCPUCaches(const std::vector<game_info>& games, bool is_fast_compilation, bool is_interactive)
 {
-	if (is_interactive && QMessageBox::question(m_game_list_frame, tr("Confirm Creation"), tr("Create LLVM cache?")) != QMessageBox::Yes)
+	// The VSH cache is only part of this batch if no specific games were selected
+	const bool vsh_selectable = games.empty();
+
+	// Non-interactive callers keep the previous behaviour
+	bool include_vsh = vsh_selectable && !is_interactive;
+
+	if (is_interactive)
 	{
-		return;
+		QMessageBox mb(QMessageBox::Question, tr("Confirm Creation"), tr("Create LLVM cache?"), QMessageBox::Yes | QMessageBox::No, m_game_list_frame);
+
+		QCheckBox* vsh_check = nullptr;
+
+		if (vsh_selectable)
+		{
+			vsh_check = new QCheckBox(tr("Include PS3 Interface (XMB, or VSH)"));
+			vsh_check->setChecked(false);
+			mb.setCheckBox(vsh_check);
+		}
+
+		if (mb.exec() != QMessageBox::Yes)
+		{
+			return;
+		}
+
+		include_vsh = vsh_check && vsh_check->isChecked();
 	}
 
 	std::set<std::string> serials;
 
-	if (games.empty())
+	if (include_vsh)
 	{
 		serials.emplace("vsh.self");
 	}
 
 	for (const auto& game : (games.empty() ? m_game_list_frame->GetGameInfo() : games))
 	{
+		// The VSH entry is part of the game list, so it has to be filtered out as well
+		if (vsh_selectable && !include_vsh && game->info.serial == "vsh.self")
+		{
+			continue;
+		}
+
 		serials.emplace(game->info.serial);
 	}
 

--- a/rpcs3/rpcs3qt/game_list_actions.cpp
+++ b/rpcs3/rpcs3qt/game_list_actions.cpp
@@ -1238,20 +1238,16 @@ void game_list_actions::BatchCreateCPUCaches(const std::vector<game_info>& games
 	// The VSH cache is only part of this batch if no specific games were selected
 	const bool vsh_selectable = games.empty();
 
-	// Non-interactive callers keep the previous behaviour
-	bool include_vsh = vsh_selectable && !is_interactive;
+	// Without a dialog to ask the user, a batch of all titles includes the VSH cache
+	bool include_vsh = vsh_selectable;
 
 	if (is_interactive)
 	{
 		QMessageBox mb(QMessageBox::Question, tr("Confirm Creation"), tr("Create LLVM cache?"), QMessageBox::Yes | QMessageBox::No, m_game_list_frame);
 
-		QCheckBox* vsh_check = nullptr;
-
 		if (vsh_selectable)
 		{
-			vsh_check = new QCheckBox(tr("Include PS3 Interface (XMB, or VSH)"));
-			vsh_check->setChecked(false);
-			mb.setCheckBox(vsh_check);
+			mb.setCheckBox(new QCheckBox(tr("Include PS3 Interface (XMB, or VSH)")));
 		}
 
 		if (mb.exec() != QMessageBox::Yes)
@@ -1259,25 +1255,24 @@ void game_list_actions::BatchCreateCPUCaches(const std::vector<game_info>& games
 			return;
 		}
 
-		include_vsh = vsh_check && vsh_check->isChecked();
+		include_vsh = mb.checkBox() && mb.checkBox()->isChecked();
 	}
 
 	std::set<std::string> serials;
+
+	for (const auto& game : (games.empty() ? m_game_list_frame->GetGameInfo() : games))
+	{
+		serials.emplace(game->info.serial);
+	}
 
 	if (include_vsh)
 	{
 		serials.emplace("vsh.self");
 	}
-
-	for (const auto& game : (games.empty() ? m_game_list_frame->GetGameInfo() : games))
+	else if (vsh_selectable)
 	{
-		// The VSH entry is part of the game list, so it has to be filtered out as well
-		if (vsh_selectable && !include_vsh && game->info.serial == "vsh.self")
-		{
-			continue;
-		}
-
-		serials.emplace(game->info.serial);
+		// The VSH entry is part of the full game list, so it has to be removed if unwanted
+		serials.erase("vsh.self");
 	}
 
 	const usz total = serials.size();


### PR DESCRIPTION
Make optional VSH CPU compilation on `File ➔ All Titles ➔ Create LLVM Caches` dialog. By default it is now excluded due to VSH caches are fully covered by the dedicated submenu `File ➔ Firmware`.

fixes #19225

<img width="630" height="289" alt="image" src="https://github.com/user-attachments/assets/0689ebc9-6df2-4b2c-ac00-d612ed80a0d0" />
