### PR TITLE
gui: Fix randomly untranslated game list categories

### DIFF
--- a/rpcs3/rpcs3qt/game_list_frame.cpp
+++ b/rpcs3/rpcs3qt/game_list_frame.cpp
@@ -577,7 +577,7 @@ void game_list_frame::Refresh(const bool from_drive, const std::vector<std::stri
 
 void game_list_frame::OnParsingFinished()
 {
-	const Localized localized;
+	const std::shared_ptr<const Localized> localized = std::make_shared<const Localized>();
 	const std::string dev_flash = g_cfg_vfs.get_dev_flash();
 	const std::string _hdd = rpcs3::utils::get_hdd0_dir();
 
@@ -593,8 +593,8 @@ void game_list_frame::OnParsingFinished()
 	const std::string localized_icon = fmt::format("ICON0_%02d.PNG", language_index);
 	const std::string localized_movie = fmt::format("ICON1_%02d.PAM", language_index);
 
-	const auto add_game = [this, localized_title, localized_icon, localized_movie, dev_flash, game_icon_path, _hdd,
-	                       cat_unknown_localized = localized.category.unknown.toStdString(), cat_unknown = cat::cat_unknown.toStdString(),
+	const auto add_game = [this, localized, localized_title, localized_icon, localized_movie, dev_flash, game_icon_path, _hdd,
+	                       cat_unknown_localized = localized->category.unknown.toStdString(), cat_unknown = cat::cat_unknown.toStdString(),
 	                       play_hover_movies = m_play_hover_movies, play_hover_music = m_play_hover_music, show_custom_icons = m_show_custom_icons]
 	                       (const std::string& dir_or_elf, const std::string& game_dir = "PS3_GAME")
 	{
@@ -632,8 +632,6 @@ void game_list_frame::OnParsingFinished()
 		gui_game_info game{};
 		game.info.path = dir_or_elf;
 		game.info.game_dir = (game_dir == "PS3_GAME") ? "" : game_dir;
-
-		const Localized thread_localized;
 
 		const std::string sfo_dir = (archive || !cache_entry.psf_data.empty()) ? game_dir : rpcs3::utils::get_sfo_dir_from_game_path(dir_or_elf);
 		const std::string sfo_path = sfo_dir + "/PARAM.SFO";
@@ -697,7 +695,7 @@ void game_list_frame::OnParsingFinished()
 					path_vfs = path_vfs.substr(pos);
 				}
 
-				if (const auto it = thread_localized.title.titles.find(path_vfs); it != thread_localized.title.titles.cend())
+				if (const auto it = localized->title.titles.find(path_vfs); it != localized->title.titles.cend())
 				{
 					game.info.name = it->second.toStdString();
 				}
@@ -858,21 +856,21 @@ void game_list_frame::OnParsingFinished()
 
 		QString qt_cat = QString::fromStdString(game.info.category);
 
-		if (const auto boot_cat = thread_localized.category.cat_boot.find(qt_cat); boot_cat != thread_localized.category.cat_boot.cend())
+		if (const auto boot_cat = localized->category.cat_boot.find(qt_cat); boot_cat != localized->category.cat_boot.cend())
 		{
 			qt_cat = boot_cat->second;
 		}
-		else if (const auto data_cat = thread_localized.category.cat_data.find(qt_cat); data_cat != thread_localized.category.cat_data.cend())
+		else if (const auto data_cat = localized->category.cat_data.find(qt_cat); data_cat != localized->category.cat_data.cend())
 		{
 			qt_cat = data_cat->second;
 		}
 		else if (game.info.category == cat_unknown)
 		{
-			qt_cat = thread_localized.category.unknown;
+			qt_cat = localized->category.unknown;
 		}
 		else
 		{
-			qt_cat = thread_localized.category.other;
+			qt_cat = localized->category.other;
 		}
 
 		game.localized_category = std::move(qt_cat);


### PR DESCRIPTION
Resolves #17632

### What was happening
`Localized` is a `QObject` whose members are initialized from `tr()` calls, so constructing one issues roughly forty `QObject::tr()` lookups. `game_list_frame::OnParsingFinished()` was constructing one inside the `add_game` lambda, and `add_game` runs on the `QtConcurrent::map` workers that scan the game list. Every game entry therefore fired its own batch of `tr()` calls, in parallel with every other entry being scanned at the same time.

Concurrent translator lookups race, and a losing lookup falls back to returning the untranslated source string. That is exactly the reported symptom: with a non-English UI language, a random subset of rows shows the English category name (`Disc Game`, `HDD Game`, ...), and which rows are affected changes on every refresh. The same `Localized` instance also backed the `dev_flash` title lookup, so VSH entry names were exposed to the same race.

### The fix
Construct `Localized` once on the UI thread in `OnParsingFinished()` and hand the workers a `std::shared_ptr<const Localized>` to read from. The workers now only do const map lookups against already-translated strings, so there is nothing left to race.

As a side effect this removes ~40 `tr()` calls and several `std::map` constructions **per game entry** from the scan path, which is a measurable win on large libraries (previously a 500-game library built the entire localization table 500 times).

### Testing steps
1. Set the RPCS3 UI language to a non-English one that has translations for the game list categories.
2. Press Refresh on the game list repeatedly.
3. The Category column stays fully translated on every refresh. Before the change, entries flipped between the translated name and the English source string at random.

Worth exercising on a reasonably large library, since the race is easier to hit the more entries are scanned in parallel.