### PR TITLE
Display all games in BPM

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_details.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_details.cpp
@@ -53,9 +53,17 @@ namespace rsx
 
 			const std::string game_dir = fs::get_parent_dir(info.icon_path);
 
-			if (const std::string pic1_path = game_dir + "/PIC1.PNG"; fs::is_file(pic1_path))
+			std::string pic_path = game_dir + "/PIC1.PNG";
+
+			if (!fs::is_file(pic_path))
 			{
-				m_pic_data = std::make_unique<image_info>(pic1_path);
+				// Some games only ship the PIC0 overlay layer, not the PIC1 background layer.
+				pic_path = game_dir + "/PIC0.PNG";
+			}
+
+			if (fs::is_file(pic_path))
+			{
+				m_pic_data = std::make_unique<image_info>(pic_path);
 				// The renderer's texture cache is keyed by this object's address, which can be reused by an
 				// unrelated image after the old one is freed - force a re-upload instead of trusting the cache.
 				m_pic_data->dirty = true;

--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_details.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_details.cpp
@@ -53,7 +53,7 @@ namespace rsx
 
 			if (const std::string pic1_path = rpcs3::utils::get_game_content_path(game_content_type::background_picture, info); !pic1_path.empty())
 			{
-				m_pic_data = std::make_unique<image_info>(pic_path);
+				m_pic_data = std::make_unique<image_info>(pic1_path);
 				// The renderer's texture cache is keyed by this object's address, which can be reused by an
 				// unrelated image after the old one is freed - force a re-upload instead of trusting the cache.
 				m_pic_data->dirty = true;

--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
@@ -94,7 +94,7 @@ namespace rsx
 
 			std::unordered_set<std::string> added_serials;
 
-			const auto add_game_entry = [&](const std::string& title_id, const std::string& path, const psf::registry& psf, std::string icon_path)
+			const auto add_game_entry = [&](const std::string& title_id, const std::string& path, const psf::registry& psf, std::string icon_path, const std::string& sfo_dir = {})
 			{
 				GameInfo info{};
 				info.path = path;
@@ -103,6 +103,13 @@ namespace rsx
 				info.name = std::string(psf::get_string(psf, "TITLE", title_id));
 				info.category = std::string(psf::get_string(psf, "CATEGORY"));
 				info.app_ver = std::string(psf::get_string(psf, "APP_VER"));
+
+				// sfo_dir is only available for regular (non-ISO) installs, so movie/audio lookup is skipped for ISOs.
+				if (!sfo_dir.empty())
+				{
+					info.movie_path = rpcs3::utils::get_game_content_path(game_content_type::content_video, info, sfo_dir);
+					info.audio_path = rpcs3::utils::get_game_content_path(game_content_type::content_sound, info, sfo_dir);
+				}
 
 				added_serials.insert(title_id);
 				m_games.push_back({ std::move(info) });
@@ -196,7 +203,7 @@ namespace rsx
 					return;
 				}
 
-				add_game_entry(title_id, path, psf, sfo_dir + "/ICON0.PNG");
+				add_game_entry(title_id, path, psf, sfo_dir + "/ICON0.PNG", sfo_dir);
 			};
 
 			// dev_hdd0/game/ (regular PKG installs) is never registered into games.yml, so list it directly.
@@ -209,15 +216,8 @@ namespace rsx
 					continue;
 				}
 
