### PR TITLE
[Mac OS X] Fix sys_ss_random_number_generator & cleanup some dead code

### DIFF
--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1234,7 +1234,7 @@ bool fs::is_optical_raw_device(const std::string& path)
 #if defined(__APPLE__)
 	// On Mac OS X optical disks will only ever be mounted under /dev/disk(whatever), similar for raw devices,
 	// so reject anything not containing the disk string.
-	if (!path.contains("disk"))
+	if (!path.starts_with("/dev/disk") && !path.starts_with("/dev/rdisk"))
 	{
 		return false;
 	}

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1230,6 +1230,15 @@ bool fs::is_optical_raw_device(const std::string& path)
 	{
 		return false;
 	}
+	
+#if defined(__APPLE__)
+	// On Mac OS X optical disks will only ever be mounted under /dev/disk(whatever), similar for raw devices,
+	// so reject anything not containing the disk string.
+	if (!path.contains("disk"))
+	{
+		return false;
+	}
+#endif
 
 	struct ::stat file_info;
 

--- a/Utilities/File.cpp
+++ b/Utilities/File.cpp
@@ -1225,21 +1225,20 @@ bool fs::is_optical_raw_device(const std::string& path)
 
 	return false;
 #else
-	// Skip a useless check if the path cannot point to a device node (device nodes always live in "/dev")
-	if (!path.starts_with("/dev/"))
-	{
-		return false;
-	}
-	
-#if defined(__APPLE__)
+#ifdef __APPLE__
 	// On Mac OS X optical disks will only ever be mounted under /dev/disk(whatever), similar for raw devices,
 	// so reject anything not containing the disk string.
 	if (!path.starts_with("/dev/disk") && !path.starts_with("/dev/rdisk"))
 	{
 		return false;
 	}
+#else
+	// Skip a useless check if the path cannot point to a device node (device nodes always live in "/dev")
+	if (!path.starts_with("/dev/"))
+	{
+		return false;
+	}
 #endif
-
 	struct ::stat file_info;
 
 	if (::stat(path.c_str(), &file_info) != 0)

--- a/rpcs3/rpcs3.cpp
+++ b/rpcs3/rpcs3.cpp
@@ -655,14 +655,6 @@ int run_rpcs3(int argc, char** argv)
 	}
 #endif
 
-#if defined(__APPLE__) && defined(__x86_64__)
-	if (const utils::OS_version os = utils::get_OS_version();
-		os.version_major == 14 && os.version_minor < 3 && (utils::get_cpu_brand().rfind("VirtualApple", 0) == 0))
-	{
-		report_fatal_error(fmt::format("RPCS3 requires macOS 14.3.0 or later.\nYou're currently using macOS %i.%i.%i.\nPlease update macOS from System Settings.\n\n", os.version_major, os.version_minor, os.version_patch));
-	}
-#endif
-
 	ensure(thread_ctrl::is_main(), "Not main thread");
 
 	// Initialize thread pool finalizer (on first use)


### PR DESCRIPTION
Fixes #19381, ignored OP's AI generated comment and had a look myself since VSH also exhibits the same issue (if it didn't, I'd have been worried as honestly I'd think VSH is the #1 user of random number generation 😂), seems to just be a case of very loose detection of what classes as an optical disk on Mac OS X, I've checked online and everything suggests they're only ever mounted as /dev/disk (and /dev/rdisk respectively for the raw device) so a check for "disk" should be enough to fix this up. (Also cleaned up a dead line of code in rpcs3.cpp too relating to unsupported Mac OS X versions, too minor to be worth doing elsewhere).