### PR TITLE
RSX: Improve fragment DP3 precision

### DIFF
--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
@@ -1088,7 +1088,9 @@ bool FragmentProgramDecompiler::handle_sct_scb(u32 opcode)
 		properties.has_divsq = true;
 		return true;
 	case RSX_FP_OPCODE_DP2: SetDst(getFunction(FUNCTION::DP2), OPFLAGS::op_extern); return true;
-	case RSX_FP_OPCODE_DP3: SetDst(getFunction(FUNCTION::DP3), OPFLAGS::op_extern); return true;
+	case RSX_FP_OPCODE_DP3:
+		SetDst(getFunction(dst.prec == RSX_FP_PRECISION_REAL && g_cfg.video.shader_precision == gpu_preset_level::ultra ? FUNCTION::DP3_FP32 : FUNCTION::DP3), OPFLAGS::op_extern);
+		return true;
 	case RSX_FP_OPCODE_DP4: SetDst(getFunction(FUNCTION::DP4), OPFLAGS::op_extern); return true;
 	case RSX_FP_OPCODE_DP2A: SetDst(getFunction(FUNCTION::DP2A), OPFLAGS::op_extern); return true;
 	case RSX_FP_OPCODE_MAD: SetDst("fma($0, $1, $2)", OPFLAGS::src_cast_f32); return true;

--- a/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
+++ b/rpcs3/Emu/RSX/Program/FragmentProgramDecompiler.cpp
@@ -1089,7 +1089,7 @@ bool FragmentProgramDecompiler::handle_sct_scb(u32 opcode)
 		return true;
 	case RSX_FP_OPCODE_DP2: SetDst(getFunction(FUNCTION::DP2), OPFLAGS::op_extern); return true;
 	case RSX_FP_OPCODE_DP3:
-		SetDst(getFunction(dst.prec == RSX_FP_PRECISION_REAL && g_cfg.video.shader_precision == gpu_preset_level::ultra ? FUNCTION::DP3_FP32 : FUNCTION::DP3), OPFLAGS::op_extern);
+		SetDst(getFunction(dst.prec == RSX_FP_PRECISION_REAL && g_cfg.video.shader_precision == gpu_preset_level::ultra ? FUNCTION::DP3_PRECISE : FUNCTION::DP3), OPFLAGS::op_extern);
 		return true;
 	case RSX_FP_OPCODE_DP4: SetDst(getFunction(FUNCTION::DP4), OPFLAGS::op_extern); return true;
 	case RSX_FP_OPCODE_DP2A: SetDst(getFunction(FUNCTION::DP2A), OPFLAGS::op_extern); return true;

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -505,7 +505,7 @@ namespace glsl
 			return "$Ty(dot($0.xy, $1.xy) + $2.x)";
 		case FUNCTION::DP3:
 			return "$Ty(dot($0.xyz, $1.xyz))";
-		case FUNCTION::DP3_FP32:
+		case FUNCTION::DP3_PRECISE:
 			return "$Ty(fma($0.x, $1.x, fma($0.y, $1.y, $0.z * $1.z)))";
 		case FUNCTION::DP4:
 			return "$Ty(dot($0, $1))";

--- a/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
+++ b/rpcs3/Emu/RSX/Program/GLSLCommon.cpp
@@ -505,6 +505,8 @@ namespace glsl
 			return "$Ty(dot($0.xy, $1.xy) + $2.x)";
 		case FUNCTION::DP3:
 			return "$Ty(dot($0.xyz, $1.xyz))";
+		case FUNCTION::DP3_FP32:
+			return "$Ty(fma($0.x, $1.x, fma($0.y, $1.y, $0.z * $1.z)))";
 		case FUNCTION::DP4:
 			return "$Ty(dot($0, $1))";
 		case FUNCTION::DPH:

--- a/rpcs3/Emu/RSX/Program/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Program/ShaderParam.h
@@ -14,7 +14,7 @@ enum class FUNCTION
 	DP2,
 	DP2A,
 	DP3,
-	DP3_FP32,
+	DP3_PRECISE,
 	DP4,
 	DPH,
 	SFL, // Set zero

--- a/rpcs3/Emu/RSX/Program/ShaderParam.h
+++ b/rpcs3/Emu/RSX/Program/ShaderParam.h
@@ -14,6 +14,7 @@ enum class FUNCTION
 	DP2,
 	DP2A,
 	DP3,
+	DP3_FP32,
 	DP4,
 	DPH,
 	SFL, // Set zero


### PR DESCRIPTION
Fixes #14709

Requires shader precision set to ultra as recommended by kd

<img width="1920" height="424" alt="god-of-war-3-master-pr-real-ps3" src="https://github.com/user-attachments/assets/bd6a6754-ed8e-4532-8df4-3b89e8c6b322" />

hwtest
[gow3-dp3-rounding-hwtest.zip](https://github.com/user-attachments/files/31332223/gow3-dp3-rounding-hwtest.zip)
