### PR TITLE
Validate SCE metadata header sizes

### DIFF
--- a/rpcs3/Crypto/unself.cpp
+++ b/rpcs3/Crypto/unself.cpp
@@ -627,7 +627,20 @@ bool SCEDecrypter::LoadMetadata(const u8 erk[32], const u8 riv[16])
 {
 	aes_context aes;
 	std::vector<u8> metadata_info(sizeof(meta_info));
-	std::vector<u8> metadata_headers(sce_hdr.se_hsize - (sizeof(sce_hdr) + sce_hdr.se_meta + sizeof(meta_info)));
+	constexpr usz sizeof_meta_and_header = sizeof(meta_info) + sizeof(sce_hdr);
+	const usz metadata_offset = static_cast<usz>(sce_hdr.se_meta);
+
+	if (metadata_offset > usz{umax} - sizeof_meta_and_header ||
+		sce_hdr.se_hsize < sizeof_meta_and_header + metadata_offset ||
+		sce_hdr.se_hsize - (sizeof_meta_and_header + metadata_offset) < sizeof(meta_hdr) ||
+		sce_hdr.se_hsize > sce_f.size())
+	{
+		self_log.error("Invalid SCE metadata header size!");
+		return false;
+	}
+
+	const usz metadata_headers_offset = sizeof_meta_and_header + metadata_offset;
+	std::vector<u8> metadata_headers(sce_hdr.se_hsize - metadata_headers_offset);
 
 	// Locate and read the encrypted metadata info.
 	sce_f.seek(sce_hdr.se_meta + sizeof(sce_hdr));
@@ -1123,7 +1136,20 @@ bool SELFDecrypter::LoadMetadata(const u8* klic_key)
 {
 	aes_context aes;
 	std::vector<u8> metadata_info(sizeof(meta_info));
-	std::vector<u8> metadata_headers(sce_hdr.se_hsize - (sizeof(sce_hdr) + sce_hdr.se_meta + sizeof(meta_info)));
+	constexpr usz sizeof_meta_and_header = sizeof(meta_info) + sizeof(sce_hdr);
+	const usz metadata_offset = static_cast<usz>(sce_hdr.se_meta);
+
+	if (metadata_offset > usz{umax} - sizeof_meta_and_header ||
+		sce_hdr.se_hsize < sizeof_meta_and_header + metadata_offset ||
+		sce_hdr.se_hsize - (sizeof_meta_and_header + metadata_offset) < sizeof(meta_hdr) ||
+		sce_hdr.se_hsize > self_f.size())
+	{
+		self_log.error("Invalid SELF metadata header size!");
+		return false;
+	}
+
+	const usz metadata_headers_offset = sizeof_meta_and_header + metadata_offset;
+	std::vector<u8> metadata_headers(sce_hdr.se_hsize - metadata_headers_offset);
 
 	// Locate and read the encrypted metadata info.
 	self_f.seek(sce_hdr.se_meta + sizeof(sce_hdr));


### PR DESCRIPTION
When RPCS3 processes a SCE/SELF file, `SCEDecrypter::LoadMetadata` and `SELFDecrypter::LoadMetadata` read the encrypted metadata info and calculate the remaining metadata-header size from `se_hsize` and `se_meta`. Those values come from the file header, and the unsigned subtraction happens before validation. A malformed header can therefore turn a too-small `se_hsize` into a near-maximum vector allocation, aborting file processing before decryption and extraction complete.

Validate the fixed metadata prefix, require room for `MetadataHeader`, and ensure `se_hsize` stays within the backing file before allocating. Apply the same guard in both metadata readers.