### PR TITLE
Fix sys_overlay saving

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_overlay.cpp
@@ -95,7 +95,7 @@ std::function<void(void*)> lv2_overlay::load(utils::serial& ar)
 	{
 		u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 		file = make_file_view(std::move(file), offset, umax);
-		ovlm = ppu_load_overlay(ppu_exec_object{ decrypt_self(std::move(file), reinterpret_cast<u8*>(&klic)) }, false, path, 0, &ar).first;
+		ovlm = ppu_load_overlay(ppu_exec_object{ decrypt_self(std::move(file), reinterpret_cast<u8*>(&klic)) }, false, path, offset, &ar).first;
 
 		if (!ovlm)
 		{

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -347,7 +347,7 @@ std::function<void(void*)> lv2_prx::load(utils::serial& ar)
 		{
 			u128 klic = g_fxo->get<loaded_npdrm_keys>().last_key();
 			file = make_file_view(std::move(file), offset, umax);
-			prx = ppu_load_prx(ppu_prx_object{decrypt_self(std::move(file), reinterpret_cast<u8*>(&klic))}, false, path, 0, &ar);
+			prx = ppu_load_prx(ppu_prx_object{decrypt_self(std::move(file), reinterpret_cast<u8*>(&klic))}, false, path, offset, &ar);
 			prx->m_loaded_flags = std::move(loaded_flags);
 			prx->m_external_loaded_flags = std::move(external_flags);
 

--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -390,7 +390,9 @@ void lv2_prx::save(utils::serial& ar)
 {
 	USING_SERIALIZATION_VERSION(lv2_prx_overlay);
 
-	ar(vfs::retrieve(path), offset, state);
+	const std::string vpath = vfs::retrieve(path);
+
+	ar(vpath, offset, state);
 
 	// Save segments count
 	ar.serialize_vle(segs.size());
@@ -401,10 +403,18 @@ void lv2_prx::save(utils::serial& ar)
 		ar(m_external_loaded_flags);
 	}
 
+	std::string segments;
+
 	for (const ppu_segment& seg : segs)
 	{
-		if (seg.type == 0x1u && seg.size) ar(seg.addr);
+		if (seg.type == 0x1u && seg.size)
+		{
+			fmt::append(segments, " 0x%x", seg.addr);
+			ar(seg.addr);
+		}
 	}
+
+	(vpath.empty() ? sys_prx.error : sys_prx.success)("lv2_prx::save(): vpath='%s', offset=0x%x, state=%x, segments:%s", vpath, offset, +state, segments);
 }
 
 error_code sys_prx_get_ppu_guid(ppu_thread& ppu)

--- a/rpcs3/Emu/VFS.cpp
+++ b/rpcs3/Emu/VFS.cpp
@@ -399,7 +399,7 @@ std::string vfs::retrieve(std::string_view path, const vfs_directory* node, std:
 
 		std::vector<std::string_view> mount_path_empty;
 
-		const std::string rpath = Emu.GetCallbacks().resolve_path(path);
+		const std::string rpath = Emu.GetCallbacks().resolve_path_may_not_exist(path);
 
 		if (!rpath.empty())
 		{

--- a/rpcs3/main_application.cpp
+++ b/rpcs3/main_application.cpp
@@ -399,7 +399,22 @@ EmuCallbacks main_application::CreateCallbacks()
 
 		const QString result = QDir(fi.canonicalFilePath()).filePath(tail);
 
+#ifdef _WIN32
+		std::string result_with_drive = QDir::cleanPath(result).toStdString();
+
+		if (!tail.isEmpty() && sv.starts_with("/") && !sv.starts_with("//"))
+		{
+			// Erase absolute path for non-existant path
+			if (result_with_drive.size() > 1 && result_with_drive[1] == ':')
+			{
+				result_with_drive.erase(result_with_drive.begin(), result_with_drive.begin() + 2);
+			}
+		}
+
+		return result_with_drive;
+#else
 		return QDir::cleanPath(result).toStdString();
+#endif
 	};
 
 	callbacks.get_font_dirs = []()


### PR DESCRIPTION
* Fix vfs::retrieve for ISO files, properly handle non-existant host paths.
* Fix offset saved in second sys_overlay module serialization. Fixing savestates for Metal Gear Solid 4.
* Fix a similar bug in sys_prx. Fixing savestate support for games using MSELF PRX.

Fixes https://github.com/RPCS3/rpcs3/issues/19355