### PR TITLE
Add IRD based integrity check

### DIFF
--- a/rpcs3/Emu/CMakeLists.txt
+++ b/rpcs3/Emu/CMakeLists.txt
@@ -137,6 +137,7 @@ target_sources(rpcs3_emu PRIVATE
     ../Loader/PSF.cpp
     ../Loader/PUP.cpp
     ../Loader/TAR.cpp
+    ../Loader/IRD.cpp
     ../Loader/ISO.cpp
     ../Loader/iso_cache.cpp
     ../Loader/content_validation.cpp

--- a/rpcs3/Emu/system_utils.hpp
+++ b/rpcs3/Emu/system_utils.hpp
@@ -2,6 +2,7 @@
 
 #include "util/types.hpp"
 #include <string>
+#include <string_view>
 #include <set>
 #include <vector>
 
@@ -79,6 +80,13 @@ namespace rpcs3::utils
 	std::string get_rap_file_path(const std::string_view& rap);
 	bool verify_c00_unlock_edat(const std::string_view& content_id, bool fast = false);
 	std::string get_sfo_dir_from_game_path(const std::string& game_path, const std::string& title_id = "");
+
+	// Check whether "name" is the name of an additional disc game directory (e.g. "PS3_GM01"), the counterpart of "PS3_GAME".
+	// NOTE: equivalent to the "^PS3_GM[[:digit:]]{2}$" regular expression, without building one for each checked name
+	inline bool is_ps3_gm_dir_name(std::string_view name)
+	{
+		return name.size() == 8 && name.starts_with("PS3_GM") && name[6] >= '0' && name[6] <= '9' && name[7] >= '0' && name[7] <= '9';
+	}
 
 	std::string get_custom_config_dir();
 	std::string get_custom_config_path(const std::string& identifier);

--- a/rpcs3/Loader/IRD.cpp
+++ b/rpcs3/Loader/IRD.cpp
@@ -1,0 +1,453 @@
+#include "stdafx.h"
+
+#include "IRD.h"
+#include "ISO.h"
+
+#include "Crypto/utils.h"
+#include "Utilities/File.h"
+
+#include <zlib.h>
+
+LOG_CHANNEL(ird_log, "IRD");
+
+// Magic every IRD file begins with, once uncompressed
+static constexpr std::array<u8, 4> s_ird_magic = {'3', 'I', 'R', 'D'};
+
+static constexpr u8 s_ird_min_version = 6;
+static constexpr u8 s_ird_max_version = 9;
+
+namespace
+{
+	// Little endian cursor over the uncompressed IRD data: every read is bounds checked, so a truncated file
+	// stops the parsing instead of running past the end of the buffer
+	struct ird_reader
+	{
+		const std::vector<u8>& data;
+		usz pos = 0;
+		bool error = false;
+
+		bool has_room(usz size)
+		{
+			if (error || pos + size > data.size())
+			{
+				error = true;
+				return false;
+			}
+
+			return true;
+		}
+
+		template <typename T>
+		T read()
+		{
+			le_t<T> value{};
+
+			if (!has_room(sizeof(T)))
+			{
+				return value;
+			}
+
+			std::memcpy(&value, data.data() + pos, sizeof(T));
+			pos += sizeof(T);
+
+			return value;
+		}
+
+		// The bytes right where they lie in the buffer, for whatever is read once and not kept
+		const u8* read_ptr(usz size)
+		{
+			if (!has_room(size))
+			{
+				return nullptr;
+			}
+
+			const u8* value = data.data() + pos;
+			pos += size;
+
+			return value;
+		}
+
+		std::vector<u8> read_bytes(usz size)
+		{
+			if (!has_room(size))
+			{
+				return {};
+			}
+
+			std::vector<u8> value(data.begin() + pos, data.begin() + pos + size);
+			pos += size;
+
+			return value;
+		}
+
+		// Fixed size string, stripped of the padding the dumping tools leave in it
+		std::string read_string(usz size)
+		{
+			if (!has_room(size))
+			{
+				return {};
+			}
+
+			std::string value(reinterpret_cast<const char*>(data.data() + pos), size);
+			pos += size;
+
+			while (!value.empty() && (value.back() == '\0' || value.back() == ' '))
+			{
+				value.pop_back();
+			}
+
+			return value;
+		}
+
+		// Length prefixed string, as it is written by ".NET BinaryWriter": the length comes as a 7 bit encoded
+		// integer (7 bits of payload per byte, the 8th bit telling whether another byte follows)
+		std::string read_prefixed_string()
+		{
+			usz size = 0;
+
+			for (u32 shift = 0; shift < 32; shift += 7)
+			{
+				const u8 byte = read<u8>();
+
+				if (error)
+				{
+					return {};
+				}
+
+				size |= static_cast<usz>(byte & 0x7f) << shift;
+
+				if (!(byte & 0x80))
+				{
+					break;
+				}
+			}
+
+			if (!has_room(size))
+			{
+				return {};
+			}
+
+			std::string value(reinterpret_cast<const char*>(data.data() + pos), size);
+			pos += size;
+
+			return value;
+		}
+
+		void skip(usz size)
+		{
+			if (has_room(size))
+			{
+				pos += size;
+			}
+		}
+	};
+} // namespace
+
+// Decompresses one gzip member, and stops right at the end of it.
+// NOTE: the shared "unzip()" helper is deliberately not used here. It keeps inflating while there is input left,
+//       and an IRD file can carry padding past the end of its gzip stream (some writers leave a block of 0x10
+//       bytes behind): on one of those, inflate reports the end of the stream over and over without ever
+//       consuming that tail, and the helper grows its output buffer forever
+static std::vector<u8> ird_ungzip(const std::vector<u8>& data)
+{
+	// A gzip member is never shorter than its header plus its trailer
+	if (data.size() < 18)
+	{
+		return {};
+	}
+
+	std::vector<u8> out(std::max<usz>(data.size() * 6, 0x10000));
+
+	z_stream zs{};
+
+	if (::inflateInit2(&zs, 16 + 15) != Z_OK)
+	{
+		return {};
+	}
+
+	zs.avail_in = ::narrow<uInt>(data.size());
+	zs.next_in = const_cast<u8*>(data.data());
+	zs.avail_out = ::narrow<uInt>(out.size());
+	zs.next_out = out.data();
+
+	for (int res = Z_OK; res != Z_STREAM_END;)
+	{
+		res = ::inflate(&zs, Z_NO_FLUSH);
+
+		if (res == Z_STREAM_END)
+		{
+			break;
+		}
+
+		// Either the input ran out before the end of the stream (i.e. it is truncated) or inflate itself gave up
+		if ((res != Z_OK && res != Z_BUF_ERROR) || zs.avail_in == 0 || zs.avail_out != 0)
+		{
+			::inflateEnd(&zs);
+			return {};
+		}
+
+		// Only the output ran out: make room and go on
+		const usz written = zs.next_out - out.data();
+
+		out.resize(out.size() + 0x100000);
+
+		zs.next_out = out.data() + written;
+		zs.avail_out = ::narrow<uInt>(out.size() - written);
+	}
+
+	out.resize(zs.next_out - out.data());
+
+	::inflateEnd(&zs);
+
+	return out;
+}
+
+// Flattens the file system tree the ISO header describes, pairing every file with the MD5 hash the IRD holds
+// for the sector the file starts at
+static void ird_flatten_tree(const iso_fs_node& node, const std::string& parent_path, const std::map<u64, std::string>& hashes, std::vector<ird_file_entry>& files)
+{
+	for (const auto& child : node.children)
+	{
+		const iso_fs_metadata& meta = child->metadata;
+
+		if (meta.name == "." || meta.name == "..")
+		{
+			continue;
+		}
+
+		const std::string path = parent_path + "/" + meta.name;
+
+		if (meta.is_directory)
+		{
+			ird_flatten_tree(*child, path, hashes, files);
+			continue;
+		}
+
+		if (meta.extents.empty())
+		{
+			continue;
+		}
+
+		const u64 sector = ::at32(meta.extents, 0).start;
+		const auto hash = hashes.find(sector);
+
+		files.push_back(ird_file_entry
+		{
+			.path = path,
+			.size = meta.size(),
+			.sector = sector,
+			.md5 = hash == hashes.cend() ? std::string{} : hash->second
+		});
+	}
+}
+
+ird_file::ird_file(const std::string& path)
+{
+	m_path = path;
+
+	const fs::file file(path);
+
+	if (!file)
+	{
+		ird_log.error("ird_file: Failed to open file: '%s'", path);
+		m_status = ird_parse_status::ERROR_OPENING_FILE;
+		return;
+	}
+
+	const std::vector<u8> raw = file.to_vector<u8>();
+
+	if (raw.size() < s_ird_magic.size())
+	{
+		ird_log.error("ird_file: File too small to be an IRD: '%s'", path);
+		m_status = ird_parse_status::ERROR_NOT_AN_IRD;
+		return;
+	}
+
+	// An IRD file is normally gzipped: only a file already exposing the magic is read as-is
+	if (std::memcmp(raw.data(), s_ird_magic.data(), s_ird_magic.size()) == 0)
+	{
+		m_status = parse(raw);
+	}
+	else
+	{
+		const std::vector<u8> data = ird_ungzip(raw);
+
+		if (data.size() < s_ird_magic.size())
+		{
+			ird_log.error("ird_file: Failed to decompress file: '%s'", path);
+			m_status = ird_parse_status::ERROR_NOT_AN_IRD;
+			return;
+		}
+
+		m_status = parse(data);
+	}
+
+	if (m_status == ird_parse_status::OK)
+	{
+		ird_log.notice("ird_file: Loaded IRD v%d for '%s' (%s): %d files, CRC32 %s", m_version, m_game_id, m_game_name,
+			m_files.size(), m_crc_valid ? "valid" : "invalid");
+	}
+}
+
+ird_parse_status ird_file::parse(const std::vector<u8>& data)
+{
+	ird_reader reader{data};
+
+	if (const std::vector<u8> magic = reader.read_bytes(s_ird_magic.size());
+		magic.size() != s_ird_magic.size() || std::memcmp(magic.data(), s_ird_magic.data(), s_ird_magic.size()) != 0)
+	{
+		ird_log.error("ird_file: Wrong magic on file: '%s'", m_path);
+		return ird_parse_status::ERROR_NOT_AN_IRD;
+	}
+
+	m_version = reader.read<u8>();
+
+	if (m_version < s_ird_min_version || m_version > s_ird_max_version)
+	{
+		ird_log.error("ird_file: Unsupported IRD version %d on file: '%s'", m_version, m_path);
+		return ird_parse_status::ERROR_BAD_VERSION;
+	}
+
+	m_game_id = reader.read_string(9);
+	m_game_name = reader.read_prefixed_string();
+	m_update_version = reader.read_string(4);
+	m_game_version = reader.read_string(5);
+	m_app_version = reader.read_string(5);
+
+	if (m_version == 7)
+	{
+		// Version 7 only: an extra id nothing else refers to
+		reader.skip(4);
+	}
+
+	// The ISO header (the ECMA-119 structures the disc begins with) and the ISO footer, both gzipped
+	const u32 header_size = reader.read<u32>();
+	const std::vector<u8> header_data = reader.read_bytes(header_size);
+	const std::vector<u8> header = ird_ungzip(header_data);
+	const u32 footer_size = reader.read<u32>();
+	reader.skip(footer_size); // The footer holds no data the validation needs
+
+	// The gzip trailer of a block tells how big its content is: a header decompressed short would silently turn
+	// the files it does not reach any more into missing ones, so it is caught right here
+	if (header_size >= 4 && header.size() != read_from_ptr<le_t<u32>>(header_data, header_size - 4))
+	{
+		ird_log.error("ird_file: Failed to decompress the ISO header of file: '%s'", m_path);
+		return ird_parse_status::ERROR_TRUNCATED;
+	}
+
+	// MD5 hash of each encrypted region of the disc: not needed to validate a JB folder, whose files are always
+	// decrypted, but it has to be walked over to reach the file hashes
+	reader.skip(reader.read<u8>() * 16ull);
+
+	const u32 file_count = reader.read<u32>();
+
+	if (reader.error)
+	{
+		ird_log.error("ird_file: Truncated file: '%s'", m_path);
+		return ird_parse_status::ERROR_TRUNCATED;
+	}
+
+	// MD5 hash of each file of the disc, keyed by the sector the file starts at
+	std::map<u64, std::string> hashes;
+
+	for (u32 i = 0; i < file_count; i++)
+	{
+		const u64 sector = reader.read<u64>();
+		const u8* hash = reader.read_ptr(16);
+
+		if (!hash)
+		{
+			ird_log.error("ird_file: Truncated file hash table: '%s'", m_path);
+			return ird_parse_status::ERROR_TRUNCATED;
+		}
+
+		bytes_to_hex(hashes[sector], hash, 16);
+	}
+
+	reader.skip(4); // Extra config and attachments (both unused)
+
+	if (m_version >= 9)
+	{
+		reader.skip(115); // PIC
+	}
+
+	// "Data1" is the D1 of the disc (i.e. the key material), "Data2" its D2
+	if (const std::vector<u8> data = reader.read_bytes(32); data.size() == 32)
+	{
+		std::memcpy(m_disc_key.data(), data.data(), m_disc_key.size());
+		std::memcpy(m_disc_id.data(), data.data() + m_disc_key.size(), m_disc_id.size());
+	}
+
+	if (m_version < 9)
+	{
+		reader.skip(115); // PIC (up to version 8 it comes after the keys)
+	}
+
+	if (m_version > 7)
+	{
+		reader.skip(4); // Unique identifier
+	}
+
+	const usz crc_pos = reader.pos;
+	const u32 crc = reader.read<u32>();
+
+	if (reader.error)
+	{
+		ird_log.error("ird_file: Truncated file: '%s'", m_path);
+		return ird_parse_status::ERROR_TRUNCATED;
+	}
+
+	m_crc_valid = crc == ::crc32(::crc32(0, nullptr, 0), data.data(), ::narrow<uInt>(crc_pos));
+
+	if (!m_crc_valid)
+	{
+		// A wrong CRC32 does not make the hashes unusable, so the parsing goes on: it is just reported
+		ird_log.warning("ird_file: Wrong CRC32 on file: '%s'", m_path);
+	}
+
+	if (!parse_iso_header(header, hashes))
+	{
+		return ird_parse_status::ERROR_PARSING_HEADER;
+	}
+
+	return ird_parse_status::OK;
+}
+
+bool ird_file::parse_iso_header(const std::vector<u8>& header, const std::map<u64, std::string>& hashes)
+{
+	if (header.empty())
+	{
+		ird_log.error("ird_file: Empty ISO header on file: '%s'", m_path);
+		return false;
+	}
+
+	// The header holds the ECMA-119 structures at the very same sectors they lie at on the disc, so the ISO file
+	// system parser can walk it as if it were the disc itself
+	fs::file stream = fs::make_stream<std::vector<u8>>(std::vector<u8>(header));
+	iso_fs_node root{};
+
+	if (!iso_parse_file_system(stream, root, m_path))
+	{
+		return false;
+	}
+
+	m_files.reserve(hashes.size());
+
+	ird_flatten_tree(root, "", hashes, m_files);
+
+	if (m_files.empty())
+	{
+		ird_log.error("ird_file: No file found on the ISO header of file: '%s'", m_path);
+		return false;
+	}
+
+	// Report the files in the order they lie on the disc, the way the dumping tools list them
+	std::sort(m_files.begin(), m_files.end(), [](const ird_file_entry& lhs, const ird_file_entry& rhs)
+	{
+		return lhs.sector < rhs.sector;
+	});
+
+	m_disc_size = m_files.back().sector * ISO_SECTOR_SIZE + m_files.back().size;
+
+	return true;
+}

--- a/rpcs3/Loader/IRD.h
+++ b/rpcs3/Loader/IRD.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "util/types.hpp"
+
+#include <array>
+#include <map>
+#include <string>
+#include <vector>
+
+// One file of the disc file system described by an IRD file
+struct ird_file_entry
+{
+	std::string path; // Path of the file inside the disc, '/' delimited (e.g. "/PS3_GAME/USRDIR/EBOOT.BIN")
+	u64 size = 0;     // Size of the file in bytes (sum of every extent it spans)
+	u64 sector = 0;   // First data sector of the file (it is the key of the MD5 table stored in the IRD)
+	std::string md5;  // MD5 hash (lowercase hex) of the file as it is stored on the original disc
+};
+
+// Enum returned by parsing an IRD file
+enum class ird_parse_status
+{
+	OK,
+	ERROR_OPENING_FILE,
+	ERROR_NOT_AN_IRD,     // Wrong magic (the file is neither a raw nor a gzipped IRD)
+	ERROR_BAD_VERSION,    // IRD version out of the supported range
+	ERROR_TRUNCATED,      // The file ends in the middle of a field
+	ERROR_PARSING_HEADER  // The ISO9660 header stored in the IRD could not be parsed
+};
+
+/*
+- An IRD (ISO ReBuild Data) file stores the file system header of a PS3 disc (the very same ECMA-119 volume
+  descriptors and directory records the disc begins with) together with the MD5 hash of each of its files.
+  That is what makes it possible to validate a game, held either by a "JB folder" or by an ISO image, file by
+  file against the disc it comes from, without owning that disc.
+
+- It also carries the "D1" of the disc, i.e. what a Redump ".dkey" file holds already derived, so an encrypted
+  image checked against an IRD can be read back even when no key file exists for it.
+
+- The whole file is usually gzipped: only when the magic is found as-is the file is read uncompressed.
+
+- Supported IRD versions: 6 to 9 (version 9 is the one every current dumping tool writes)
+*/
+class ird_file
+{
+private:
+	ird_parse_status m_status = ird_parse_status::ERROR_OPENING_FILE;
+	bool m_crc_valid = false;
+	u8 m_version = 0;
+	std::string m_path;
+	std::string m_game_id;
+	std::string m_game_name;
+	std::string m_update_version;
+	std::string m_game_version;
+	std::string m_app_version;
+	u64 m_disc_size = 0;
+	std::array<u8, 16> m_disc_key{}; // "D1", the field of the disc the decryption key is derived from
+	std::array<u8, 16> m_disc_id{};  // "D2"
+	std::vector<ird_file_entry> m_files;
+
+	ird_parse_status parse(const std::vector<u8>& data);
+	bool parse_iso_header(const std::vector<u8>& header, const std::map<u64, std::string>& hashes);
+
+public:
+	ird_file(const std::string& path);
+
+	ird_parse_status get_status() const { return m_status; }
+	bool is_valid() const { return m_status == ird_parse_status::OK; }
+
+	// Whether the CRC32 stored at the end of the IRD matches its content
+	bool is_crc_valid() const { return m_crc_valid; }
+
+	u8 get_version() const { return m_version; }
+	const std::string& get_path() const { return m_path; }
+	const std::string& get_game_id() const { return m_game_id; }
+	const std::string& get_game_name() const { return m_game_name; }
+	const std::string& get_update_version() const { return m_update_version; }
+	const std::string& get_game_version() const { return m_game_version; }
+	const std::string& get_app_version() const { return m_app_version; }
+	u64 get_disc_size() const { return m_disc_size; }
+
+	// The "D1" of the disc: the very field a 3k3y image carries in its watermark and a ".dkey" file holds
+	// already derived, so an encrypted image whose key file is missing can still be read back through it
+	const std::array<u8, 16>& get_disc_key() const { return m_disc_key; }
+	const std::array<u8, 16>& get_disc_id() const { return m_disc_id; }
+
+	// Every file of the disc, ordered by its first data sector (i.e. in the order it lies on the disc)
+	const std::vector<ird_file_entry>& get_files() const { return m_files; }
+};

--- a/rpcs3/Loader/ISO.cpp
+++ b/rpcs3/Loader/ISO.cpp
@@ -60,14 +60,15 @@ static void* get_aligned_buf()
 
 static bool is_iso_file(iso_file& file, u64* size = nullptr)
 {
-	if (!file || file.size() < 32768ULL + 6)
+	// The standard identifier ("CD001") follows the type of the first volume descriptor
+	if (!file || file.size() < ISO_DESCRIPTORS_OFFSET + 6)
 	{
 		return false;
 	}
 
 	char magic[5];
 
-	if (file.read_at(32768ULL + 1, magic, 5) != 5)
+	if (file.read_at(ISO_DESCRIPTORS_OFFSET + 1, magic, 5) != 5)
 	{
 		return false;
 	}
@@ -550,6 +551,34 @@ bool iso_file_decryption::init(const std::string& path, iso_archive* archive)
 	return true;
 }
 
+bool iso_file_decryption::set_key_from_d1(const std::array<u8, 16>& disc_key)
+{
+	// The "D1" of a disc is not the key itself: the key comes out of encrypting it with the very same constants
+	// the 3k3y watermark path above uses, since both carry that same field of the disc
+	static constexpr u8 key_d1[] = {0x38, 0x0b, 0xcf, 0x0b, 0x53, 0x45, 0x5b, 0x3c, 0x78, 0x17, 0xab, 0x4f, 0xa3, 0xba, 0x90, 0xed};
+	static constexpr u8 iv_d1[] = {0x69, 0x47, 0x47, 0x72, 0xaf, 0x6f, 0xda, 0xb3, 0x42, 0x74, 0x3a, 0xef, 0xaa, 0x18, 0x62, 0x87};
+
+	u8 key[16];
+	u8 iv[16];
+
+	std::memcpy(key, disc_key.data(), sizeof(key));
+	std::memcpy(iv, iv_d1, sizeof(iv));
+
+	aes_context aes_d1;
+
+	if (aes_setkey_enc(&aes_d1, key_d1, 128) != 0 || aes_crypt_cbc(&aes_d1, AES_ENCRYPT, sizeof(key), iv, key, key) != 0 ||
+		aes_setkey_dec(&m_aes_dec, key, 128) != 0)
+	{
+		iso_log.error("set_key_from_d1: Failed to derive the decryption key from the disc key");
+		return false;
+	}
+
+	// The regions of the image are already known: only its type was left as "not encrypted" for the lack of a key
+	m_enc_type = iso_encryption_type::REDUMP;
+
+	return !m_region_info.empty();
+}
+
 bool iso_file_decryption::decrypt(u64 offset, const std::span<u8> buffer, const std::string& name)
 {
 	// If it's a non-encrypted type, nothing more to do
@@ -1010,6 +1039,60 @@ static bool iso_form_hierarchy(fs::file& file, iso_fs_node& node, bool use_ucs2_
 	return true;
 }
 
+bool iso_parse_file_system(fs::file& file, iso_fs_node& root, const std::string& path)
+{
+	u8 descriptor_type = -2;
+	bool use_ucs2_decoding = false;
+
+	// Skip the system area: scanning it sector by sector would read 16 sectors (a physical read each, on an optical
+	// drive) only to find boot data, which could even be mistaken for a volume descriptor.
+	// NOTE: the caller already verified the standard identifier is right here
+	file.seek(ISO_DESCRIPTORS_OFFSET);
+
+	do
+	{
+		const auto descriptor_start = file.pos();
+
+		descriptor_type = file.read<u8>();
+
+		// 1 = primary vol descriptor, 2 = joliet SVD
+		if (descriptor_type == 1 || descriptor_type == 2)
+		{
+			use_ucs2_decoding = descriptor_type == 2;
+
+			// Skip the rest of descriptor's data
+			file.seek(155, fs::seek_cur);
+
+			const auto node = iso_read_directory_entry(file, use_ucs2_decoding);
+
+			if (node)
+			{
+				root = iso_fs_node
+				{
+					.metadata = node.value()
+				};
+			}
+		}
+
+		file.seek(descriptor_start + ISO_SECTOR_SIZE);
+	}
+	while (descriptor_type != 255 && file.pos() < file.size());
+
+	if (descriptor_type != 255)
+	{
+		iso_log.error("iso_parse_file_system: Corrupt ISO file system '%s': Volume Descriptor Set Terminator not found", path);
+		return false;
+	}
+
+	if (!iso_form_hierarchy(file, root, use_ucs2_decoding))
+	{
+		iso_log.error("iso_parse_file_system: Corrupt ISO file system '%s': Failed to form hierarchy", path);
+		return false;
+	}
+
+	return true;
+}
+
 u64 iso_fs_metadata::size() const
 {
 	u64 total_size = 0;
@@ -1029,57 +1112,24 @@ iso_archive::iso_archive(const std::string& path)
 	// "m_path" is updated with the raw device path in case "path" points to a BD drive
 	fs::get_optical_raw_device(path, &m_path);
 
-	if (!is_iso_file(m_path))
+	// NOTE: the file is opened once here and then handed over to the parsing below. Recognizing the ISO through its
+	//       path (i.e. "is_iso_file(m_path)") would open it and read its volume descriptor a second time, which is a
+	//       physical read when the path points to an optical drive
+	auto file = std::make_unique<iso_file>(m_path);
+
+	if (!is_iso_file(*file))
 	{
 		iso_log.error("iso_archive: Failed to recognize ISO file: '%s'", path);
 		invalidate();
 		return;
 	}
 
-	fs::file iso_file(std::make_unique<iso_file>(m_path));
+	// NOTE: "is_iso_file()" reads through "read_at()", which does not move the position, so the file is still at its
+	//       beginning here
+	fs::file iso_file(std::move(file));
 
-	u8 descriptor_type = -2;
-	bool use_ucs2_decoding = false;
-
-	do
+	if (!iso_parse_file_system(iso_file, m_root, path))
 	{
-		const auto descriptor_start = iso_file.pos();
-
-		descriptor_type = iso_file.read<u8>();
-
-		// 1 = primary vol descriptor, 2 = joliet SVD
-		if (descriptor_type == 1 || descriptor_type == 2)
-		{
-			use_ucs2_decoding = descriptor_type == 2;
-
-			// Skip the rest of descriptor's data
-			iso_file.seek(155, fs::seek_cur);
-
-			const auto node = iso_read_directory_entry(iso_file, use_ucs2_decoding);
-
-			if (node)
-			{
-				m_root = iso_fs_node
-				{
-					.metadata = node.value()
-				};
-			}
-		}
-
-		iso_file.seek(descriptor_start + ISO_SECTOR_SIZE);
-	}
-	while (descriptor_type != 255 && iso_file.pos() < iso_file.size());
-
-	if (descriptor_type != 255)
-	{
-		iso_log.error("iso_archive: Corrupt ISO file '%s': Volume Descriptor Set Terminator not found", path);
-		invalidate();
-		return;
-	}
-
-	if (!iso_form_hierarchy(iso_file, m_root, use_ucs2_decoding))
-	{
-		iso_log.error("iso_archive: Corrupt ISO file '%s': Failed to form hierarchy", path);
 		invalidate();
 		return;
 	}
@@ -1093,6 +1143,11 @@ iso_archive::iso_archive(const std::string& path)
 		invalidate();
 		return;
 	}
+}
+
+bool iso_archive::set_disc_key(const std::array<u8, 16>& disc_key)
+{
+	return m_dec && m_dec->set_key_from_d1(disc_key);
 }
 
 iso_fs_node* iso_archive::retrieve(const std::string& passed_path)

--- a/rpcs3/Loader/ISO.h
+++ b/rpcs3/Loader/ISO.h
@@ -6,6 +6,7 @@
 #include "util/types.hpp"
 #include "Crypto/aes.h"
 
+#include <array>
 #include <span>
 
 bool is_iso_file(const std::string& path, u64* size = nullptr, bool* is_raw_device = nullptr);
@@ -14,6 +15,9 @@ void load_iso(const std::string& path);
 void unload_iso();
 
 constexpr u64 ISO_SECTOR_SIZE = 2048;
+
+// The first 16 sectors are the system area (boot data): the volume descriptors always start right after it (ECMA-119)
+constexpr u64 ISO_DESCRIPTORS_OFFSET = ISO_SECTOR_SIZE * 16;
 
 /*
 - Hijacked the "iso_archive::iso_archive" method to test if the ".iso" file is encrypted and sets a flag.
@@ -78,6 +82,11 @@ public:
 	iso_encryption_type get_enc_type() const { return m_enc_type; }
 
 	bool init(const std::string& path, iso_archive* archive = nullptr);
+
+	// Sets the decryption key out of the "D1" of the disc, for an encrypted image no key file was found for
+	// (an IRD file stores that very field, so a game checked against one can be read back without a ".dkey")
+	bool set_key_from_d1(const std::array<u8, 16>& disc_key);
+
 	bool decrypt(u64 offset, const std::span<u8> buffer, const std::string& name);
 };
 
@@ -103,6 +112,12 @@ struct iso_fs_node
 	iso_fs_metadata metadata {};
 	std::vector<std::unique_ptr<iso_fs_node>> children;
 };
+
+// Parses the volume descriptor set and the directory records of an ISO9660 file system out of an already opened
+// stream, filling in the hierarchy rooted at "root" ("path" is only used for logging).
+// It works on any stream holding the ECMA-119 structures at the sector positions they lie at on the disc, so it
+// serves both a whole ISO image and the ISO header an IRD file stores
+bool iso_parse_file_system(fs::file& file, iso_fs_node& root, const std::string& path);
 
 class iso_file : public fs::file_base
 {
@@ -174,6 +189,10 @@ private:
 
 public:
 	iso_archive(const std::string& path);
+
+	// Hands the decryption the "D1" of the disc, so that an encrypted image whose key file is missing can still
+	// be read back. Only worth calling when the image turned out to be unreadable as it is
+	bool set_disc_key(const std::array<u8, 16>& disc_key);
 
 	const std::string& path() const { return m_path; }
 	const iso_fs_node& root() const { return m_root; }

--- a/rpcs3/Loader/content_validation.cpp
+++ b/rpcs3/Loader/content_validation.cpp
@@ -1,13 +1,20 @@
 #include "stdafx.h"
 
 #include "content_validation.h"
+#include "IRD.h"
 #include "ISO.h"
+#include "PSF.h"
 
 #include "Emu/system_utils.hpp"
 #include "Utilities/File.h"
+#include "Utilities/StrUtil.h"
 #include "Utilities/rXml.h"
 #include "Crypto/md5.h"
 #include "Crypto/utils.h"
+
+#include <zlib.h>
+
+#include <map>
 
 LOG_CHANNEL(sys_log, "VALIDATION");
 
@@ -184,4 +191,590 @@ content_hash_status content_validation::calculate_hash(std::string& hash)
 
 	m_status = content_hash_status::COMPLETED;
 	return m_status;
+}
+
+//
+// Disc content validation against an IRD file
+//
+
+// Path of the license file every PS3 disc holds. A JB folder missing it can still be valid, since its content
+// is fully determined by the id of the game (see "check_content")
+static const std::string s_lic_dat_path = "/PS3_GAME/LICDIR/LIC.DAT";
+
+// Rebuilds the "LIC.DAT" file of a game the very same way the dumping tools do, so that a folder missing it (or
+// holding a stripped one) can still be validated against the disc without writing anything to the drive
+static std::vector<u8> generate_lic_dat(const std::string& game_id)
+{
+	static constexpr std::array<u8, 32> lic_header =
+	{
+		'P', 'S', '3', 'L', 'I', 'C', 'D', 'A',
+		0x00, 0x00, 0x00, 0x01, 0x80, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x08, 0x00,
+		0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01
+	};
+
+	std::vector<u8> lic(0x10000);
+
+	std::memcpy(lic.data(), lic_header.data(), lic_header.size());
+
+	// The id of the game is stored on the second sector, right after a "1" marking the sector as used
+	lic[0x800] = 0x01;
+	std::memcpy(lic.data() + 0x801, game_id.data(), std::min<usz>(game_id.size(), 0x10));
+
+	// CRC32 of the first 2304 bytes (i.e. up to the end of the id), stored big endian right after the header
+	const be_t<u32> crc = ::crc32(::crc32(0, nullptr, 0), lic.data(), 2304);
+	std::memcpy(lic.data() + lic_header.size(), &crc, sizeof(crc));
+
+	return lic;
+}
+
+// MD5 hash (lowercase hex) of a buffer, i.e. of a file rebuilt in memory rather than read from the drive
+static std::string md5_of_buffer(const std::vector<u8>& buffer)
+{
+	mbedtls_md5_context md5_ctx;
+	unsigned char md5_hash[16];
+	std::string hash;
+
+	mbedtls_md5_starts_ret(&md5_ctx);
+	mbedtls_md5_update_ret(&md5_ctx, buffer.data(), buffer.size());
+
+	if (mbedtls_md5_finish_ret(&md5_ctx, md5_hash) != 0)
+	{
+		return {};
+	}
+
+	bytes_to_hex(hash, md5_hash, 16);
+	return hash;
+}
+
+// A file of the game as it lies on the drive, either inside a JB folder or inside an ISO image
+struct disc_content_file
+{
+	std::string path;                  // Path relative to the root of the game, with the case it has on the drive
+	u64 size = 0;
+	const iso_fs_node* node = nullptr; // Set only for a file held by an ISO image
+	bool paired = false;               // Whether a file of the disc was matched with this one
+};
+
+// The file system of a PS3 disc is case insensitive, so every listing below is keyed by the uppercase path: the
+// case a ripping tool used must not turn a file into a missing one
+using disc_content_list = std::map<std::string, disc_content_file>;
+
+// Lists every file the JB folder holds
+static void list_folder_files(const std::string& root, const std::string& parent_path, disc_content_list& files)
+{
+	for (const fs::dir_entry& entry : fs::dir(root + parent_path))
+	{
+		if (entry.name == "." || entry.name == "..")
+		{
+			continue;
+		}
+
+		const std::string path = parent_path + "/" + entry.name;
+
+		if (entry.is_directory)
+		{
+			list_folder_files(root, path, files);
+			continue;
+		}
+
+		files.emplace(fmt::to_upper(path), disc_content_file{path, entry.size});
+	}
+}
+
+// Lists every file the ISO image holds, keeping the node of each one so that it can be read back without walking
+// the file system of the image again
+static void list_iso_files(const iso_fs_node& node, const std::string& parent_path, disc_content_list& files)
+{
+	for (const auto& child : node.children)
+	{
+		const iso_fs_metadata& meta = child->metadata;
+
+		if (meta.name == "." || meta.name == "..")
+		{
+			continue;
+		}
+
+		const std::string path = parent_path + "/" + meta.name;
+
+		if (meta.is_directory)
+		{
+			list_iso_files(*child, path, files);
+			continue;
+		}
+
+		files.emplace(fmt::to_upper(path), disc_content_file{path, meta.size(), child.get()});
+	}
+}
+
+// Finds the root of the JB folder (i.e. the directory the disc starts at, the one holding "PS3_GAME") out of the
+// path of a game, which can point either at the root itself or at the game directory inside it, and reports the
+// name of that game directory ("PS3_GAME", or a "PS3_GMxx" one for a disc holding more than one game)
+static bool resolve_jb_folder(std::string& root, std::string& game_dir)
+{
+	while (!root.empty() && (root.back() == '/' || root.back() == '\\'))
+	{
+		root.pop_back();
+	}
+
+	if (root.empty())
+	{
+		return false;
+	}
+
+	// The path points at the game directory of the disc: the root is the parent one
+	if (fs::is_file(root + "/PARAM.SFO"))
+	{
+		game_dir = root.substr(root.find_last_of("/\\") + 1);
+		root = fs::get_parent_dir(root);
+
+		return !root.empty();
+	}
+
+	// The path points at the root of the disc: look for the game directory inside it
+	for (const fs::dir_entry& entry : fs::dir(root))
+	{
+		if (!entry.is_directory || (entry.name != "PS3_GAME" && !rpcs3::utils::is_ps3_gm_dir_name(entry.name)))
+		{
+			continue;
+		}
+
+		if (fs::is_file(root + "/" + entry.name + "/PARAM.SFO"))
+		{
+			game_dir = entry.name;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// Same as above for an ISO image, whose root is the image itself: only the game directory has to be found
+static std::string resolve_iso_game_dir(const disc_content_list& files)
+{
+	static const std::string sfo_suffix = "/PARAM.SFO";
+
+	for (const auto& [key, file] : files)
+	{
+		if (!key.ends_with(sfo_suffix))
+		{
+			continue;
+		}
+
+		// Only the "PARAM.SFO" of a game directory ("/PS3_GAME/PARAM.SFO") is the one of the disc: the ones deeper
+		// down the tree belong to the packages the disc carries.
+		// NOTE: the name is returned with the case it has inside the image, since that is the only one the file
+		//       system of the image answers to
+		const std::string dir = file.path.substr(1, file.path.size() - sfo_suffix.size() - 1);
+
+		if (dir.find('/') != umax)
+		{
+			continue;
+		}
+
+		if (const std::string upper_dir = fmt::to_upper(dir); upper_dir == "PS3_GAME" || rpcs3::utils::is_ps3_gm_dir_name(upper_dir))
+		{
+			return dir;
+		}
+	}
+
+	return {};
+}
+
+// Tells whether the files of an ISO image can be read back at all. An image whose key is missing still lists its
+// files just fine (the file system of a PS3 disc lies in the clear, and so does its "PARAM.SFO" more often than
+// not), but hands out nothing but noise for whatever sits in an encrypted region: without this, the check would
+// read the whole image only to call every single one of its files wrong.
+// The files below are the very ones the key detection of "iso_file_decryption" relies on, so their magic is the
+// same yardstick used there
+static bool iso_content_is_readable(iso_archive& archive, const disc_content_list& content, const std::string& game_dir)
+{
+	static const std::array<std::pair<std::string, std::string>, 2> known_magics
+	{{
+		{"/USRDIR/EBOOT.BIN", "SCE"},
+		{"/LICDIR/LIC.DAT", "PS3LICDA"}
+	}};
+
+	const std::string upper_game_dir = "/" + fmt::to_upper(game_dir);
+
+	for (const auto& [suffix, magic] : known_magics)
+	{
+		const auto found = content.find(upper_game_dir + suffix);
+
+		if (found == content.cend() || !found->second.node || found->second.size < magic.size())
+		{
+			continue;
+		}
+
+		const fs::file file(archive.get_iso_file(archive.path(), fs::read, *found->second.node));
+		std::string head(magic.size(), '\0');
+
+		if (!file || file.read(head.data(), head.size()) != head.size())
+		{
+			return false;
+		}
+
+		return head == magic;
+	}
+
+	// Neither file is there to tell: whatever the image holds, it is not for this check to refuse it
+	return true;
+}
+
+// Read block of the hashing below. A megabyte a time is what makes reading a whole disc worth it: on an
+// encrypted image every read is split into sectors and decrypted, so the fewer of them the better
+static constexpr u64 s_hash_block_size = 0x100000;
+
+bool content_validation::hash_content_file(const fs::file& file, u64 disc_size, std::string& hash)
+{
+	if (!file)
+	{
+		sys_log.error("hash_content_file: Failed to open file: %s", m_name);
+		return false;
+	}
+
+	// Kept between files: a buffer of this size is zeroed out on construction, and doing that once per file of a
+	// disc costs more than the reads it serves
+	if (m_hash_buffer.size() != s_hash_block_size)
+	{
+		m_hash_buffer.resize(s_hash_block_size);
+	}
+
+	u8* const buf = m_hash_buffer.data();
+	mbedtls_md5_context md5_ctx;
+	unsigned char md5_hash[16];
+	u64 size = 0;
+
+	mbedtls_md5_starts_ret(&md5_ctx);
+
+	// Only a read returning nothing at all ends the file: a short one is not to be trusted as the end of it,
+	// since a file held by an ISO image is read back extent by extent
+	while (m_status != content_hash_status::ABORTED)
+	{
+		const u64 bytes_read = file.read(buf, s_hash_block_size);
+
+		if (!bytes_read)
+		{
+			break;
+		}
+
+		mbedtls_md5_update_ret(&md5_ctx, buf, bytes_read);
+
+		size += bytes_read;
+		m_bytes_read += bytes_read;
+	}
+
+	// A file shorter than the one on the disc can only match once its missing tail is hashed as zeros: that is how
+	// a "PS3UPDAT.PUP" downloaded apart is turned back into the 256 MB one the disc holds
+	if (disc_size > size)
+	{
+		std::memset(buf, 0, s_hash_block_size);
+
+		for (u64 left = disc_size - size; left && m_status != content_hash_status::ABORTED;)
+		{
+			const u64 chunk = std::min<u64>(left, s_hash_block_size);
+
+			mbedtls_md5_update_ret(&md5_ctx, buf, chunk);
+
+			left -= chunk;
+			m_bytes_read += chunk;
+		}
+	}
+
+	if (m_status == content_hash_status::ABORTED)
+	{
+		return false;
+	}
+
+	if (mbedtls_md5_finish_ret(&md5_ctx, md5_hash) != 0)
+	{
+		sys_log.error("hash_content_file: Failed to calculate MD5 hash on file: %s", m_name);
+		return false;
+	}
+
+	bytes_to_hex(hash, md5_hash, 16);
+	return true;
+}
+
+disc_check_status content_validation::check_content(const std::string& game_path, const std::string& ird_path, disc_check_report& report)
+{
+	report = {};
+
+	// Set right away, so that the progress bar reports something sensible while the IRD file is being parsed and
+	// the content is being listed (and so that a cancellation asked for meanwhile is not lost)
+	m_path = game_path;
+	m_name = game_path;
+	m_size = 0;
+	m_bytes_read = 0;
+	m_status = content_hash_status::INITIALIZED;
+
+	std::string root = game_path;
+	std::string game_dir;
+	std::unique_ptr<iso_archive> archive;
+	disc_content_list content;
+
+	report.is_iso = is_iso_file(game_path);
+
+	if (report.is_iso)
+	{
+		// The whole file system of the image is walked once here: every file is then read back through the node it
+		// is listed with, and an encrypted image (3k3y, Redump) is decrypted on the fly while doing so
+		archive = std::make_unique<iso_archive>(game_path);
+
+		if (!archive->is_valid())
+		{
+			sys_log.error("check_content: Failed to open ISO file: %s", game_path);
+			report.status = disc_check_status::ERROR_OPENING_ISO;
+			return report.status;
+		}
+
+		list_iso_files(archive->root(), "", content);
+		game_dir = resolve_iso_game_dir(content);
+	}
+	else
+	{
+		// The IRD describes the disc from its root, so the check needs the directory the disc starts at: the game
+		// list points at it only when it holds a "PS3_DISC.SFB" file, otherwise it points at the game directory
+		if (resolve_jb_folder(root, game_dir))
+		{
+			list_folder_files(root, "", content);
+		}
+	}
+
+	if (game_dir.empty() || content.empty())
+	{
+		sys_log.error("check_content: No 'PS3_GAME/PARAM.SFO' file found: %s", game_path);
+		report.status = disc_check_status::ERROR_NOT_A_PS3_GAME;
+		return report.status;
+	}
+
+	sys_log.notice("check_content: Checking the %s '%s' against the IRD file '%s'", report.is_iso ? "ISO file" : "JB folder", game_path, ird_path);
+
+	// The IRD comes first since, besides the hashes, it carries the key of the disc: an encrypted image whose key
+	// file is missing is read back through that one
+	const ird_file ird(ird_path);
+
+	if (!ird.is_valid())
+	{
+		sys_log.error("check_content: Failed to parse IRD file: %s", ird_path);
+		report.status = disc_check_status::ERROR_PARSING_IRD;
+		return report.status;
+	}
+
+	// Caught before anything is hashed: reading an encrypted image no key was found for would take as long as
+	// reading the whole disc, only to report every single one of its files as invalid
+	if (report.is_iso && !iso_content_is_readable(*archive, content, game_dir))
+	{
+		if (!archive->set_disc_key(ird.get_disc_key()) || !iso_content_is_readable(*archive, content, game_dir))
+		{
+			sys_log.error("check_content: The ISO file is encrypted and neither a key file nor the key stored in the "
+				"IRD file can read it back: %s", game_path);
+			report.status = disc_check_status::ERROR_ISO_ENCRYPTED;
+			return report.status;
+		}
+
+		report.decrypted_with_ird_key = true;
+		sys_log.success("check_content: The ISO file is decrypted through the key stored in the IRD file: %s", game_path);
+	}
+
+	// The game is recognized the very same way the dumping tools do: through the "PARAM.SFO" of its game directory
+	const std::string sfo_path = game_dir + "/PARAM.SFO";
+	const psf::registry sfo = report.is_iso ? archive->open_psf(sfo_path) : psf::load_object(root + "/" + sfo_path);
+
+	report.game_id = std::string(psf::get_string(sfo, "TITLE_ID", ""));
+	report.game_title = std::string(psf::get_string(sfo, "TITLE", ""));
+
+	if (report.game_id.empty())
+	{
+		sys_log.error("check_content: No 'TITLE_ID' found on '%s': %s", sfo_path, game_path);
+		report.status = disc_check_status::ERROR_NOT_A_PS3_GAME;
+		return report.status;
+	}
+
+	report.ird_crc_valid = ird.is_crc_valid();
+	report.ird_game_id = ird.get_game_id();
+	report.ird_game_name = ird.get_game_name();
+	report.ird_game_version = ird.get_game_version();
+	report.ird_app_version = ird.get_app_version();
+	report.ird_update_version = ird.get_update_version();
+
+	// The IRD of another game still tells which files are wrong, so the check goes on: the mismatch is only
+	// reported, exactly like the dumping tools do (they just give up rebuilding the files they could fix)
+	report.serial_mismatch = report.game_id != report.ird_game_id;
+
+	if (report.serial_mismatch)
+	{
+		sys_log.warning("check_content: The IRD file belongs to '%s' while the game is '%s'", report.ird_game_id, report.game_id);
+	}
+
+	// An ISO image is meant to hold the disc as it is, so nothing of it is ever rebuilt: only a folder, which a
+	// ripping tool regularly strips, is given the benefit of the doubt
+	const bool allow_rebuild = !report.is_iso && !report.serial_mismatch;
+
+	// Pair each file of the disc with the one of the game before hashing anything, so that the progress can be
+	// reported over the whole amount of data to read
+	std::vector<std::pair<const ird_file_entry*, disc_content_file*>> work_list;
+	const ird_file_entry* lic_dat_file = nullptr;
+	u64 total_size = 0;
+
+	work_list.reserve(ird.get_files().size());
+
+	for (const ird_file_entry& disc_file : ird.get_files())
+	{
+		const std::string key = fmt::to_upper(disc_file.path);
+
+		// Spotted here, where the uppercase path is at hand: the loop below then tells the license file apart by
+		// its very address, without a string comparison per file
+		if (key == s_lic_dat_path)
+		{
+			lic_dat_file = &disc_file;
+		}
+
+		auto found = content.find(key);
+
+		// Ripping tools drop the trailing dot of a name the file system of the host cannot store, so a file only
+		// differing by it is still the file the disc holds
+		if (found == content.end())
+		{
+			found = content.find(key + ".");
+		}
+
+		// Whatever the game holds answers for a single file of the disc only
+		if (found == content.end() || found->second.paired)
+		{
+			work_list.emplace_back(&disc_file, nullptr);
+			continue;
+		}
+
+		found->second.paired = true;
+
+		// Only the files that are going to be read weigh on the progress: a size of its own already tells a file
+		// apart from the one of the disc, unless a shorter one can still be padded with zeros up to it
+		if (!disc_file.md5.empty() &&
+			(found->second.size == disc_file.size || (allow_rebuild && found->second.size < disc_file.size)))
+		{
+			total_size += disc_file.size;
+		}
+
+		work_list.emplace_back(&disc_file, &found->second);
+	}
+
+	if (m_status == content_hash_status::ABORTED)
+	{
+		report.status = disc_check_status::ABORTED;
+		return report.status;
+	}
+
+	m_path = root;
+	m_size = total_size;
+
+	// Rebuilt once, not once per file: what a rebuilt file hashes to depends on nothing but the game itself
+	const std::string lic_dat_md5 = allow_rebuild ? md5_of_buffer(generate_lic_dat(report.game_id)) : std::string{};
+	const std::string empty_file_md5 = allow_rebuild ? md5_of_buffer({}) : std::string{};
+
+	usz file_index = 0;
+
+	for (const auto& [disc_file, content_file] : work_list)
+	{
+		disc_file_status status = disc_file_status::MISSING;
+
+		file_index++;
+
+		if (content_file)
+		{
+			// The count goes into the name since that is all the progress dialog shows: without it, hashing every
+			// file of a disc looks exactly like hashing the whole image
+			m_name = fmt::format("(%d/%d) %s", file_index, work_list.size(), content_file->path);
+
+			// Reading a file of a different size would only confirm what that size already tells: the MD5 of the
+			// disc can never come out of it. Only a shorter one that is going to be padded is still worth reading.
+			// An entry the IRD lists but holds no hash for has nothing to be compared against either
+			if (disc_file->md5.empty() ||
+				(content_file->size != disc_file->size && !(allow_rebuild && content_file->size < disc_file->size)))
+			{
+				status = disc_file_status::MISMATCH;
+			}
+			else
+			{
+				std::string hash;
+
+				const fs::file file = content_file->node ?
+					fs::file(archive->get_iso_file(archive->path(), fs::read, *content_file->node)) :
+					fs::file(root + content_file->path);
+
+				if (!hash_content_file(file, allow_rebuild ? disc_file->size : 0, hash))
+				{
+					if (m_status == content_hash_status::ABORTED)
+					{
+						report.status = disc_check_status::ABORTED;
+						return report.status;
+					}
+
+					status = disc_file_status::MISMATCH;
+				}
+				else if (hash != disc_file->md5)
+				{
+					status = disc_file_status::MISMATCH;
+				}
+				else
+				{
+					status = content_file->size < disc_file->size ? disc_file_status::MATCH_REBUILT : disc_file_status::MATCH;
+				}
+			}
+		}
+
+		// Some of the files a rip regularly leaves out need nothing but the game itself to be rebuilt: the license
+		// file is fully determined by its id, and an empty file has no content at all. They are rebuilt in memory
+		// (nothing is ever written to the game) only to tell whether it would still work
+		if (allow_rebuild && status != disc_file_status::MATCH && status != disc_file_status::MATCH_REBUILT)
+		{
+			if ((disc_file == lic_dat_file && lic_dat_md5 == disc_file->md5) ||
+				(disc_file->size == 0 && empty_file_md5 == disc_file->md5))
+			{
+				status = disc_file_status::MATCH_REBUILT;
+			}
+		}
+
+		switch (status)
+		{
+		case disc_file_status::MATCH:
+			report.matched++;
+			continue; // A file matching the disc is not worth reporting
+		case disc_file_status::MATCH_REBUILT:
+			report.matched++;
+			report.rebuilt++;
+			break;
+		case disc_file_status::MISMATCH:
+			report.mismatched++;
+			break;
+		case disc_file_status::MISSING:
+			report.missing++;
+			break;
+		case disc_file_status::NOT_REQUIRED:
+			break;
+		}
+
+		report.entries.push_back(disc_file_entry{disc_file->path, disc_file->size, status});
+	}
+
+	// Whatever went unpaired is not part of the disc (updates installed over a rip, leftovers of the ripping tool,
+	// files added to a rebuilt image, etc.): it does not make the game invalid, so it is only listed
+	for (const auto& [key, content_file] : content)
+	{
+		if (content_file.paired)
+		{
+			continue;
+		}
+
+		report.not_required++;
+		report.entries.push_back(disc_file_entry{content_file.path, content_file.size, disc_file_status::NOT_REQUIRED});
+	}
+
+	m_status = content_hash_status::COMPLETED;
+	report.status = (report.mismatched || report.missing) ? disc_check_status::FAILED : disc_check_status::PASSED;
+
+	sys_log.notice("check_content: '%s' checked against '%s': %d valid | %d invalid | %d missing | %d not required",
+		game_path, ird_path, report.matched, report.mismatched, report.missing, report.not_required);
+
+	return report.status;
 }

--- a/rpcs3/Loader/content_validation.h
+++ b/rpcs3/Loader/content_validation.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "util/types.hpp"
+#include "Utilities/File.h"
+
+#include <string>
+#include <vector>
 
 // Enum identifying the content file type
 enum class content_file_type
@@ -28,6 +32,66 @@ enum class content_integrity_status
 	ERROR_PARSING_DB
 };
 
+// Status of a single file of a game, compared against the IRD of the disc the game comes from
+enum class disc_file_status
+{
+	MATCH,         // The game holds the file and its MD5 hash matches the one the IRD holds
+	MATCH_REBUILT, // Same as above, but only once the file is rebuilt (see "check_content")
+	MISMATCH,      // The game holds the file but its content differs from the one of the disc
+	MISSING,       // The IRD lists the file but the game does not hold it
+	NOT_REQUIRED   // The game holds the file but the IRD does not list it
+};
+
+// One file of a disc content validation report
+struct disc_file_entry
+{
+	std::string path; // Path of the file relative to the root of the disc (e.g. "/PS3_GAME/USRDIR/EBOOT.BIN")
+	u64 size = 0;     // Size of the file (the one on the disc, or the one of the game for a file not on the disc)
+	disc_file_status status = disc_file_status::MATCH;
+};
+
+// Enum returned by validating the content of a game against an IRD file
+enum class disc_check_status
+{
+	PASSED,               // Every file the IRD lists is there and matches
+	FAILED,               // At least one file is missing or does not match
+	ABORTED,              // Validation aborted by the user
+	ERROR_NOT_A_PS3_GAME, // No "PS3_GAME/PARAM.SFO" file found
+	ERROR_OPENING_ISO,    // The ISO file could not be opened or recognized
+	ERROR_ISO_ENCRYPTED,  // The ISO file is encrypted and no key to read it back was found
+	ERROR_PARSING_IRD     // The IRD file could not be read
+};
+
+// Report filled in by validating the content of a game against an IRD file
+struct disc_check_report
+{
+	disc_check_status status = disc_check_status::FAILED;
+
+	bool is_iso = false;          // Whether the game is held by an ISO image instead of a JB folder
+	bool ird_crc_valid = false;   // Whether the CRC32 stored in the IRD matches its content
+	bool serial_mismatch = false; // Whether the IRD belongs to a different game
+
+	// Whether the image turned out to be encrypted with no key file for it, and was read back through the key
+	// the IRD file stores
+	bool decrypted_with_ird_key = false;
+
+	std::string game_id;           // TITLE_ID read from the PARAM.SFO of the game
+	std::string game_title;        // TITLE read from the PARAM.SFO of the game
+	std::string ird_game_id;       // Game the IRD belongs to
+	std::string ird_game_name;     // Name of the disc the IRD was made from
+	std::string ird_game_version;  // VERSION of the disc
+	std::string ird_app_version;   // APP_VER of the disc
+	std::string ird_update_version;// PS3_SYSTEM_VER of the disc
+
+	u32 matched = 0;      // Files matching the disc (rebuilt ones included)
+	u32 rebuilt = 0;      // Files matching the disc only once rebuilt
+	u32 mismatched = 0;   // Files whose content differs from the one of the disc
+	u32 missing = 0;      // Files of the disc the game does not hold
+	u32 not_required = 0; // Files of the game the disc does not hold
+
+	std::vector<disc_file_entry> entries; // Only the files needing the attention of the user
+};
+
 // Content validation class
 class content_validation
 {
@@ -38,6 +102,14 @@ private:
 	u64 m_bytes_read = 0;
 	u16 m_count = 0; // Set only by set_count()
 	content_hash_status m_status = content_hash_status::INITIALIZED;
+
+	// Read buffer of hash_content_file(), kept between files rather than built anew for each of them
+	std::vector<u8> m_hash_buffer;
+
+	// MD5 hash of a single file of a game: whenever the file is shorter than the size it has on the disc
+	// ("disc_size"), the missing tail is hashed as zeros, the way the padding of "PS3UPDAT.PUP" is handled by the
+	// dumping tools ("disc_size" of 0 hashes the file as it is). Progress information is updated as it goes
+	bool hash_content_file(const fs::file& file, u64 disc_size, std::string& hash);
 
 public:
 	static content_integrity_status check_integrity(content_file_type file_type, std::string_view hash, std::string* game_name = nullptr);
@@ -54,4 +126,21 @@ public:
 
 	bool init_hash(const std::string& path);
 	content_hash_status calculate_hash(std::string& hash);
+
+	/*
+	  Validates a game against the IRD file of the disc it comes from, comparing the MD5 hash of each of its files.
+
+	  - The game can be held either by a JB folder (the one holding the "PS3_GAME" directory, or that very
+	    directory) or by an ISO image: the two are told apart on their own.
+
+	  - An encrypted image (3k3y, Redump) is decrypted while reading it. Should no key file be found for it, the
+	    key stored in the IRD is used, so that a ".dkey" is never actually needed; an image that stays unreadable
+	    is refused right away instead of being read through only to report every one of its files as invalid.
+
+	  - Only a folder, which a ripping tool regularly strips, is given the benefit of the doubt: a file it does
+	    not hold is rebuilt in memory (never written to the drive) whenever the game alone determines its content,
+	    i.e. the license file, an empty file, and the zero padded tail of a file shorter than the one of the disc.
+	    An image is meant to hold the disc as it is, so nothing of it is ever rebuilt.
+	*/
+	disc_check_status check_content(const std::string& game_path, const std::string& ird_path, disc_check_report& report);
 };

