### PR TITLE
[Mac OS X] Fix get_aligned_buf() crashes with ISOs

### DIFF
--- a/rpcs3/Loader/ISO.cpp
+++ b/rpcs3/Loader/ISO.cpp
@@ -40,7 +40,7 @@ static void* get_aligned_buf()
 #if defined(_WIN32)
 			buf = _aligned_malloc(ISO_SECTOR_SIZE, ISO_SECTOR_SIZE * 2);
 #else
-			buf = std::aligned_alloc(ISO_SECTOR_SIZE * 2, ISO_SECTOR_SIZE);
+			buf = std::aligned_alloc(ISO_SECTOR_SIZE * 2, ISO_SECTOR_SIZE * 2);
 #endif
 		}
 


### PR DESCRIPTION
This bug ticked me off as it causes the entire emulator to persistently crash on launch if any valid ISOs get read in ~/Library/Application Support/rpcs3/games/. ~~Turns out it's another case of aligned allocations being downright broken on Mac OS X compared to other platforms so I copied over the existing workaround already used in aligned_malloc.hpp (dating back to PR #17800).~~ Or maybe it's as simple as the size not being a multiple of the alignment, guh. Needs review from @kd-11.

