### PR TITLE
Big picture: fix crashes and unwanted exit

### DIFF
--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture.cpp
@@ -84,6 +84,7 @@ namespace rsx
 				break;
 			}
 
+			const bool main_menu_is_current_page = m_main_menu.is_current_page;
 			const page_navigation navigation = m_main_menu.handle_button_press(button_press, is_auto_repeat, m_auto_repeat_ms_interval);
 
 			switch (navigation)
@@ -110,6 +111,12 @@ namespace rsx
 			}
 			case page_navigation::exit:
 			{
+				// Don't exit if circle was pressed in the main menu
+				if (main_menu_is_current_page && button_press == pad_button::circle)
+				{
+					break;
+				}
+
 				// Don't call close() synchronously from the input thread - just like the pause menu's own
 				// "Exit Game", tearing down the shell on the main thread takes this dialog down as a side effect.
 				g_big_picture_mode_active = false;

--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
@@ -322,12 +322,8 @@ namespace rsx
 				if (button_press == pad_button::circle)
 				{
 					play_sound(sound_effect::cancel);
-					if (parent)
-					{
-						set_current_page(parent);
-						return page_navigation::back;
-					}
-					return page_navigation::exit;
+					set_current_page(ensure(parent));
+					return page_navigation::back;
 				}
 
 				return page_navigation::stay;
@@ -372,12 +368,8 @@ namespace rsx
 				return page_navigation::stay;
 			case pad_button::circle:
 				play_sound(sound_effect::cancel);
-				if (parent)
-				{
-					set_current_page(parent);
-					return page_navigation::back;
-				}
-				return page_navigation::exit;
+				set_current_page(ensure(parent));
+				return page_navigation::back;
 			default:
 				return page_navigation::stay;
 			}

--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.cpp
@@ -161,7 +161,7 @@ namespace rsx
 
 		void big_picture_game_grid::finish_reload(std::vector<std::unique_ptr<big_picture_game_tile>>&& tiles)
 		{
-			std::lock_guard lock(m_reload_mutex);
+			std::lock_guard lock(m_mutex);
 
 			if (thread_ctrl::state() == thread_state::aborting)
 			{
@@ -280,6 +280,8 @@ namespace rsx
 
 		page_navigation big_picture_game_grid::handle_button_press(pad_button button_press, bool is_auto_repeat, u64 auto_repeat_interval_ms)
 		{
+			std::lock_guard lock(m_mutex);
+
 			if (m_loading) return page_navigation::stay;
 
 			const bool do_play_sound = !is_auto_repeat || auto_repeat_interval_ms >= user_interface::m_auto_repeat_ms_interval_default;
@@ -384,7 +386,7 @@ namespace rsx
 
 		compiled_resource& big_picture_game_grid::get_compiled()
 		{
-			std::lock_guard lock(m_reload_mutex);
+			std::lock_guard lock(m_mutex);
 
 			if (!m_highlight->is_compiled() ||
 				(!m_tiles.empty() && m_grid && !m_grid->is_compiled()) ||

--- a/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.h
+++ b/rpcs3/Emu/RSX/Overlays/BigPicture/overlay_big_picture_game_grid.h
@@ -52,7 +52,7 @@ namespace rsx
 			static constexpr u16 m_columns = 5;
 			static constexpr u16 m_tile_size = 200;
 
-			std::mutex m_reload_mutex;
+			std::mutex m_mutex;
 			std::unique_ptr<named_thread<std::function<void()>>> m_game_enumeration_thread;
 
 			game_enumeration<big_picture_game_info> m_game_enumeration;

--- a/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
+++ b/rpcs3/Emu/RSX/Overlays/overlay_manager.cpp
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "overlay_manager.h"
-#include "Emu/System.h"
 #include <util/asm.hpp>
 
 namespace rsx

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -943,6 +943,8 @@ bool Emulator::BootRsxCapture(const std::string& path)
 	GetCallbacks().on_ready();
 
 	GetCallbacks().init_gs_render(nullptr);
+	GetCallbacks().init_kb_handler();
+	GetCallbacks().init_mouse_handler();
 	GetCallbacks().init_pad_handler("");
 
 	GetCallbacks().on_run(false);
@@ -1001,6 +1003,8 @@ bool Emulator::BootBigPictureMode()
 	GetCallbacks().on_ready();
 
 	GetCallbacks().init_gs_render(nullptr);
+	GetCallbacks().init_kb_handler();
+	GetCallbacks().init_mouse_handler();
 	GetCallbacks().init_pad_handler("");
 
 	GetCallbacks().on_run(false);


### PR DESCRIPTION
- Initialize missing input handlers
We need to init the input handlers, otherwise we have a chance to crash when the fxo is used in some input loop.
This is easily observed on opengl, where we probably handle threading a bit differently.

- Do not exit big picture with circle button
This is the default behavior of the home_menu_page, which was only intended for use during gameplay originally.
We also expect the game grid to have a parent.

- Add lock to handle_button_press
We don't want to change UI elements while we are compiling.