### PR TITLE
Improve Ps Move tracker dialog

### DIFF
--- a/rpcs3/Input/ps_move_config.h
+++ b/rpcs3/Input/ps_move_config.h
@@ -28,6 +28,7 @@ struct cfg_ps_moves final : cfg::node
 
 	cfg::_float<0, 50> min_radius{ this, "Minimum Radius", 1.0f, true }; // Percentage of image width
 	cfg::_float<0, 50> max_radius{ this, "Maximum Radius", 10.0f, true }; // Percentage of image width
+	cfg::uint<1, 100> default_brightness{ this, "Default Orb Brightness", 1, true }; // Percentage
 
 	std::array<cfg_ps_move*, 4> move{ &move1, &move2, &move3, &move4 };
 

--- a/rpcs3/Input/ps_move_tracker.cpp
+++ b/rpcs3/Input/ps_move_tracker.cpp
@@ -69,7 +69,7 @@ void ps_move_tracker<DiagnosticsEnabled>::set_valid(ps_move_info& info, u32 inde
 
 	info.valid = valid;
 	fail_count = 0; // Reset fail count
-};
+}
 
 template <bool DiagnosticsEnabled>
 void ps_move_tracker<DiagnosticsEnabled>::set_image_data(const void* buf, u64 size, u32 width, u32 height, s32 format)

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -289,7 +289,7 @@ bool ps_move_tracker_dialog::eventFilter(QObject* object, QEvent* event)
 {
 	if (event && object == ui->imageLabel && event->type() == QEvent::Type::MouseButtonRelease && m_view_mode == view_mode::contours)
 	{
-		const QMouseEvent* me = reinterpret_cast<QMouseEvent*>(event);
+		const QMouseEvent* me = static_cast<QMouseEvent*>(event);
 
 		if (me->button() == Qt::MouseButton::LeftButton)
 		{
@@ -303,7 +303,7 @@ bool ps_move_tracker_dialog::eventFilter(QObject* object, QEvent* event)
 			{
 				std::lock_guard lock(m_image_mutex);
 
-				const auto pos = me->localPos().toPoint();
+				const auto pos = me->position().toPoint();
 				const QPixmap pixmap = ui->imageLabel->pixmap();
 
 				if (pixmap.rect().contains(pos))

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -103,6 +103,14 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		}
 	});
 
+	ui->brightnessSlider->setRange(g_cfg_move.default_brightness.min, g_cfg_move.default_brightness.max);
+	connect(ui->brightnessSlider, &QSlider::valueChanged, this, [this](int value)
+	{
+		const u32 brightness = std::clamp<u32>(value, g_cfg_move.default_brightness.min, g_cfg_move.default_brightness.max);
+		g_cfg_move.default_brightness.set(brightness);
+		update_default_brightness(false);
+	});
+
 	ui->hueSlider->setRange(g_cfg_move.move1.hue.min, g_cfg_move.move1.hue.max);
 	connect(ui->hueSlider, &QSlider::valueChanged, this, [this](int value)
 	{
@@ -210,6 +218,7 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		if (const auto qvar = ui->comboSelectDevice->currentData(); qvar.canConvert<int>())
 		{
 			m_index = qvar.toInt();
+			update_default_brightness(true);
 			update_color(true, false);
 			update_hue(true, false, true);
 			update_hue_threshold(true);
@@ -238,6 +247,7 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 
 	adjustSize();
 
+	update_default_brightness(true);
 	update_color(true, false);
 	update_hue(true, false, true);
 	update_hue_threshold(true);
@@ -379,6 +389,17 @@ void ps_move_tracker_dialog::update_color(bool update_rgb_sliders, bool update_h
 	}
 }
 
+void ps_move_tracker_dialog::update_default_brightness(bool update_slider)
+{
+	const u32 brightness = g_cfg_move.default_brightness.get();
+	ui->brightnessGb->setTitle(tr("Default Orb Brightness: %0 %").arg(brightness));
+
+	if (update_slider)
+	{
+		ui->brightnessSlider->setValue(brightness);
+	}
+}
+
 void ps_move_tracker_dialog::update_hue(bool update_slider, bool update_rgb_sliders, bool no_signal)
 {
 	const u32 hue = ::at32(g_cfg_move.move, m_index)->hue.get();
@@ -393,10 +414,11 @@ void ps_move_tracker_dialog::update_hue(bool update_slider, bool update_rgb_slid
 	else if (update_rgb_sliders)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
+		const f32 default_brightness = g_cfg_move.default_brightness.get() / static_cast<f32>(g_cfg_move.default_brightness.max);
 		const auto [r, g, b] = ps_move_tracker<true>::hsv_to_rgb(hue, 1.0f, 1.0f);
-		config->r.set(r / 100);
-		config->g.set(g / 100);
-		config->b.set(b / 100);
+		config->r.set(r * default_brightness);
+		config->g.set(g * default_brightness);
+		config->b.set(b * default_brightness);
 		update_color(true, false);
 	}
 }

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -20,7 +20,6 @@ LOG_CHANNEL(ps_move);
 
 extern u32 get_buffer_size_by_format(s32, s32, s32);
 
-static constexpr bool tie_hue_to_color = true;
 static constexpr int radius_range = 1000;
 static const constexpr f64 min_radius_conversion = radius_range / g_cfg_move.min_radius.max;
 static const constexpr f64 max_radius_conversion = radius_range / g_cfg_move.max_radius.max;
@@ -110,7 +109,7 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
 		const u16 hue = std::clamp<u16>(value, config->hue.min, config->hue.max);
 		config->hue.set(hue);
-		update_hue();
+		update_hue(false, true, false);
 	});
 
 	ui->hueThresholdSlider->setRange(g_cfg_move.move1.hue_threshold.min, g_cfg_move.move1.hue_threshold.max);
@@ -154,19 +153,19 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
 		config->r.set(std::clamp<u8>(value, config->r.min, config->r.max));
-		update_color();
+		update_color(false, true);
 	});
 	connect(ui->colorSliderG, &QSlider::valueChanged, this, [this](int value)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
 		config->g.set(std::clamp<u8>(value, config->g.min, config->g.max));
-		update_color();
+		update_color(false, true);
 	});
 	connect(ui->colorSliderB, &QSlider::valueChanged, this, [this](int value)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
 		config->b.set(std::clamp<u8>(value, config->b.min, config->b.max));
-		update_color();
+		update_color(false, true);
 	});
 
 	connect(ui->filterSmallContoursBox, &QCheckBox::toggled, [this](bool checked)
@@ -211,8 +210,8 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		if (const auto qvar = ui->comboSelectDevice->currentData(); qvar.canConvert<int>())
 		{
 			m_index = qvar.toInt();
-			update_color(true);
-			update_hue(true);
+			update_color(true, false);
+			update_hue(true, false, true);
 			update_hue_threshold(true);
 			update_saturation_threshold(true);
 		}
@@ -239,8 +238,8 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 
 	adjustSize();
 
-	update_color(true);
-	update_hue(true);
+	update_color(true, false);
+	update_hue(true, false, true);
 	update_hue_threshold(true);
 	update_saturation_threshold(true);
 	update_min_radius(true);
@@ -331,7 +330,7 @@ bool ps_move_tracker_dialog::eventFilter(QObject* object, QEvent* event)
 				cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
 				const auto [hue, saturation, value] = ps_move_tracker<true>::rgb_to_hsv(r, g, b);
 				config->hue.set(std::clamp<u32>(hue, config->hue.min, config->hue.max));
-				update_hue(true);
+				update_hue(true, false, false);
 			}
 		}
 	}
