### PR TITLE
fix: check ticket encoded correctly

### DIFF
--- a/rpcs3/Emu/NP/clans_client.cpp
+++ b/rpcs3/Emu/NP/clans_client.cpp
@@ -30,7 +30,6 @@
 
 LOG_CHANNEL(clan_log, "clans");
 
-
 const char* REQ_TYPE_FUNC = "func";
 const char* REQ_TYPE_SEC = "sec";
 
@@ -128,6 +127,11 @@ void fmt_class_string<clan::ClanRequestAction>::format(std::string& out, u64 arg
 
 namespace clan
 {
+	constexpr size_t base64_size(size_t size)
+	{
+		return (size + 2) / 3 * 4 + 1;
+	}
+
 	size_t clans_client::curl_write_callback(void* data, size_t size, size_t nmemb, void* clientp)
 	{
 		const size_t realsize = size * nmemb;
@@ -341,11 +345,16 @@ namespace clan
 			return "";
 		}
 
-		std::vector<byte> ticket_bytes(1024);
-		uint32_t ticket_size = UINT32_MAX;
+		std::vector<byte> ticket_bytes(base64_size(clan_ticket.size()));
+		uint32_t encoded_ticket_size = ::size32(ticket_bytes);
 
-		Base64_Encode_NoNl(clan_ticket.data(), static_cast<u32>(clan_ticket.size()), ticket_bytes.data(), &ticket_size);
-		const std::string ticket_str = std::string(reinterpret_cast<char*>(ticket_bytes.data()), ticket_size);
+		if (Base64_Encode_NoNl(clan_ticket.data(), ::size32(clan_ticket), ticket_bytes.data(), &encoded_ticket_size) != 0)
+		{
+			clan_log.error("Failed to encode clan ticket to base64");
+			return "";
+		}
+
+		const std::string ticket_str = std::string(reinterpret_cast<char*>(ticket_bytes.data()), encoded_ticket_size);
 
 		return ticket_str;
 	}


### PR DESCRIPTION
Used a static buffer size and didn't verify it encoded properly.