--- a/rpcs3/emucore.vcxproj
+++ b/rpcs3/emucore.vcxproj
@@ -569,6 +569,7 @@
     <ClCompile Include="Loader\PSF.cpp" />
     <ClCompile Include="Loader\PUP.cpp" />
     <ClCompile Include="Loader\TAR.cpp" />
+    <ClCompile Include="Loader\IRD.cpp" />
     <ClCompile Include="Loader\ISO.cpp" />
     <ClCompile Include="Loader\iso_cache.cpp" />
     <ClCompile Include="Loader\mself.cpp" />
@@ -1081,6 +1082,7 @@
     <ClInclude Include="Loader\PSF.h" />
     <ClInclude Include="Loader\PUP.h" />
     <ClInclude Include="Loader\TAR.h" />
+    <ClInclude Include="Loader\IRD.h" />
     <ClInclude Include="Loader\ISO.h" />
     <ClInclude Include="Loader\TROPUSR.h" />
     <ClInclude Include="Loader\TRP.h" />

--- a/rpcs3/emucore.vcxproj.filters
+++ b/rpcs3/emucore.vcxproj.filters
@@ -1417,6 +1417,9 @@
     <ClCompile Include="Emu\NP\clans_client.cpp">
       <Filter>Emu\NP</Filter>
     </ClCompile>
