### PR TITLE
Patch manager fixes

### DIFF
--- a/rpcs3/Emu/Cell/Modules/cellCamera.cpp
+++ b/rpcs3/Emu/Cell/Modules/cellCamera.cpp
@@ -1716,20 +1716,20 @@ void camera_context::operator()()
 			{
 				if (auto queue = lv2_event_queue::find(key))
 				{
+					constexpr u64 camera_id = 0;
 					u64 data2 = 0;
 					u64 data3 = 0;
 
 					if (read_mode.load() == CELL_CAMERA_READ_DIRECT)
 					{
 						const u64 image_data_size = static_cast<u64>(info.bytesize);
-						const u64 camera_id = 0;
 
 						data2 = image_data_size << 32 | buffer_number << 16 | camera_id;
 						data3 = get_guest_system_time() - start_timestamp_us; // timestamp
 					}
 					else // CELL_CAMERA_READ_FUNCCALL, also default
 					{
-						data2 = 0; // device id (always 0)
+						data2 = camera_id;
 						data3 = 0; // unused
 					}
 

--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -4689,9 +4689,9 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 	// Its disadvantage:
 	// 1. B instruction can wander up to 16MB relatively to its range,
 	// each additional split of JIT instance results in a downgraded version of around (100% / N-1th) - (100% / Nth) percent of instructions
-	// where N is the total amunt of JIT instances
+	// where N is the total amount of JIT instances
 	// Subject to change
-	constexpr u32 c_moudles_per_jit = 100;
+	constexpr u32 c_modules_per_jit = 100;
 
 	std::shared_ptr<std::pair<u32, u32>> local_jit_bounds = std::make_shared<std::pair<u32, u32>>(u32{umax}, 0);
 
@@ -5091,7 +5091,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				sha1_update(&ctx, ensure(info.get_ptr<const u8>(func.addr)), func.size);
 			}
 
-			if (fpos >= info.get_funcs().size() || module_counter % c_moudles_per_jit == c_moudles_per_jit - 1)
+			if (fpos >= info.get_funcs().size() || (module_counter % c_modules_per_jit) == (c_modules_per_jit - 1))
 			{
 				// Hash the entire function grouped addresses for the integrity of the symbol resolver function
 				// Potentially occuring during patches
@@ -5184,7 +5184,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				settings += ppu_settings::accurate_vnan, settings -= ppu_settings::fixup_vnan, fmt::throw_exception("VNAN Not implemented");
 			if (g_cfg.core.ppu_use_nj_bit)
 				settings += ppu_settings::accurate_nj_mode, fmt::throw_exception("NJ Not implemented");
-			if (fpos >= info.get_funcs().size() || module_counter % c_moudles_per_jit == c_moudles_per_jit - 1)
+			if (fpos >= info.get_funcs().size() || (module_counter % c_modules_per_jit) == (c_modules_per_jit - 1))
 				settings += ppu_settings::contains_symbol_resolver; // Avoid invalidating all modules for this purpose
 			if (g_cfg.core.set_daz_and_ftz)
 				settings += ppu_settings::daz_and_ftz;
@@ -5386,7 +5386,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 	}
 
 	// Initialize compiler instance
-	while (jits.size() < utils::aligned_div<u64>(module_counter, c_moudles_per_jit) && is_being_used_in_emulation)
+	while (jits.size() < utils::aligned_div<u64>(module_counter, c_modules_per_jit) && is_being_used_in_emulation)
 	{
 		jits.emplace_back(std::make_shared<jit_compiler>(s_link_table, g_cfg.core.llvm_cpu.to_string(), 0, symbols_cement));
 
@@ -5429,7 +5429,7 @@ bool ppu_initialize(const ppu_module<lv2_obj>& info, bool check_only, u64 file_s
 				break;
 			}
 
-			if (!failed_to_load && !jits[mod_index / c_moudles_per_jit]->add(cache_path + obj_name))
+			if (!failed_to_load && !jits[mod_index / c_modules_per_jit]->add(cache_path + obj_name))
 			{
 				ppu_log.error("LLVM: Failed to load module %s", obj_name);
 				failed_to_load = true;

--- a/rpcs3/Emu/RSX/Common/texture_cache_utils.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache_utils.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Emu/System.h"
 #include "texture_cache_types.h"
 #include "texture_cache_predictor.h"
 #include "TextureUtils.h"
@@ -1066,13 +1065,13 @@ namespace rsx
 
 	protected:
 
-		u16 width;
-		u16 height;
-		u16 depth;
-		u16 mipmaps;
+		u16 width = 0;
+		u16 height = 0;
+		u16 depth = 0;
+		u16 mipmaps = 0;
 
-		u32 real_pitch;
-		u32 rsx_pitch;
+		u32 real_pitch = 0;
+		u32 rsx_pitch = 0;
 
 		u32 gcm_format = 0;
 		bool pack_unpack_swap_bytes = false;
@@ -1090,9 +1089,9 @@ namespace rsx
 
 		address_range_vector32 flush_exclusions; // Address ranges that will be skipped during flush
 
-		predictor_type *m_predictor = nullptr;
+		predictor_type* m_predictor = nullptr;
 		usz m_predictor_key_hash = 0;
-		predictor_entry_type *m_predictor_entry = nullptr;
+		predictor_entry_type* m_predictor_entry = nullptr;
 
 	public:
 		u64 cache_tag = 0;
@@ -1104,12 +1103,12 @@ namespace rsx
 		}
 
 		cached_texture_section() = default;
-		cached_texture_section(ranged_storage_block_type *block)
+		cached_texture_section(ranged_storage_block_type* block)
 		{
 			initialize(block);
 		}
 
-		void initialize(ranged_storage_block_type *block)
+		void initialize(ranged_storage_block_type* block)
 		{
 			ensure(m_block == nullptr && m_tex_cache == nullptr && m_storage == nullptr);
 			m_block = block;
@@ -1120,11 +1119,10 @@ namespace rsx
 			update_unreleased();
 		}
 
-
 		/**
 		 * Reset
 		 */
-		void reset(const address_range32 &memory_range)
+		void reset(const address_range32& memory_range)
 		{
 			AUDIT(memory_range.valid());
 			AUDIT(!is_locked());

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -342,7 +342,7 @@ void patch_manager_dialog::populate_tree()
 							std::pair<int, QVariant>(persistance_role, true)
 						};
 
-						// Add counter to leafs if the name already exists due to different hashes of the same game (PPU, SPU, PRX, OVL)
+						// Add hash to leafs if the name already exists due to different hashes of the same game (PPU, SPU, PRX, OVL)
 						std::vector<QTreeWidgetItem*> matches;
 						gui::utils::find_children_by_data(serial_level_item, matches, match_criteria, false);
 
@@ -350,12 +350,9 @@ void patch_manager_dialog::populate_tree()
 						{
 							if (auto only_match = matches.size() == 1 ? matches[0] : nullptr)
 							{
-								only_match->setText(0, q_description + QStringLiteral(" (01)"));
+								only_match->setText(0, q_description + QStringLiteral(" (") + only_match->data(0, hash_role).toString() + QStringLiteral(")"));
 							}
-							const usz counter = matches.size() + 1;
-							visible_description += QStringLiteral(" (");
-							if (counter < 10) visible_description += '0';
-							visible_description += QString::number(counter) + ')';
+							visible_description += QStringLiteral(" (") + q_hash + QStringLiteral(")");
 						}
 
 						QVariantMap q_config_values;

--- a/rpcs3/rpcs3qt/patch_manager_dialog.cpp
+++ b/rpcs3/rpcs3qt/patch_manager_dialog.cpp
@@ -23,17 +23,6 @@
 
 LOG_CHANNEL(patch_log, "PAT");
 
-enum patch_column : int
-{
-	enabled,
-	title,
-	serials,
-	description,
-	patch_version,
-	author,
-	notes
-};
-
 enum patch_role : int
 {
 	hash_role = Qt::UserRole,
@@ -447,18 +436,21 @@ void patch_manager_dialog::filter_patches(const QString& term)
 {
 	// Recursive function to show all matching items and their children.
 	// @return number of visible children of item, including item
-	std::function<int(QTreeWidgetItem*, bool)> show_matches;
-	show_matches = [this, &show_matches, search_text = term.toLower()](QTreeWidgetItem* item, bool parent_visible) -> int
+	std::function<int(QTreeWidgetItem*, bool, bool)> show_matches;
+	show_matches = [this, &show_matches, search_text = term.toLower()](QTreeWidgetItem* item, bool parent_visible, bool parent_is_all) -> int
 	{
 		if (!item) return 0;
 
 		const node_level level = static_cast<node_level>(item->data(0, node_level_role).toInt());
+		bool is_all = false;
 
-		// Hide nodes that aren't in the game list
-		if (m_show_owned_games_only && level == node_level::serial_level)
+		if (level == node_level::serial_level)
 		{
 			const std::string serial = item->data(0, serial_role).toString().toStdString();
-			if (serial != patch_key::all)
+			is_all = serial == patch_key::all;
+
+			// Hide nodes that aren't in the game list
+			if (m_show_owned_games_only && !is_all)
 			{
 				const std::string app_version = item->data(0, app_version_role).toString().toStdString();
 
@@ -472,12 +464,30 @@ void patch_manager_dialog::filter_patches(const QString& term)
 
 		// Only try to match if the parent is not visible
 		parent_visible = parent_visible || item->text(0).toLower().contains(search_text);
+
+		// Try to match text in the notes as well
+		if (!parent_visible && parent_is_all && level == node_level::patch_level)
+		{
+			const std::string hash = item->data(0, hash_role).toString().toStdString();
+			if (m_map.contains(hash))
+			{
+				const patch_engine::patch_container& container = ::at32(m_map, hash);
+				const std::string description = item->data(0, description_role).toString().toStdString();
+
+				if (container.patch_info_map.contains(description))
+				{
+					const patch_engine::patch_info& found_info = ::at32(container.patch_info_map, description);
+					parent_visible = QString::fromStdString(found_info.notes).toLower().contains(search_text);
+				}
+			}
+		}
+
 		int visible_items = 0;
 
 		// Get the number of visible children recursively
 		for (int i = 0; i < item->childCount(); i++)
 		{
-			visible_items += show_matches(item->child(i), parent_visible);
+			visible_items += show_matches(item->child(i), parent_visible, is_all);
 		}
 
 		if (parent_visible)
@@ -502,7 +512,7 @@ void patch_manager_dialog::filter_patches(const QString& term)
 		if (!top_level_item)
 			continue;
 
-		const int matches = show_matches(top_level_item, false);
+		const int matches = show_matches(top_level_item, false, false);
 
 		if (matches <= 0 || !m_expand_current_match)
 			continue;


### PR DESCRIPTION
- Qt: use hash instead of counter for identical patch names
- Qt: Also search in notes of "All titles" in the patch manager
- Fix typo c_moudles_per_jit
- rsx: default initialize some members

fixes #19320