-				GameInfo info{};
-				info.path = path;
-				info.serial = title_id;
-				info.name = std::string(psf::get_string(psf, "TITLE", title_id));
-				info.category = std::string(psf::get_string(psf, "CATEGORY"));
-				info.app_ver = std::string(psf::get_string(psf, "APP_VER"));
-				info.icon_path = rpcs3::utils::get_game_content_path(game_content_type::content_icon, info, sfo_dir);
-				info.movie_path = rpcs3::utils::get_game_content_path(game_content_type::content_video, info, sfo_dir);
-				info.audio_path = rpcs3::utils::get_game_content_path(game_content_type::content_sound, info, sfo_dir);
+				try_add_game(entry.name, hdd0_game_dir + entry.name);
+			}
 
 			for (const auto& [title_id, raw_path] : Emu.GetGamesConfig().get_games())
 			{

--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
@@ -14,17 +14,6 @@ namespace rsx
 {
 	namespace overlays
 	{
-		namespace
-		{
-			// ISO icons have no on-disk file of their own, so cache the extracted bytes to one.
-			std::string get_iso_icon_cache_path(const std::string& title_id)
-			{
-				const std::string dir = rpcs3::utils::get_cache_dir() + "big_picture_iso_icons/";
-				fs::create_path(dir);
-				return dir + title_id + ".png";
-			}
-		}
-
 		big_picture_game_tile::big_picture_game_tile(const big_picture_game_entry& entry, u16 tile_width)
 		{
 			pack_padding = 8;
@@ -192,15 +181,10 @@ namespace rsx
 						return;
 					}
 
-					std::string icon_path;
+					// iso_cache::save()/load() above already wrote the icon bytes to this exact path.
+					const std::string icon_path = icon_data.empty() ? std::string() : iso_cache::get_icon_cache_path(path);
 
-					if (!icon_data.empty())
-					{
-						icon_path = get_iso_icon_cache_path(title_id);
-						fs::write_file(icon_path, fs::rewrite, icon_data);
-					}
-
-					add_game_entry(title_id, path, psf, std::move(icon_path));
+					add_game_entry(title_id, path, psf, icon_path);
 					return;
 				}
 

--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
@@ -4,13 +4,27 @@
 #include "Emu/System.h"
 #include "Emu/system_utils.hpp"
 #include "Loader/PSF.h"
+#include "Loader/ISO.h"
+#include "Loader/iso_cache.h"
 
 #include <algorithm>
+#include <unordered_set>
 
 namespace rsx
 {
 	namespace overlays
 	{
+		namespace
+		{
+			// ISO icons have no on-disk file of their own, so cache the extracted bytes to one.
+			std::string get_iso_icon_cache_path(const std::string& title_id)
+			{
+				const std::string dir = rpcs3::utils::get_cache_dir() + "big_picture_iso_icons/";
+				fs::create_path(dir);
+				return dir + title_id + ".png";
+			}
+		}
+
 		big_picture_game_tile::big_picture_game_tile(const big_picture_game_entry& entry, u16 tile_width)
 		{
 			pack_padding = 8;
@@ -89,14 +103,105 @@ namespace rsx
 			m_games.clear();
 			m_tiles.clear();
 
-			for (const auto& [title_id, raw_path] : Emu.GetGamesConfig().get_games())
+			std::unordered_set<std::string> added_serials;
+
+			const auto add_game_entry = [&](const std::string& title_id, const std::string& path, const psf::registry& psf, std::string icon_path)
+			{
+				GameInfo info{};
+				info.path = path;
+				info.icon_path = std::move(icon_path);
+				info.serial = title_id;
+				info.name = std::string(psf::get_string(psf, "TITLE", title_id));
+				info.category = std::string(psf::get_string(psf, "CATEGORY"));
+				info.app_ver = std::string(psf::get_string(psf, "APP_VER"));
+
+				added_serials.insert(title_id);
+				m_games.push_back({ std::move(info) });
+			};
+
+			const auto try_add_game = [&](const std::string& title_id, const std::string& raw_path)
 			{
 				std::string path = raw_path;
 				path.resize(path.find_last_not_of('/') + 1);
 
 				if (path.empty())
 				{
-					continue;
+					return;
+				}
+
+				if (is_iso_file(path))
+				{
+					iso_metadata_cache_entry cache_entry{};
+					std::vector<u8> psf_data;
+					std::vector<u8> icon_data;
+
+					if (iso_cache::load(path, path, cache_entry))
+					{
+						psf_data = std::move(cache_entry.psf_data);
+						icon_data = std::move(cache_entry.icon_data);
+					}
+					else
+					{
+						iso_archive archive(path);
+
+						if (!archive.is_valid())
+						{
+							return;
+						}
+
+						const psf::registry iso_psf = archive.open_psf("PS3_GAME/PARAM.SFO");
+
+						if (iso_psf.empty())
+						{
+							return;
+						}
+
+						psf_data = psf::save_object(iso_psf);
+
+						if (archive.exists("PS3_GAME/ICON0.PNG"))
+						{
+							if (auto icon_file = archive.open("PS3_GAME/ICON0.PNG"); icon_file && icon_file->size() > 0)
+							{
+								icon_data.resize(icon_file->size());
+								icon_file->read(icon_data.data(), icon_data.size());
+							}
+						}
+
+						fs::stat_t iso_stat{};
+
+						if (fs::get_stat(path, iso_stat))
+						{
+							iso_metadata_cache_entry entry_to_save{};
+							entry_to_save.mtime = iso_stat.mtime;
+							entry_to_save.psf_data = psf_data;
+							entry_to_save.icon_data = icon_data;
+							entry_to_save.icon_path = "PS3_GAME/ICON0.PNG";
+							iso_cache::save(path, path, entry_to_save);
+						}
+					}
+
+					if (psf_data.empty())
+					{
+						return;
+					}
+
+					const psf::registry psf = psf::load_object(fs::file(psf_data.data(), psf_data.size()), "PARAM.SFO");
+
+					if (psf.empty())
+					{
+						return;
+					}
+
+					std::string icon_path;
+
+					if (!icon_data.empty())
+					{
+						icon_path = get_iso_icon_cache_path(title_id);
+						fs::write_file(icon_path, fs::rewrite, icon_data);
+					}
+
+					add_game_entry(title_id, path, psf, std::move(icon_path));
+					return;
 				}
 
 				const std::string sfo_dir = rpcs3::utils::get_sfo_dir_from_game_path(path, title_id);
@@ -104,18 +209,33 @@ namespace rsx
 
 				if (psf.empty())
 				{
+					return;
+				}
+
+				add_game_entry(title_id, path, psf, sfo_dir + "/ICON0.PNG");
+			};
+
+			// dev_hdd0/game/ (regular PKG installs) is never registered into games.yml, so list it directly.
+			const std::string hdd0_game_dir = rpcs3::utils::get_hdd0_game_dir();
+
+			for (const auto& entry : fs::dir(hdd0_game_dir))
+			{
+				if (!entry.is_directory || entry.name == "." || entry.name == "..")
+				{
 					continue;
 				}
 
-				GameInfo info{};
-				info.path = path;
-				info.icon_path = sfo_dir + "/ICON0.PNG";
-				info.serial = title_id;
-				info.name = std::string(psf::get_string(psf, "TITLE", title_id));
-				info.category = std::string(psf::get_string(psf, "CATEGORY"));
-				info.app_ver = std::string(psf::get_string(psf, "APP_VER"));
+				try_add_game(entry.name, hdd0_game_dir + entry.name);
+			}
 
-				m_games.push_back({ std::move(info) });
+			for (const auto& [title_id, raw_path] : Emu.GetGamesConfig().get_games())
+			{
+				if (added_serials.contains(title_id))
+				{
+					continue;
+				}
+
+				try_add_game(title_id, raw_path);
 			}
 
 			std::sort(m_games.begin(), m_games.end(), [](const big_picture_game_entry& a, const big_picture_game_entry& b)

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -964,6 +964,9 @@ bool Emulator::BootBigPictureMode()
 
 	sys_log.notice("Big Picture Mode: booting window");
 
+	// The grid only reads games.yml, so rescan the Games folder for anything not registered there yet.
+	AddGamesFromDir(rpcs3::utils::get_games_dir());
+
 	m_state = system_state::loading;
 
 	m_path.clear();

--- a/rpcs3/Loader/iso_cache.cpp
+++ b/rpcs3/Loader/iso_cache.cpp
@@ -40,6 +40,11 @@ namespace
 
 namespace iso_cache
 {
+	std::string get_icon_cache_path(std::string_view cache_key)
+	{
+		return get_cache_dir() + get_cache_stem(cache_key) + ".png";
+	}
+
 	bool load(const std::string& iso_path, std::string_view cache_key, iso_metadata_cache_entry& out_entry)
 	{
 		fs::stat_t iso_stat{};

--- a/rpcs3/Loader/iso_cache.h
+++ b/rpcs3/Loader/iso_cache.h
@@ -22,6 +22,9 @@ struct iso_metadata_cache_entry
 
 namespace iso_cache
 {
+	// Path a cached icon is (or would be) saved to by save() below.
+	std::string get_icon_cache_path(std::string_view cache_key);
+
 	// Returns false if no valid cache entry exists or mtime has changed.
 	bool load(const std::string& iso_path, std::string_view cache_key, iso_metadata_cache_entry& out_entry);
 


### PR DESCRIPTION
Previously the BPM(Big Picture Mode) could only see games in games.yml file. Making other games like .iso and HDD completely invisible in the UI. This PR fixes that gap.