### PR TITLE
[SPU LLVM] Add `SHUFB` known never particular special constant fast paths

### DIFF
--- a/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
+++ b/rpcs3/Emu/Cell/SPULLVMRecompiler.cpp
@@ -7484,6 +7484,9 @@ public:
 		const auto known_idx = get_known_bits(c);
 		const bool perm_only = known_idx.Zero[7];
 		const bool perm_or_zero_only = known_idx.Zero[6];
+		const bool consts_only = known_idx.One[7];
+		const bool consts_never_msb = known_idx.Zero[5];
+		const bool consts_never_allones = known_idx.One[5];
 		const bool idx_selects_single = known_idx.extractBits(1, 4).isConstant();
 
 		const auto a = get_vr<u8[16]>(op.ra);
@@ -7546,7 +7549,11 @@ public:
 		// NOTE: LLVM doesn't emit BCAX	(llvm-project/issues/200699)
 		//		 Verify if `(x ^ 0x0F) & 0x?F` is reassociated when upstreamed
 
-		if (single_src)
+		if (consts_only)
+		{
+			// NOP to avoid doing any shuffles
+		}
+		else if (single_src)
 		{
 			const auto only_src = single_src.value();
 
@@ -7558,8 +7565,7 @@ public:
 
 			if (only_src_is_splat)
 			{
-				const auto lut = build<u8[16]>(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x80, 0x80, 0x80, 0x80);
-				set_vr(op.rt4, tbx(only_src, lut, (c >> 3) ^ 0x10));
+				set_vr(op.rt4, tbl(splat_lut, (c >> 4)));
 				return;
 			}
 
@@ -7569,15 +7575,8 @@ public:
 				set_vr(op.rt4, tbl(only_src, cm));
 				return;
 			}
-
-			const auto x = tbl(build<u8[16]>(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x80, 0x80), (c >> 4));
-			const auto xv = perm_or_zero_only ? eval(splat<u8[16]>(0)) : x;
-			const auto cm = eval(cv & 0x8f);
-			set_vr(op.rt4, tbx(xv, only_src, cm));
-			return;
 		}
-
-		if (a_is_splat && b_is_splat)
+		else if (a_is_splat && b_is_splat)
 		{
 			if (perm_only)
 			{
@@ -7596,10 +7595,39 @@ public:
 			return;
 		}
 
-		const auto x = tbl(build<u8[16]>(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x80, 0x80), (c >> 4));
-		const auto xv = perm_or_zero_only ? eval(splat<u8[16]>(0)) : x;
+		// Calculate special index constants
+
+		value_t<u8[16]> idx_consts;
+		if (perm_or_zero_only)
+		{
+			idx_consts = eval(splat<u8[16]>(0));
+		}
+		else if (consts_never_msb)
+		{
+			idx_consts = eval(noncast<u8[16]>(sext<s8[16]>(c >= 0xc0)));
+		}
+		else
+		{
+			idx_consts = tbl(build<u8[16]>(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x80, 0x80), (c >> 4));
+		}
+
+		if (consts_only)
+		{
+			set_vr(op.rt4, idx_consts);
+			return;
+		}
+
+		// Combine shuffle and special index constants
+
+		if (single_src)
+		{
+			const auto cm = eval(cv & 0x8f);
+			set_vr(op.rt4, tbx(idx_consts, single_src.value(), cm));
+			return;
+		}
+
 		const auto cm = eval(cv & 0x9f);
-		set_vr(op.rt4, tbx2(xv, av, bv, cm));
+		set_vr(op.rt4, tbx2(idx_consts, av, bv, cm));
 		return;
 #else
 
@@ -7608,7 +7636,12 @@ public:
 		bool or_combine_safe = false;
 
 		value_t<u8[16]> ab_shuf;
-		if (single_src)
+		if (consts_only)
+		{
+			// NOP to avoid doing any shuffles
+			ab_shuf = value_t<u8[16]>();
+		}
+		else if (single_src)
 		{
 			if (only_src_is_splat)
 			{
@@ -7663,6 +7696,18 @@ public:
 		{
 			idx_consts = eval(splat<u8[16]>(0));
 		}
+		else if (consts_never_msb)
+		{
+			// Saves on a constant + prevents pessimation where kmask implementation has worse latency than GFNI
+			if (or_combine_safe)
+				idx_consts = eval(bitcast<u8[16]>(sext<s8[16]>(c >= 0xc0)));
+			else
+				idx_consts = eval(bitcast<u8[16]>(noncast<s8[16]>(c + c) >> 7));
+		}
+		else if (consts_never_allones)
+		{
+			idx_consts = eval(sub_sat(c, splat<u8[16]>(0x60)) & 0x80);
+		}
 		else if (m_use_gfni)
 		{
 			// TODO: Due to vpblendvb, the pshufb OR combine path is one fewer micro-ops post Rocket Lake. Check if it is faster.
@@ -7676,6 +7721,12 @@ public:
 		{
 			const auto pshufb_lut = build<u8[16]>(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0x80, 0x80);
 			idx_consts = eval(pshufb(pshufb_lut, (c >> 4)));
+		}
+
+		if (consts_only)
+		{
+			set_vr(op.rt4, idx_consts);
+			return;
 		}
 
 		// Combine shuffle and special index constants


### PR DESCRIPTION
By using static analysis, I found some examples where games would restrict the special index constants they generate by modifying the index beforehand or to only generate those constants instead of shuffling. This patch adds additional fast paths for those cases and changes the following:

- Adds a path to avoid shuffling the input when we know the index's MSB is set.
- Adds a known "never MSB" constant fast path.
- Adds a known "never all ones" constant fast path.
- Replaces the ARM "only source is splat" path to use the same method as the "both sources are splat" LUT method, which is a lot faster.
- Splits the ARM constants calculation into its own step.