### PR TITLE
VFS: remove double slash from paths

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_fs.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.cpp
@@ -466,7 +466,7 @@ lv2_fs_mount_point* lv2_fs_object::get_mp(std::string_view filename, std::string
 	{
 		for (auto mp = &g_mp_sys_dev_root; mp; mp = mp->next)
 		{
-			const auto& device_alias_check = !is_path && (
+			const bool device_alias_check = !is_path && (
 				(mp == &g_mp_sys_dev_hdd0 && mp_name == "CELL_FS_IOS:PATA0_HDD_DRIVE"sv) ||
 				(mp == &g_mp_sys_dev_hdd1 && mp_name == "CELL_FS_IOS:PATA1_HDD_DRIVE"sv) ||
 				(mp == &g_mp_sys_dev_flash && mp_name == "CELL_FS_IOS:BUILTIN_FLASH"sv) ||

--- a/rpcs3/Emu/Cell/lv2/sys_fs.h
+++ b/rpcs3/Emu/Cell/lv2/sys_fs.h
@@ -264,14 +264,7 @@ public:
 	static std::array<char, 0x420> get_name(std::string_view filename)
 	{
 		std::array<char, 0x420> name;
-
-		if (filename.size() >= 0x420)
-		{
-			filename = filename.substr(0, 0x420 - 1);
-		}
-
-		filename.copy(name.data(), filename.size());
-		name[filename.size()] = 0;
+		strcpy_trunc(name, filename);
 		return name;
 	}
 

--- a/rpcs3/Emu/vfs_config.cpp
+++ b/rpcs3/Emu/vfs_config.cpp
@@ -36,10 +36,12 @@ std::string cfg_vfs::get(std::string_view _cfg, std::string_view def, std::strin
 
 		if (_emu_dir.empty())
 		{
-			_emu_dir = fs::get_config_dir() + '/';
+			_emu_dir = fs::get_config_dir();
+			ensure(!_emu_dir.empty());
 		}
+
 		// Check if path does not end with a delimiter
-		else if (_emu_dir.back() != fs::delim[0] && _emu_dir.back() != fs::delim[1])
+		if (_emu_dir.back() != fs::delim[0] && _emu_dir.back() != fs::delim[1])
 		{
 			_emu_dir += '/';
 		}


### PR DESCRIPTION
- sys_fs: simplify get_name function
- vfs: avoid double slash in case dev_flash is uses the default path and get_dev_flash is used