@@ -339,23 +338,23 @@ bool ps_move_tracker_dialog::eventFilter(QObject* object, QEvent* event)
 	return QDialog::eventFilter(object, event);
 }
 
-void ps_move_tracker_dialog::update_color(bool update_sliders)
+void ps_move_tracker_dialog::update_color(bool update_rgb_sliders, bool update_hue_slider)
 {
 	cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
 
 	ui->colorGb->setTitle(tr("Color: R=%0, G=%1, B=%2").arg(config->r.get()).arg(config->g.get()).arg(config->b.get()));
 
-	if (update_sliders)
+	if (update_rgb_sliders)
 	{
 		ui->colorSliderR->setValue(config->r.get());
 		ui->colorSliderG->setValue(config->g.get());
 		ui->colorSliderB->setValue(config->b.get());
 	}
-	else if (tie_hue_to_color)
+	else if (update_hue_slider)
 	{
 		const auto [hue, saturation, value] = ps_move_tracker<true>::rgb_to_hsv(config->r.get() / 255.0f, config->g.get() / 255.0f, config->b.get() / 255.0f);
 		config->hue.set(std::clamp<u32>(hue, config->hue.min, config->hue.max));
-		update_hue(true);
+		update_hue(true, false, true);
 	}
 
 	if (!m_input_thread)
@@ -380,23 +379,25 @@ void ps_move_tracker_dialog::update_color(bool update_sliders)
 	}
 }
 
