### PR TITLE
[Mac OS X] Fix PPU LLVM compilation regression/sporadic failures (#19103)

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -5308,8 +5308,9 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				// Set low priority
 				thread_ctrl::scoped_priority low_prio(-1);
 
-				jit_write_guard jit_guard;
-
+#ifdef __APPLE__
+				pthread_jit_write_protect_np(false);
+#endif
 				for (usz i = (*work_cv)++; i < workload.size(); i = (*work_cv)++, (*work_done)++, g_progr_pdone++)
 				{
 					if (cpu ? cpu->state.all_of(cpu_flag::exit) : Emu.IsStopped())


### PR DESCRIPTION
Eliminates an added pthread_jit_write_protect_np(true); call that can cause extended bouts of PPU module compilation to fail & need to be rerun multiple times for a complete cache to be built. Performed a couple of full PPU module compilations on GOW3 on both master and with this change and it looks to have resolved the issue entirely I hope. (PR #18774 introduced the broken call explicitly, later on PR #18707 streamlined this inside of the jit_write_guard struct, hence why I've removed that line in favour of only calling pthread_jit_write_protect_np(false); as it was prior to #18774).