### PR TITLE
rsx/qt: Move blit engine upscaling option to debug settings

### DIFF
--- a/rpcs3/Emu/RSX/Common/texture_cache.h
+++ b/rpcs3/Emu/RSX/Common/texture_cache.h
@@ -1784,7 +1784,7 @@ namespace rsx
 					};
 
 					surface_scaling_config_t scaling_config{};
-					if (g_cfg.video.allow_blit_engine_upscaling)
+					if (!g_cfg.video.disable_blit_engine_upscaling)
 					{
 						scaling_config =
 						{

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -180,7 +180,7 @@ struct cfg_root : cfg::node
 		cfg::_bool record_with_overlays{ this, "Record With Overlays", true, true };
 		cfg::_bool disable_hardware_texel_remapping{ this, "Disable Hardware ColorSpace Remapping", false, true };
 		cfg::uint<0, 100> rcas_sharpening_intensity{ this, "FidelityFX CAS Sharpening Intensity", 50, true };
-		cfg::_bool allow_blit_engine_upscaling{ this, "Allow Blit Engine Upscaling", false, true };
+		cfg::_bool disable_blit_engine_upscaling{ this, "Disable Blit Engine Upscaling", false, true };
 
 		struct node_vk : cfg::node
 		{

--- a/rpcs3/rpcs3qt/emu_settings_type.cpp
+++ b/rpcs3/rpcs3qt/emu_settings_type.cpp
@@ -113,7 +113,7 @@ const std::map<emu_settings_type, cfg_location> settings_location =
 	{ emu_settings_type::RecordWithOverlays,         get_cfg_location(local_cfg.video.record_with_overlays) },
 	{ emu_settings_type::DisableHWTexelRemapping,    get_cfg_location(local_cfg.video.disable_hardware_texel_remapping) },
 	{ emu_settings_type::FsrSharpeningStrength,      get_cfg_location(local_cfg.video.rcas_sharpening_intensity) },
-	{ emu_settings_type::EnableBlitEngineScaling,    get_cfg_location(local_cfg.video.allow_blit_engine_upscaling) },
+	{ emu_settings_type::DisableBlitEngineScaling,    get_cfg_location(local_cfg.video.disable_blit_engine_upscaling) },
 
 	// Vulkan
 	{ emu_settings_type::VulkanAdapter,                    get_cfg_location(local_cfg.video.vk.adapter) },

--- a/rpcs3/rpcs3qt/emu_settings_type.h
+++ b/rpcs3/rpcs3qt/emu_settings_type.h
@@ -112,7 +112,7 @@ enum class emu_settings_type
 	UseReBAR,
 	RecordWithOverlays,
 	DisableHWTexelRemapping,
-	EnableBlitEngineScaling,
+	DisableBlitEngineScaling,
 
 	// Anaglyph Matrix
 	CustomAnaglyphMatrixLeft,

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -600,7 +600,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 
 	EnhanceCheckBox(emu_settings_type::VulkanAsyncTextureUploads, ui->asyncTextureStreaming, tooltips.settings.async_texture_streaming);
 
-	m_emu_settings->EnhanceCheckBox(ui->blitEngineScaling, emu_settings_type::EnableBlitEngineScaling);
+	m_emu_settings->EnhanceCheckBox(ui->blitEngineScaling, emu_settings_type::DisableBlitEngineScaling);
 	SubscribeTooltip(ui->blitEngineScaling, tooltips.settings.blit_engine_scaling);
 
 	// Radio buttons

--- a/rpcs3/rpcs3qt/settings_dialog.ui
+++ b/rpcs3/rpcs3qt/settings_dialog.ui
@@ -997,13 +997,6 @@
                    </widget>
                   </item>
                   <item>
-                    <widget class="QCheckBox" name="blitEngineScaling">
-                    <property name="text">
-                      <string>Allow Blit Engine Upscaling</string>
-                    </property>
-                    </widget>
-                  </item>
-                  <item>
                    <spacer name="additional_settings_spacer">
                     <property name="orientation">
                      <enum>Qt::Orientation::Vertical</enum>
@@ -4456,6 +4449,13 @@
                    <string>Disable Asynchronous Memory Manager</string>
                   </property>
                  </widget>
+                </item>
+                <item>
+                  <widget class="QCheckBox" name="blitEngineScaling">
+                  <property name="text">
+                    <string>Disable Blit Engine Upscaling</string>
+                  </property>
+                  </widget>
                 </item>
                 <item>
                  <widget class="QCheckBox" name="disableFIFOReordering">

--- a/rpcs3/rpcs3qt/tooltips.h
+++ b/rpcs3/rpcs3qt/tooltips.h
@@ -217,7 +217,7 @@ public:
 
 		const QString texture_lod_bias = tr("Changes Texture sampling accuracy. (Small changes have a big effect.)\nAvoid using values outside the range of -12 to +12 if you're unsure.\n-3 to +3 is plenty for most usecases");
 
-		const QString blit_engine_scaling = tr("Allow upscaling to affect the RSX image scaling and rotation engine (NV3089) output images.\nThis can allow upscaling to work on some games where it normally doesn't work, but can also cause visual artifacts in other titles.");
+		const QString blit_engine_scaling = tr("Disable upscaling on the RSX image scaling and rotation engine (NV3089) output images.\nThis may fix some bugs that are present when upscaling is being used, but some games will appear as if they're running at 100% resolution regardless of the real setting.");
 
 		// gui
 


### PR DESCRIPTION
Followup to https://github.com/RPCS3/rpcs3/pull/19013
The setting was present for debugging. We need to remove it long term, so I am making it a debug setting for now.