-void ps_move_tracker_dialog::update_hue(bool update_slider)
+void ps_move_tracker_dialog::update_hue(bool update_slider, bool update_rgb_sliders, bool no_signal)
 {
 	const u32 hue = ::at32(g_cfg_move.move, m_index)->hue.get();
 	ui->hueGb->setTitle(tr("Hue: %0").arg(hue));
 
 	if (update_slider)
 	{
+		if (no_signal) ui->hueSlider->blockSignals(true);
 		ui->hueSlider->setValue(hue);
+		if (no_signal) ui->hueSlider->blockSignals(false);
 	}
-	else if (tie_hue_to_color)
+	else if (update_rgb_sliders)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
 		const auto [r, g, b] = ps_move_tracker<true>::hsv_to_rgb(hue, 1.0f, 1.0f);
 		config->r.set(r / 100);
 		config->g.set(g / 100);
 		config->b.set(b / 100);
-		update_color(true);
+		update_color(true, false);
 	}
 }
 

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -547,7 +547,7 @@ void ps_move_tracker_dialog::process_camera_frame()
 	{
 		result = &m_ps_move_tracker->rgba();
 		format = QImage::Format::Format_RGBA8888;
-		bytes_per_line = width * 4;
+		bytes_per_line = width * 4ULL;
 		break;
 	}
 	case view_mode::grayscale:
@@ -561,11 +561,11 @@ void ps_move_tracker_dialog::process_camera_frame()
 	case view_mode::hsv_saturation:
 	case view_mode::hsv_value:
 	{
-		const int index = static_cast<int>(m_view_mode) - static_cast<int>(view_mode::hsv_hue);
+		const u32 index = static_cast<u32>(m_view_mode) - static_cast<u32>(view_mode::hsv_hue);
 		const std::vector<u8>& hsv = m_ps_move_tracker->hsv();
 		static std::vector<u8> hsv_single;
 		hsv_single.resize(hsv.size() / 3);
-		for (int i = 0; i < static_cast<int>(hsv_single.size()); i++)
+		for (usz i = 0; i < hsv_single.size(); i++)
 		{
 			hsv_single[i] = hsv[i * 3 + index];
 		}
@@ -585,7 +585,7 @@ void ps_move_tracker_dialog::process_camera_frame()
 	{
 		result = &m_ps_move_tracker->rgba_contours();
 		format = QImage::Format::Format_RGBA8888;
-		bytes_per_line = width * 4;
+		bytes_per_line = width * 4ULL;
 		break;
 	}
 	}

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -104,6 +104,7 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		}
 	});
 
+	ui->hueSlider->setRange(g_cfg_move.move1.hue.min, g_cfg_move.move1.hue.max);
 	connect(ui->hueSlider, &QSlider::valueChanged, this, [this](int value)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
@@ -111,8 +112,8 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		config->hue.set(hue);
 		update_hue();
 	});
-	ui->hueSlider->setRange(g_cfg_move.move1.hue.min, g_cfg_move.move1.hue.max);
 
+	ui->hueThresholdSlider->setRange(g_cfg_move.move1.hue_threshold.min, g_cfg_move.move1.hue_threshold.max);
 	connect(ui->hueThresholdSlider, &QSlider::valueChanged, this, [this](int value)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
@@ -120,8 +121,8 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		config->hue_threshold.set(hue_threshold);
 		update_hue_threshold();
 	});
-	ui->hueThresholdSlider->setRange(g_cfg_move.move1.hue_threshold.min, g_cfg_move.move1.hue_threshold.max);
 
+	ui->saturationThresholdSlider->setRange(g_cfg_move.move1.saturation_threshold.min, g_cfg_move.move1.saturation_threshold.max);
 	connect(ui->saturationThresholdSlider, &QSlider::valueChanged, this, [this](int value)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
@@ -129,24 +130,26 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		config->saturation_threshold.set(saturation_threshold);
 		update_saturation_threshold();
 	});