+    <ClCompile Include="Loader\IRD.cpp">
+      <Filter>Loader</Filter>
+    </ClCompile>
     <ClCompile Include="Loader\ISO.cpp">
       <Filter>Loader</Filter>
     </ClCompile>
@@ -2910,6 +2913,9 @@
     </ClInclude>
     <ClInclude Include="Emu\NP\clans_config.h">
       <Filter>Emu\NP</Filter>
+    </ClInclude>
+    <ClInclude Include="Loader\IRD.h">
+      <Filter>Loader</Filter>
     </ClInclude>
     <ClInclude Include="Loader\ISO.h">
       <Filter>Loader</Filter>

--- a/rpcs3/rpcs3qt/game_list_actions.cpp
+++ b/rpcs3/rpcs3qt/game_list_actions.cpp
@@ -502,7 +502,7 @@ void game_list_actions::ShowGameIntegrityDialog(content_file_type file_type, con
 
 		if (m_game_validator->get_status() == content_hash_status::ABORTED)
 		{
-			text_dialog = tr("Hash calculation failed!\n\nIntegrity check aborted");
+			text_dialog = tr("Integrity check aborted!\n\nHash calculation failed!");
 			info_dialog = false;
 		}
 		else
@@ -528,6 +528,11 @@ void game_list_actions::ShowGameIntegrityDialog(content_file_type file_type, con
 		}, nullptr, false);
 	});
 
