### PR TITLE
Allow savestate on game exit

### DIFF
--- a/rpcs3/Emu/System.h
+++ b/rpcs3/Emu/System.h
@@ -469,6 +469,7 @@ public:
 	bool IsStopped(bool test_fully = false) const { return test_fully ? m_state == system_state::stopped : m_state <= system_state::stopping; }
 	bool IsReady()   const { return m_state == system_state::ready; }
 	bool IsStarting() const { return m_state == system_state::starting; }
+	bool IsClosePending() const { return m_emu_state_close_pending; }
 	void WaitReady() const { m_state.wait(system_state::ready); }
 	auto GetStatus(bool fixup = true) const { system_state state = m_state; return fixup && state == system_state::frozen ? system_state::paused : fixup && state == system_state::stopping ? system_state::stopped : state; }
 

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -329,7 +329,16 @@ void gs_frame::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const QKey
 	{
 		if (!Emu.IsStopped())
 		{
-			Emu.GracefulShutdown(true, true);
+			if (m_gui_settings->GetValue(gui::ib_confirm_exit).toBool() && visibility() == FullScreen)
+			{
+				// The confirmation dialog would be hidden behind the game window in fullscreen mode
+				toggle_fullscreen();
+			}
+
+			if (m_gui_settings->GetStopConfirmation(nullptr, tr("Exit Game?"), tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>")))
+			{
+				Emu.GracefulShutdown(true, true);
+			}
 		}
 		break;
 	}
@@ -1206,22 +1215,15 @@ bool gs_frame::event(QEvent* ev)
 {
 	if (ev->type() == QEvent::Close)
 	{
-		if (m_gui_settings->GetValue(gui::ib_confirm_exit).toBool())
+		if (m_gui_settings->GetValue(gui::ib_confirm_exit).toBool() && visibility() == FullScreen)
 		{
-			if (visibility() == FullScreen)
-			{
-				toggle_fullscreen();
-			}
+			// The confirmation dialog would be hidden behind the game window in fullscreen mode
+			toggle_fullscreen();
+		}
 
-			int result = QMessageBox::Yes;
-			m_gui_settings->ShowConfirmationBox(tr("Exit Game?"),
-				tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>"),
-				gui::ib_confirm_exit, &result, nullptr);
-
-			if (result != QMessageBox::Yes)
-			{
-				return true;
-			}
+		if (!m_gui_settings->GetStopConfirmation(nullptr, tr("Exit Game?"), tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>")))
+		{
+			return true;
 		}
 
 		gui_log.notice("Game window close event issued");
@@ -1233,7 +1235,7 @@ bool gs_frame::event(QEvent* ev)
 
 		if (Emu.IsStopped())
 		{
-			// This should be unreachable, but never say never. Properly close the window anyway.
+			// Reachable if the confirmation above created a savestate, which stops the emulation. Properly close the window anyway.
 			close();
 		}
 		else

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -25,7 +25,6 @@
 #include <QApplication>
 #include <QDateTime>
 #include <QKeyEvent>
-#include <QMessageBox>
 #include <QPainter>
 #include <QScreen>
 
@@ -327,18 +326,9 @@ void gs_frame::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const QKey
 	}
 	case gui::shortcuts::shortcut::gw_stop:
 	{
-		if (!Emu.IsStopped())
+		if (confirm_stop())
 		{
-			if (m_gui_settings->GetValue(gui::ib_confirm_exit).toBool() && visibility() == FullScreen)
-			{
-				// The confirmation dialog would be hidden behind the game window in fullscreen mode
-				toggle_fullscreen();
-			}
-
-			if (m_gui_settings->GetStopConfirmation(nullptr, tr("Exit Game?"), tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>")))
-			{
-				Emu.GracefulShutdown(true, true);
-			}
+			Emu.GracefulShutdown(true, true);
 		}
 		break;
 	}
@@ -659,7 +649,8 @@ bool gs_frame::get_mouse_lock_state()
 void gs_frame::hide_on_close()
 {
 	// Make sure not to save the hidden state, which is useless to us.
-	const Visibility current_visibility = visibility();
+	// If fullscreen was only left to make room for a confirmation dialog, save what the user actually had.
+	const Visibility current_visibility = m_fullscreen_for_dialog ? Visibility::FullScreen : visibility();
 	m_gui_settings->SetValue(gui::gs_visibility, gui::visibility_to_string(current_visibility == Visibility::Hidden ? m_visibility : current_visibility), false);
 	m_gui_settings->SetValue(gui::gs_geometry, geometry(), true);
 
@@ -1211,17 +1202,42 @@ void gs_frame::mouse_hide_timeout()
 	}
 }
 
+bool gs_frame::confirm_stop()
+{
+	// These are the conditions under which GetStopConfirmation actually shows its dialog. Leaving fullscreen for one that never appears would be a glitch.
+	const bool dialog_expected = !Emu.IsStopped() && !Emu.IsClosePending() && m_gui_settings->GetValue(gui::ib_confirm_exit).toBool();
+	const bool left_fullscreen = dialog_expected && visibility() == FullScreen;
+
+	// Remember it, so that closing the window does not persist the windowed state we are about to force
+	m_fullscreen_for_dialog = left_fullscreen;
+
+	if (left_fullscreen)
+	{
+		// The confirmation dialog would be hidden behind the game window in fullscreen mode
+		toggle_fullscreen();
+	}
+
+	// This is a top level window of its own, so the dialog gets no parent and is kept on top instead
+	if (m_gui_settings->GetStopConfirmation(nullptr, tr("Exit Game?"), tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>")))
+	{
+		return true;
+	}
+
+	// The game keeps running, so put the window back the way the user had it
+	if (left_fullscreen && visibility() != FullScreen)
+	{
+		toggle_fullscreen();
+	}
+
+	m_fullscreen_for_dialog = false;
+	return false;
+}
+
 bool gs_frame::event(QEvent* ev)
 {
 	if (ev->type() == QEvent::Close)
 	{
-		if (m_gui_settings->GetValue(gui::ib_confirm_exit).toBool() && visibility() == FullScreen)
-		{
-			// The confirmation dialog would be hidden behind the game window in fullscreen mode
-			toggle_fullscreen();
-		}
-
-		if (!m_gui_settings->GetStopConfirmation(nullptr, tr("Exit Game?"), tr("Do you really want to exit the game?<br><br>Any unsaved progress will be lost!<br>")))
+		if (!confirm_stop())
 		{
 			return true;
 		}

--- a/rpcs3/rpcs3qt/gs_frame.h
+++ b/rpcs3/rpcs3qt/gs_frame.h
@@ -47,6 +47,7 @@ private:
 	u32 m_hide_mouse_idletime = 2000; // ms
 	bool m_flip_showed_frame = false;
 	bool m_start_games_fullscreen = false;
+	bool m_fullscreen_for_dialog = false;
 	bool m_ignore_stop_events = false;
 
 	std::shared_ptr<utils::video_encoder> m_video_encoder{};
@@ -110,6 +111,7 @@ protected:
 
 private:
 	void load_gui_settings();
+	bool confirm_stop();
 	void hide_on_close();
 	void toggle_recording();
 	void toggle_mouselock();

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -181,7 +181,8 @@ void gui_settings::SetCategoryVisibility(int cat, bool val, bool is_list_mode) c
 	SetValue(value, val);
 }
 
-void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr, bool always_on_top = false, const QString& option_text = {}, bool* option_checked = nullptr)
+// Returns false if the dialog was suppressed because the user disabled it
+bool gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr, bool always_on_top = false, const QString& option_text = {}, bool* option_checked = nullptr)
 {
 	const std::string dialog_type = icon != QMessageBox::Information ? "Confirmation" : "Info";
 	const bool has_gui_setting = !entry.name.isEmpty();
@@ -189,7 +190,7 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 	if (has_gui_setting && !GetValue(entry).toBool())
 	{
 		cfg_log.notice("%s Dialog for Entry %s was ignored", dialog_type, entry.name);
-		return;
+		return false;
 	}
 
 	const QFlags<QMessageBox::StandardButton> buttons = icon != QMessageBox::Information ? QMessageBox::Yes | QMessageBox::No : QMessageBox::Ok;
@@ -207,39 +208,36 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 
 	QCheckBox* option_box = nullptr;
 
-	if (!option_text.isEmpty())
+	// The message box only manages a single check box, so the additional option needs a spot in the layout if that slot is taken
+	if (!option_text.isEmpty() && (!dont_show_again || mb.layout()))
 	{
-		QCheckBox* existing_box = mb.checkBox();
+		option_box = new QCheckBox(option_text, &mb);
 
-		if (!existing_box)
+		if (!dont_show_again)
 		{
 			// The check box slot of the message box is still free
-			option_box = new QCheckBox(option_text);
 			mb.setCheckBox(option_box);
 		}
 		else if (QGridLayout* grid = qobject_cast<QGridLayout*>(mb.layout()))
 		{
-			// The message box only manages a single check box, so the additional option has to be put into the layout manually
 			int row = 0, column = 0, row_span = 1, column_span = 1;
 
-			if (const int index = grid->indexOf(existing_box); index >= 0)
+			if (const int index = grid->indexOf(dont_show_again); index >= 0)
 			{
 				grid->getItemPosition(index, &row, &column, &row_span, &column_span);
 			}
 
-			option_box = new QCheckBox(option_text, &mb);
-
 			QDialogButtonBox* button_box = mb.findChild<QDialogButtonBox*>();
-			const int button_index = button_box ? grid->indexOf(button_box) : -1;
 
-			if (button_index >= 0)
+			if (const int index = button_box ? grid->indexOf(button_box) : -1; index >= 0)
 			{
-				int button_row, button_column, button_row_span, button_column_span;
-				grid->getItemPosition(button_index, &button_row, &button_column, &button_row_span, &button_column_span);
+				int button_row = 0, button_column = 0, button_row_span = 1, button_column_span = 1;
+				grid->getItemPosition(index, &button_row, &button_column, &button_row_span, &button_column_span);
 
-				// Move the buttons one row down in order to insert the additional option right below the existing check box
+				// Keep both check boxes together: the option goes right below the existing one, and the buttons move one row down.
+				// If that cell is taken, fall back to the row the buttons just left.
 				grid->removeWidget(button_box);
-				grid->addWidget(option_box, button_row, column, row_span, column_span);
+				grid->addWidget(option_box, grid->itemAtPosition(row + row_span, column) ? button_row : row + row_span, column, row_span, column_span);
 				grid->addWidget(button_box, button_row + 1, button_column, button_row_span, button_column_span);
 			}
 			else
@@ -247,10 +245,9 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 				grid->addWidget(option_box, grid->rowCount(), column, row_span, column_span);
 			}
 		}
-		else if (QLayout* layout = mb.layout())
+		else
 		{
-			option_box = new QCheckBox(option_text, &mb);
-			layout->addWidget(option_box);
+			mb.layout()->addWidget(option_box);
 		}
 	}
 
@@ -274,11 +271,12 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 	});
 
 	mb.exec();
+	return true;
 }
 
-void gui_settings::ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent, const QString& option_text, bool* option_checked)
+void gui_settings::ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr)
 {
-	ShowBox(QMessageBox::Question, title, text, entry, result, parent, true, option_text, option_checked);
+	ShowBox(QMessageBox::Question, title, text, entry, result, parent, true);
 }
 
 void gui_settings::ShowInfoBox(const QString& title, const QString& text, const gui_save& entry, QWidget* parent = nullptr)
@@ -307,15 +305,8 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 
 	if (!Emu.IsStopped())
 	{
-		// The emulation is already being closed (e.g. a savestate is being created). Do not interfere with it.
-		if (Emu.IsClosePending())
-		{
-			cfg_log.notice("Ignoring the request: the current emulation is already being closed.");
-			return false;
-		}
-
-		QString title = tr("Close Running Game?");
-		QString message = tr("Performing this action will close the current game.<br>Do you really want to continue?<br><br>Any unsaved progress will be lost!<br>");
+		QString title;
+		QString message;
 
 		if (gui_save_entry == gui::ib_confirm_boot)
 		{
@@ -327,22 +318,7 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 			message = tr("A game is currently running. Do you really want to close RPCS3?<br><br>Any unsaved progress will be lost!<br>");
 		}
 
-		int result = QMessageBox::Yes;
-		bool create_savestate = false;
-
-		ShowBox(QMessageBox::Question, title, message, gui_save_entry, &result, parent, false, tr("Create savestate"), &create_savestate);
-
-		if (result != QMessageBox::Yes)
-		{
-			return false;
-		}
-
-		cfg_log.notice("User accepted to stop the current emulation.");
-
-		if (create_savestate && !CreateSavestateAndStop(parent))
-		{
-			return false;
-		}
+		return ConfirmStop(parent, title, message, gui_save_entry, false);
 	}
 
 	return true;
@@ -350,12 +326,19 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 
 bool gui_settings::GetStopConfirmation(QWidget* parent, const QString& title, const QString& message, const gui_save& gui_save_entry)
 {
-	// Only ask if the user did not disable this confirmation
-	if (Emu.IsStopped() || (!gui_save_entry.name.isEmpty() && !GetValue(gui_save_entry).toBool()))
+	if (Emu.IsStopped())
 	{
 		return true;
 	}
 
+	// Keep the dialog on top: some callers (e.g. the game window) have no parent widget to be modal to
+	return ConfirmStop(parent, title, message, gui_save_entry, true);
+}
+
+// Asks whether the running game may be closed, and creates a savestate first if the user opted in.
+// Returns false if the user declined or if the savestate failed, in which case the caller must leave the emulation alone.
+bool gui_settings::ConfirmStop(QWidget* parent, const QString& title, const QString& message, const gui_save& gui_save_entry, bool always_on_top)
+{
 	// The emulation is already being closed (e.g. a savestate is being created). Do not interfere with it.
 	if (Emu.IsClosePending())
 	{
@@ -366,9 +349,17 @@ bool gui_settings::GetStopConfirmation(QWidget* parent, const QString& title, co
 	int result = QMessageBox::Yes;
 	bool create_savestate = false;
 
-	ShowConfirmationBox(title.isEmpty() ? tr("Close Running Game?") : title,
+	// Kill() ignores savestate requests while the game is still booting, so do not offer an option that can only fail
+	const QString savestate_text = Emu.IsStarting() ? QString() : tr("Create savestate");
+
+	if (!ShowBox(QMessageBox::Question,
+		title.isEmpty() ? tr("Close Running Game?") : title,
 		message.isEmpty() ? tr("Performing this action will close the current game.<br>Do you really want to continue?<br><br>Any unsaved progress will be lost!<br>") : message,
-		gui_save_entry, &result, parent, tr("Create savestate"), &create_savestate);
+		gui_save_entry, &result, parent, always_on_top, savestate_text, &create_savestate))
+	{
+		// The user disabled this confirmation, so nothing was asked and nothing was ticked
+		return true;
+	}
 
 	if (result != QMessageBox::Yes)
 	{
@@ -377,17 +368,12 @@ bool gui_settings::GetStopConfirmation(QWidget* parent, const QString& title, co
 
 	cfg_log.notice("User accepted to stop the current emulation.");
 
-	if (create_savestate && !CreateSavestateAndStop(parent))
-	{
-		return false;
-	}
-
-	return true;
+	return !create_savestate || CreateSavestateAndStop(parent, always_on_top);
 }
 
 // Creates a savestate of the currently running game and stops the emulation.
 // Any subsequent shutdown of the caller becomes a no-op. Returns false if the savestate could not be created.
-bool gui_settings::CreateSavestateAndStop(QWidget* parent)
+bool gui_settings::CreateSavestateAndStop(QWidget* parent, bool always_on_top)
 {
 	cfg_log.notice("User requested a savestate before stopping the current emulation.");
 
@@ -407,7 +393,11 @@ bool gui_settings::CreateSavestateAndStop(QWidget* parent)
 	if (!Emu.IsStopped() && info == Emu.GetEmulationIdentifier())
 	{
 		cfg_log.error("Savestate creation failed. The current emulation will not be stopped.");
-		ShowInfoBox(tr("Savestate failed!"), tr("Failed to create a savestate.<br>The game will keep running.<br><br>See the log for more information."), gui_save(), parent);
+
+		// The game is still running, so this needs the same on-top treatment as the confirmation it follows
+		ShowBox(QMessageBox::Information, tr("Savestate failed!"),
+			tr("Failed to create a savestate.<br>The game will keep running.<br><br>See the log for more information."),
+			gui_save(), nullptr, parent, always_on_top);
 		return false;
 	}
 

--- a/rpcs3/rpcs3qt/gui_settings.cpp
+++ b/rpcs3/rpcs3qt/gui_settings.cpp
@@ -7,6 +7,8 @@
 
 #include <QCheckBox>
 #include <QCoreApplication>
+#include <QDialogButtonBox>
+#include <QGridLayout>
 #include <QMessageBox>
 
 LOG_CHANNEL(cfg_log, "CFG");
@@ -179,7 +181,7 @@ void gui_settings::SetCategoryVisibility(int cat, bool val, bool is_list_mode) c
 	SetValue(value, val);
 }
 
-void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr, bool always_on_top = false)
+void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr, bool always_on_top = false, const QString& option_text = {}, bool* option_checked = nullptr)
 {
 	const std::string dialog_type = icon != QMessageBox::Information ? "Confirmation" : "Info";
 	const bool has_gui_setting = !entry.name.isEmpty();
@@ -195,9 +197,61 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 	QMessageBox mb(icon, title, text, buttons, parent, Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint | (always_on_top ? Qt::WindowStaysOnTopHint : Qt::Widget));
 	mb.setTextFormat(Qt::RichText);
 
+	QCheckBox* dont_show_again = nullptr;
+
 	if (has_gui_setting && icon != QMessageBox::Critical)
 	{
-		mb.setCheckBox(new QCheckBox(tr("Don't show again")));
+		dont_show_again = new QCheckBox(tr("Don't show again"));
+		mb.setCheckBox(dont_show_again);
+	}
+
+	QCheckBox* option_box = nullptr;
+
+	if (!option_text.isEmpty())
+	{
+		QCheckBox* existing_box = mb.checkBox();
+
+		if (!existing_box)
+		{
+			// The check box slot of the message box is still free
+			option_box = new QCheckBox(option_text);
+			mb.setCheckBox(option_box);
+		}
+		else if (QGridLayout* grid = qobject_cast<QGridLayout*>(mb.layout()))
+		{
+			// The message box only manages a single check box, so the additional option has to be put into the layout manually
+			int row = 0, column = 0, row_span = 1, column_span = 1;
+
+			if (const int index = grid->indexOf(existing_box); index >= 0)
+			{
+				grid->getItemPosition(index, &row, &column, &row_span, &column_span);
+			}
+
+			option_box = new QCheckBox(option_text, &mb);
+
+			QDialogButtonBox* button_box = mb.findChild<QDialogButtonBox*>();
+			const int button_index = button_box ? grid->indexOf(button_box) : -1;
+
+			if (button_index >= 0)
+			{
+				int button_row, button_column, button_row_span, button_column_span;
+				grid->getItemPosition(button_index, &button_row, &button_column, &button_row_span, &button_column_span);
+
+				// Move the buttons one row down in order to insert the additional option right below the existing check box
+				grid->removeWidget(button_box);
+				grid->addWidget(option_box, button_row, column, row_span, column_span);
+				grid->addWidget(button_box, button_row + 1, button_column, button_row_span, button_column_span);
+			}
+			else
+			{
+				grid->addWidget(option_box, grid->rowCount(), column, row_span, column_span);
+			}
+		}
+		else if (QLayout* layout = mb.layout())
+		{
+			option_box = new QCheckBox(option_text, &mb);
+			layout->addWidget(option_box);
+		}
 	}
 
 	connect(&mb, &QMessageBox::finished, [&](int res)
@@ -207,9 +261,12 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 			*result = res;
 		}
 
-		const auto checkBox = mb.checkBox();
+		if (option_checked)
+		{
+			*option_checked = option_box && option_box->isChecked();
+		}
 
-		if (checkBox && checkBox->isChecked())
+		if (dont_show_again && dont_show_again->isChecked())
 		{
 			SetValue(entry, false);
 			cfg_log.notice("%s Dialog for Entry %s is now disabled", dialog_type, entry.name);
@@ -219,9 +276,9 @@ void gui_settings::ShowBox(QMessageBox::Icon icon, const QString& title, const Q
 	mb.exec();
 }
 
-void gui_settings::ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr)
+void gui_settings::ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent, const QString& option_text, bool* option_checked)
 {
-	ShowBox(QMessageBox::Question, title, text, entry, result, parent, true);
+	ShowBox(QMessageBox::Question, title, text, entry, result, parent, true, option_text, option_checked);
 }
 
 void gui_settings::ShowInfoBox(const QString& title, const QString& text, const gui_save& entry, QWidget* parent = nullptr)
@@ -250,6 +307,13 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 
 	if (!Emu.IsStopped())
 	{
+		// The emulation is already being closed (e.g. a savestate is being created). Do not interfere with it.
+		if (Emu.IsClosePending())
+		{
+			cfg_log.notice("Ignoring the request: the current emulation is already being closed.");
+			return false;
+		}
+
 		QString title = tr("Close Running Game?");
 		QString message = tr("Performing this action will close the current game.<br>Do you really want to continue?<br><br>Any unsaved progress will be lost!<br>");
 
@@ -264,8 +328,9 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 		}
 
 		int result = QMessageBox::Yes;
+		bool create_savestate = false;
 
-		ShowBox(QMessageBox::Question, title, message, gui_save_entry, &result, parent);
+		ShowBox(QMessageBox::Question, title, message, gui_save_entry, &result, parent, false, tr("Create savestate"), &create_savestate);
 
 		if (result != QMessageBox::Yes)
 		{
@@ -273,6 +338,77 @@ bool gui_settings::GetBootConfirmation(QWidget* parent, const gui_save& gui_save
 		}
 
 		cfg_log.notice("User accepted to stop the current emulation.");
+
+		if (create_savestate && !CreateSavestateAndStop(parent))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool gui_settings::GetStopConfirmation(QWidget* parent, const QString& title, const QString& message, const gui_save& gui_save_entry)
+{
+	// Only ask if the user did not disable this confirmation
+	if (Emu.IsStopped() || (!gui_save_entry.name.isEmpty() && !GetValue(gui_save_entry).toBool()))
+	{
+		return true;
+	}
+
+	// The emulation is already being closed (e.g. a savestate is being created). Do not interfere with it.
+	if (Emu.IsClosePending())
+	{
+		cfg_log.notice("Ignoring the request: the current emulation is already being closed.");
+		return false;
+	}
+
+	int result = QMessageBox::Yes;
+	bool create_savestate = false;
+
+	ShowConfirmationBox(title.isEmpty() ? tr("Close Running Game?") : title,
+		message.isEmpty() ? tr("Performing this action will close the current game.<br>Do you really want to continue?<br><br>Any unsaved progress will be lost!<br>") : message,
+		gui_save_entry, &result, parent, tr("Create savestate"), &create_savestate);
+
+	if (result != QMessageBox::Yes)
+	{
+		return false;
+	}
+
+	cfg_log.notice("User accepted to stop the current emulation.");
+
+	if (create_savestate && !CreateSavestateAndStop(parent))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+// Creates a savestate of the currently running game and stops the emulation.
+// Any subsequent shutdown of the caller becomes a no-op. Returns false if the savestate could not be created.
+bool gui_settings::CreateSavestateAndStop(QWidget* parent)
+{
+	cfg_log.notice("User requested a savestate before stopping the current emulation.");
+
+	// Make sure no game can be booted while the savestate is being created
+	const auto guard = Emu.MakeEmulationStateGuard();
+
+	const auto info = Emu.GetEmulationIdentifier();
+
+	Emu.Kill(false, true);
+
+	// Savestate creation is asynchronous, so wait for it to either finish or fail
+	qt_events_aware_op(16, [&]()
+	{
+		return Emu.IsStopped() || info != Emu.GetEmulationIdentifier() || !Emu.IsClosePending();
+	});
+
+	if (!Emu.IsStopped() && info == Emu.GetEmulationIdentifier())
+	{
+		cfg_log.error("Savestate creation failed. The current emulation will not be stopped.");
+		ShowInfoBox(tr("Savestate failed!"), tr("Failed to create a savestate.<br>The game will keep running.<br><br>See the log for more information."), gui_save(), parent);
+		return false;
 	}
 
 	return true;

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -349,9 +349,10 @@ public:
 
 	bool GetCategoryVisibility(int cat, bool is_list_mode) const;
 
-	void ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent);
+	void ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr, const QString& option_text = {}, bool* option_checked = nullptr);
 	void ShowInfoBox(const QString& title, const QString& text, const gui_save& entry, QWidget* parent);
 	bool GetBootConfirmation(QWidget* parent, const gui_save& gui_save_entry = gui_save());
+	bool GetStopConfirmation(QWidget* parent, const QString& title = {}, const QString& message = {}, const gui_save& gui_save_entry = gui::ib_confirm_exit);
 
 	logs::level GetLogLevel() const;
 	bool GetSavestateGamelistColVisibility(gui::savestate_game_list_columns col) const;
@@ -384,5 +385,6 @@ private:
 	static gui_save GetGuiSaveForGameColumn(gui::game_list_columns col);
 	static gui_save GetGuiSaveForCategory(int cat, bool is_list_mode);
 
-	void ShowBox(QMessageBox::Icon icon, const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent, bool always_on_top);
+	void ShowBox(QMessageBox::Icon icon, const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent, bool always_on_top, const QString& option_text, bool* option_checked);
+	bool CreateSavestateAndStop(QWidget* parent);
 };

--- a/rpcs3/rpcs3qt/gui_settings.h
+++ b/rpcs3/rpcs3qt/gui_settings.h
@@ -349,7 +349,7 @@ public:
 
 	bool GetCategoryVisibility(int cat, bool is_list_mode) const;
 
-	void ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result = nullptr, QWidget* parent = nullptr, const QString& option_text = {}, bool* option_checked = nullptr);
+	void ShowConfirmationBox(const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent);
 	void ShowInfoBox(const QString& title, const QString& text, const gui_save& entry, QWidget* parent);
 	bool GetBootConfirmation(QWidget* parent, const gui_save& gui_save_entry = gui_save());
 	bool GetStopConfirmation(QWidget* parent, const QString& title = {}, const QString& message = {}, const gui_save& gui_save_entry = gui::ib_confirm_exit);
@@ -385,6 +385,7 @@ private:
 	static gui_save GetGuiSaveForGameColumn(gui::game_list_columns col);
 	static gui_save GetGuiSaveForCategory(int cat, bool is_list_mode);
 
-	void ShowBox(QMessageBox::Icon icon, const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent, bool always_on_top, const QString& option_text, bool* option_checked);
-	bool CreateSavestateAndStop(QWidget* parent);
+	bool ShowBox(QMessageBox::Icon icon, const QString& title, const QString& text, const gui_save& entry, int* result, QWidget* parent, bool always_on_top, const QString& option_text, bool* option_checked);
+	bool ConfirmStop(QWidget* parent, const QString& title, const QString& message, const gui_save& gui_save_entry, bool always_on_top);
+	bool CreateSavestateAndStop(QWidget* parent, bool always_on_top);
 };

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -437,8 +437,10 @@ void main_window::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const Q
 	}
 	case gui::shortcuts::shortcut::mw_stop:
 	{
-		if (status != system_state::stopped)
+		if (m_gui_settings->GetStopConfirmation(this))
+		{
 			Emu.GracefulShutdown(false, true);
+		}
 		break;
 	}
 	default:
@@ -3016,10 +3018,14 @@ void main_window::CreateConnects()
 	connect(ui->createFirmwareCacheAct, &QAction::triggered, this, &main_window::CreateFirmwareCache);
 
 	connect(ui->sysPauseAct, &QAction::triggered, this, &main_window::OnPlayOrPause);
-	connect(ui->sysStopAct, &QAction::triggered, this, []()
+	connect(ui->sysStopAct, &QAction::triggered, this, [this]()
 	{
 		gui_log.notice("User triggered stop action in menu bar");
-		Emu.GracefulShutdown(false, true);
+
+		if (m_gui_settings->GetStopConfirmation(this))
+		{
+			Emu.GracefulShutdown(false, true);
+		}
 	});
 	connect(ui->sysRebootAct, &QAction::triggered, this, []()
 	{
@@ -3685,10 +3691,14 @@ void main_window::CreateConnects()
 
 	connect(ui->toolbar_open, &QAction::triggered, this, &main_window::BootGame);
 	connect(ui->toolbar_refresh, &QAction::triggered, this, [this]() { m_game_list_frame->Refresh(true); });
-	connect(ui->toolbar_stop, &QAction::triggered, this, []()
+	connect(ui->toolbar_stop, &QAction::triggered, this, [this]()
 	{
 		gui_log.notice("User triggered stop action in toolbar");
-		Emu.GracefulShutdown(false);
+
+		if (m_gui_settings->GetStopConfirmation(this))
+		{
+			Emu.GracefulShutdown(false);
+		}
 	});
 	connect(ui->toolbar_start, &QAction::triggered, this, &main_window::OnPlayOrPause);
 

--- a/rpcs3/rpcs3qt/main_window.cpp
+++ b/rpcs3/rpcs3qt/main_window.cpp
@@ -438,9 +438,7 @@ void main_window::handle_shortcut(gui::shortcuts::shortcut shortcut_key, const Q
 	case gui::shortcuts::shortcut::mw_stop:
 	{
 		if (m_gui_settings->GetStopConfirmation(this))
-		{
 			Emu.GracefulShutdown(false, true);
-		}
 		break;
 	}
 	default:
@@ -2214,6 +2212,7 @@ void main_window::EnableMenus(bool enabled) const
 	ui->toolsSystemCommandsAct->setEnabled(enabled);
 	ui->actionCreate_RSX_Capture->setEnabled(enabled);
 	ui->actionCreate_Savestate->setEnabled(enabled);
+	ui->actionCreate_Savestate_And_Exit->setEnabled(enabled);
 }
 
 void main_window::OnAddBreakpoint(u32 addr) const

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -351,8 +351,11 @@ void user_manager_dialog::OnUserLogin()
 {
 	if (!Emu.IsStopped())
 	{
-		if (!m_gui_settings->GetStopConfirmation(this, tr("Stop emulator?"),
-			tr("In order to change the user you have to stop the emulator first.<br><br>Stop the emulator now?"), gui_save()))
+		// Keep the original wording as the translation key. ShowBox renders rich text, so only the line breaks need converting.
+		QString message = tr("In order to change the user you have to stop the emulator first.\n\nStop the emulator now?");
+		message.replace(QStringLiteral("\n"), QStringLiteral("<br>"));
+
+		if (!m_gui_settings->GetStopConfirmation(this, tr("Stop emulator?"), message, gui_save()))
 		{
 			return;
 		}

--- a/rpcs3/rpcs3qt/user_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/user_manager_dialog.cpp
@@ -351,9 +351,8 @@ void user_manager_dialog::OnUserLogin()
 {
 	if (!Emu.IsStopped())
 	{
-		if (QMessageBox::question(this, tr("Stop emulator?"),
-			tr("In order to change the user you have to stop the emulator first.\n\nStop the emulator now?"),
-			QMessageBox::Yes | QMessageBox::Abort) != QMessageBox::Yes)
+		if (!m_gui_settings->GetStopConfirmation(this, tr("Stop emulator?"),
+			tr("In order to change the user you have to stop the emulator first.<br><br>Stop the emulator now?"), gui_save()))
 		{
 			return;
 		}


### PR DESCRIPTION
Add an optional checkbox (by default unchecked) to save savestate on every path to game exit (with the exception of exit on the OSD).
Minor safety checks and cleanup suggested by AI.

fixes #18130

<img width="596" height="452" alt="image" src="https://github.com/user-attachments/assets/4334cbd2-c4c9-42d0-ab74-f0315acca966" />