-	ui->saturationThresholdSlider->setRange(g_cfg_move.move1.saturation_threshold.min, g_cfg_move.move1.saturation_threshold.max);
 
+	ui->minRadiusSlider->setRange(0, radius_range);
 	connect(ui->minRadiusSlider, &QSlider::valueChanged, this, [this](int value)
 	{
 		const f32 min_radius = std::clamp(value / min_radius_conversion, g_cfg_move.min_radius.min, g_cfg_move.min_radius.max);
 		g_cfg_move.min_radius.set(min_radius);
 		update_min_radius();
 	});
-	ui->minRadiusSlider->setRange(0, radius_range);
 
+	ui->maxRadiusSlider->setRange(0, radius_range);
 	connect(ui->maxRadiusSlider, &QSlider::valueChanged, this, [this](int value)
 	{
 		const f32 max_radius = std::clamp(value / max_radius_conversion, g_cfg_move.max_radius.min, g_cfg_move.max_radius.max);
 		g_cfg_move.max_radius.set(max_radius);
 		update_max_radius();
 	});
-	ui->maxRadiusSlider->setRange(0, radius_range);
 
+	ui->colorSliderR->setRange(g_cfg_move.move1.r.min, g_cfg_move.move1.r.max);
+	ui->colorSliderG->setRange(g_cfg_move.move1.g.min, g_cfg_move.move1.g.max);
+	ui->colorSliderB->setRange(g_cfg_move.move1.b.min, g_cfg_move.move1.b.max);
 	connect(ui->colorSliderR, &QSlider::valueChanged, this, [this](int value)
 	{
 		cfg_ps_move* config = ::at32(g_cfg_move.move, m_index);
@@ -165,9 +168,6 @@ ps_move_tracker_dialog::ps_move_tracker_dialog(QWidget* parent)
 		config->b.set(std::clamp<u8>(value, config->b.min, config->b.max));
 		update_color();
 	});
