### PR TITLE
Filter UnlockTrophy reply

### DIFF
--- a/rpcs3/Emu/NP/rpcn_client.cpp
+++ b/rpcs3/Emu/NP/rpcn_client.cpp
@@ -659,6 +659,16 @@ namespace rpcn
 				break;
 			}
 
+			if (command == CommandType::UnlockTrophy)
+			{
+				const ErrorType err = static_cast<ErrorType>(data[0]);
+
+				if (err != ErrorType::NoError)
+					rpcn_log.error("UnlockTrophy failed with %s", err);
+
+				break;
+			}
+
 			// Those commands are handled synchronously and won't be forwarded to NP Handler
 			if (command == CommandType::Login || command == CommandType::GetServerList || command == CommandType::Create || command == CommandType::Delete ||
 				command == CommandType::AddFriend || command == CommandType::RemoveFriend ||
@@ -680,7 +690,7 @@ namespace rpcn
 				}
 				else
 				{
-					rpcn_log.error("Tried to forward a reply whose packet_id marks it as internal to RPCN");
+					rpcn_log.error("Tried to forward a reply whose packet_id marks it as internal to RPCN: %s:0x%x", command, packet_id);
 				}
 			}
 


### PR DESCRIPTION
Minor fixup, reply was causing an error to be logged as we didn't explicitly filter it out..