+	StartHashProgressDialog();
+}
+
+void game_list_actions::StartHashProgressDialog()
+{
 	progress_dialog* pdlg = new progress_dialog(tr("File Hash Calculation"), "", tr("Cancel"),
 		0, 100, false, m_game_list_frame);
 
@@ -566,6 +571,189 @@ void game_list_actions::ShowGameIntegrityDialog(content_file_type file_type, con
 	});
 
 	update_timer->start(500);
+}
+
+void game_list_actions::ShowIrdIntegrityDialog(const std::string& game_path)
+{
+	if (m_game_integrity_future.isRunning()) // Still running the last request
+		return;
+
+	// A game is validated file by file against the IRD file of the disc it comes from: it is the only place the
+	// MD5 hash of each file of the disc can be read from (and the key of an encrypted image, when its key file is
+	// missing), so the user has to provide it
+	const QString ird_path = QFileDialog::getOpenFileName(nullptr, tr("Select the IRD file of the game"),
+		QString::fromStdString(game_path), tr("IRD files (*.ird *.IRD);;All files (*.*)"));
+
+	if (ird_path.isEmpty())
+	{
+		return;
+	}
+
+	// Tell the progress bar thread that a check is running: how far it got is reported by the validator itself,
+	// which knows how many files are left only once the IRD is parsed
+	m_game_validator->set_count(1);
+
+	// Hashing every file of a game can take a while (in particular on non ssd/m.2 disks) so run it on a concurrent
+	// thread avoiding to block the entire GUI
+	m_game_integrity_future = QtConcurrent::run([this, game_path, ird_path]()
+	{
+		thread_base::set_name("Game Integrity");
+
+		disc_check_report report;
+
+		m_game_validator->check_content(game_path, ird_path.toStdString(), report);
+
+		QString text_result, text_dialog, text_details;
+		bool info_dialog = false;
+
+		switch (report.status)
+		{
+		case disc_check_status::PASSED:
+		case disc_check_status::FAILED:
+		{
+			info_dialog = report.status == disc_check_status::PASSED;
+
+			text_result = (info_dialog ? tr("Game check PASSED\n\n") : tr("Game check NOT PASSED\n\n"));
+
+			text_result += tr("Main info:\n - %0: %1\n - Game: %2 [%3]\n - IRD: %4 [%5] (game v%6, app v%7, firmware v%8)\n\n"
+				"%9 valid | %10 invalid | %11 missing | %12 not required")
+				.arg(report.is_iso ? tr("ISO") : tr("Folder"))
+				.arg(QString::fromStdString(game_path))
+				.arg(QString::fromStdString(report.game_title))
+				.arg(QString::fromStdString(report.game_id))
+				.arg(QString::fromStdString(report.ird_game_name))
+				.arg(QString::fromStdString(report.ird_game_id))
+				.arg(QString::fromStdString(report.ird_game_version))
+				.arg(QString::fromStdString(report.ird_app_version))
+				.arg(QString::fromStdString(report.ird_update_version))
+				.arg(report.matched)
+				.arg(report.mismatched)
+				.arg(report.missing)
+				.arg(report.not_required);
+
+			if (report.decrypted_with_ird_key)
+			{
+				text_result += tr("\n\nNOTE: no key file was found for this encrypted image, so it was read back through "
+					"the key stored in the IRD file");
+			}
+
+			if (report.serial_mismatch)
+			{
+				text_result += tr("\n\nWARNING: the IRD file belongs to another game!");
+				info_dialog = false;
+			}
+
+			if (!report.ird_crc_valid)
+			{
+				text_result += tr("\n\nWARNING: the IRD file is corrupted (wrong CRC32)!");
+				info_dialog = false;
+			}
+
+			// A rip regularly leaves out the firmware update the disc holds: it does not belong to the game, so
+			// telling it apart from a game file spares the user the hunt through the list of the details
+			bool game_data_matches = report.status == disc_check_status::FAILED;
+
+			for (const disc_file_entry& entry : report.entries)
+			{
+				if ((entry.status == disc_file_status::MISMATCH || entry.status == disc_file_status::MISSING) &&
+					!entry.path.starts_with("/PS3_UPDATE/"))
+				{
+					game_data_matches = false;
+				}
+
+				switch (entry.status)
+				{
+				case disc_file_status::MATCH:
+					continue;
+				case disc_file_status::MATCH_REBUILT:
+					text_details += tr("[VALID, TO BE REBUILT] %0\n").arg(QString::fromStdString(entry.path));
+					break;
+				case disc_file_status::MISMATCH:
+					text_details += tr("[INVALID] %0\n").arg(QString::fromStdString(entry.path));
+					break;
+				case disc_file_status::MISSING:
+					text_details += tr("[MISSING] %0\n").arg(QString::fromStdString(entry.path));
+					break;
+				case disc_file_status::NOT_REQUIRED:
+					text_details += tr("[NOT REQUIRED] %0\n").arg(QString::fromStdString(entry.path));
+					break;
+				}
+			}
+
+			if (report.rebuilt)
+			{
+				text_result += tr("\n\nNOTE: %0 file(s) match the disc only once rebuilt (e.g. a missing license file or "
+					"a firmware update not padded to its size on the disc)").arg(report.rebuilt);
+			}
+
+			if (game_data_matches)
+			{
+				text_result += tr("\n\nNOTE: only the firmware update of the disc is missing or invalid: the data of the "
+					"game itself fully matches the disc");
+			}
+
+			break;
+		}
+		case disc_check_status::ABORTED:
+			text_dialog = tr("Integrity check aborted!\n\nHash calculation failed!");
+			break;
+		case disc_check_status::ERROR_NOT_A_PS3_GAME:
+			text_dialog = tr("Integrity check failed!\n\n'%0' does not hold a PS3 game").arg(QString::fromStdString(game_path));
+
+			// The file system of a disc lies in the clear even on an encrypted image, while its "PARAM.SFO" does
+			// not: an image whose files are listed but unreadable is one no key was found for
+			if (report.is_iso)
+			{
+				text_dialog += tr("\n\nNOTE: if the image is encrypted, check that its key file (.dkey or .key) is next "
+					"to it or in the Redump keys folder");
+			}
+
+			break;
+		case disc_check_status::ERROR_OPENING_ISO:
+			text_dialog = tr("Integrity check failed!\n\nFailed to open the ISO file: '%0'").arg(QString::fromStdString(game_path));
+			break;
+		case disc_check_status::ERROR_ISO_ENCRYPTED:
+			text_dialog = tr("Integrity check failed!\n\nThe ISO file is encrypted and no key to read it back was found:\n'%0'\n\n"
+				"Put its key file (.dkey or .key), named after the image, next to it or in the Redump keys folder")
+				.arg(QString::fromStdString(game_path));
+			break;
+		case disc_check_status::ERROR_PARSING_IRD:
+			text_dialog = tr("Integrity check failed!\n\nFailed to parse the IRD file: '%0'").arg(ird_path);
+			break;
+		}
+
+		if (!text_result.isEmpty())
+		{
+			text_dialog = tr("Integrity check completed!\n\n%0").arg(text_result);
+		}
+
+		// Tell the progress bar thread to terminate
+		m_game_validator->set_count(0);
+
+		Emu.CallFromMainThread([this, text_dialog, text_details, info_dialog]()
+		{
+			QMessageBox mb(info_dialog ? QMessageBox::Information : QMessageBox::Critical, tr("Game Integrity"),
+				text_dialog, QMessageBox::Ok, m_game_list_frame);
+
+			if (!text_details.isEmpty())
+			{
+				mb.setDetailedText(text_details);
+			}
+
+			if (info_dialog)
+			{
+				sys_log.success("%s", text_dialog.toStdString());
+			}
+			else
+			{
+				sys_log.error("%s", text_dialog.toStdString());
+			}
+
+			mb.exec();
+		}, nullptr, false);
+	});
+
+	StartHashProgressDialog();
 }
 
 void game_list_actions::ShowDiskUsageDialog()

