### PR TITLE
Reject overflowing savestate collection counts

### DIFF
--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -209,6 +209,9 @@ public:
 		template <typename T> requires Integral<T>
 		bool deserialize_vle(T& value)
 		{
+			using unsigned_type = std::make_unsigned_t<T>;
+			unsigned_type result{};
+			constexpr u32 bit_width = sizeof(T) * 8;
 			value = {};
 
 			for (u32 i = 0;; i += 7)
@@ -220,11 +223,24 @@ public:
 					return false;
 				}
 
-				value |= static_cast<T>(byte_data % 0x80) << i;
+				const unsigned_type payload = static_cast<unsigned_type>(byte_data % 0x80);
+
+				if (i >= bit_width || payload > (~unsigned_type{} >> i))
+				{
+					return false;
+				}
+
+				result |= payload << i;
 
 				if (!(byte_data & 0x80))
 				{
+					value = static_cast<T>(result);
 					break;
+				}
+
+				if (i > bit_width - 7)
+				{
+					return false;
 				}
 			}
 
@@ -297,7 +313,14 @@ public:
 
 			if constexpr (Bitcopy<typename T::value_type>)
 			{
-				if (!raw_serialize([&](){ obj.resize(size); return obj.data(); }, sizeof(obj[0]) * size))
+				if (size > static_cast<usz>(umax) / sizeof(obj[0]))
+				{
+					return false;
+				}
+
+				const usz data_size = sizeof(obj[0]) * size;
+
+				if (!raw_serialize([&](){ obj.resize(size); return obj.data(); }, data_size))
 				{
 					obj.clear();
 					return false;


### PR DESCRIPTION
The savestate compatibility check trusts the collection length encoded in the file. For bitwise-serializable vectors, the length is multiplied by the element size before reading the data. That multiplication can wrap, allowing a small input to pass the read check and then trigger an enormous vector resize.

This adds checked VLE decoding and rejects collection sizes whose serialized byte count cannot be represented. Normal savestates retain the existing format, while truncated or oversized data is rejected.