### PR TITLE
Bound Clans member attribute encoding

### DIFF
--- a/rpcs3/Emu/NP/clans_client.cpp
+++ b/rpcs3/Emu/NP/clans_client.cpp
@@ -923,11 +923,14 @@ namespace clan
 
 		pugi::xml_node status = clan.append_child("bin-attr1"sv);
 
-		byte bin_attr_1[SCE_NP_CLANS_MEMBER_BINARY_ATTRIBUTE1_MAX_SIZE * 2 + 1] = {0};
-		uint32_t bin_attr_1_size = UINT32_MAX;
-		Base64_Encode_NoNl(info.binAttr1, info.binData1Size, bin_attr_1, &bin_attr_1_size);
+		const u32 bin_data_size = static_cast<u32>(info.binData1Size);
+		if (bin_data_size > sizeof(info.binAttr1))
+			return SCE_NP_CLANS_ERROR_INVALID_ARGUMENT;
 
-		if (bin_attr_1_size == UINT32_MAX)
+		byte bin_attr_1[SCE_NP_CLANS_MEMBER_BINARY_ATTRIBUTE1_MAX_SIZE * 2 + 1] = {0};
+		uint32_t bin_attr_1_size = sizeof(bin_attr_1);
+
+		if (Base64_Encode_NoNl(info.binAttr1, bin_data_size, bin_attr_1, &bin_attr_1_size) != 0)
 			return SCE_NP_CLANS_ERROR_INVALID_ARGUMENT;
 
 		// `reinterpret_cast` used to let the compiler select the correct overload of `set`


### PR DESCRIPTION
When the Clans client handles `sceNpClansUpdateMemberInfo`, `clans_client::update_member_info` Base64-encodes the guest-provided `binAttr1` using `binData1Size`. `binAttr1` is a fixed 16-byte array, but the size was passed through unchecked and the output capacity was set to `UINT32_MAX`. A guest can provide a larger length, causing WolfSSL to read beyond the fixed attribute and write past the 33-byte stack buffer.

Reject sizes larger than `binAttr1` before encoding and pass the actual output-buffer capacity to WolfSSL. Encoding failures are returned as invalid arguments.