### PR TITLE
Update opencv to 4.14.0

### DIFF
--- a/buildfiles/msvc/rpcs3_default.props
+++ b/buildfiles/msvc/rpcs3_default.props
@@ -9,8 +9,8 @@
     <IntDir>$(SolutionDir)build\tmp\$(ProjectName)-$(Configuration)-$(Platform)\</IntDir>
     <GTestPath>$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.8\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets</GTestPath>
     <GTestInstalled Condition="Exists('$(GTestPath)')">true</GTestInstalled>
-    <OpenCvBuildDir>$(SolutionDir)3rdparty\opencv\opencv\opencv413\build</OpenCvBuildDir>
-    <OpenCvWorld>opencv_world4130</OpenCvWorld>
+    <OpenCvBuildDir>$(SolutionDir)3rdparty\opencv\opencv\opencv414\build</OpenCvBuildDir>
+    <OpenCvWorld>opencv_world4140</OpenCvWorld>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Lib>

--- a/rpcs3/Emu/Io/PadHandler.h
+++ b/rpcs3/Emu/Io/PadHandler.h
@@ -17,6 +17,7 @@ extern "C" {
 #endif
 
 #include <cmath>
+#include <numbers>
 #include <functional>
 #include <string>
 #include <set>
@@ -292,16 +293,14 @@ public:
 	virtual void get_motion_sensors(const std::string& pad_id, const motion_callback& callback, const motion_fail_callback& fail_callback, motion_preview_values preview_values, const std::array<AnalogSensor, 4>& sensors);
 	virtual std::unordered_map<u32, std::string> get_motion_axis_list() const { return {}; }
 
-	static constexpr f32 PI = 3.14159265f;
-
 	static f32 degree_to_rad(f32 degree)
 	{
-		return degree * PI / 180.0f;
+		return degree * std::numbers::pi_v<f32> / 180.0f;
 	}
 
 	static f32 rad_to_degree(f32 radians)
 	{
-		return radians * 180.0f / PI;
+		return radians * 180.0f / std::numbers::pi_v<f32>;
 	};
 
 private:

--- a/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_controls.cpp
@@ -7,6 +7,8 @@
 #include "Utilities/File.h"
 #include "Emu/Cell/timers.hpp"
 
+#include <numbers>
+
 #ifndef _WIN32
 #include <unistd.h>
 #include <libgen.h>
@@ -350,9 +352,8 @@ namespace rsx
 		{
 			if (sinus_modifier >= 0)
 			{
-				static constexpr f32 PI = 3.14159265f;
 				const f32 pulse_sinus_x = static_cast<f32>(get_system_time() / 1000) * pulse_speed_modifier;
-				pulse_sinus_offset = fmod(pulse_sinus_x + sinus_modifier * PI, 2.0f * PI);
+				pulse_sinus_offset = fmod(pulse_sinus_x + sinus_modifier * std::numbers::pi_v<f32>, 2.0f * std::numbers::pi_v<f32>);
 			}
 		}
 

--- a/rpcs3/Input/ps_move_calibration.cpp
+++ b/rpcs3/Input/ps_move_calibration.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "ps_move_calibration.h"
 
+#include <numbers>
+
 LOG_CHANNEL(move_log, "Move");
 
 // This is basically the same as in ps move api
@@ -176,8 +178,7 @@ void psmove_calibration_get_usb_gyro_values(const reports::ps_move_calibration_b
 {
 	const u8* data = calibration.data.data();
 
-	constexpr f32 PI = 3.14159265f;
-	constexpr f32 rpm_to_rad_per_sec = (2.0f * PI) / 60.0f;
+	constexpr f32 rpm_to_rad_per_sec = (2.0f * std::numbers::pi_v<f32>) / 60.0f;
 
 	switch (device.model)
 	{

--- a/rpcs3/Input/ps_move_tracker.cpp
+++ b/rpcs3/Input/ps_move_tracker.cpp
@@ -6,13 +6,11 @@
 #include <cmath>
 
 #ifdef HAVE_OPENCV
-#include <opencv2/photo.hpp>
-
-// OpenCV 5.x moved some functions to this header
-#if __has_include(<opencv2/geometry.hpp>)
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#if CV_VERSION_MAJOR >= 5
 #include <opencv2/geometry.hpp>
 #endif
-
 #endif
 
 LOG_CHANNEL(ps_move);

--- a/rpcs3/Input/ps_move_tracker.cpp
+++ b/rpcs3/Input/ps_move_tracker.cpp
@@ -388,7 +388,7 @@ void ps_move_tracker<DiagnosticsEnabled>::process_contours(ps_move_info& info, u
 			// Simply drop dark and colorless pixels as well as pixels that don't match our hue
 			if ((wrapped_hue ? (hue < config.min_hue && hue > config.max_hue) : (hue < config.min_hue || hue > config.max_hue)) ||
 				saturation < config.saturation_threshold_u8 || saturation > 200 ||
-				value < 150 || value > 255)
+				value < 150)
 			{
 				dst[x] = 0;
 			}
@@ -436,19 +436,24 @@ void ps_move_tracker<DiagnosticsEnabled>::process_contours(ps_move_info& info, u
 	}
 
 	std::vector<std::vector<cv::Point>> contours;
-	contours.reserve(all_contours.size());
-
 	std::vector<cv::Point2f> centers;
-	centers.reserve(all_contours.size());
-
 	std::vector<f32> radii;
-	radii.reserve(all_contours.size());
+
+	if constexpr (DiagnosticsEnabled)
+	{
+		contours.reserve(all_contours.size());
+		centers.reserve(all_contours.size());
+		radii.reserve(all_contours.size());
+	}
 
 	const f32 min_radius = m_min_radius * width;
 	const f32 max_radius = m_max_radius * width;
 
 	usz best_index = umax;
 	f32 best_area = 0.0f;
+	f32 best_radius = 0.0f;
+	cv::Point2f best_center {};
+
 	for (usz i = 0; i < all_contours.size(); i++)
 	{
 		const std::vector<cv::Point>& contour = all_contours[i];
@@ -465,18 +470,27 @@ void ps_move_tracker<DiagnosticsEnabled>::process_contours(ps_move_info& info, u
 		if (radius < min_radius || radius > max_radius)
 			continue;
 
-		contours.push_back(std::move(all_contours[i]));
-		centers.push_back(std::move(center));
-		radii.push_back(std::move(radius));
+		if constexpr (DiagnosticsEnabled)
+		{
+			contours.push_back(std::move(all_contours[i]));
+			centers.push_back(center);
+			radii.push_back(radius);
+		}
 
 		if (area > best_area)
 		{
 			best_area = area;
-			best_index = contours.size() - 1;
+			best_center = center;
+			best_radius = radius;
+
+			if constexpr (DiagnosticsEnabled)
+			{
+				best_index = contours.size() - 1;
+			}
 		}
 	}
 
-	if (best_index == umax)
+	if (best_area <= 0.0f)
 	{
 		set_valid(info, index, false);
 
@@ -488,7 +502,7 @@ void ps_move_tracker<DiagnosticsEnabled>::process_contours(ps_move_info& info, u
 	}
 
 	// Calculate distance from sphere to camera
-	const f32 sphere_radius_pixels = radii[best_index];
+	const f32 sphere_radius_pixels = best_radius;
 	constexpr f32 focal_length_mm = 3.5f; // Based on common webcam specs
 	constexpr f32 sensor_width_mm = 3.6f; // Based on common webcam specs
 	const f32 image_width_pixels = static_cast<f32>(width);
@@ -498,16 +512,20 @@ void ps_move_tracker<DiagnosticsEnabled>::process_contours(ps_move_info& info, u
 	// Set results
 	set_valid(info, index, true);
 
-	const u32 x_pos = std::clamp(static_cast<u32>(centers[best_index].x), 0u, width);
-	const u32 y_pos = std::clamp(static_cast<u32>(centers[best_index].y), 0u, height);
+	const u32 x_pos = std::clamp(static_cast<u32>(best_center.x), 0u, width);
+	const u32 y_pos = std::clamp(static_cast<u32>(best_center.y), 0u, height);
 
 	// Only set new values if the new shape and position are relatively similar to the old ones.
-	const auto distance_travelled = [](int x1, int y1, int x2, int y2)
+	const auto distance_squared = [](int x1, int y1, int x2, int y2)
 	{
-		return std::sqrt(std::pow(x2 - x1, 2) + pow(y2 - y1, 2));
+		const int dx = x2 - x1;
+		const int dy = y2 - y1;
+		return dx * dx + dy * dy;
 	};
+	const f32 max_distance = info.radius * 8.0f;
+	const f32 max_distance_squared = max_distance * max_distance;
 	const bool shape_matches = std::abs(info.radius - sphere_radius_pixels) < (info.radius * 2) &&
-	                           distance_travelled(info.x_pos, info.y_pos, x_pos, y_pos) < (info.radius * 8);
+	                           distance_squared(info.x_pos, info.y_pos, x_pos, y_pos) < max_distance_squared;
 
 	if (shape_matches || ++m_shape_fail_count[index] >= 3)
 	{
@@ -534,8 +552,8 @@ void ps_move_tracker<DiagnosticsEnabled>::process_contours(ps_move_info& info, u
 	{
 		std::vector<cv::Point> contour = std::move(contours[best_index]);
 		contours = { std::move(contour) };
-		centers = { centers[best_index] };
-		radii = { radii[best_index] };
+		centers = { best_center };
+		radii = { best_radius };
 	}
 
 	static const cv::Scalar contour_color(255, 0, 0, 255);

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -14,6 +14,7 @@
 #include <QPushButton>
 #include <QSlider>
 #include <QMessageBox>
+#include <QMouseEvent>
 
 LOG_CHANNEL(ps_move);
 
@@ -252,6 +253,8 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 			QMessageBox::warning(this, QObject::tr("Tracking not supported!"), QObject::tr("The PS Move tracking is not yet supported on this operating system."));
 		});
 	}
+
+	ui->imageLabel->installEventFilter(this);
 }
 
 ps_move_tracker_dialog::~ps_move_tracker_dialog()
@@ -271,6 +274,69 @@ ps_move_tracker_dialog::~ps_move_tracker_dialog()
 
 	// Join thread
 	m_input_thread.reset();
+}
+
+bool ps_move_tracker_dialog::eventFilter(QObject* object, QEvent* event)
+{
+	if (event && object == ui->imageLabel && event->type() == QEvent::Type::MouseButtonRelease && m_view_mode == view_mode::contours)
+	{
+		const QMouseEvent* me = reinterpret_cast<QMouseEvent*>(event);
+
+		if (me->button() == Qt::MouseButton::LeftButton)
+		{
+			ps_move.notice("Selecting color with mouse click.");
+
+			f32 r = 0.0f;
+			f32 g = 0.0f;
+			f32 b = 0.0f;
+			u32 count = 0;
+
+			{
+				std::lock_guard lock(m_image_mutex);
+
+				const auto pos = me->localPos().toPoint();
+				const QPixmap pixmap = ui->imageLabel->pixmap();
+
+				if (pixmap.rect().contains(pos))
+				{
+					const QImage image = pixmap.toImage();
+					constexpr int radius = 3;
+
+					for (int y = pos.y() - radius; y <= pos.y() + radius; ++y)
+					{
+						for (int x = pos.x() - radius; x <= pos.x() + radius; ++x)
+						{
+							if (!image.rect().contains(x, y))
+								continue;
+
+							const QColor color = image.pixelColor(x, y);
+
+							r += color.redF();
+							g += color.greenF();
+							b += color.blueF();
+							count++;
+						}
+					}
+				}
+			}
+
+			if (count > 0)
+			{
+				r /= count;
+				g /= count;
+				b /= count;
+
+				ps_move.notice("Selected new color with mouse click (r=%f, b=%f, g=%f)", r, g, b);
+
+				cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
+				const auto [hue, saturation, value] = ps_move_tracker<true>::rgb_to_hsv(r, g, b);
+				config->hue.set(std::clamp<u32>(hue, config->hue.min, config->hue.max));
+				update_hue(true);
+			}
+		}
+	}
+
+	return QDialog::eventFilter(object, event);
 }
 
 void ps_move_tracker_dialog::update_color(bool update_sliders)

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.h
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.h
@@ -26,6 +26,8 @@ public:
 	virtual ~ps_move_tracker_dialog();
 
 private:
+	bool eventFilter(QObject* object, QEvent* event) override;
+
 	void update_color(bool update_sliders = false);
 	void update_hue(bool update_slider = false);
 	void update_hue_threshold(bool update_slider = false);


### PR DESCRIPTION
- Update opencv to 4.14.0
- Add minor optimization to ps move tracker
- Allow to select hue by clicking the orb in the live image while in contours mode