### PR TITLE
SaveStates: Reject unrealistic memory allocations

### DIFF
--- a/rpcs3/Emu/Cell/lv2/sys_prx.cpp
+++ b/rpcs3/Emu/Cell/lv2/sys_prx.cpp
@@ -324,7 +324,7 @@ std::function<void(void*)> lv2_prx::load(utils::serial& ar)
 	const u32 state{ar};
 
 	usz seg_count = 0;
-	ar.deserialize_vle(seg_count);
+	ar.deserialize_vle<9>(seg_count);
 
 	shared_ptr<lv2_prx> prx;
 

--- a/rpcs3/util/serialization.hpp
+++ b/rpcs3/util/serialization.hpp
@@ -206,12 +206,12 @@ public:
 			return true;
 		}
 
-		template <typename T> requires Integral<T>
+		template <uint MaxBits = 0, typename T> requires Integral<T> && (MaxBits <= sizeof(T) * 8)
 		bool deserialize_vle(T& value)
 		{
 			using unsigned_type = std::make_unsigned_t<T>;
 			unsigned_type result{};
-			constexpr u32 bit_width = sizeof(T) * 8;
+			constexpr u32 bit_width = MaxBits ? sizeof(T) * 8 : MaxBits;
 			value = {};
 
 			for (u32 i = 0;; i += 7)
@@ -306,7 +306,7 @@ public:
 			}
 
 			usz size = 0;
-			if (!deserialize_vle(size))
+			if (!deserialize_vle<28>(size))
 			{
 				return false;
 			}
@@ -423,7 +423,7 @@ public:
 			}
 
 			usz size = 0;
-			if (!deserialize_vle(size))
+			if (!deserialize_vle<28>(size))
 			{
 				return false;
 			}


### PR DESCRIPTION
Continuation of https://github.com/RPCS3/rpcs3/pull/19386
While protection against overflow has been added, protection against false (due to corruption) allocations which can cause RAM shortage can still happen.
This affects the loading stage of savestates, where the size of arrays is loaded from the file.
I have limited dynamic allocations to be 256MB at maximum which correlates to the maximum PS3 memory single allocation size.
Even that is unrealistic 99% of the time, but it protects against RPCS3 crashing due to memory bottlenecking until the FXO verifications tell us that indeed there is corruption and stop deserialization altogether before anything bad happens.
Unique limits to each dynamic container deserialization call may be added in the future.