### PR TITLE
Add Audio support for BPM ICON1.PAM

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_details.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_details.cpp
@@ -73,7 +73,8 @@ namespace rsx
 
 			if (const std::string icon1_path = game_dir + "/ICON1.PAM"; fs::is_file(icon1_path))
 			{
-				m_video = std::make_unique<video_view>(icon1_path, "", info.icon_path);
+				const std::string snd0_path = game_dir + "/SND0.AT3";
+				m_video = std::make_unique<video_view>(icon1_path, snd0_path, info.icon_path);
 				m_video->set_pos(m_icon.x, m_icon.y);
 				m_video->set_size(m_icon.w, m_icon.h);
 				m_video->set_active(true);

--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_details.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_details.cpp
@@ -71,7 +71,7 @@ namespace rsx
 
 			if (!info.movie_path.empty())
 			{
-				m_video = std::make_unique<video_view>(info.movie_path, "", info.icon_path);
+				m_video = std::make_unique<video_view>(info.movie_path, info.audio_path, info.icon_path);
 				m_video->set_pos(m_icon.x, m_icon.y);
 				m_video->set_size(m_icon.w, m_icon.h);
 				m_video->set_active(true);

--- a/rpcs3/rpcs3qt/qt_video_source.cpp
+++ b/rpcs3/rpcs3qt/qt_video_source.cpp
@@ -482,7 +482,7 @@ void qt_video_source_wrapper::set_active(bool active)
 	Emu.CallFromMainThread([this, active]()
 	{
 		ensure(m_qt_video_source);
-		m_qt_video_source->set_active(true);
+		m_qt_video_source->set_active(active);
 	});
 }
 


### PR DESCRIPTION
Previously in the Big Picture Mode when selecting a game to look at its details, the ICON1.PAM video would start to play but there would be no audio playing if the .PAM file had it. This PR fixes that.

Note: the change in qt_video_source.cpp is needed because it seemed like it didn't use it's own parameter. Without that, the audio would not fade out even after you left the game details.