### PR TITLE
[Mac OS X] [RSX] Disable Apple-specific hacks for features & formats supported on Apple GPUs

### DIFF
--- a/rpcs3/Emu/RSX/Common/TextureUtils.cpp
+++ b/rpcs3/Emu/RSX/Common/TextureUtils.cpp
@@ -33,7 +33,7 @@ namespace utils
 namespace
 {
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) || !defined(ARCH_X64)
 u16 convert_rgb655_to_rgb565(const u16 bits)
 {
 	// g6 = g5
@@ -946,7 +946,7 @@ namespace rsx
 			break;
 		}
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) || !defined(ARCH_X64)
 		case CELL_GCM_TEXTURE_R6G5B5:
 		{
 			if (is_swizzled)

--- a/rpcs3/Emu/RSX/VK/VKFormats.cpp
+++ b/rpcs3/Emu/RSX/VK/VKFormats.cpp
@@ -197,7 +197,7 @@ namespace vk
 		const bool supports_dxt = vk::get_current_renderer()->get_texture_compression_bc_support();
 		switch (format)
 		{
-#ifndef __APPLE__
+#if !defined(__APPLE__) || !defined(ARCH_X64)
 		case CELL_GCM_TEXTURE_R5G6B5: return VK_FORMAT_R5G6B5_UNORM_PACK16;
 		case CELL_GCM_TEXTURE_R6G5B5: return VK_FORMAT_R5G6B5_UNORM_PACK16; // Expand, discard high bit?
 		case CELL_GCM_TEXTURE_R5G5B5A1: return VK_FORMAT_R5G5B5A1_UNORM_PACK16;
@@ -205,7 +205,7 @@ namespace vk
 		case CELL_GCM_TEXTURE_A1R5G5B5: return VK_FORMAT_A1R5G5B5_UNORM_PACK16;
 		case CELL_GCM_TEXTURE_A4R4G4B4: return VK_FORMAT_R4G4B4A4_UNORM_PACK16;
 #else
-		// assign B8G8R8A8_UNORM to formats that are not supported by Metal
+		// assign B8G8R8A8_UNORM to formats that are not supported by Metal on non-Apple GPUs
 		case CELL_GCM_TEXTURE_R6G5B5: return VK_FORMAT_B8G8R8A8_UNORM;
 		case CELL_GCM_TEXTURE_R5G6B5: return VK_FORMAT_B8G8R8A8_UNORM;
 		case CELL_GCM_TEXTURE_R5G5B5A1: return VK_FORMAT_B8G8R8A8_UNORM;

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -37,7 +37,7 @@ namespace vk
 
 		switch (color_format)
 		{
-#ifndef __APPLE__
+#if !defined(__APPLE__) || !defined(ARCH_X64)
 		case rsx::surface_color_format::r5g6b5:
 			return std::make_pair(VK_FORMAT_R5G6B5_UNORM_PACK16, vk::default_component_map);
 
@@ -47,7 +47,7 @@ namespace vk
 		case rsx::surface_color_format::x1r5g5b5_z1r5g5b5:
 			return std::make_pair(VK_FORMAT_A1R5G5B5_UNORM_PACK16, z_rgb);
 #else
-		// assign B8G8R8A8_UNORM to formats that are not supported by Metal
+		// assign B8G8R8A8_UNORM to formats that are not supported by Metal on non-Apple GPUs
 		case rsx::surface_color_format::r5g6b5:
 			return std::make_pair(VK_FORMAT_B8G8R8A8_UNORM, vk::default_component_map);
 
@@ -728,11 +728,6 @@ VKGSRender::VKGSRender(utils::serial* ar) noexcept : GSRender(ar)
 		}
 		break;
 #endif
-	case vk::driver_vendor::MVK:
-		// Async compute crashes immediately on Apple GPUs
-		rsx_log.error("Apple GPUs are incompatible with the current implementation of asynchronous texture decoding.");
-		backend_config.supports_asynchronous_compute = false;
-		break;
 	case vk::driver_vendor::INTEL:
 		// As expected host allocations won't work on INTEL despite the extension being present
 		if (backend_config.supports_passthrough_dma)

--- a/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
+++ b/rpcs3/Emu/RSX/VK/VKTextureCache.cpp
@@ -1384,11 +1384,11 @@ namespace vk
 			//TODO
 			warn_once("Format incompatibility detected, reporting failure to force data copy (VK_FORMAT=0x%X, GCM_FORMAT=0x%X)", static_cast<u32>(vk_format), gcm_format);
 			return false;
-#ifndef __APPLE__
+#if !defined(__APPLE__) || !defined(ARCH_X64)
 		case CELL_GCM_TEXTURE_R5G6B5:
 			return (vk_format == VK_FORMAT_R5G6B5_UNORM_PACK16);
 #else
-		// R5G6B5 is not supported by Metal
+		// R5G6B5 is not supported by Metal on non-Apple GPUs
 		case CELL_GCM_TEXTURE_R5G6B5:
 			return (vk_format == VK_FORMAT_B8G8R8A8_UNORM);
 #endif


### PR DESCRIPTION
The main workarounds now being disabled relate to format conversions for formats Metal used to not support, but these have been supported for a while now as of at least Metal 3 on modern Apple GPUs (i.e. on all Apple Silicon Macs) so the conversions are completely redundant on the Apple Silicon builds. I've gated off those changes to just Apple Silicon whilst Intel retains the format conversion workarounds, as all non-Apple GPUs only support at best the feature-set specified for the Mac2 Metal GPU family, which does not include support for the formats concerned. See Apple's own docs for reference:
[Metal-Feature-Set-Tables.pdf](https://github.com/user-attachments/files/31405280/Metal-Feature-Set-Tables.pdf)

I've also (very tentatively) enabled async compute on Mac builds now. Whilst this needs wider testing, I myself have confirmed that Async Texture Streaming does not crash any games on my Mac (M4 Pro SOC), though it didn't really help in MGS2 in a test area at 700% res scale, FPS dropped with it on from ~55-56fps to ~50-52fps, GOW3 at 300% res scale meanwhile had a possible margin-of-error uplift in-game from 60-61fps in the Realm of Hades and on the menus, to around 62-64fps.

(Triangle fans being converted to triangle lists in VKVertexBuffers is one hack I've left untouched, using MVK's 'native support' (which also just converts to triangle lists under the hood, see https://github.com/KhronosGroup/MoltenVK/commit/e5d3939322d1f791fbee9b528a6a6a0c3f4d5568) crippled performance on the menus in MGS2 at 700% res scale.
Conditional rendering remains unsupported too due to TBDR limitations, checking against the Skate 3 demo as people reported issues with its full game counterpart years ago, the previously reported black flickering still occurs with CR enabled.)

Needs review from @kd-11 ofc.