### PR TITLE
Fall back to lexical normalization on canonicalization failure

### DIFF
--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -952,11 +952,20 @@ bool package_reader::fill_data(std::map<std::string, install_entry*>& all_instal
 		default:
 		{
 			// TODO: check for valid utf8 characters
-			const std::string true_path = std::filesystem::weakly_canonical(path).string();
+			std::error_code ec;
+			std::filesystem::path normalized_path = std::filesystem::weakly_canonical(path, ec);
+
+			if (ec)
+			{
+				pkg_log.warning("Failed to canonicalize package path '%s' (%s); falling back to lexical normalization.", path, ec.message());
+				normalized_path = std::filesystem::path(path).lexically_normal();
+			}
+
+			const std::string true_path = normalized_path.string();
 			if (true_path.empty())
 			{
 				num_failures++;
-				pkg_log.error("Failed to get weakly_canonical path for '%s'", path);
+				pkg_log.error("Failed to normalize package path for '%s'", path);
 				break;
 			}
 

--- a/rpcs3/Crypto/unpkg.cpp
+++ b/rpcs3/Crypto/unpkg.cpp
@@ -952,16 +952,7 @@ bool package_reader::fill_data(std::map<std::string, install_entry*>& all_instal
 		default:
 		{
 			// TODO: check for valid utf8 characters
-			std::error_code ec;
-			std::filesystem::path normalized_path = std::filesystem::weakly_canonical(path, ec);
-
-			if (ec)
-			{
-				pkg_log.warning("Failed to canonicalize package path '%s' (%s); falling back to lexical normalization.", path, ec.message());
-				normalized_path = std::filesystem::path(path).lexically_normal();
-			}
-
-			const std::string true_path = normalized_path.string();
+			const std::string true_path = std::filesystem::path(path).lexically_normal().string();
 			if (true_path.empty())
 			{
 				num_failures++;


### PR DESCRIPTION
Some filesystems, like rclone's mounts in my case, don't support canonicalization, which causes Windows to return a "no recognized filesystem" error and cause the emulator to crash. Falling back to lexical normalization allows such filesystems to be used.

LLM was used to aid in finding the issue and spitballing a solution, change was tested on both rclone mount and local filesystem with both working correctly