### PR TITLE
Reject overflowing ELF section ranges

### DIFF
--- a/rpcs3/Loader/ELF.h
+++ b/rpcs3/Loader/ELF.h
@@ -373,7 +373,9 @@ public:
 					// Try to find it in phdr data instead of allocating new section
 					p_index++;
 
-					if (hdr.p_offset <= shdr.sh_offset && shdr.sh_offset + shdr.sh_size <= hdr.p_offset + hdr.p_filesz)
+					if (hdr.p_offset <= shdr.sh_offset &&
+						shdr.sh_size <= hdr.p_filesz &&
+						shdr.sh_offset - hdr.p_offset <= hdr.p_filesz - shdr.sh_size)
 					{
 						const auto& prog = ::at32(progs, p_index);
 						shdrs.back().bin_view = {prog.bin.data() + shdr.sh_offset - hdr.p_offset, shdr.sh_size};
@@ -469,7 +471,9 @@ public:
 					p_index++;
 
 					// Rely on previous sh_offset value!
-					if (hdr.p_offset <= shdr.sh_offset && shdr.sh_offset + shdr.sh_size - 1 <= hdr.p_offset + hdr.p_filesz - 1)
+					if (hdr.p_offset <= shdr.sh_offset &&
+						shdr.sh_size <= hdr.p_filesz &&
+						shdr.sh_offset - hdr.p_offset <= hdr.p_filesz - shdr.sh_size)
 					{
 						out.sh_offset = ::narrow<sz_t>(data_base + static_cast<usz>(shdr.sh_offset - hdr.p_offset));
 						result = true;


### PR DESCRIPTION
When RPCS3 loads an ELF, `elf::load` tries to reuse data already read for each loadable section by creating `bin_view` into the matching program-header buffer. The range check adds attacker-controlled section offsets and sizes to segment bounds, so integer wraparound can make an invalid section appear to fit. Callers such as `ppu_load_rel_exec` later copy that view into emulated memory, causing a host out-of-bounds read for a malformed ELF.

Replace the checks in both the load and save paths with subtraction-based bounds checks. These verify that the section size fits in the segment and that its offset remains within the available segment bytes without overflowing.