--- a/rpcs3/rpcs3qt/game_list_actions.h
+++ b/rpcs3/rpcs3qt/game_list_actions.h
@@ -60,6 +60,11 @@ public:
 	void ShowRemoveGameDialog(const std::vector<game_info>& games);
 	void ShowGameInfoDialog(const std::vector<game_info>& games);
 	void ShowGameIntegrityDialog(content_file_type file_type, const std::string& game_path);
+
+	// Validates a game, held either by a JB folder or by an ISO image, against the IRD file of the disc it
+	// comes from, asking the user for the IRD file to check it against
+	void ShowIrdIntegrityDialog(const std::string& game_path);
+
 	void ShowDiskUsageDialog();
 
 	// Fills a game collection menu with the default entry and one per collection. The rename and removal
@@ -122,6 +127,10 @@ public:
 	static bool RemoveContentBySerial(const std::string& base_dir, const std::string& serial, const std::string& desc);
 
 private:
+	// Opens the progress dialog reporting how far the hash calculation driven by the validator has got, and
+	// closes it as soon as the validator reports it is done
+	void StartHashProgressDialog();
+
 	game_list_frame* m_game_list_frame = nullptr;
 	std::shared_ptr<gui_settings> m_gui_settings;
 	QFuture<void> m_disk_usage_future;

