### PR TITLE
rsx: Relax checking of NV4097_SET_SHADE_MODE inputs to match hw

### DIFF
--- a/rpcs3/Emu/RSX/NV47/HW/nv4097.cpp
+++ b/rpcs3/Emu/RSX/NV47/HW/nv4097.cpp
@@ -672,6 +672,23 @@ namespace rsx
 			RSX(ctx)->enable_conditional_rendering(vm::cast(address_ptr));
 		}
 
+		void set_shading_mode(context* ctx, u32 reg, u32 arg)
+		{
+			if (arg == REGS(ctx)->latch)
+			{
+				return;
+			}
+
+			if (to_shading_mode(arg))
+			{
+				RSX(ctx)->m_graphics_state |= rsx::vertex_program_state_dirty | rsx::fragment_program_state_dirty;
+				return;
+			}
+
+			// Rollback
+			REGS(ctx)->decode(reg, REGS(ctx)->latch);
+		}
+
 		void set_zcull_render_enable(context* ctx, u32, u32)
 		{
 			RSX(ctx)->notify_zcull_info_changed();

--- a/rpcs3/Emu/RSX/NV47/HW/nv4097.h
+++ b/rpcs3/Emu/RSX/NV47/HW/nv4097.h
@@ -55,6 +55,8 @@ namespace rsx
 
 		void set_render_mode(context* ctx, u32, u32 arg);
 
+		void set_shading_mode(context* ctx, u32 reg, u32 arg);
+
 		void set_zcull_render_enable(context* ctx, u32, u32);
 
 		void set_zcull_stats_enable(context* ctx, u32, u32);

--- a/rpcs3/Emu/RSX/rsx_methods.cpp
+++ b/rpcs3/Emu/RSX/rsx_methods.cpp
@@ -709,7 +709,6 @@ namespace rsx
 			state_signals[NV4097_SET_TEX_COORD_CONTROL + 9] = rsx::fragment_program_state_dirty;
 			state_signals[NV4097_SET_TWO_SIDE_LIGHT_EN] = rsx::fragment_program_state_dirty;
 			state_signals[NV4097_SET_POINT_SPRITE_CONTROL] = rsx::fragment_program_state_dirty;
-			state_signals[NV4097_SET_SHADE_MODE] = rsx::vertex_program_state_dirty | rsx::fragment_program_state_dirty;
 			state_signals[NV4097_SET_USER_CLIP_PLANE_CONTROL] = rsx::vertex_state_dirty;
 			state_signals[NV4097_SET_TRANSFORM_BRANCH_BITS] = rsx::vertex_state_dirty;
 			state_signals[NV4097_SET_CLIP_MIN] = rsx::invalidate_zclip_bits;
@@ -1704,6 +1703,7 @@ namespace rsx
 		bind(NV4097_WAIT_FOR_IDLE, nv4097::sync);
 		bind(NV4097_INVALIDATE_L2, nv4097::set_shader_program_dirty);
 		bind(NV4097_SET_SHADER_PROGRAM, nv4097::set_shader_program_dirty);
+		bind(NV4097_SET_SHADE_MODE, nv4097::set_shading_mode);
 
 		bind(NV4097_SET_TRANSFORM_PROGRAM_START, nv4097::set_transform_program_start);
 		bind(NV4097_SET_VERTEX_ATTRIB_OUTPUT_MASK, nv4097::set_vertex_attribute_output_mask);


### PR DESCRIPTION
Closes https://github.com/RPCS3/rpcs3/issues/19297

HWTEST (Tagflag2d): https://github.com/RPCS3/rpcs3/issues/19297#issuecomment-5387656126