### PR TITLE
Qt: Don't set game window visibility on boot if resize is enabled

### DIFF
--- a/Utilities/date_time.h
+++ b/Utilities/date_time.h
@@ -47,7 +47,7 @@ namespace date_time
 
 		std::string parse_buf;
 
-		if constexpr(separator != 0)
+		if constexpr (separator != 0)
 			parse_buf = std::string("%Y") + separator + "%m" + separator + "%d" + separator + "%H" + separator + "%M" + separator + "%S";
 		else
 			parse_buf = "%Y%m%d%H%M%S";

--- a/rpcs3/rpcs3qt/gs_frame.cpp
+++ b/rpcs3/rpcs3qt/gs_frame.cpp
@@ -722,7 +722,7 @@ void gs_frame::show()
 		{
 			setVisibility(FullScreen);
 		}
-		else if (const QVariant var = m_gui_settings->GetValue(gui::gs_visibility); var.canConvert<QString>())
+		else if (const QVariant var = m_gui_settings->GetValue(gui::gs_visibility); var.canConvert<QString>() && !m_gui_settings->GetValue(gui::gs_resize).toBool())
 		{
 			// Restore saved visibility from last time. Make sure not to hide the window, or the user can't access it anymore.
 			if (const Visibility visibility = gui::string_to_visibility(var.value<QString>()); visibility != Visibility::Hidden)


### PR DESCRIPTION
- Don't set game window visibility on boot if "Resize game window on boot" is enabled
Setting the visibility will cause the window to be maximized or fullscreen even though we want a specific window size.

Fixes #19372