--- a/rpcs3/rpcs3qt/game_list_context_menu.cpp
+++ b/rpcs3/rpcs3qt/game_list_context_menu.cpp
@@ -633,10 +633,10 @@ void game_list_context_menu::show_single_selection_context_menu(const game_info&
 		// That is to highlight a Redump ISO from a non Redump ISO
 		if (raw_archive || iso_type != iso_type_status::NOT_ISO)
 		{
-			QAction* check_iso_integrity = addAction(tr("&Check ISO Integrity"));
+			QAction* check_iso_integrity = addAction(tr("&Check ISO Integrity (Redump)"));
 
 			// If it's a Redump ISO and the integrity DB exists
-			if ((raw_archive || iso_type == iso_type_status::REDUMP_ISO) &&
+			if ((iso_type == iso_type_status::REDUMP_ISO) &&
 				content_validation::check_integrity(content_file_type::ISO, "") != content_integrity_status::ERROR_OPENING_DB)
 			{
 				connect(check_iso_integrity, &QAction::triggered, this, [this, gameinfo]()
@@ -648,6 +648,26 @@ void game_list_context_menu::show_single_selection_context_menu(const game_info&
 			{
 				check_iso_integrity->setEnabled(false);
 			}
+
+			// Unlike the check above, which weighs the image as a whole against the Redump DB, this one weighs each
+			// file of the image against the IRD file of the disc, so it also tells which file is wrong
+			QAction* check_iso_files_integrity = addAction(tr("&Check ISO Integrity (IRD)"));
+
+			connect(check_iso_files_integrity, &QAction::triggered, this, [this, gameinfo]()
+			{
+				m_game_list_actions->ShowIrdIntegrityDialog(gameinfo->path);
+			});
+		}
+		else if (fs::is_file(current_game.path + "/PARAM.SFO") || fs::is_file(current_game.path + "/PS3_GAME/PARAM.SFO"))
+		{
+			// The game is not held by an ISO file but by a "JB folder": it is validated file by file against the
+			// IRD file of the disc it was ripped from
+			QAction* check_jb_folder_integrity = addAction(tr("&Check JB Folder Integrity (IRD)"));
+
+			connect(check_jb_folder_integrity, &QAction::triggered, this, [this, gameinfo]()
+			{
+				m_game_list_actions->ShowIrdIntegrityDialog(gameinfo->path);
+			});
 		}
 	}
 


### PR DESCRIPTION
Add IRD based integrity check for:
- ISO encrypted: alternative to the already existing integrity check based on Redump DB in case you are interested to know the files where integrity check fails.

  NOTE: decryption key from IRD file is used in case no key file is found for the encrypted ISO file. This is also reported as a note in the panel when the check is completed
- ISO decrypted
- JB Folder

This feature should complete the task (not even opened) **Add content integrity check for any kind of content**.

Porting of the logic from PS3-ISO-Rebuilder assisted by Opus 5.

A dialog box to select the `.ird` file is prompted when pressing on the new game's context entry, e.g. `Check JB Folder Integrity (IRD)`.

fixes #13407

### JB Folder Integrity Check:

<img width="3791" height="1246" alt="image" src="https://github.com/user-attachments/assets/cffbaf91-3327-4fdd-92cd-cdc9a85989b7" />

</br>
</br>

<img width="1181" height="281" alt="image" src="https://github.com/user-attachments/assets/7b7f2380-4d62-4254-a07f-293541021eac" />

</br>
</br>

### PASSED:

<img width="1086" height="648" alt="image" src="https://github.com/user-attachments/assets/4c509e1c-abef-48b7-b574-63ab0aa155cf" />

### NOT PASSED:

<img width="1041" height="828" alt="image" src="https://github.com/user-attachments/assets/a9dae809-3856-4646-af28-834fe683ce42" />