-	ui->colorSliderR->setRange(g_cfg_move.move1.r.min, g_cfg_move.move1.r.max);
-	ui->colorSliderG->setRange(g_cfg_move.move1.g.min, g_cfg_move.move1.g.max);
-	ui->colorSliderB->setRange(g_cfg_move.move1.b.min, g_cfg_move.move1.b.max);
 
 	connect(ui->filterSmallContoursBox, &QCheckBox::toggled, [this](bool checked)
 	{

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp
@@ -634,11 +634,14 @@ void ps_move_tracker_dialog::process_camera_frame()
 QPixmap ps_move_tracker_dialog::get_histogram(const std::array<u32, 360>& hues, bool ignore_zero) const
 {
 	// Create image
+	const int width = ui->histogramLabel->width();
 	const int height = ui->histogramLabel->height();
+	const f32 pixelsPerHue = width / static_cast<f32>(hues.size());
+
 	static QPixmap background = [&]()
 	{
 		// Paint background
-		QPixmap pxmap(static_cast<int>(hues.size()), height);
+		QPixmap pxmap(width, height);
 		pxmap.fill(Qt::white);
 		return pxmap;
 	}();
@@ -664,10 +667,18 @@ QPixmap ps_move_tracker_dialog::get_histogram(const std::array<u32, 360>& hues, 
 		painter.fillRect(0, 0, max_hue - 360, histo.height(), Qt::lightGray);
 	}
 
+	const auto get_hue_bar_x = [pixelsPerHue](u16 hue)
+	{
+		const int x0 = hue * pixelsPerHue;
+		const int x1 = std::max<int>(x0, x0 + pixelsPerHue - 1);
+		return std::pair<int, int>(x0, x1);
+	};
+
 	// Paint target hue
 	const auto [r, g, b] = ps_move_tracker<true>::hsv_to_rgb(hue, 1.0f, 1.0f);
+	const auto [x0, x1] = get_hue_bar_x(hue);
 	painter.setPen(QColor(r, g, b));
-	painter.drawLine(hue, 0, hue, histo.height() - 1);
+	painter.drawLine(x0, 0, x1, histo.height() - 1);
 
 	// Paint histogram
 	painter.setPen(Qt::black);
@@ -684,7 +695,9 @@ QPixmap ps_move_tracker_dialog::get_histogram(const std::array<u32, 360>& hues, 
 	{
 		const int bar_height = (hues[i] / static_cast<float>(max_value)) * height;
 		if (bar_height <= 0) continue;
-		painter.drawLine(i, height - 1, i, height - bar_height);
+
+		const auto [x0, x1] = get_hue_bar_x(i);
+		painter.drawLine(x0, height - 1, x1, height - bar_height);
 	}
 
 	return histo;

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.h
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.h
@@ -29,6 +29,7 @@ private:
 	bool eventFilter(QObject* object, QEvent* event) override;
 
 	void update_color(bool update_rgb_sliders, bool update_hue_slider);
+	void update_default_brightness(bool update_slider);
 	void update_hue(bool update_hue_slider, bool update_rgb_sliders, bool no_signal);
 	void update_hue_threshold(bool update_slider = false);
 	void update_saturation_threshold(bool update_slider = false);

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.h
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.h
@@ -28,8 +28,8 @@ public:
 private:
 	bool eventFilter(QObject* object, QEvent* event) override;
 
-	void update_color(bool update_sliders = false);
-	void update_hue(bool update_slider = false);
+	void update_color(bool update_rgb_sliders, bool update_hue_slider);
+	void update_hue(bool update_hue_slider, bool update_rgb_sliders, bool no_signal);
 	void update_hue_threshold(bool update_slider = false);
 	void update_saturation_threshold(bool update_slider = false);
 	void update_min_radius(bool update_slider = false);

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.ui
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>988</width>
-    <height>710</height>
+    <width>992</width>
+    <height>1024</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -68,10 +68,10 @@
           <item>
            <spacer name="verticalSpacer_2">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeType">
-             <enum>QSizePolicy::MinimumExpanding</enum>
+             <enum>QSizePolicy::Policy::MinimumExpanding</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -109,7 +109,7 @@
              <item>
               <widget class="QSlider" name="minRadiusSlider">
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -125,7 +125,23 @@
              <item>
               <widget class="QSlider" name="maxRadiusSlider">
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="brightnessGb">
+            <property name="title">
+             <string>Default Orb Brightness</string>
+            </property>
+            <layout class="QVBoxLayout" name="brightnessGbLayout">
+             <item>
+              <widget class="QSlider" name="brightnessSlider">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
               </widget>
              </item>
@@ -153,7 +169,7 @@
                    <number>255</number>
                   </property>
                   <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                   <enum>Qt::Orientation::Horizontal</enum>
                   </property>
                  </widget>
                 </item>
@@ -163,7 +179,7 @@
                    <number>255</number>
                   </property>
                   <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                   <enum>Qt::Orientation::Horizontal</enum>
                   </property>
                  </widget>
                 </item>
@@ -173,7 +189,7 @@
                    <number>255</number>
                   </property>
                   <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                   <enum>Qt::Orientation::Horizontal</enum>
                   </property>
                  </widget>
                 </item>
@@ -192,7 +208,7 @@
                    <number>359</number>
                   </property>
                   <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                   <enum>Qt::Orientation::Horizontal</enum>
                   </property>
                  </widget>
                 </item>
@@ -211,7 +227,7 @@
                    <number>359</number>
                   </property>
                   <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                   <enum>Qt::Orientation::Horizontal</enum>
                   </property>
                  </widget>
                 </item>
@@ -230,7 +246,7 @@
                    <number>255</number>
                   </property>
                   <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
+                   <enum>Qt::Orientation::Horizontal</enum>
                   </property>
                  </widget>
                 </item>
@@ -326,10 +342,10 @@
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -346,10 +362,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Close|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Close|QDialogButtonBox::StandardButton::Save</set>
      </property>
     </widget>
    </item>

--- a/rpcs3/rpcs3qt/ps_move_tracker_dialog.ui
+++ b/rpcs3/rpcs3qt/ps_move_tracker_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>992</width>
-    <height>1024</height>
+    <width>880</width>
+    <height>672</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,304 +43,329 @@
             </property>
            </widget>
           </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="gistoGb">
+         <property name="title">
+          <string>Histogram</string>
+         </property>
+         <layout class="QVBoxLayout" name="gistoGbLayout">
           <item>
-           <widget class="QGroupBox" name="gistoGb">
-            <property name="title">
-             <string>Histogram</string>
+           <widget class="QLabel" name="histogramLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <layout class="QVBoxLayout" name="gistoGbLayout">
-             <item>
-              <widget class="QLabel" name="histogramLabel">
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>100</height>
-                </size>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Policy::MinimumExpanding</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
+            <property name="minimumSize">
              <size>
               <width>0</width>
-              <height>0</height>
+              <height>50</height>
              </size>
             </property>
-           </spacer>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
+       </item>
+       <item>
+        <spacer name="previewSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </item>
      <item>
       <layout class="QVBoxLayout" name="rightLayout">
        <item>
-        <widget class="QGroupBox" name="settingsGb">
-         <property name="minimumSize">
-          <size>
-           <width>300</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Settings</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QGroupBox" name="minRadiusGb">
-            <property name="title">
-             <string>Min Radius</string>
-            </property>
-            <layout class="QVBoxLayout" name="minRadiusGbLayout">
-             <item>
-              <widget class="QSlider" name="minRadiusSlider">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="maxRadiusGb">
-            <property name="title">
-             <string>Max Radius</string>
-            </property>
-            <layout class="QVBoxLayout" name="maxRadiusGbLayout">
-             <item>
-              <widget class="QSlider" name="maxRadiusSlider">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="brightnessGb">
-            <property name="title">
-             <string>Default Orb Brightness</string>
-            </property>
-            <layout class="QVBoxLayout" name="brightnessGbLayout">
-             <item>
-              <widget class="QSlider" name="brightnessSlider">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="psMoveGb">
-            <property name="title">
-             <string>PS Move</string>
-            </property>
-            <layout class="QVBoxLayout" name="psMoveGbLayout">
-             <item>
-              <widget class="QComboBox" name="comboSelectDevice"/>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="colorGb">
-               <property name="title">
-                <string>Color</string>
-               </property>
-               <layout class="QVBoxLayout" name="colorGbLayout">
-                <item>
-                 <widget class="QSlider" name="colorSliderR">
-                  <property name="maximum">
-                   <number>255</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QSlider" name="colorSliderG">
-                  <property name="maximum">
-                   <number>255</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QSlider" name="colorSliderB">
-                  <property name="maximum">
-                   <number>255</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="hueGb">
-               <property name="title">
-                <string>Hue</string>
-               </property>
-               <layout class="QVBoxLayout" name="hueGbLayout">
-                <item>
-                 <widget class="QSlider" name="hueSlider">
-                  <property name="maximum">
-                   <number>359</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="hueThresholdGb">
-               <property name="title">
-                <string>Hue Threshold</string>
-               </property>
-               <layout class="QVBoxLayout" name="hueThresholdLayout">
-                <item>
-                 <widget class="QSlider" name="hueThresholdSlider">
-                  <property name="maximum">
-                   <number>359</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="saturationThresholdGb">
-               <property name="title">
-                <string>Saturation Threshold</string>
-               </property>
-               <layout class="QVBoxLayout" name="saturationThresholdGbLayout">
-                <item>
-                 <widget class="QSlider" name="saturationThresholdSlider">
-                  <property name="maximum">
-                   <number>255</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Orientation::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
+        <widget class="QTabWidget" name="settingsTabWidget">
+         <widget class="QWidget" name="settingsPage" native="true">
+          <attribute name="title">
+           <string>Settings</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="settingsPageLayout">
+           <item>
+            <widget class="QGroupBox" name="minRadiusGb">
+             <property name="title">
+              <string>Min Radius</string>
+             </property>
+             <layout class="QVBoxLayout" name="minRadiusGbLayout">
+              <item>
+               <widget class="QSlider" name="minRadiusSlider">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="maxRadiusGb">
+             <property name="title">
+              <string>Max Radius</string>
+             </property>
+             <layout class="QVBoxLayout" name="maxRadiusGbLayout">
+              <item>
+               <widget class="QSlider" name="maxRadiusSlider">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="brightnessGb">
+             <property name="title">
+              <string>Default Orb Brightness</string>
+             </property>
+             <layout class="QVBoxLayout" name="brightnessGbLayout">
+              <item>
+               <widget class="QSlider" name="brightnessSlider">
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="psMoveGb">
+             <property name="title">
+              <string>PS Move</string>
+             </property>
+             <layout class="QVBoxLayout" name="psMoveGbLayout">
+              <item>
+               <widget class="QComboBox" name="comboSelectDevice"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="colorGb">
+             <property name="title">
+              <string>Color</string>
+             </property>
+             <layout class="QVBoxLayout" name="colorGbLayout">
+              <item>
+               <widget class="QSlider" name="colorSliderR">
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSlider" name="colorSliderG">
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSlider" name="colorSliderB">
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="hueGb">
+             <property name="title">
+              <string>Hue</string>
+             </property>
+             <layout class="QVBoxLayout" name="hueGbLayout">
+              <item>
+               <widget class="QSlider" name="hueSlider">
+                <property name="maximum">
+                 <number>359</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="hueThresholdGb">
+             <property name="title">
+              <string>Hue Threshold</string>
+             </property>
+             <layout class="QVBoxLayout" name="hueThresholdLayout">
+              <item>
+               <widget class="QSlider" name="hueThresholdSlider">
+                <property name="maximum">
+                 <number>359</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="saturationThresholdGb">
+             <property name="title">
+              <string>Saturation Threshold</string>
+             </property>
+             <layout class="QVBoxLayout" name="saturationThresholdGbLayout">
+              <item>
+               <widget class="QSlider" name="saturationThresholdSlider">
+                <property name="maximum">
+                 <number>255</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="displayPage">
+          <attribute name="title">
+           <string>Display</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="displayPageLayout">
+           <item>
+            <widget class="QGroupBox" name="inputFormatGb">
+             <property name="title">
+              <string>Input Format</string>
+             </property>
+             <layout class="QVBoxLayout" name="input_format_layout">
+              <item>
+               <widget class="QComboBox" name="inputFormatCombo"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="histoSettingsGb">
+             <property name="title">
+              <string>Histogram</string>
+             </property>
+             <layout class="QVBoxLayout" name="histoSettingsGbLayout">
+              <item>
+               <widget class="QComboBox" name="histoCombo"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="viewGb">
+             <property name="title">
+              <string>View</string>
+             </property>
+             <layout class="QVBoxLayout" name="view_layout">
+              <item>
+               <widget class="QComboBox" name="viewCombo"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="displayGb">
+             <property name="title">
+              <string>Display</string>
+             </property>
+             <layout class="QVBoxLayout" name="filterGbLayout">
+              <item>
+               <widget class="QCheckBox" name="filterSmallContoursBox">
+                <property name="text">
+                 <string>Filter Small Contours</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="freezeFrameBox">
+                <property name="text">
+                 <string>Freeze Frame</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="showAllContoursBox">
+                <property name="text">
+                 <string>Show All Contours</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="drawContoursBox">
+                <property name="text">
+                 <string>Draw Contours</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="drawOverlaysBox">
+                <property name="text">
+                 <string>Draw Overlays</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="displayPageSpacer">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="inputFormatGb">
-         <property name="title">
-          <string>Input Format</string>
-         </property>
-         <layout class="QVBoxLayout" name="input_format_layout">
-          <item>
-           <widget class="QComboBox" name="inputFormatCombo"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="viewGb">
-         <property name="title">
-          <string>View</string>
-         </property>
-         <layout class="QVBoxLayout" name="view_layout">
-          <item>
-           <widget class="QComboBox" name="viewCombo"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="histoSettingsGb">
-         <property name="title">
-          <string>Histogram</string>
-         </property>
-         <layout class="QVBoxLayout" name="histoSettingsGbLayout">
-          <item>
-           <widget class="QComboBox" name="histoCombo"/>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="displayGb">
-         <property name="title">
-          <string>Display</string>
-         </property>
-         <layout class="QVBoxLayout" name="filterGbLayout">
-          <item>
-           <widget class="QCheckBox" name="filterSmallContoursBox">
-            <property name="text">
-             <string>Filter Small Contours</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="freezeFrameBox">
-            <property name="text">
-             <string>Freeze Frame</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="showAllContoursBox">
-            <property name="text">
-             <string>Show All Contours</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="drawContoursBox">
-            <property name="text">
-             <string>Draw Contours</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="drawOverlaysBox">
-            <property name="text">
-             <string>Draw Overlays</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
+        <spacer name="rightLayoutSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
          </property>


### PR DESCRIPTION
- Do not update color sliders recursively after changing the color
- Add default orb brightness slider
- Improve ? layout a bit (it got way too high)

This fixes an issue where the RGB values would always jump back to the calculated RGB based on the new hue (e.g. when opening the dialog).
The default orb brightness is used when the hue slider is changed manually or when the hue is calculated with the secret color picker feature (left click on the video image).